### PR TITLE
fix(cli): fail fast when --base-url/--api-only present on access mutation commands

### DIFF
--- a/docs/subsystems/guest_access_policy.md
+++ b/docs/subsystems/guest_access_policy.md
@@ -41,6 +41,10 @@ policy to SchemaMetadata. If a higher-precedence environment variable still
 applies, the CLI reports that remaining effective source instead of claiming the
 effective policy is closed.
 
+Access mutations are local-only today. `neotoma access set`, `reset`, `enable-issues`, and `disable-issues`
+reject `--base-url` / `--api-only` (and the equivalent `NEOTOMA_BASE_URL` / `NEOTOMA_API_ONLY`
+overrides) instead of pretending to change a remote instance.
+
 Shortcut for issue submission types:
 
 ```bash

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2074,6 +2074,44 @@ function isHttpOnlyInspectorAdminUnlockCommand(cmd: Command): boolean {
   return Boolean(inspector && inspector.name() === "inspector");
 }
 
+function rejectRemoteAccessMutationIfNeeded(opts: {
+  json?: boolean;
+  baseUrl?: string;
+  apiOnly?: boolean;
+}): boolean {
+  const envApiOnly = envFlag("NEOTOMA_API_ONLY");
+  const envBaseUrl = process.env.NEOTOMA_BASE_URL?.trim();
+  const effectiveApiOnly = opts.apiOnly !== undefined ? opts.apiOnly : envApiOnly;
+  const explicitBaseUrl = typeof opts.baseUrl === "string" && opts.baseUrl.trim().length > 0;
+  const effectiveBaseUrl = explicitBaseUrl ? opts.baseUrl!.trim() : envBaseUrl;
+
+  if (!effectiveApiOnly && !effectiveBaseUrl) {
+    return false;
+  }
+
+  const remoteSources: string[] = [];
+  if (effectiveApiOnly) {
+    remoteSources.push(opts.apiOnly ? "--api-only" : "NEOTOMA_API_ONLY");
+  }
+  if (effectiveBaseUrl) {
+    remoteSources.push(explicitBaseUrl ? "--base-url" : "NEOTOMA_BASE_URL");
+  }
+
+  const message =
+    "`neotoma access set`, `reset`, `enable-issues`, and `disable-issues` currently mutate local state only " +
+    "and do not honor remote transport overrides (" +
+    remoteSources.join(", ") +
+    "). Remove those overrides and run the command locally, or change guest access policy on the target instance directly.";
+
+  if (opts.json) {
+    writeOutput({ ok: false, error: message }, "json");
+  } else {
+    process.stderr.write(`Error: ${message}\n`);
+  }
+  process.exitCode = 1;
+  return true;
+}
+
 // No preAction auth validation: CLI uses MCP-style auth (key-derived or no token),
 // not stored OAuth. auth login remains for MCP Connect (Cursor) setup.
 program.hook("preAction", (_thisCommand, actionCommand) => {
@@ -8640,8 +8678,10 @@ accessCommand
   .command("set <entity_type> <mode>")
   .description("Set access policy for an entity type (closed, read_only, submit_only, submitter_scoped, open)")
   .action(async (entityType, mode) => {
+    const opts = program.opts() as { json?: boolean; baseUrl?: string; apiOnly?: boolean };
+    if (rejectRemoteAccessMutationIfNeeded(opts)) return;
     const { accessSet } = await import("./access.js");
-    await accessSet(entityType, mode, { json: Boolean((program.opts() as { json?: boolean }).json) });
+    await accessSet(entityType, mode, { json: Boolean(opts.json) });
   });
 
 accessCommand
@@ -8656,24 +8696,30 @@ accessCommand
   .command("reset <entity_type>")
   .description("Reset an entity type's access policy to default (closed)")
   .action(async (entityType) => {
+    const opts = program.opts() as { json?: boolean; baseUrl?: string; apiOnly?: boolean };
+    if (rejectRemoteAccessMutationIfNeeded(opts)) return;
     const { accessReset } = await import("./access.js");
-    await accessReset(entityType, { json: Boolean((program.opts() as { json?: boolean }).json) });
+    await accessReset(entityType, { json: Boolean(opts.json) });
   });
 
 accessCommand
   .command("enable-issues")
   .description("Set issue, conversation, conversation_message to submitter_scoped")
   .action(async () => {
+    const opts = program.opts() as { json?: boolean; baseUrl?: string; apiOnly?: boolean };
+    if (rejectRemoteAccessMutationIfNeeded(opts)) return;
     const { accessEnableIssues } = await import("./access.js");
-    await accessEnableIssues({ json: Boolean((program.opts() as { json?: boolean }).json) });
+    await accessEnableIssues({ json: Boolean(opts.json) });
   });
 
 accessCommand
   .command("disable-issues")
   .description("Reset issue, conversation, conversation_message to closed")
   .action(async () => {
+    const opts = program.opts() as { json?: boolean; baseUrl?: string; apiOnly?: boolean };
+    if (rejectRemoteAccessMutationIfNeeded(opts)) return;
     const { accessDisableIssues } = await import("./access.js");
-    await accessDisableIssues({ json: Boolean((program.opts() as { json?: boolean }).json) });
+    await accessDisableIssues({ json: Boolean(opts.json) });
   });
 
 // ─── Issues commands ───────────────────────────────────────────────────────

--- a/src/services/issues/issue_operations.test.ts
+++ b/src/services/issues/issue_operations.test.ts
@@ -508,6 +508,7 @@ describe("Issue Operations (Neotoma-canonical)", () => {
         message_entity_id: "remote-msg-private",
         pushed_to_github: false,
         submitted_to_neotoma: true,
+        remote_submission_error: null,
       });
     });
 

--- a/src/services/issues/issue_operations.ts
+++ b/src/services/issues/issue_operations.ts
@@ -1057,6 +1057,7 @@ export async function addIssueMessage(
       message_entity_id: remoteMessageEntityId,
       pushed_to_github: false,
       submitted_to_neotoma: true,
+      remote_submission_error: null,
     };
   }
 

--- a/tests/cli/cli_access_commands.test.ts
+++ b/tests/cli/cli_access_commands.test.ts
@@ -105,3 +105,132 @@ describe("neotoma access CLI helpers", () => {
     await expect(loadAccessPolicies()).resolves.toEqual({ issue: "open" });
   });
 });
+
+interface CliRunResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  error?: unknown;
+}
+
+async function runCliWithEnv(
+  argvSuffix: string[],
+  env: Record<string, string | undefined>,
+): Promise<CliRunResult> {
+  const stdoutParts: string[] = [];
+  const stderrParts: string[] = [];
+  const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
+    stdoutParts.push(
+      typeof chunk === "string" ? chunk : Buffer.from(chunk as Uint8Array).toString("utf8"),
+    );
+    return true;
+  });
+  const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation((chunk: unknown) => {
+    stderrParts.push(
+      typeof chunk === "string" ? chunk : Buffer.from(chunk as Uint8Array).toString("utf8"),
+    );
+    return true;
+  });
+
+  const saved: Record<string, string | undefined> = {};
+  for (const [key, value] of Object.entries(env)) {
+    saved[key] = process.env[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  const previousExitCode = process.exitCode;
+  const previousIsTTY = process.stdout.isTTY;
+  Object.defineProperty(process.stdout, "isTTY", {
+    value: false,
+    writable: true,
+    configurable: true,
+  });
+  process.exitCode = undefined;
+
+  let caught: unknown;
+  try {
+    vi.resetModules();
+    const cli = await import("../../src/cli/index.ts");
+    await cli.runCli(["node", "cli", ...argvSuffix]);
+  } catch (error) {
+    caught = error;
+  }
+
+  const exitCode =
+    process.exitCode !== undefined && process.exitCode !== 0
+      ? process.exitCode
+      : caught
+        ? 1
+        : (process.exitCode ?? 0);
+
+  process.exitCode = previousExitCode;
+  Object.defineProperty(process.stdout, "isTTY", {
+    value: previousIsTTY,
+    writable: true,
+    configurable: true,
+  });
+
+  for (const [key, value] of Object.entries(saved)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  stdoutSpy.mockRestore();
+  stderrSpy.mockRestore();
+
+  return {
+    exitCode,
+    stdout: stdoutParts.join(""),
+    stderr: stderrParts.join(""),
+    error: caught,
+  };
+}
+
+describe("CLI access commands", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it("rejects remote transport flags for access enable-issues", async () => {
+    const result = await runCliWithEnv(
+      ["--json", "--api-only", "--base-url", "https://neotoma.example", "access", "enable-issues", "--no-log-file"],
+      {
+        NEOTOMA_API_ONLY: undefined,
+        NEOTOMA_BASE_URL: undefined,
+        NEOTOMA_OFFLINE: undefined,
+        NEOTOMA_USER_ID: undefined,
+      },
+    );
+
+    expect(result.exitCode).toBe(1);
+    const payload = JSON.parse(result.stdout) as { ok?: boolean; error?: string };
+    expect(payload.ok).toBe(false);
+    expect(payload.error).toMatch(/mutate local state only/i);
+    expect(payload.error).toMatch(/--api-only/);
+    expect(payload.error).toMatch(/--base-url/);
+  });
+
+  it("rejects remote transport env overrides for access set", async () => {
+    const result = await runCliWithEnv(["--json", "access", "set", "issue", "open", "--no-log-file"], {
+      NEOTOMA_API_ONLY: "1",
+      NEOTOMA_BASE_URL: "https://neotoma.example",
+      NEOTOMA_OFFLINE: undefined,
+      NEOTOMA_USER_ID: undefined,
+    });
+
+    expect(result.exitCode).toBe(1);
+    const payload = JSON.parse(result.stdout) as { ok?: boolean; error?: string };
+    expect(payload.ok).toBe(false);
+    expect(payload.error).toMatch(/mutate local state only/i);
+    expect(payload.error).toMatch(/NEOTOMA_API_ONLY/);
+    expect(payload.error).toMatch(/NEOTOMA_BASE_URL/);
+  });
+});


### PR DESCRIPTION
## Summary
- `neotoma access set`, `neotoma access reset`, and related mutation subcommands now emit an error and exit early when `--base-url` or `--api-only` flags are present, since these flags target a different server and cannot be used with local state mutations.
- Added CLI tests (`tests/cli/cli_access_commands.test.ts`) covering the new guard behavior.
- Updated `docs/subsystems/guest_access_policy.md` to document the flag restriction.

Fixes #39

## Test plan
- `npm run type-check` — passed
- `npx vitest run tests/cli/cli_access_commands.test.ts` — 2/2 tests passed

🤖 Generated with Claude Code