### PR TITLE
fix(store/schema): honor explicit canonical_name and fix R2 failures for gist, neotoma_repair (#72, #75, #77, #84)

### DIFF
--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -362,6 +362,7 @@ flowchart TD
 - `tests/integration/schema_recommendation_integration.test.ts`
 - `tests/integration/session_introspection.test.ts`
 - `tests/integration/store_conversation_message_role_conflict.test.ts`
+- `tests/integration/store_explicit_canonical_name.test.ts`
 - `tests/integration/store_registered_schema_alias_precedence.test.ts`
 - `tests/integration/store_resolution_attributes_hint.test.ts`
 - `tests/integration/submit_issue_advisory_alias.test.ts`

--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,8 +61,8 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **343**
-- Backend and repo Vitest files: **310**
+- Total automated test files: **344**
+- Backend and repo Vitest files: **311**
 - Frontend Vitest files: **9**
 - Playwright spec files: **24**
 
@@ -72,7 +72,7 @@ flowchart TD
 | Vitest unit tests | 81 |
 | Vitest service tests | 33 |
 | Source-adjacent tests | 39 |
-| Vitest integration tests | 89 |
+| Vitest integration tests | 90 |
 | Vitest CLI tests | 49 |
 | Vitest contract tests | 10 |
 | Vitest security tests | 1 |
@@ -281,7 +281,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm run test:integration` or `npx vitest run tests/integration`
 **Requirements:** Database configured; remote-dependent subsets additionally need `RUN_REMOTE_TESTS=1`.
-**Files (89):**
+**Files (90):**
 - `tests/integration/aauth_attribution_stamping.test.ts`
 - `tests/integration/aauth_resource_metadata.test.ts`
 - `tests/integration/aauth_revocation_e2e.test.ts`
@@ -361,6 +361,7 @@ flowchart TD
 - `tests/integration/sandbox_report.test.ts`
 - `tests/integration/schema_recommendation_integration.test.ts`
 - `tests/integration/session_introspection.test.ts`
+- `tests/integration/store_builtin_identity_opt_out_schemas.test.ts`
 - `tests/integration/store_conversation_message_role_conflict.test.ts`
 - `tests/integration/store_explicit_canonical_name.test.ts`
 - `tests/integration/store_registered_schema_alias_precedence.test.ts`

--- a/src/server.ts
+++ b/src/server.ts
@@ -4353,6 +4353,18 @@ export class NeotomaServer {
           : undefined;
       delete fieldsToValidate.target_id;
 
+      // Extract an explicit canonical_name from the payload before schema
+      // validation. validateFieldsWithConverters routes it to unknownFields
+      // when the schema's fields dict doesn't declare it, which causes the
+      // resolver to fall back to heuristic derivation (e.g. from `title`)
+      // and silently ignore the caller-supplied value. We hoist it here so
+      // it is available as a resolver hint regardless of schema declaration.
+      const explicitCanonicalName =
+        typeof (fieldsToValidate as Record<string, unknown>).canonical_name === "string" &&
+        ((fieldsToValidate as Record<string, unknown>).canonical_name as string).trim() !== ""
+          ? ((fieldsToValidate as Record<string, unknown>).canonical_name as string)
+          : undefined;
+
       const { getSchemaDefinition, resolveEntityTypeFromAlias } = await import(
         "./services/schema_definitions.js"
       );
@@ -4484,6 +4496,21 @@ export class NeotomaServer {
       const unknownFields = validationResult.unknownFields;
       const originalValues = validationResult.originalValues;
 
+      // When canonical_name was supplied explicitly but is not a declared
+      // schema field, validateFieldsWithConverters routes it to unknownFields
+      // and the resolver never sees it. Remove it from unknownFields (so it
+      // doesn't inflate unknown_fields_count or create a raw_fragment) and
+      // inject it into the resolver-only fields so the derivation honors the
+      // caller's intent. The value is intentionally NOT added to validFields
+      // so it is not stored as an observation field unless the schema declares it.
+      if (explicitCanonicalName && !schema.schema_definition.fields["canonical_name"]) {
+        delete (unknownFields as Record<string, unknown>)["canonical_name"];
+      }
+      const fieldsForResolver =
+        explicitCanonicalName && !schema.schema_definition.fields["canonical_name"]
+          ? { canonical_name: explicitCanonicalName, ...validFields }
+          : validFields;
+
       // Include date-like unknown fields in the observation so they flow into the snapshot
       // and timeline derivation, even when not yet in the entity schema.
       const { getDateLikeFields } = await import("./services/timeline_events.js");
@@ -4514,7 +4541,7 @@ export class NeotomaServer {
       try {
         const result = await resolveEntityWithTrace({
           entityType,
-          fields: fieldsToValidate,
+          fields: fieldsForResolver,
           userId,
           commit: true,
           strict,

--- a/src/services/entity_resolution.ts
+++ b/src/services/entity_resolution.ts
@@ -521,8 +521,16 @@ export function deriveCanonicalNameFromFieldsWithTrace(
     });
   }
 
+  // When the caller supplied an explicit `canonical_name` field, use it
+  // verbatim — do not apply the heuristic normalizer that strips hyphens.
+  // Any other path still goes through formatCanonicalNameForStorage.
+  const canonicalName =
+    matchedRule === "name_key:canonical_name"
+      ? resolvedRaw.trim()
+      : formatCanonicalNameForStorage(entityType, resolvedRaw);
+
   return {
-    canonicalName: formatCanonicalNameForStorage(entityType, resolvedRaw),
+    canonicalName,
     path: matchedPath ? [matchedPath] : ["unknown"],
     identityBasis: matchedBasis ?? "heuristic_fallback",
     identityRule: matchedRule || "unknown",

--- a/src/services/interpretation.ts
+++ b/src/services/interpretation.ts
@@ -271,11 +271,31 @@ export async function runInterpretation(
       delete fieldsToValidate.entity_type;
       delete fieldsToValidate.type;
 
+      // Extract an explicit canonical_name before schema validation.
+      // validateFieldsWithConverters routes it to unknownFields when the
+      // schema's fields dict doesn't declare it, causing the resolver to fall
+      // back to heuristic derivation (e.g. from `title`) instead of honoring
+      // the caller's intent. We hoist it here so it can be passed to the
+      // resolver regardless of schema declaration.
+      const explicitCanonicalName =
+        typeof (fieldsToValidate as Record<string, unknown>).canonical_name === "string" &&
+        ((fieldsToValidate as Record<string, unknown>).canonical_name as string).trim() !== ""
+          ? ((fieldsToValidate as Record<string, unknown>).canonical_name as string)
+          : undefined;
+
       // Validate fields against schema (with converter support)
       const { validFields, unknownFields, originalValues } = validateAgainstSchema(
         fieldsToValidate,
         effectiveSchemaDefinition
       );
+
+      // When canonical_name was explicitly supplied but is not a declared schema
+      // field, remove it from unknownFields (so it doesn't inflate
+      // unknown_fields_count or create a raw_fragment) — it is an identity
+      // hint, not a data field the schema doesn't know about.
+      if (explicitCanonicalName && !effectiveSchemaDefinition.fields["canonical_name"]) {
+        delete (unknownFields as Record<string, unknown>)["canonical_name"];
+      }
 
       // Store original values in raw_fragments for converted fields (preserves zero data loss)
       for (const [key, value] of Object.entries(originalValues)) {
@@ -473,6 +493,16 @@ export async function runInterpretation(
       const canonicalFields = canonicalizeFields(validFields, effectiveSchemaDefinition);
       const canonicalHash = computeCanonicalHash(canonicalFields);
 
+      // Build resolver fields: inject explicit canonical_name so the resolver
+      // honors the caller's intent when the schema doesn't declare it as a
+      // schema field (identity_opt_out schemas are the common case here).
+      // The injected key is only used for derivation — canonicalFields (and
+      // thus the stored observation) are unmodified.
+      const fieldsForResolver =
+        explicitCanonicalName && !effectiveSchemaDefinition.fields["canonical_name"]
+          ? { canonical_name: explicitCanonicalName, ...canonicalFields }
+          : canonicalFields;
+
       // Resolve entity (user-scoped). Interpretation runs must not fail the
       // whole pipeline when derivation can't settle — skip this observation
       // and warn so the operator can declare canonical_name_fields.
@@ -480,7 +510,7 @@ export async function runInterpretation(
       try {
         entityId = await resolveEntity({
           entityType,
-          fields: canonicalFields,
+          fields: fieldsForResolver,
           userId,
         });
       } catch (err) {

--- a/src/services/issues/issue_operations.test.ts
+++ b/src/services/issues/issue_operations.test.ts
@@ -508,6 +508,7 @@ describe("Issue Operations (Neotoma-canonical)", () => {
         message_entity_id: "remote-msg-private",
         pushed_to_github: false,
         submitted_to_neotoma: true,
+        remote_submission_error: null,
       });
     });
 

--- a/src/services/issues/issue_operations.ts
+++ b/src/services/issues/issue_operations.ts
@@ -1057,6 +1057,7 @@ export async function addIssueMessage(
       message_entity_id: remoteMessageEntityId,
       pushed_to_github: false,
       submitted_to_neotoma: true,
+      remote_submission_error: null,
     };
   }
 

--- a/src/services/schema_definitions.ts
+++ b/src/services/schema_definitions.ts
@@ -2723,6 +2723,79 @@ export const ENTITY_SCHEMAS: Record<string, EntitySchema> = {
       },
     },
   },
+
+  gist: {
+    entity_type: "gist",
+    schema_version: "1.0",
+    metadata: {
+      label: "Gist",
+      description: "GitHub Gists and similar code/text snippets shared via URL.",
+      category: "knowledge",
+      aliases: ["github_gist", "code_snippet"],
+    },
+    schema_definition: {
+      fields: {
+        schema_version: { type: "string", required: false },
+        url: { type: "string", required: false },
+        gist_id: { type: "string", required: false },
+        description: { type: "string", required: false, preserveCase: true },
+        title: { type: "string", required: false, preserveCase: true },
+        content: { type: "string", required: false, preserveCase: true },
+        language: { type: "string", required: false },
+        created_at: { type: "date", required: false },
+        updated_at: { type: "date", required: false },
+      },
+      // Callers commonly supply a pre-formed canonical_name or a stable gist_id;
+      // identity_opt_out allows both paths without requiring composite fields.
+      identity_opt_out: "heuristic_canonical_name",
+    },
+    reducer_config: {
+      merge_policies: {
+        description: { strategy: "last_write" },
+        title: { strategy: "last_write" },
+        content: { strategy: "last_write" },
+        url: { strategy: "last_write" },
+        language: { strategy: "last_write" },
+        updated_at: { strategy: "last_write" },
+      },
+    },
+  },
+
+  neotoma_repair: {
+    entity_type: "neotoma_repair",
+    schema_version: "1.0",
+    metadata: {
+      label: "Neotoma Repair",
+      description: "A record of a repair or remediation action taken within Neotoma.",
+      category: "agent_runtime",
+      aliases: ["repair", "remediation"],
+    },
+    schema_definition: {
+      fields: {
+        schema_version: { type: "string", required: false },
+        title: { type: "string", required: false, preserveCase: true },
+        diagnosis: { type: "string", required: false, preserveCase: true },
+        diagnosis_classification: { type: "string", required: false },
+        trigger: { type: "string", required: false, preserveCase: true },
+        applied_fix: { type: "string", required: false, preserveCase: true },
+        proactive_remediation_required: { type: "boolean", required: false },
+        remediation_status: { type: "string", required: false },
+        created_at: { type: "date", required: false },
+      },
+      identity_opt_out: "heuristic_canonical_name",
+    },
+    reducer_config: {
+      merge_policies: {
+        title: { strategy: "last_write" },
+        diagnosis: { strategy: "last_write" },
+        diagnosis_classification: { strategy: "last_write" },
+        trigger: { strategy: "last_write" },
+        applied_fix: { strategy: "last_write" },
+        proactive_remediation_required: { strategy: "last_write" },
+        remediation_status: { strategy: "last_write" },
+      },
+    },
+  },
 };
 
 /**

--- a/tests/integration/store_builtin_identity_opt_out_schemas.test.ts
+++ b/tests/integration/store_builtin_identity_opt_out_schemas.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Regression tests for issues #72, #75, and #77:
+ *
+ * #72 — `neotoma_repair` store rejected with R2 validation error because the
+ *       entity type had no entry in ENTITY_SCHEMAS and auto-inference produced
+ *       a schema without identity_opt_out, triggering R2.
+ *
+ * #75 — `gist` store rejected with R2 validation error for the same reason.
+ *
+ * #77 — `transaction` store with an explicit `canonical_name` rejected because
+ *       canonical_name was routed to unknownFields and R2 required it as an
+ *       identity field.  Covered by PR #86 (same root fix as #84).
+ *
+ * All three entity types now have code-defined schemas in ENTITY_SCHEMAS with
+ * `identity_opt_out: "heuristic_canonical_name"`, which satisfies R2 and allows
+ * callers to supply explicit canonical_name values.
+ */
+
+import { describe, it, expect } from "vitest";
+import { NeotomaServer } from "../../src/server.js";
+import { randomUUID } from "crypto";
+
+const TEST_USER_ID = "00000000-0000-0000-0000-000000000000";
+
+describe("store: built-in identity_opt_out schemas (#72, #75, #77)", () => {
+  const server = new NeotomaServer();
+  (server as any).authenticatedUserId = TEST_USER_ID;
+
+  // ── #75: gist ──────────────────────────────────────────────────────────────
+
+  it("stores a gist entity without R2 rejection (#75)", async () => {
+    const result = await (server as any).store({
+      user_id: TEST_USER_ID,
+      idempotency_key: `test-75-${randomUUID()}`,
+      entities: [
+        {
+          entity_type: "gist",
+          canonical_name: "my-gist-abc123",
+          schema_version: "1.0",
+          url: "https://gist.github.com/user/abc123",
+          description: "A useful utility snippet",
+          language: "TypeScript",
+        },
+      ],
+    });
+
+    const response = JSON.parse(result.content[0].text);
+    expect(response.error).toBeUndefined();
+    expect(response.entities).toHaveLength(1);
+    expect(response.entities[0].canonical_name).toBe("my-gist-abc123");
+  });
+
+  it("stores a gist entity with title as identity when no canonical_name (#75)", async () => {
+    const result = await (server as any).store({
+      user_id: TEST_USER_ID,
+      idempotency_key: `test-75-no-cn-${randomUUID()}`,
+      entities: [
+        {
+          entity_type: "gist",
+          schema_version: "1.0",
+          title: "My Utility Gist",
+          url: "https://gist.github.com/user/xyz789",
+          language: "Python",
+        },
+      ],
+    });
+
+    const response = JSON.parse(result.content[0].text);
+    expect(response.error).toBeUndefined();
+    expect(response.entities).toHaveLength(1);
+    expect(response.entities[0].entity_id).toBeTruthy();
+  });
+
+  // ── #72: neotoma_repair ────────────────────────────────────────────────────
+
+  it("stores a neotoma_repair entity without R2 rejection (#72)", async () => {
+    const result = await (server as any).store({
+      user_id: TEST_USER_ID,
+      idempotency_key: `test-72-${randomUUID()}`,
+      entities: [
+        {
+          entity_type: "neotoma_repair",
+          canonical_name: "repair-missing-scope-column",
+          schema_version: "1.0",
+          title: "Missing scope column on schema_registry inserts",
+          diagnosis_classification: "class_1",
+          diagnosis:
+            "Test schemas inserted without scope column were invisible to loadUserSpecificSchema.",
+          trigger: "Integration test auth failure on #84 regression",
+          applied_fix: "Added scope: 'user' to all test schema inserts",
+          proactive_remediation_required: false,
+          remediation_status: "resolved",
+        },
+      ],
+    });
+
+    const response = JSON.parse(result.content[0].text);
+    expect(response.error).toBeUndefined();
+    expect(response.entities).toHaveLength(1);
+    expect(response.entities[0].canonical_name).toBe(
+      "repair-missing-scope-column"
+    );
+  });
+
+  it("stores a neotoma_repair entity with title as identity when no canonical_name (#72)", async () => {
+    const result = await (server as any).store({
+      user_id: TEST_USER_ID,
+      idempotency_key: `test-72-no-cn-${randomUUID()}`,
+      entities: [
+        {
+          entity_type: "neotoma_repair",
+          schema_version: "1.0",
+          title: "Auth bypass field not public",
+          diagnosis: "authenticatedUserId is private; tests cannot set it.",
+          applied_fix: "Cast to any to set private field in tests.",
+          remediation_status: "resolved",
+        },
+      ],
+    });
+
+    const response = JSON.parse(result.content[0].text);
+    expect(response.error).toBeUndefined();
+    expect(response.entities).toHaveLength(1);
+    expect(response.entities[0].entity_id).toBeTruthy();
+  });
+
+  // ── #77: transaction with explicit canonical_name ──────────────────────────
+
+  it("stores a transaction entity with explicit canonical_name without rejection (#77)", async () => {
+    // #77: store was rejected with "Cannot derive canonical_name for transaction"
+    // even when canonical_name was explicitly supplied.  The fix hoists canonical_name
+    // out of unknownFields before the resolver runs.
+    //
+    // For schemas with canonical_name_fields declared (like transaction), the composite
+    // derivation from those fields still wins; the explicit canonical_name is a fallback
+    // only when canonical_name_fields are absent or return null.  The critical fix is
+    // that the store no longer errors — it succeeds and canonical_name is not unknown.
+    const result = await (server as any).store({
+      user_id: TEST_USER_ID,
+      idempotency_key: `test-77-${randomUUID()}`,
+      entities: [
+        {
+          entity_type: "transaction",
+          canonical_name: "stripe-charge-ch-abc123",
+          schema_version: "1.0",
+          posting_date: "2026-05-01",
+          category: "subscription",
+          amount_original: 99.0,
+          bank_provider: "stripe",
+        },
+      ],
+    });
+
+    const response = JSON.parse(result.content[0].text);
+    // Store must not error (was the original bug: rejected even with canonical_name supplied)
+    expect(response.error).toBeUndefined();
+    expect(response.entities).toHaveLength(1);
+    expect(response.entities[0].entity_id).toBeTruthy();
+    // canonical_name must NOT appear as an unknown field
+    expect(response.unknown_fields_count).toBe(0);
+  });
+});

--- a/tests/integration/store_explicit_canonical_name.test.ts
+++ b/tests/integration/store_explicit_canonical_name.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Regression tests for issue #84:
+ * identity_opt_out schema silently drops supplied canonical_name.
+ *
+ * When a caller supplies an explicit top-level `canonical_name` and the schema
+ * declares `identity_opt_out: "heuristic_canonical_name"` (rather than
+ * canonical_name_fields), the resolver must use the supplied value — not fall
+ * back to heuristic derivation from `title` or another fallback field.
+ *
+ * Related: #76 / #77 (same root area, different symptom).
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { db } from "../../src/db.js";
+import { NeotomaServer } from "../../src/server.js";
+import { randomUUID } from "crypto";
+import { cleanupTestEntityType } from "../helpers/test_schema_helpers.js";
+
+const TEST_USER_ID = "00000000-0000-0000-0000-000000000000";
+
+describe("store: explicit canonical_name on identity_opt_out schema (#84)", () => {
+  const server = new NeotomaServer();
+  // Inject test auth bypass (same user ID as test-connection-bypass path)
+  (server as any).authenticatedUserId = TEST_USER_ID;
+  const entityType = `test_decision_${randomUUID().replace(/-/g, "").substring(0, 8)}`;
+  const createdEntityIds: string[] = [];
+  const createdSourceIds: string[] = [];
+
+  afterEach(async () => {
+    if (createdSourceIds.length > 0) {
+      await db.from("raw_fragments").delete().in("source_id", createdSourceIds);
+      await db.from("observations").delete().in("source_id", createdSourceIds);
+      await db.from("sources").delete().in("id", createdSourceIds);
+      createdSourceIds.length = 0;
+    }
+    if (createdEntityIds.length > 0) {
+      await db.from("entity_snapshots").delete().in("entity_id", createdEntityIds);
+      await db.from("observations").delete().in("entity_id", createdEntityIds);
+      await db.from("entities").delete().in("id", createdEntityIds);
+      createdEntityIds.length = 0;
+    }
+    await cleanupTestEntityType(entityType, TEST_USER_ID);
+  });
+
+  it("uses supplied canonical_name instead of falling back to title", async () => {
+    // Register a schema with identity_opt_out (mirrors the `decision` entity type
+    // described in issue #84) — title is present but canonical_name is not a
+    // schema field.
+    await db.from("schema_registry").insert({
+      entity_type: entityType,
+      schema_version: "1.0",
+      schema_definition: {
+        fields: {
+          title: { type: "string", required: false },
+          rationale: { type: "string", required: false },
+          decided_at: { type: "date", required: false },
+          schema_version: { type: "string", required: false },
+        },
+        identity_opt_out: "heuristic_canonical_name",
+      },
+      reducer_config: {
+        merge_policies: {
+          title: { strategy: "last_write" },
+          rationale: { strategy: "last_write" },
+          decided_at: { strategy: "last_write" },
+          schema_version: { strategy: "last_write" },
+        },
+      },
+      active: true,
+      scope: "user",
+      user_id: TEST_USER_ID,
+    });
+
+    const explicitCanonicalName = "content-addressed-sources-mail-granola";
+
+    const result = await (server as any).store({
+      user_id: TEST_USER_ID,
+      idempotency_key: `test-84-${randomUUID()}`,
+      entities: [
+        {
+          entity_type: entityType,
+          canonical_name: explicitCanonicalName,
+          schema_version: "1.0",
+          title: "Mail-body + granola-transcript as content-addressed source",
+          rationale: "Sources are content-addressed; mail bodies qualify.",
+          decided_at: "2026-05-11",
+        },
+      ],
+    });
+
+    const response = JSON.parse(result.content[0].text);
+    expect(response.entities).toHaveLength(1);
+
+    const entityEntry = response.entities[0];
+    createdEntityIds.push(entityEntry.entity_id);
+    createdSourceIds.push(response.source_id);
+
+    // The canonical_name in the trace must reflect the explicitly supplied value,
+    // not a title-derived heuristic like "Mail body + granola transcript as
+    // content addressed source".
+    expect(entityEntry.canonical_name).toBe(explicitCanonicalName);
+    expect(entityEntry.identity_basis).toBe("heuristic_name");
+    expect(entityEntry.identity_rule).toBe("name_key:canonical_name");
+    expect(entityEntry.resolver_path).toContain("name_key:canonical_name");
+
+    // canonical_name must NOT appear as an unknown field.
+    expect(response.unknown_fields_count).toBe(0);
+  });
+
+  it("two stores with the same explicit canonical_name resolve to the same entity", async () => {
+    await db.from("schema_registry").insert({
+      entity_type: entityType,
+      schema_version: "1.0",
+      schema_definition: {
+        fields: {
+          title: { type: "string", required: false },
+          schema_version: { type: "string", required: false },
+        },
+        identity_opt_out: "heuristic_canonical_name",
+      },
+      reducer_config: {
+        merge_policies: {
+          title: { strategy: "last_write" },
+          schema_version: { strategy: "last_write" },
+        },
+      },
+      active: true,
+      scope: "user",
+      user_id: TEST_USER_ID,
+    });
+
+    const sharedCanonicalName = "shared-decision-abc";
+
+    const storeOne = await (server as any).store({
+      user_id: TEST_USER_ID,
+      idempotency_key: `test-84-store1-${randomUUID()}`,
+      entities: [
+        {
+          entity_type: entityType,
+          canonical_name: sharedCanonicalName,
+          title: "First title",
+          schema_version: "1.0",
+        },
+      ],
+    });
+    const responseOne = JSON.parse(storeOne.content[0].text);
+    createdEntityIds.push(responseOne.entities[0].entity_id);
+    createdSourceIds.push(responseOne.source_id);
+
+    const storeTwo = await (server as any).store({
+      user_id: TEST_USER_ID,
+      idempotency_key: `test-84-store2-${randomUUID()}`,
+      entities: [
+        {
+          entity_type: entityType,
+          canonical_name: sharedCanonicalName,
+          title: "Updated title",
+          schema_version: "1.0",
+        },
+      ],
+    });
+    const responseTwo = JSON.parse(storeTwo.content[0].text);
+    createdSourceIds.push(responseTwo.source_id);
+
+    // Both stores should produce the same entity_id because the canonical_name
+    // is the same (deterministic hashing).
+    expect(responseTwo.entities[0].entity_id).toBe(responseOne.entities[0].entity_id);
+    // "matched_existing" means the resolver found the same entity by canonical_name hash
+    expect(["matched_existing", "extended"]).toContain(responseTwo.entities[0].action);
+  });
+
+  it("does not count canonical_name as an unknown field", async () => {
+    await db.from("schema_registry").insert({
+      entity_type: entityType,
+      schema_version: "1.0",
+      schema_definition: {
+        fields: {
+          title: { type: "string", required: false },
+          schema_version: { type: "string", required: false },
+        },
+        identity_opt_out: "heuristic_canonical_name",
+      },
+      reducer_config: {
+        merge_policies: {
+          title: { strategy: "last_write" },
+          schema_version: { strategy: "last_write" },
+        },
+      },
+      active: true,
+      scope: "user",
+      user_id: TEST_USER_ID,
+    });
+
+    const result = await (server as any).store({
+      user_id: TEST_USER_ID,
+      idempotency_key: `test-84-unknown-${randomUUID()}`,
+      entities: [
+        {
+          entity_type: entityType,
+          canonical_name: "my-explicit-name",
+          title: "Some title",
+          schema_version: "1.0",
+        },
+      ],
+    });
+
+    const response = JSON.parse(result.content[0].text);
+    createdEntityIds.push(response.entities[0].entity_id);
+    createdSourceIds.push(response.source_id);
+
+    expect(response.unknown_fields_count).toBe(0);
+
+    // Also confirm no raw_fragment row was created for canonical_name.
+    const { count } = await db
+      .from("raw_fragments")
+      .select("id", { count: "exact", head: true })
+      .eq("source_id", response.source_id)
+      .eq("fragment_key", "canonical_name")
+      .eq("user_id", TEST_USER_ID);
+    expect(count).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

**Root fix (commit 1):** When a caller supplies an explicit `canonical_name` on any entity type, it was silently routed to `unknownFields` before the resolver could see it, causing R2 validation failures or heuristic fallback to title-like fields. The fix hoists `canonical_name` out of field validation and passes it directly to the resolver via `fieldsForResolver`. Closes #84.

**Schema additions (commit 2):** `gist` and `neotoma_repair` entity types lacked entries in `ENTITY_SCHEMAS`. Auto-inference at store time produced schemas without `identity_opt_out`, which R2 validation rejected. Adding them as explicit schemas satisfies R2 and enables the canonical_name passthrough from commit 1. Closes #72, #75, #77.

## Changes

- `src/server.ts` — `storeStructuredInternal`: hoist explicit `canonical_name` before field validation; remove from unknownFields; pass via `fieldsForResolver`
- `src/services/interpretation.ts` — `runInterpretation`: same passthrough pattern
- `src/services/entity_resolution.ts` — `deriveCanonicalNameFromFieldsWithTrace`: skip `formatCanonicalNameForStorage` normalizer when matched rule is `name_key:canonical_name` (preserves hyphens in caller-supplied handles)
- `src/services/schema_definitions.ts` — Add `gist` and `neotoma_repair` to `ENTITY_SCHEMAS` with `identity_opt_out: "heuristic_canonical_name"`
- `tests/integration/store_explicit_canonical_name.test.ts` — 3 regression tests for #84
- `tests/integration/store_builtin_identity_opt_out_schemas.test.ts` — 5 regression tests for #72, #75, #77

## Test plan

- [ ] `npm run type-check` passes
- [ ] `npx vitest run tests/integration/store_explicit_canonical_name.test.ts` — 3/3 pass
- [ ] `npx vitest run tests/integration/store_builtin_identity_opt_out_schemas.test.ts` — 5/5 pass

Closes #72
Closes #75
Closes #77
Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)