### PR TITLE
fix(schema): add external_link entity type with gist metadata fields

### DIFF
--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -364,6 +364,7 @@ flowchart TD
 - `tests/integration/store_builtin_identity_opt_out_schemas.test.ts`
 - `tests/integration/store_conversation_message_role_conflict.test.ts`
 - `tests/integration/store_explicit_canonical_name.test.ts`
+- `tests/integration/store_external_link_schema.test.ts`
 - `tests/integration/store_registered_schema_alias_precedence.test.ts`
 - `tests/integration/store_resolution_attributes_hint.test.ts`
 - `tests/integration/submit_issue_advisory_alias.test.ts`

--- a/src/services/schema_definitions.ts
+++ b/src/services/schema_definitions.ts
@@ -2796,6 +2796,38 @@ export const ENTITY_SCHEMAS: Record<string, EntitySchema> = {
       },
     },
   },
+
+  external_link: {
+    entity_type: "external_link",
+    schema_version: "1.0",
+    metadata: {
+      label: "External Link",
+      description:
+        "A URL bookmark or reference with optional metadata. Supports common link provenance fields: description, data_source, link_kind, visibility.",
+      category: "knowledge",
+      aliases: ["bookmark", "link", "url_reference"],
+    },
+    schema_definition: {
+      fields: {
+        title: { type: "string", required: true },
+        url: { type: "string", required: true },
+        description: { type: "string", required: false },
+        data_source: { type: "string", required: false },
+        link_kind: { type: "string", required: false },
+        visibility: { type: "string", required: false },
+      },
+      canonical_name_fields: ["url", "title"],
+    },
+    reducer_config: {
+      merge_policies: {
+        title: { strategy: "last_write" },
+        description: { strategy: "last_write" },
+        data_source: { strategy: "last_write" },
+        link_kind: { strategy: "last_write" },
+        visibility: { strategy: "last_write" },
+      },
+    },
+  },
 };
 
 /**

--- a/tests/integration/store_external_link_schema.test.ts
+++ b/tests/integration/store_external_link_schema.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Regression test for issue #53: external_link schema drops gist metadata.
+ *
+ * Verifies that storing an external_link with description, data_source,
+ * link_kind, and visibility produces unknown_fields_count: 0 and projects
+ * all fields into the snapshot.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { db } from "../../src/db.js";
+import { NeotomaServer } from "../../src/server.js";
+
+const TEST_USER_ID = "00000000-0000-0000-0000-000000000000";
+
+describe("store external_link — gist metadata fields (issue #53)", () => {
+  let server: NeotomaServer;
+  const createdSourceIds: string[] = [];
+  const createdEntityIds: string[] = [];
+
+  beforeAll(() => {
+    server = new NeotomaServer();
+    (server as any).authenticatedUserId = TEST_USER_ID;
+  });
+
+  afterAll(async () => {
+    for (const sourceId of createdSourceIds) {
+      await db.from("observations").delete().eq("source_id", sourceId);
+      await db.from("raw_fragments").delete().eq("source_id", sourceId);
+      await db.from("sources").delete().eq("id", sourceId);
+    }
+    for (const entityId of createdEntityIds) {
+      await db.from("entity_snapshots").delete().eq("entity_id", entityId);
+    }
+  });
+
+  it("stores all external_link fields without unknown_fields_count > 0", async () => {
+    const rawResult = await (server as any).store({
+      user_id: TEST_USER_ID,
+      idempotency_key: `issue-53-regression-1-${Date.now()}`,
+      entities: [
+        {
+          entity_type: "external_link",
+          title: "GitHub Gist — Neotoma architectural brief v0.3",
+          url: "https://gist.github.com/test-gist-id",
+          description: "Secret GitHub Gist containing a sanitized version of a brief.",
+          data_source: "gh gist create brief.md",
+          link_kind: "github_gist",
+          visibility: "secret",
+        },
+      ],
+    });
+
+    const result = JSON.parse(rawResult.content[0].text);
+
+    expect(result.source_id).toBeDefined();
+    createdSourceIds.push(result.source_id);
+
+    expect(result.entities).toHaveLength(1);
+    const entity = result.entities[0];
+    expect(entity.entity_type).toBe("external_link");
+    createdEntityIds.push(entity.entity_id);
+
+    // The core regression: all four previously-unknown fields should now be recognized.
+    expect(result.unknown_fields_count ?? 0).toBe(0);
+  });
+
+  it("projects description, data_source, link_kind, visibility into the snapshot", async () => {
+    const storeRaw = await (server as any).store({
+      user_id: TEST_USER_ID,
+      idempotency_key: `issue-53-regression-2-${Date.now()}`,
+      entities: [
+        {
+          entity_type: "external_link",
+          title: "Snapshot projection test link",
+          url: "https://gist.github.com/snapshot-test",
+          description: "A test link for snapshot projection.",
+          data_source: "gh gist create test.md",
+          link_kind: "github_gist",
+          visibility: "public",
+        },
+      ],
+    });
+
+    const storeResult = JSON.parse(storeRaw.content[0].text);
+    const entityId = storeResult.entities[0].entity_id;
+    createdSourceIds.push(storeResult.source_id);
+    createdEntityIds.push(entityId);
+
+    const snapshotRaw = await (server as any).retrieveEntitySnapshot({
+      entity_id: entityId,
+      format: "json",
+    });
+    const snapshot = JSON.parse(snapshotRaw.content[0].text);
+
+    expect(snapshot.snapshot?.description).toBe("A test link for snapshot projection.");
+    expect(snapshot.snapshot?.data_source).toBe("gh gist create test.md");
+    expect(snapshot.snapshot?.link_kind).toBe("github_gist");
+    expect(snapshot.snapshot?.visibility).toBe("public");
+  });
+});


### PR DESCRIPTION
## Summary

- `external_link` was not in `ENTITY_SCHEMAS`, so storing a link with `description`, `data_source`, `link_kind`, or `visibility` returned `unknown_fields_count: 4` and those fields were dropped from the projected snapshot.
- Added `external_link` schema to `ENTITY_SCHEMAS` with the six common fields (`title`, `url`, `description`, `data_source`, `link_kind`, `visibility`), category `knowledge`, and aliases `bookmark`, `link`, `url_reference`.

Fixes #53

## Test plan

- New regression test at `tests/integration/store_external_link_schema.test.ts` (two cases):
  1. Stores an `external_link` with all four previously-unknown fields and asserts `unknown_fields_count: 0`.
  2. Retrieves the snapshot and asserts all four fields (`description`, `data_source`, `link_kind`, `visibility`) are present in the projected snapshot.
- Both tests pass: `npx vitest run tests/integration/store_external_link_schema.test.ts` → 2/2 passed.
- Type check passes: `npm run type-check` → no errors.
- Test catalog regenerated and validated.

🤖 Generated with Claude Code