### PR TITLE
fix(ci): resolve 4 post-v0.12.1 test failures

### DIFF
--- a/.github/workflows/ci_test_lanes.yml
+++ b/.github/workflows/ci_test_lanes.yml
@@ -34,12 +34,14 @@ jobs:
       - name: Init inspector submodule (Vitest imports inspector sources)
         run: git submodule update --init --depth 1 inspector
 
-      - name: Build @neotoma/client and cursor-hooks (Vitest hook tests)
+      - name: Build @neotoma/client, cursor-hooks, and opencode-plugin (Vitest hook tests)
         run: |
           npm ci --prefix packages/client
           npm run build --prefix packages/client
           npm ci --prefix packages/cursor-hooks
           npm run build --prefix packages/cursor-hooks
+          npm ci --prefix packages/opencode-plugin
+          npm run build --prefix packages/opencode-plugin
 
       - name: Type check
         run: npm run type-check

--- a/packages/opencode-plugin/package-lock.json
+++ b/packages/opencode-plugin/package-lock.json
@@ -1,0 +1,99 @@
+{
+  "name": "@neotoma/opencode-plugin",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@neotoma/opencode-plugin",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@neotoma/client": "file:../client"
+      },
+      "devDependencies": {
+        "@types/node": "^20.11.0",
+        "typescript": "^5.4.0"
+      },
+      "peerDependencies": {
+        "@opencode-ai/plugin": "*"
+      },
+      "peerDependenciesMeta": {
+        "@opencode-ai/plugin": {
+          "optional": true
+        }
+      }
+    },
+    "../client": {
+      "name": "@neotoma/client",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^20.10.6",
+        "typescript": "^5.3.3"
+      },
+      "peerDependencies": {
+        "neotoma": ">=0.4.0"
+      },
+      "peerDependenciesMeta": {
+        "neotoma": {
+          "optional": true
+        }
+      }
+    },
+    "../client/node_modules/@types/node": {
+      "version": "20.19.39",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "../client/node_modules/typescript": {
+      "version": "5.9.3",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "../client/node_modules/undici-types": {
+      "version": "6.21.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@neotoma/client": {
+      "resolved": "../client",
+      "link": true
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.39",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/packages/opencode-plugin/package.json
+++ b/packages/opencode-plugin/package.json
@@ -40,16 +40,18 @@
     "url": "https://github.com/markmhendrickson/neotoma/issues"
   },
   "dependencies": {
-    "@neotoma/client": "^0.1.0"
+    "@neotoma/client": "file:../client"
   },
   "peerDependencies": {
     "@opencode-ai/plugin": "*"
   },
   "peerDependenciesMeta": {
-    "@opencode-ai/plugin": { "optional": true }
+    "@opencode-ai/plugin": {
+      "optional": true
+    }
   },
   "devDependencies": {
-    "typescript": "^5.4.0",
-    "@types/node": "^20.11.0"
+    "@types/node": "^20.11.0",
+    "typescript": "^5.4.0"
   }
 }

--- a/src/cli/commands/processes.ts
+++ b/src/cli/commands/processes.ts
@@ -813,7 +813,7 @@ function buildServerContextByPid(rows: readonly NeotomaProcessRow[]): Map<number
 
 export function buildNeotomaServerSummaries(
   rows: readonly NeotomaProcessRow[],
-  options: { psSnapshotRaw?: string } = {}
+  options: { psSnapshotRaw?: string; platform?: NodeJS.Platform } = {}
 ): NeotomaServerProcessSummary[] {
   const filtered = filterNeotomaServerRows(rows);
   const psIndex = readPsIndexBestEffort(options.psSnapshotRaw);
@@ -860,7 +860,7 @@ export function buildNeotomaServerSummaries(
       pid: representative.pid,
       neotoma_env,
       port: formatListenPortsForServers(ports),
-      launchagent: inferLaunchAgentLabel(process.platform, representative.pid, representative.ppid, representative.command, psIndex),
+      launchagent: inferLaunchAgentLabel(options.platform ?? process.platform, representative.pid, representative.ppid, representative.command, psIndex),
       data_dir,
       log_paths,
     });

--- a/src/services/issues/issue_operations.test.ts
+++ b/src/services/issues/issue_operations.test.ts
@@ -507,6 +507,7 @@ describe("Issue Operations (Neotoma-canonical)", () => {
         message_entity_id: "remote-msg-private",
         pushed_to_github: false,
         submitted_to_neotoma: true,
+        remote_submission_error: null,
       });
     });
 

--- a/src/services/schema_definitions.ts
+++ b/src/services/schema_definitions.ts
@@ -1514,10 +1514,19 @@ export const ENTITY_SCHEMAS: Record<string, EntitySchema> = {
     schema_definition: {
       fields: {
         schema_version: { type: "string", required: true },
+        amount: { type: "number", required: false },
+        amount_original: { type: "number", required: false },
+        currency: { type: "string", required: false },
+        merchant_name: { type: "string", required: false },
+        status: { type: "string", required: false },
+        account_id: { type: "string", required: false },
         posting_date: { type: "date", required: false },
+        transaction_date: { type: "date", required: false },
         category: { type: "string", required: false },
         bank_provider: { type: "string", required: false },
-        amount_original: { type: "number", required: false },
+        description: { type: "string", required: false },
+        transaction_id: { type: "string", required: false },
+        external_id: { type: "string", required: false },
       },
       canonical_name_fields: [
         "posting_date",
@@ -1534,6 +1543,9 @@ export const ENTITY_SCHEMAS: Record<string, EntitySchema> = {
       merge_policies: {
         posting_date: { strategy: "last_write" },
         category: { strategy: "last_write" },
+        status: { strategy: "last_write" },
+        amount: { strategy: "last_write" },
+        amount_original: { strategy: "last_write" },
       },
     },
   },
@@ -1606,8 +1618,13 @@ export const ENTITY_SCHEMAS: Record<string, EntitySchema> = {
       fields: {
         schema_version: { type: "string", required: true },
         name: { type: "string", required: false },
+        status: { type: "string", required: false },
         signed_date: { type: "date", required: false },
+        effective_date: { type: "date", required: false },
+        expiration_date: { type: "date", required: false },
         companies: { type: "string", required: false },
+        parties: { type: "string", required: false },
+        contract_number: { type: "string", required: false },
         files: { type: "string", required: false },
         type: { type: "string", required: false },
         notes: { type: "string", required: false },
@@ -1620,6 +1637,7 @@ export const ENTITY_SCHEMAS: Record<string, EntitySchema> = {
     reducer_config: {
       merge_policies: {
         signed_date: { strategy: "last_write" },
+        status: { strategy: "last_write" },
         files: { strategy: "merge_array" },
       },
     },
@@ -1637,6 +1655,10 @@ export const ENTITY_SCHEMAS: Record<string, EntitySchema> = {
     schema_definition: {
       fields: {
         schema_version: { type: "string", required: true },
+        external_id: { type: "string", required: false },
+        institution: { type: "string", required: false },
+        currency: { type: "string", required: false },
+        balance: { type: "number", required: false },
         wallet: { type: "string", required: false },
         wallet_name: { type: "string", required: false },
         number: { type: "string", required: false },
@@ -1645,14 +1667,12 @@ export const ENTITY_SCHEMAS: Record<string, EntitySchema> = {
         status: { type: "string", required: false },
         notes: { type: "string", required: false },
       },
-      // R2: bookkeeping/auxiliary schema with no inherent strong identifier;
-      // declare explicit opt-out so resolution falls through to the heuristic
-      // path. See docs/foundation/schema_agnostic_design_rules.md.
-      identity_opt_out: "heuristic_canonical_name",
+      canonical_name_fields: ["external_id", "institution", "wallet_name", "wallet"],
     },
     reducer_config: {
       merge_policies: {
         status: { strategy: "last_write" },
+        balance: { strategy: "last_write" },
         categories: { strategy: "merge_array" },
       },
     },

--- a/tests/__snapshots__/agentic_eval/agent_skips_store__cursor-hooks__claude-haiku-4.snap.json
+++ b/tests/__snapshots__/agentic_eval/agent_skips_store__cursor-hooks__claude-haiku-4.snap.json
@@ -8,22 +8,21 @@
           {
             "client_name": "Cursor",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation",
             "harness": "cursor-hook",
             "hook_event": "beforeSubmitPrompt",
-            "repository_name": "neotoma",
-            "repository_remote": "git@github.com:markmhendrickson/neotoma.git",
-            "repository_root": "/Users/markmhendrickson/repos/neotoma",
-            "scope_summary": "Cursor session in git repository neotoma.",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "scope_summary": "<env>",
             "thread_kind": "human_agent",
-            "title": "Cursor session neotoma",
-            "workspace_kind": "git_repository"
+            "title": "<env>",
+            "workspace_kind": "<env>"
           },
           {
             "content": "What time is it?",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_message",
             "harness": "cursor",
@@ -51,7 +50,7 @@
           {
             "context_source": "cursor-hook",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -65,7 +64,7 @@
             "started_at": "<ts>",
             "turn_id": "<id:3>",
             "turn_key": "agent_skips_store__cursor-hooks__claude-haiku-4:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -78,7 +77,7 @@
         "entities": [
           {
             "content": "I cannot tell the time without a clock tool.",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_message",
             "harness": "cursor",
@@ -100,18 +99,17 @@
           {
             "client_name": "Cursor",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation",
             "harness": "cursor-hook",
             "hook_event": "stop_backfill",
-            "repository_name": "neotoma",
-            "repository_remote": "git@github.com:markmhendrickson/neotoma.git",
-            "repository_root": "/Users/markmhendrickson/repos/neotoma",
-            "scope_summary": "Cursor session in git repository neotoma.",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "scope_summary": "<env>",
             "thread_kind": "human_agent",
-            "title": "Cursor session neotoma",
-            "workspace_kind": "git_repository"
+            "title": "<env>",
+            "workspace_kind": "<env>"
           }
         ],
         "idempotency_key": "<id:6>"
@@ -125,7 +123,7 @@
           {
             "context_source": "cursor-hook",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "diagnosis_confidence": "high",
             "ended_at": "<ts>",
@@ -173,7 +171,7 @@
             "tool_invocation_count": 0,
             "turn_id": "<id:3>",
             "turn_key": "agent_skips_store__cursor-hooks__claude-haiku-4:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -190,7 +188,7 @@
       "hook": "stop",
       "exitCode": 0,
       "output": {
-        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: hook state incomplete — No reminders were injected and no tool calls were observed this turn — sessionStart/postToolUse may not be wired up. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Re-run the cursor-hooks installer (`packages/cursor-hooks/scripts/install.mjs`) and confirm `.cursor/hooks.json` references the compiled hooks. Verify NEOTOMA_HOOK_STATE_DIR is writable and that hooks are emitting JSON on stdout. Run `npm run eval:tier1` against `tests/fixtures/agentic_eval/agent_skips_store.json` to spot regressions.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nNote: this client (claude-haiku-4) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial."
+        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: hook state incomplete — No reminders were injected and no tool calls were observed this turn — sessionStart/postToolUse may not be wired up. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Re-run the cursor-hooks installer (`packages/cursor-hooks/scripts/install.mjs`) and confirm `.cursor/hooks.json` references the compiled hooks. Verify NEOTOMA_HOOK_STATE_DIR is writable and that hooks are emitting JSON on stdout. Run `npm run eval:tier1` against `tests/fixtures/agentic_eval/agent_skips_store.json` to spot regressions.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nForbidden: reusing the user-phase conversation_message `turn_key` for the closing assistant store (must use `{conversation_id}:{turn_id}:assistant`, not the bare `{conversation_id}:{turn_id}`).\nNote: this client (claude-haiku-4) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial."
       }
     }
   ]

--- a/tests/__snapshots__/agentic_eval/agent_skips_store__cursor-hooks__claude-sonnet-4.5.snap.json
+++ b/tests/__snapshots__/agentic_eval/agent_skips_store__cursor-hooks__claude-sonnet-4.5.snap.json
@@ -8,22 +8,21 @@
           {
             "client_name": "Cursor",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation",
             "harness": "cursor-hook",
             "hook_event": "beforeSubmitPrompt",
-            "repository_name": "neotoma",
-            "repository_remote": "git@github.com:markmhendrickson/neotoma.git",
-            "repository_root": "/Users/markmhendrickson/repos/neotoma",
-            "scope_summary": "Cursor session in git repository neotoma.",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "scope_summary": "<env>",
             "thread_kind": "human_agent",
-            "title": "Cursor session neotoma",
-            "workspace_kind": "git_repository"
+            "title": "<env>",
+            "workspace_kind": "<env>"
           },
           {
             "content": "What time is it?",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_message",
             "harness": "cursor",
@@ -51,7 +50,7 @@
           {
             "context_source": "cursor-hook",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -65,7 +64,7 @@
             "started_at": "<ts>",
             "turn_id": "<id:3>",
             "turn_key": "agent_skips_store__cursor-hooks__claude-sonnet-4.5:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -78,7 +77,7 @@
         "entities": [
           {
             "content": "I cannot tell the time without a clock tool.",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_message",
             "harness": "cursor",
@@ -100,18 +99,17 @@
           {
             "client_name": "Cursor",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation",
             "harness": "cursor-hook",
             "hook_event": "stop_backfill",
-            "repository_name": "neotoma",
-            "repository_remote": "git@github.com:markmhendrickson/neotoma.git",
-            "repository_root": "/Users/markmhendrickson/repos/neotoma",
-            "scope_summary": "Cursor session in git repository neotoma.",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "scope_summary": "<env>",
             "thread_kind": "human_agent",
-            "title": "Cursor session neotoma",
-            "workspace_kind": "git_repository"
+            "title": "<env>",
+            "workspace_kind": "<env>"
           }
         ],
         "idempotency_key": "<id:6>"
@@ -125,7 +123,7 @@
           {
             "context_source": "cursor-hook",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "diagnosis_confidence": "high",
             "ended_at": "<ts>",
@@ -173,7 +171,7 @@
             "tool_invocation_count": 0,
             "turn_id": "<id:3>",
             "turn_key": "agent_skips_store__cursor-hooks__claude-sonnet-4.5:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -190,7 +188,7 @@
       "hook": "stop",
       "exitCode": 0,
       "output": {
-        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: hook state incomplete — No reminders were injected and no tool calls were observed this turn — sessionStart/postToolUse may not be wired up. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Re-run the cursor-hooks installer (`packages/cursor-hooks/scripts/install.mjs`) and confirm `.cursor/hooks.json` references the compiled hooks. Verify NEOTOMA_HOOK_STATE_DIR is writable and that hooks are emitting JSON on stdout. Run `npm run eval:tier1` against `tests/fixtures/agentic_eval/agent_skips_store.json` to spot regressions.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique."
+        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: hook state incomplete — No reminders were injected and no tool calls were observed this turn — sessionStart/postToolUse may not be wired up. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Re-run the cursor-hooks installer (`packages/cursor-hooks/scripts/install.mjs`) and confirm `.cursor/hooks.json` references the compiled hooks. Verify NEOTOMA_HOOK_STATE_DIR is writable and that hooks are emitting JSON on stdout. Run `npm run eval:tier1` against `tests/fixtures/agentic_eval/agent_skips_store.json` to spot regressions.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nForbidden: reusing the user-phase conversation_message `turn_key` for the closing assistant store (must use `{conversation_id}:{turn_id}:assistant`, not the bare `{conversation_id}:{turn_id}`)."
       }
     }
   ]

--- a/tests/__snapshots__/agentic_eval/agent_skips_store__cursor-hooks__composer-2.snap.json
+++ b/tests/__snapshots__/agentic_eval/agent_skips_store__cursor-hooks__composer-2.snap.json
@@ -8,22 +8,21 @@
           {
             "client_name": "Cursor",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation",
             "harness": "cursor-hook",
             "hook_event": "beforeSubmitPrompt",
-            "repository_name": "neotoma",
-            "repository_remote": "git@github.com:markmhendrickson/neotoma.git",
-            "repository_root": "/Users/markmhendrickson/repos/neotoma",
-            "scope_summary": "Cursor session in git repository neotoma.",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "scope_summary": "<env>",
             "thread_kind": "human_agent",
-            "title": "Cursor session neotoma",
-            "workspace_kind": "git_repository"
+            "title": "<env>",
+            "workspace_kind": "<env>"
           },
           {
             "content": "What time is it?",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_message",
             "harness": "cursor",
@@ -51,7 +50,7 @@
           {
             "context_source": "cursor-hook",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -65,7 +64,7 @@
             "started_at": "<ts>",
             "turn_id": "<id:3>",
             "turn_key": "agent_skips_store__cursor-hooks__composer-2:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -78,7 +77,7 @@
         "entities": [
           {
             "content": "I cannot tell the time without a clock tool.",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_message",
             "harness": "cursor",
@@ -100,18 +99,17 @@
           {
             "client_name": "Cursor",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation",
             "harness": "cursor-hook",
             "hook_event": "stop_backfill",
-            "repository_name": "neotoma",
-            "repository_remote": "git@github.com:markmhendrickson/neotoma.git",
-            "repository_root": "/Users/markmhendrickson/repos/neotoma",
-            "scope_summary": "Cursor session in git repository neotoma.",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "scope_summary": "<env>",
             "thread_kind": "human_agent",
-            "title": "Cursor session neotoma",
-            "workspace_kind": "git_repository"
+            "title": "<env>",
+            "workspace_kind": "<env>"
           }
         ],
         "idempotency_key": "<id:6>"
@@ -125,7 +123,7 @@
           {
             "context_source": "cursor-hook",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "diagnosis_confidence": "high",
             "ended_at": "<ts>",
@@ -173,7 +171,7 @@
             "tool_invocation_count": 0,
             "turn_id": "<id:3>",
             "turn_key": "agent_skips_store__cursor-hooks__composer-2:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -190,7 +188,7 @@
       "hook": "stop",
       "exitCode": 0,
       "output": {
-        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: hook state incomplete — No reminders were injected and no tool calls were observed this turn — sessionStart/postToolUse may not be wired up. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Re-run the cursor-hooks installer (`packages/cursor-hooks/scripts/install.mjs`) and confirm `.cursor/hooks.json` references the compiled hooks. Verify NEOTOMA_HOOK_STATE_DIR is writable and that hooks are emitting JSON on stdout. Run `npm run eval:tier1` against `tests/fixtures/agentic_eval/agent_skips_store.json` to spot regressions.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nNote: this client (composer-2) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial."
+        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: hook state incomplete — No reminders were injected and no tool calls were observed this turn — sessionStart/postToolUse may not be wired up. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Re-run the cursor-hooks installer (`packages/cursor-hooks/scripts/install.mjs`) and confirm `.cursor/hooks.json` references the compiled hooks. Verify NEOTOMA_HOOK_STATE_DIR is writable and that hooks are emitting JSON on stdout. Run `npm run eval:tier1` against `tests/fixtures/agentic_eval/agent_skips_store.json` to spot regressions.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nForbidden: reusing the user-phase conversation_message `turn_key` for the closing assistant store (must use `{conversation_id}:{turn_id}:assistant`, not the bare `{conversation_id}:{turn_id}`).\nNote: this client (composer-2) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial."
       }
     }
   ]

--- a/tests/__snapshots__/agentic_eval/agent_skips_store__cursor-hooks__gpt-5.5-fast.snap.json
+++ b/tests/__snapshots__/agentic_eval/agent_skips_store__cursor-hooks__gpt-5.5-fast.snap.json
@@ -8,22 +8,21 @@
           {
             "client_name": "Cursor",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation",
             "harness": "cursor-hook",
             "hook_event": "beforeSubmitPrompt",
-            "repository_name": "neotoma",
-            "repository_remote": "git@github.com:markmhendrickson/neotoma.git",
-            "repository_root": "/Users/markmhendrickson/repos/neotoma",
-            "scope_summary": "Cursor session in git repository neotoma.",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "scope_summary": "<env>",
             "thread_kind": "human_agent",
-            "title": "Cursor session neotoma",
-            "workspace_kind": "git_repository"
+            "title": "<env>",
+            "workspace_kind": "<env>"
           },
           {
             "content": "What time is it?",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_message",
             "harness": "cursor",
@@ -51,7 +50,7 @@
           {
             "context_source": "cursor-hook",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -65,7 +64,7 @@
             "started_at": "<ts>",
             "turn_id": "<id:3>",
             "turn_key": "agent_skips_store__cursor-hooks__gpt-5.5-fast:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -78,7 +77,7 @@
         "entities": [
           {
             "content": "I cannot tell the time without a clock tool.",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_message",
             "harness": "cursor",
@@ -100,18 +99,17 @@
           {
             "client_name": "Cursor",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation",
             "harness": "cursor-hook",
             "hook_event": "stop_backfill",
-            "repository_name": "neotoma",
-            "repository_remote": "git@github.com:markmhendrickson/neotoma.git",
-            "repository_root": "/Users/markmhendrickson/repos/neotoma",
-            "scope_summary": "Cursor session in git repository neotoma.",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "scope_summary": "<env>",
             "thread_kind": "human_agent",
-            "title": "Cursor session neotoma",
-            "workspace_kind": "git_repository"
+            "title": "<env>",
+            "workspace_kind": "<env>"
           }
         ],
         "idempotency_key": "<id:6>"
@@ -125,7 +123,7 @@
           {
             "context_source": "cursor-hook",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "diagnosis_confidence": "high",
             "ended_at": "<ts>",
@@ -173,7 +171,7 @@
             "tool_invocation_count": 0,
             "turn_id": "<id:3>",
             "turn_key": "agent_skips_store__cursor-hooks__gpt-5.5-fast:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -190,7 +188,7 @@
       "hook": "stop",
       "exitCode": 0,
       "output": {
-        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: hook state incomplete — No reminders were injected and no tool calls were observed this turn — sessionStart/postToolUse may not be wired up. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Re-run the cursor-hooks installer (`packages/cursor-hooks/scripts/install.mjs`) and confirm `.cursor/hooks.json` references the compiled hooks. Verify NEOTOMA_HOOK_STATE_DIR is writable and that hooks are emitting JSON on stdout. Run `npm run eval:tier1` against `tests/fixtures/agentic_eval/agent_skips_store.json` to spot regressions.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nNote: this client (gpt-5.5-fast) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial."
+        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: hook state incomplete — No reminders were injected and no tool calls were observed this turn — sessionStart/postToolUse may not be wired up. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Re-run the cursor-hooks installer (`packages/cursor-hooks/scripts/install.mjs`) and confirm `.cursor/hooks.json` references the compiled hooks. Verify NEOTOMA_HOOK_STATE_DIR is writable and that hooks are emitting JSON on stdout. Run `npm run eval:tier1` against `tests/fixtures/agentic_eval/agent_skips_store.json` to spot regressions.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nForbidden: reusing the user-phase conversation_message `turn_key` for the closing assistant store (must use `{conversation_id}:{turn_id}:assistant`, not the bare `{conversation_id}:{turn_id}`).\nNote: this client (gpt-5.5-fast) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial."
       }
     }
   ]

--- a/tests/__snapshots__/agentic_eval/agent_skips_store__cursor-hooks__gpt-5.5-medium.snap.json
+++ b/tests/__snapshots__/agentic_eval/agent_skips_store__cursor-hooks__gpt-5.5-medium.snap.json
@@ -8,22 +8,21 @@
           {
             "client_name": "Cursor",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation",
             "harness": "cursor-hook",
             "hook_event": "beforeSubmitPrompt",
-            "repository_name": "neotoma",
-            "repository_remote": "git@github.com:markmhendrickson/neotoma.git",
-            "repository_root": "/Users/markmhendrickson/repos/neotoma",
-            "scope_summary": "Cursor session in git repository neotoma.",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "scope_summary": "<env>",
             "thread_kind": "human_agent",
-            "title": "Cursor session neotoma",
-            "workspace_kind": "git_repository"
+            "title": "<env>",
+            "workspace_kind": "<env>"
           },
           {
             "content": "What time is it?",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_message",
             "harness": "cursor",
@@ -51,7 +50,7 @@
           {
             "context_source": "cursor-hook",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -65,7 +64,7 @@
             "started_at": "<ts>",
             "turn_id": "<id:3>",
             "turn_key": "agent_skips_store__cursor-hooks__gpt-5.5-medium:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -78,7 +77,7 @@
         "entities": [
           {
             "content": "I cannot tell the time without a clock tool.",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_message",
             "harness": "cursor",
@@ -100,18 +99,17 @@
           {
             "client_name": "Cursor",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation",
             "harness": "cursor-hook",
             "hook_event": "stop_backfill",
-            "repository_name": "neotoma",
-            "repository_remote": "git@github.com:markmhendrickson/neotoma.git",
-            "repository_root": "/Users/markmhendrickson/repos/neotoma",
-            "scope_summary": "Cursor session in git repository neotoma.",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "scope_summary": "<env>",
             "thread_kind": "human_agent",
-            "title": "Cursor session neotoma",
-            "workspace_kind": "git_repository"
+            "title": "<env>",
+            "workspace_kind": "<env>"
           }
         ],
         "idempotency_key": "<id:6>"
@@ -125,7 +123,7 @@
           {
             "context_source": "cursor-hook",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "diagnosis_confidence": "high",
             "ended_at": "<ts>",
@@ -173,7 +171,7 @@
             "tool_invocation_count": 0,
             "turn_id": "<id:3>",
             "turn_key": "agent_skips_store__cursor-hooks__gpt-5.5-medium:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -190,7 +188,7 @@
       "hook": "stop",
       "exitCode": 0,
       "output": {
-        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: hook state incomplete — No reminders were injected and no tool calls were observed this turn — sessionStart/postToolUse may not be wired up. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Re-run the cursor-hooks installer (`packages/cursor-hooks/scripts/install.mjs`) and confirm `.cursor/hooks.json` references the compiled hooks. Verify NEOTOMA_HOOK_STATE_DIR is writable and that hooks are emitting JSON on stdout. Run `npm run eval:tier1` against `tests/fixtures/agentic_eval/agent_skips_store.json` to spot regressions.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique."
+        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: hook state incomplete — No reminders were injected and no tool calls were observed this turn — sessionStart/postToolUse may not be wired up. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Re-run the cursor-hooks installer (`packages/cursor-hooks/scripts/install.mjs`) and confirm `.cursor/hooks.json` references the compiled hooks. Verify NEOTOMA_HOOK_STATE_DIR is writable and that hooks are emitting JSON on stdout. Run `npm run eval:tier1` against `tests/fixtures/agentic_eval/agent_skips_store.json` to spot regressions.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nForbidden: reusing the user-phase conversation_message `turn_key` for the closing assistant store (must use `{conversation_id}:{turn_id}:assistant`, not the bare `{conversation_id}:{turn_id}`)."
       }
     }
   ]

--- a/tests/__snapshots__/agentic_eval/agent_skips_store_after_reminder__cursor-hooks__claude-haiku-4.snap.json
+++ b/tests/__snapshots__/agentic_eval/agent_skips_store_after_reminder__cursor-hooks__claude-haiku-4.snap.json
@@ -15,7 +15,7 @@
       "body": {
         "entities": [
           {
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "tool_invocation",
             "harness": "cursor",
@@ -39,7 +39,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -56,7 +56,7 @@
             "tool_invocation_count": 1,
             "turn_id": "<id:3>",
             "turn_key": "agent_skips_store_after_reminder__cursor-hooks__claude-haiku-4:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -69,7 +69,7 @@
         "entities": [
           {
             "content": "Here is the file content: Hello world",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_message",
             "harness": "cursor",
@@ -91,18 +91,17 @@
           {
             "client_name": "Cursor",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation",
             "harness": "cursor-hook",
             "hook_event": "stop_backfill",
-            "repository_name": "neotoma",
-            "repository_remote": "git@github.com:markmhendrickson/neotoma.git",
-            "repository_root": "/Users/markmhendrickson/repos/neotoma",
-            "scope_summary": "Cursor session in git repository neotoma.",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "scope_summary": "<env>",
             "thread_kind": "human_agent",
-            "title": "Cursor session neotoma",
-            "workspace_kind": "git_repository"
+            "title": "<env>",
+            "workspace_kind": "<env>"
           }
         ],
         "idempotency_key": "<id:6>"
@@ -116,7 +115,7 @@
           {
             "context_source": "cursor-hook",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "diagnosis_confidence": "high",
             "ended_at": "<ts>",
@@ -167,7 +166,7 @@
             "tool_invocation_count": 1,
             "turn_id": "<id:3>",
             "turn_key": "agent_skips_store_after_reminder__cursor-hooks__claude-haiku-4:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -186,14 +185,14 @@
       "hook": "postToolUse",
       "exitCode": 0,
       "output": {
-        "additional_context": "Neotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nNote: this client (claude-haiku-4) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial."
+        "additional_context": "Neotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nForbidden: reusing the user-phase conversation_message `turn_key` for the closing assistant store (must use `{conversation_id}:{turn_id}:assistant`, not the bare `{conversation_id}:{turn_id}`).\nNote: this client (claude-haiku-4) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial."
       }
     },
     {
       "hook": "sessionStart",
       "exitCode": 0,
       "output": {
-        "additional_context": "Neotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nNote: this client (claude-haiku-4) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial.",
+        "additional_context": "Neotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nForbidden: reusing the user-phase conversation_message `turn_key` for the closing assistant store (must use `{conversation_id}:{turn_id}:assistant`, not the bare `{conversation_id}:{turn_id}`).\nNote: this client (claude-haiku-4) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial.",
         "env": {
           "NEOTOMA_HOOK_SMALL_MODEL_DETECTED": "1"
         }
@@ -203,7 +202,7 @@
       "hook": "stop",
       "exitCode": 0,
       "output": {
-        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: agent ignored available instructions — Compact reminder was injected and Neotoma tooling was reachable, but the agent did not call **`store`**. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Add or extend a Tier 1 fixture in `tests/fixtures/agentic_eval/` that asserts the `agent_ignored_available_instructions` classification for this model. Check the postToolUse reminder gate so wrapped host tool calls still receive the compact Neotoma reminder. Investigate whether the MCP `[COMPACT MODE]` block omits a contract this model needs; expand `docs/developer/mcp/instructions.md` accordingly.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nNote: this client (claude-haiku-4) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial."
+        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: agent ignored available instructions — Compact reminder was injected and Neotoma tooling was reachable, but the agent did not call **`store`**. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Add or extend a Tier 1 fixture in `tests/fixtures/agentic_eval/` that asserts the `agent_ignored_available_instructions` classification for this model. Check the postToolUse reminder gate so wrapped host tool calls still receive the compact Neotoma reminder. Investigate whether the MCP `[COMPACT MODE]` block omits a contract this model needs; expand `docs/developer/mcp/instructions.md` accordingly.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nForbidden: reusing the user-phase conversation_message `turn_key` for the closing assistant store (must use `{conversation_id}:{turn_id}:assistant`, not the bare `{conversation_id}:{turn_id}`).\nNote: this client (claude-haiku-4) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial."
       }
     }
   ]

--- a/tests/__snapshots__/agentic_eval/agent_skips_store_after_reminder__cursor-hooks__claude-sonnet-4.5.snap.json
+++ b/tests/__snapshots__/agentic_eval/agent_skips_store_after_reminder__cursor-hooks__claude-sonnet-4.5.snap.json
@@ -15,7 +15,7 @@
       "body": {
         "entities": [
           {
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "tool_invocation",
             "harness": "cursor",
@@ -39,7 +39,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -56,7 +56,7 @@
             "tool_invocation_count": 1,
             "turn_id": "<id:3>",
             "turn_key": "agent_skips_store_after_reminder__cursor-hooks__claude-sonnet-4.5:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -69,7 +69,7 @@
         "entities": [
           {
             "content": "Here is the file content: Hello world",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_message",
             "harness": "cursor",
@@ -91,18 +91,17 @@
           {
             "client_name": "Cursor",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation",
             "harness": "cursor-hook",
             "hook_event": "stop_backfill",
-            "repository_name": "neotoma",
-            "repository_remote": "git@github.com:markmhendrickson/neotoma.git",
-            "repository_root": "/Users/markmhendrickson/repos/neotoma",
-            "scope_summary": "Cursor session in git repository neotoma.",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "scope_summary": "<env>",
             "thread_kind": "human_agent",
-            "title": "Cursor session neotoma",
-            "workspace_kind": "git_repository"
+            "title": "<env>",
+            "workspace_kind": "<env>"
           }
         ],
         "idempotency_key": "<id:6>"
@@ -116,7 +115,7 @@
           {
             "context_source": "cursor-hook",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "diagnosis_confidence": "high",
             "ended_at": "<ts>",
@@ -167,7 +166,7 @@
             "tool_invocation_count": 1,
             "turn_id": "<id:3>",
             "turn_key": "agent_skips_store_after_reminder__cursor-hooks__claude-sonnet-4.5:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -186,21 +185,21 @@
       "hook": "postToolUse",
       "exitCode": 0,
       "output": {
-        "additional_context": "Neotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique."
+        "additional_context": "Neotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nForbidden: reusing the user-phase conversation_message `turn_key` for the closing assistant store (must use `{conversation_id}:{turn_id}:assistant`, not the bare `{conversation_id}:{turn_id}`)."
       }
     },
     {
       "hook": "sessionStart",
       "exitCode": 0,
       "output": {
-        "additional_context": "Neotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique."
+        "additional_context": "Neotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nForbidden: reusing the user-phase conversation_message `turn_key` for the closing assistant store (must use `{conversation_id}:{turn_id}:assistant`, not the bare `{conversation_id}:{turn_id}`)."
       }
     },
     {
       "hook": "stop",
       "exitCode": 0,
       "output": {
-        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: agent ignored available instructions — Compact reminder was injected and Neotoma tooling was reachable, but the agent did not call **`store`**. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Add or extend a Tier 1 fixture in `tests/fixtures/agentic_eval/` that asserts the `agent_ignored_available_instructions` classification for this model. Check the postToolUse reminder gate so wrapped host tool calls still receive the compact Neotoma reminder. Investigate whether the MCP `[COMPACT MODE]` block omits a contract this model needs; expand `docs/developer/mcp/instructions.md` accordingly.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique."
+        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: agent ignored available instructions — Compact reminder was injected and Neotoma tooling was reachable, but the agent did not call **`store`**. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Add or extend a Tier 1 fixture in `tests/fixtures/agentic_eval/` that asserts the `agent_ignored_available_instructions` classification for this model. Check the postToolUse reminder gate so wrapped host tool calls still receive the compact Neotoma reminder. Investigate whether the MCP `[COMPACT MODE]` block omits a contract this model needs; expand `docs/developer/mcp/instructions.md` accordingly.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nForbidden: reusing the user-phase conversation_message `turn_key` for the closing assistant store (must use `{conversation_id}:{turn_id}:assistant`, not the bare `{conversation_id}:{turn_id}`)."
       }
     }
   ]

--- a/tests/__snapshots__/agentic_eval/agent_skips_store_after_reminder__cursor-hooks__composer-2.snap.json
+++ b/tests/__snapshots__/agentic_eval/agent_skips_store_after_reminder__cursor-hooks__composer-2.snap.json
@@ -15,7 +15,7 @@
       "body": {
         "entities": [
           {
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "tool_invocation",
             "harness": "cursor",
@@ -39,7 +39,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -56,7 +56,7 @@
             "tool_invocation_count": 1,
             "turn_id": "<id:3>",
             "turn_key": "agent_skips_store_after_reminder__cursor-hooks__composer-2:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -69,7 +69,7 @@
         "entities": [
           {
             "content": "Here is the file content: Hello world",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_message",
             "harness": "cursor",
@@ -91,18 +91,17 @@
           {
             "client_name": "Cursor",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation",
             "harness": "cursor-hook",
             "hook_event": "stop_backfill",
-            "repository_name": "neotoma",
-            "repository_remote": "git@github.com:markmhendrickson/neotoma.git",
-            "repository_root": "/Users/markmhendrickson/repos/neotoma",
-            "scope_summary": "Cursor session in git repository neotoma.",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "scope_summary": "<env>",
             "thread_kind": "human_agent",
-            "title": "Cursor session neotoma",
-            "workspace_kind": "git_repository"
+            "title": "<env>",
+            "workspace_kind": "<env>"
           }
         ],
         "idempotency_key": "<id:6>"
@@ -116,7 +115,7 @@
           {
             "context_source": "cursor-hook",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "diagnosis_confidence": "high",
             "ended_at": "<ts>",
@@ -167,7 +166,7 @@
             "tool_invocation_count": 1,
             "turn_id": "<id:3>",
             "turn_key": "agent_skips_store_after_reminder__cursor-hooks__composer-2:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -186,14 +185,14 @@
       "hook": "postToolUse",
       "exitCode": 0,
       "output": {
-        "additional_context": "Neotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nNote: this client (composer-2) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial."
+        "additional_context": "Neotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nForbidden: reusing the user-phase conversation_message `turn_key` for the closing assistant store (must use `{conversation_id}:{turn_id}:assistant`, not the bare `{conversation_id}:{turn_id}`).\nNote: this client (composer-2) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial."
       }
     },
     {
       "hook": "sessionStart",
       "exitCode": 0,
       "output": {
-        "additional_context": "Neotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nNote: this client (composer-2) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial.",
+        "additional_context": "Neotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nForbidden: reusing the user-phase conversation_message `turn_key` for the closing assistant store (must use `{conversation_id}:{turn_id}:assistant`, not the bare `{conversation_id}:{turn_id}`).\nNote: this client (composer-2) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial.",
         "env": {
           "NEOTOMA_HOOK_SMALL_MODEL_DETECTED": "1"
         }
@@ -203,7 +202,7 @@
       "hook": "stop",
       "exitCode": 0,
       "output": {
-        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: agent ignored available instructions — Compact reminder was injected and Neotoma tooling was reachable, but the agent did not call **`store`**. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Add or extend a Tier 1 fixture in `tests/fixtures/agentic_eval/` that asserts the `agent_ignored_available_instructions` classification for this model. Check the postToolUse reminder gate so wrapped host tool calls still receive the compact Neotoma reminder. Investigate whether the MCP `[COMPACT MODE]` block omits a contract this model needs; expand `docs/developer/mcp/instructions.md` accordingly.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nNote: this client (composer-2) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial."
+        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: agent ignored available instructions — Compact reminder was injected and Neotoma tooling was reachable, but the agent did not call **`store`**. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Add or extend a Tier 1 fixture in `tests/fixtures/agentic_eval/` that asserts the `agent_ignored_available_instructions` classification for this model. Check the postToolUse reminder gate so wrapped host tool calls still receive the compact Neotoma reminder. Investigate whether the MCP `[COMPACT MODE]` block omits a contract this model needs; expand `docs/developer/mcp/instructions.md` accordingly.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nForbidden: reusing the user-phase conversation_message `turn_key` for the closing assistant store (must use `{conversation_id}:{turn_id}:assistant`, not the bare `{conversation_id}:{turn_id}`).\nNote: this client (composer-2) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial."
       }
     }
   ]

--- a/tests/__snapshots__/agentic_eval/agent_skips_store_after_reminder__cursor-hooks__gpt-5.5-fast.snap.json
+++ b/tests/__snapshots__/agentic_eval/agent_skips_store_after_reminder__cursor-hooks__gpt-5.5-fast.snap.json
@@ -15,7 +15,7 @@
       "body": {
         "entities": [
           {
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "tool_invocation",
             "harness": "cursor",
@@ -39,7 +39,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -56,7 +56,7 @@
             "tool_invocation_count": 1,
             "turn_id": "<id:3>",
             "turn_key": "agent_skips_store_after_reminder__cursor-hooks__gpt-5.5-fast:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -69,7 +69,7 @@
         "entities": [
           {
             "content": "Here is the file content: Hello world",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_message",
             "harness": "cursor",
@@ -91,18 +91,17 @@
           {
             "client_name": "Cursor",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation",
             "harness": "cursor-hook",
             "hook_event": "stop_backfill",
-            "repository_name": "neotoma",
-            "repository_remote": "git@github.com:markmhendrickson/neotoma.git",
-            "repository_root": "/Users/markmhendrickson/repos/neotoma",
-            "scope_summary": "Cursor session in git repository neotoma.",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "scope_summary": "<env>",
             "thread_kind": "human_agent",
-            "title": "Cursor session neotoma",
-            "workspace_kind": "git_repository"
+            "title": "<env>",
+            "workspace_kind": "<env>"
           }
         ],
         "idempotency_key": "<id:6>"
@@ -116,7 +115,7 @@
           {
             "context_source": "cursor-hook",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "diagnosis_confidence": "high",
             "ended_at": "<ts>",
@@ -167,7 +166,7 @@
             "tool_invocation_count": 1,
             "turn_id": "<id:3>",
             "turn_key": "agent_skips_store_after_reminder__cursor-hooks__gpt-5.5-fast:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -186,14 +185,14 @@
       "hook": "postToolUse",
       "exitCode": 0,
       "output": {
-        "additional_context": "Neotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nNote: this client (gpt-5.5-fast) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial."
+        "additional_context": "Neotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nForbidden: reusing the user-phase conversation_message `turn_key` for the closing assistant store (must use `{conversation_id}:{turn_id}:assistant`, not the bare `{conversation_id}:{turn_id}`).\nNote: this client (gpt-5.5-fast) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial."
       }
     },
     {
       "hook": "sessionStart",
       "exitCode": 0,
       "output": {
-        "additional_context": "Neotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nNote: this client (gpt-5.5-fast) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial.",
+        "additional_context": "Neotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nForbidden: reusing the user-phase conversation_message `turn_key` for the closing assistant store (must use `{conversation_id}:{turn_id}:assistant`, not the bare `{conversation_id}:{turn_id}`).\nNote: this client (gpt-5.5-fast) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial.",
         "env": {
           "NEOTOMA_HOOK_SMALL_MODEL_DETECTED": "1"
         }
@@ -203,7 +202,7 @@
       "hook": "stop",
       "exitCode": 0,
       "output": {
-        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: agent ignored available instructions — Compact reminder was injected and Neotoma tooling was reachable, but the agent did not call **`store`**. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Add or extend a Tier 1 fixture in `tests/fixtures/agentic_eval/` that asserts the `agent_ignored_available_instructions` classification for this model. Check the postToolUse reminder gate so wrapped host tool calls still receive the compact Neotoma reminder. Investigate whether the MCP `[COMPACT MODE]` block omits a contract this model needs; expand `docs/developer/mcp/instructions.md` accordingly.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nNote: this client (gpt-5.5-fast) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial."
+        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: agent ignored available instructions — Compact reminder was injected and Neotoma tooling was reachable, but the agent did not call **`store`**. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Add or extend a Tier 1 fixture in `tests/fixtures/agentic_eval/` that asserts the `agent_ignored_available_instructions` classification for this model. Check the postToolUse reminder gate so wrapped host tool calls still receive the compact Neotoma reminder. Investigate whether the MCP `[COMPACT MODE]` block omits a contract this model needs; expand `docs/developer/mcp/instructions.md` accordingly.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nForbidden: reusing the user-phase conversation_message `turn_key` for the closing assistant store (must use `{conversation_id}:{turn_id}:assistant`, not the bare `{conversation_id}:{turn_id}`).\nNote: this client (gpt-5.5-fast) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial."
       }
     }
   ]

--- a/tests/__snapshots__/agentic_eval/agent_skips_store_after_reminder__cursor-hooks__gpt-5.5-medium.snap.json
+++ b/tests/__snapshots__/agentic_eval/agent_skips_store_after_reminder__cursor-hooks__gpt-5.5-medium.snap.json
@@ -15,7 +15,7 @@
       "body": {
         "entities": [
           {
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "tool_invocation",
             "harness": "cursor",
@@ -39,7 +39,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -56,7 +56,7 @@
             "tool_invocation_count": 1,
             "turn_id": "<id:3>",
             "turn_key": "agent_skips_store_after_reminder__cursor-hooks__gpt-5.5-medium:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -69,7 +69,7 @@
         "entities": [
           {
             "content": "Here is the file content: Hello world",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_message",
             "harness": "cursor",
@@ -91,18 +91,17 @@
           {
             "client_name": "Cursor",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation",
             "harness": "cursor-hook",
             "hook_event": "stop_backfill",
-            "repository_name": "neotoma",
-            "repository_remote": "git@github.com:markmhendrickson/neotoma.git",
-            "repository_root": "/Users/markmhendrickson/repos/neotoma",
-            "scope_summary": "Cursor session in git repository neotoma.",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "scope_summary": "<env>",
             "thread_kind": "human_agent",
-            "title": "Cursor session neotoma",
-            "workspace_kind": "git_repository"
+            "title": "<env>",
+            "workspace_kind": "<env>"
           }
         ],
         "idempotency_key": "<id:6>"
@@ -116,7 +115,7 @@
           {
             "context_source": "cursor-hook",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "diagnosis_confidence": "high",
             "ended_at": "<ts>",
@@ -167,7 +166,7 @@
             "tool_invocation_count": 1,
             "turn_id": "<id:3>",
             "turn_key": "agent_skips_store_after_reminder__cursor-hooks__gpt-5.5-medium:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -186,21 +185,21 @@
       "hook": "postToolUse",
       "exitCode": 0,
       "output": {
-        "additional_context": "Neotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique."
+        "additional_context": "Neotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nForbidden: reusing the user-phase conversation_message `turn_key` for the closing assistant store (must use `{conversation_id}:{turn_id}:assistant`, not the bare `{conversation_id}:{turn_id}`)."
       }
     },
     {
       "hook": "sessionStart",
       "exitCode": 0,
       "output": {
-        "additional_context": "Neotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique."
+        "additional_context": "Neotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nForbidden: reusing the user-phase conversation_message `turn_key` for the closing assistant store (must use `{conversation_id}:{turn_id}:assistant`, not the bare `{conversation_id}:{turn_id}`)."
       }
     },
     {
       "hook": "stop",
       "exitCode": 0,
       "output": {
-        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: agent ignored available instructions — Compact reminder was injected and Neotoma tooling was reachable, but the agent did not call **`store`**. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Add or extend a Tier 1 fixture in `tests/fixtures/agentic_eval/` that asserts the `agent_ignored_available_instructions` classification for this model. Check the postToolUse reminder gate so wrapped host tool calls still receive the compact Neotoma reminder. Investigate whether the MCP `[COMPACT MODE]` block omits a contract this model needs; expand `docs/developer/mcp/instructions.md` accordingly.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique."
+        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: agent ignored available instructions — Compact reminder was injected and Neotoma tooling was reachable, but the agent did not call **`store`**. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Add or extend a Tier 1 fixture in `tests/fixtures/agentic_eval/` that asserts the `agent_ignored_available_instructions` classification for this model. Check the postToolUse reminder gate so wrapped host tool calls still receive the compact Neotoma reminder. Investigate whether the MCP `[COMPACT MODE]` block omits a contract this model needs; expand `docs/developer/mcp/instructions.md` accordingly.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nForbidden: reusing the user-phase conversation_message `turn_key` for the closing assistant store (must use `{conversation_id}:{turn_id}:assistant`, not the bare `{conversation_id}:{turn_id}`)."
       }
     }
   ]

--- a/tests/__snapshots__/agentic_eval/attachment_with_extracted_entities__cursor-hooks__claude-haiku-4.snap.json
+++ b/tests/__snapshots__/agentic_eval/attachment_with_extracted_entities__cursor-hooks__claude-haiku-4.snap.json
@@ -8,22 +8,21 @@
           {
             "client_name": "Cursor",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation",
             "harness": "cursor-hook",
             "hook_event": "beforeSubmitPrompt",
-            "repository_name": "neotoma",
-            "repository_remote": "git@github.com:markmhendrickson/neotoma.git",
-            "repository_root": "/Users/markmhendrickson/repos/neotoma",
-            "scope_summary": "Cursor session in git repository neotoma.",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "scope_summary": "<env>",
             "thread_kind": "human_agent",
-            "title": "Cursor session neotoma",
-            "workspace_kind": "git_repository"
+            "title": "<env>",
+            "workspace_kind": "<env>"
           },
           {
             "content": "What does this receipt total?",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_message",
             "harness": "cursor",
@@ -51,7 +50,7 @@
           {
             "context_source": "cursor-hook",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -65,7 +64,7 @@
             "started_at": "<ts>",
             "turn_id": "<id:3>",
             "turn_key": "attachment_with_extracted_entities__cursor-hooks__claude-haiku-4:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -78,7 +77,7 @@
         "entities": [
           {
             "content": "I cannot read the image directly; please paste the line items as text.",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_message",
             "harness": "cursor",
@@ -100,18 +99,17 @@
           {
             "client_name": "Cursor",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation",
             "harness": "cursor-hook",
             "hook_event": "stop_backfill",
-            "repository_name": "neotoma",
-            "repository_remote": "git@github.com:markmhendrickson/neotoma.git",
-            "repository_root": "/Users/markmhendrickson/repos/neotoma",
-            "scope_summary": "Cursor session in git repository neotoma.",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "scope_summary": "<env>",
             "thread_kind": "human_agent",
-            "title": "Cursor session neotoma",
-            "workspace_kind": "git_repository"
+            "title": "<env>",
+            "workspace_kind": "<env>"
           }
         ],
         "idempotency_key": "<id:6>"
@@ -125,7 +123,7 @@
           {
             "context_source": "cursor-hook",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "diagnosis_confidence": "high",
             "ended_at": "<ts>",
@@ -173,7 +171,7 @@
             "tool_invocation_count": 0,
             "turn_id": "<id:3>",
             "turn_key": "attachment_with_extracted_entities__cursor-hooks__claude-haiku-4:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -190,7 +188,7 @@
       "hook": "stop",
       "exitCode": 0,
       "output": {
-        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: hook state incomplete — No reminders were injected and no tool calls were observed this turn — sessionStart/postToolUse may not be wired up. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Re-run the cursor-hooks installer (`packages/cursor-hooks/scripts/install.mjs`) and confirm `.cursor/hooks.json` references the compiled hooks. Verify NEOTOMA_HOOK_STATE_DIR is writable and that hooks are emitting JSON on stdout. Run `npm run eval:tier1` against `tests/fixtures/agentic_eval/agent_skips_store.json` to spot regressions.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nNote: this client (claude-haiku-4) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial."
+        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: hook state incomplete — No reminders were injected and no tool calls were observed this turn — sessionStart/postToolUse may not be wired up. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Re-run the cursor-hooks installer (`packages/cursor-hooks/scripts/install.mjs`) and confirm `.cursor/hooks.json` references the compiled hooks. Verify NEOTOMA_HOOK_STATE_DIR is writable and that hooks are emitting JSON on stdout. Run `npm run eval:tier1` against `tests/fixtures/agentic_eval/agent_skips_store.json` to spot regressions.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nForbidden: reusing the user-phase conversation_message `turn_key` for the closing assistant store (must use `{conversation_id}:{turn_id}:assistant`, not the bare `{conversation_id}:{turn_id}`).\nNote: this client (claude-haiku-4) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial."
       }
     }
   ]

--- a/tests/__snapshots__/agentic_eval/attachment_with_extracted_entities__cursor-hooks__claude-sonnet-4.5.snap.json
+++ b/tests/__snapshots__/agentic_eval/attachment_with_extracted_entities__cursor-hooks__claude-sonnet-4.5.snap.json
@@ -8,22 +8,21 @@
           {
             "client_name": "Cursor",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation",
             "harness": "cursor-hook",
             "hook_event": "beforeSubmitPrompt",
-            "repository_name": "neotoma",
-            "repository_remote": "git@github.com:markmhendrickson/neotoma.git",
-            "repository_root": "/Users/markmhendrickson/repos/neotoma",
-            "scope_summary": "Cursor session in git repository neotoma.",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "scope_summary": "<env>",
             "thread_kind": "human_agent",
-            "title": "Cursor session neotoma",
-            "workspace_kind": "git_repository"
+            "title": "<env>",
+            "workspace_kind": "<env>"
           },
           {
             "content": "What does this receipt total?",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_message",
             "harness": "cursor",
@@ -51,7 +50,7 @@
           {
             "context_source": "cursor-hook",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -65,7 +64,7 @@
             "started_at": "<ts>",
             "turn_id": "<id:3>",
             "turn_key": "attachment_with_extracted_entities__cursor-hooks__claude-sonnet-4.5:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -78,7 +77,7 @@
         "entities": [
           {
             "content": "I cannot read the image directly; please paste the line items as text.",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_message",
             "harness": "cursor",
@@ -100,18 +99,17 @@
           {
             "client_name": "Cursor",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation",
             "harness": "cursor-hook",
             "hook_event": "stop_backfill",
-            "repository_name": "neotoma",
-            "repository_remote": "git@github.com:markmhendrickson/neotoma.git",
-            "repository_root": "/Users/markmhendrickson/repos/neotoma",
-            "scope_summary": "Cursor session in git repository neotoma.",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "scope_summary": "<env>",
             "thread_kind": "human_agent",
-            "title": "Cursor session neotoma",
-            "workspace_kind": "git_repository"
+            "title": "<env>",
+            "workspace_kind": "<env>"
           }
         ],
         "idempotency_key": "<id:6>"
@@ -125,7 +123,7 @@
           {
             "context_source": "cursor-hook",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "diagnosis_confidence": "high",
             "ended_at": "<ts>",
@@ -173,7 +171,7 @@
             "tool_invocation_count": 0,
             "turn_id": "<id:3>",
             "turn_key": "attachment_with_extracted_entities__cursor-hooks__claude-sonnet-4.5:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -190,7 +188,7 @@
       "hook": "stop",
       "exitCode": 0,
       "output": {
-        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: hook state incomplete — No reminders were injected and no tool calls were observed this turn — sessionStart/postToolUse may not be wired up. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Re-run the cursor-hooks installer (`packages/cursor-hooks/scripts/install.mjs`) and confirm `.cursor/hooks.json` references the compiled hooks. Verify NEOTOMA_HOOK_STATE_DIR is writable and that hooks are emitting JSON on stdout. Run `npm run eval:tier1` against `tests/fixtures/agentic_eval/agent_skips_store.json` to spot regressions.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique."
+        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: hook state incomplete — No reminders were injected and no tool calls were observed this turn — sessionStart/postToolUse may not be wired up. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Re-run the cursor-hooks installer (`packages/cursor-hooks/scripts/install.mjs`) and confirm `.cursor/hooks.json` references the compiled hooks. Verify NEOTOMA_HOOK_STATE_DIR is writable and that hooks are emitting JSON on stdout. Run `npm run eval:tier1` against `tests/fixtures/agentic_eval/agent_skips_store.json` to spot regressions.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nForbidden: reusing the user-phase conversation_message `turn_key` for the closing assistant store (must use `{conversation_id}:{turn_id}:assistant`, not the bare `{conversation_id}:{turn_id}`)."
       }
     }
   ]

--- a/tests/__snapshots__/agentic_eval/attachment_with_extracted_entities__cursor-hooks__composer-2.snap.json
+++ b/tests/__snapshots__/agentic_eval/attachment_with_extracted_entities__cursor-hooks__composer-2.snap.json
@@ -8,22 +8,21 @@
           {
             "client_name": "Cursor",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation",
             "harness": "cursor-hook",
             "hook_event": "beforeSubmitPrompt",
-            "repository_name": "neotoma",
-            "repository_remote": "git@github.com:markmhendrickson/neotoma.git",
-            "repository_root": "/Users/markmhendrickson/repos/neotoma",
-            "scope_summary": "Cursor session in git repository neotoma.",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "scope_summary": "<env>",
             "thread_kind": "human_agent",
-            "title": "Cursor session neotoma",
-            "workspace_kind": "git_repository"
+            "title": "<env>",
+            "workspace_kind": "<env>"
           },
           {
             "content": "What does this receipt total?",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_message",
             "harness": "cursor",
@@ -51,7 +50,7 @@
           {
             "context_source": "cursor-hook",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -65,7 +64,7 @@
             "started_at": "<ts>",
             "turn_id": "<id:3>",
             "turn_key": "attachment_with_extracted_entities__cursor-hooks__composer-2:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -78,7 +77,7 @@
         "entities": [
           {
             "content": "I cannot read the image directly; please paste the line items as text.",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_message",
             "harness": "cursor",
@@ -100,18 +99,17 @@
           {
             "client_name": "Cursor",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation",
             "harness": "cursor-hook",
             "hook_event": "stop_backfill",
-            "repository_name": "neotoma",
-            "repository_remote": "git@github.com:markmhendrickson/neotoma.git",
-            "repository_root": "/Users/markmhendrickson/repos/neotoma",
-            "scope_summary": "Cursor session in git repository neotoma.",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "scope_summary": "<env>",
             "thread_kind": "human_agent",
-            "title": "Cursor session neotoma",
-            "workspace_kind": "git_repository"
+            "title": "<env>",
+            "workspace_kind": "<env>"
           }
         ],
         "idempotency_key": "<id:6>"
@@ -125,7 +123,7 @@
           {
             "context_source": "cursor-hook",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "diagnosis_confidence": "high",
             "ended_at": "<ts>",
@@ -173,7 +171,7 @@
             "tool_invocation_count": 0,
             "turn_id": "<id:3>",
             "turn_key": "attachment_with_extracted_entities__cursor-hooks__composer-2:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -190,7 +188,7 @@
       "hook": "stop",
       "exitCode": 0,
       "output": {
-        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: hook state incomplete — No reminders were injected and no tool calls were observed this turn — sessionStart/postToolUse may not be wired up. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Re-run the cursor-hooks installer (`packages/cursor-hooks/scripts/install.mjs`) and confirm `.cursor/hooks.json` references the compiled hooks. Verify NEOTOMA_HOOK_STATE_DIR is writable and that hooks are emitting JSON on stdout. Run `npm run eval:tier1` against `tests/fixtures/agentic_eval/agent_skips_store.json` to spot regressions.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nNote: this client (composer-2) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial."
+        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: hook state incomplete — No reminders were injected and no tool calls were observed this turn — sessionStart/postToolUse may not be wired up. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Re-run the cursor-hooks installer (`packages/cursor-hooks/scripts/install.mjs`) and confirm `.cursor/hooks.json` references the compiled hooks. Verify NEOTOMA_HOOK_STATE_DIR is writable and that hooks are emitting JSON on stdout. Run `npm run eval:tier1` against `tests/fixtures/agentic_eval/agent_skips_store.json` to spot regressions.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nForbidden: reusing the user-phase conversation_message `turn_key` for the closing assistant store (must use `{conversation_id}:{turn_id}:assistant`, not the bare `{conversation_id}:{turn_id}`).\nNote: this client (composer-2) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial."
       }
     }
   ]

--- a/tests/__snapshots__/agentic_eval/attachment_with_extracted_entities__cursor-hooks__gpt-5.5-fast.snap.json
+++ b/tests/__snapshots__/agentic_eval/attachment_with_extracted_entities__cursor-hooks__gpt-5.5-fast.snap.json
@@ -8,22 +8,21 @@
           {
             "client_name": "Cursor",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation",
             "harness": "cursor-hook",
             "hook_event": "beforeSubmitPrompt",
-            "repository_name": "neotoma",
-            "repository_remote": "git@github.com:markmhendrickson/neotoma.git",
-            "repository_root": "/Users/markmhendrickson/repos/neotoma",
-            "scope_summary": "Cursor session in git repository neotoma.",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "scope_summary": "<env>",
             "thread_kind": "human_agent",
-            "title": "Cursor session neotoma",
-            "workspace_kind": "git_repository"
+            "title": "<env>",
+            "workspace_kind": "<env>"
           },
           {
             "content": "What does this receipt total?",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_message",
             "harness": "cursor",
@@ -51,7 +50,7 @@
           {
             "context_source": "cursor-hook",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -65,7 +64,7 @@
             "started_at": "<ts>",
             "turn_id": "<id:3>",
             "turn_key": "attachment_with_extracted_entities__cursor-hooks__gpt-5.5-fast:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -78,7 +77,7 @@
         "entities": [
           {
             "content": "I cannot read the image directly; please paste the line items as text.",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_message",
             "harness": "cursor",
@@ -100,18 +99,17 @@
           {
             "client_name": "Cursor",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation",
             "harness": "cursor-hook",
             "hook_event": "stop_backfill",
-            "repository_name": "neotoma",
-            "repository_remote": "git@github.com:markmhendrickson/neotoma.git",
-            "repository_root": "/Users/markmhendrickson/repos/neotoma",
-            "scope_summary": "Cursor session in git repository neotoma.",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "scope_summary": "<env>",
             "thread_kind": "human_agent",
-            "title": "Cursor session neotoma",
-            "workspace_kind": "git_repository"
+            "title": "<env>",
+            "workspace_kind": "<env>"
           }
         ],
         "idempotency_key": "<id:6>"
@@ -125,7 +123,7 @@
           {
             "context_source": "cursor-hook",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "diagnosis_confidence": "high",
             "ended_at": "<ts>",
@@ -173,7 +171,7 @@
             "tool_invocation_count": 0,
             "turn_id": "<id:3>",
             "turn_key": "attachment_with_extracted_entities__cursor-hooks__gpt-5.5-fast:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -190,7 +188,7 @@
       "hook": "stop",
       "exitCode": 0,
       "output": {
-        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: hook state incomplete — No reminders were injected and no tool calls were observed this turn — sessionStart/postToolUse may not be wired up. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Re-run the cursor-hooks installer (`packages/cursor-hooks/scripts/install.mjs`) and confirm `.cursor/hooks.json` references the compiled hooks. Verify NEOTOMA_HOOK_STATE_DIR is writable and that hooks are emitting JSON on stdout. Run `npm run eval:tier1` against `tests/fixtures/agentic_eval/agent_skips_store.json` to spot regressions.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nNote: this client (gpt-5.5-fast) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial."
+        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: hook state incomplete — No reminders were injected and no tool calls were observed this turn — sessionStart/postToolUse may not be wired up. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Re-run the cursor-hooks installer (`packages/cursor-hooks/scripts/install.mjs`) and confirm `.cursor/hooks.json` references the compiled hooks. Verify NEOTOMA_HOOK_STATE_DIR is writable and that hooks are emitting JSON on stdout. Run `npm run eval:tier1` against `tests/fixtures/agentic_eval/agent_skips_store.json` to spot regressions.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nForbidden: reusing the user-phase conversation_message `turn_key` for the closing assistant store (must use `{conversation_id}:{turn_id}:assistant`, not the bare `{conversation_id}:{turn_id}`).\nNote: this client (gpt-5.5-fast) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial."
       }
     }
   ]

--- a/tests/__snapshots__/agentic_eval/attachment_with_extracted_entities__cursor-hooks__gpt-5.5-medium.snap.json
+++ b/tests/__snapshots__/agentic_eval/attachment_with_extracted_entities__cursor-hooks__gpt-5.5-medium.snap.json
@@ -8,22 +8,21 @@
           {
             "client_name": "Cursor",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation",
             "harness": "cursor-hook",
             "hook_event": "beforeSubmitPrompt",
-            "repository_name": "neotoma",
-            "repository_remote": "git@github.com:markmhendrickson/neotoma.git",
-            "repository_root": "/Users/markmhendrickson/repos/neotoma",
-            "scope_summary": "Cursor session in git repository neotoma.",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "scope_summary": "<env>",
             "thread_kind": "human_agent",
-            "title": "Cursor session neotoma",
-            "workspace_kind": "git_repository"
+            "title": "<env>",
+            "workspace_kind": "<env>"
           },
           {
             "content": "What does this receipt total?",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_message",
             "harness": "cursor",
@@ -51,7 +50,7 @@
           {
             "context_source": "cursor-hook",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -65,7 +64,7 @@
             "started_at": "<ts>",
             "turn_id": "<id:3>",
             "turn_key": "attachment_with_extracted_entities__cursor-hooks__gpt-5.5-medium:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -78,7 +77,7 @@
         "entities": [
           {
             "content": "I cannot read the image directly; please paste the line items as text.",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_message",
             "harness": "cursor",
@@ -100,18 +99,17 @@
           {
             "client_name": "Cursor",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation",
             "harness": "cursor-hook",
             "hook_event": "stop_backfill",
-            "repository_name": "neotoma",
-            "repository_remote": "git@github.com:markmhendrickson/neotoma.git",
-            "repository_root": "/Users/markmhendrickson/repos/neotoma",
-            "scope_summary": "Cursor session in git repository neotoma.",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "scope_summary": "<env>",
             "thread_kind": "human_agent",
-            "title": "Cursor session neotoma",
-            "workspace_kind": "git_repository"
+            "title": "<env>",
+            "workspace_kind": "<env>"
           }
         ],
         "idempotency_key": "<id:6>"
@@ -125,7 +123,7 @@
           {
             "context_source": "cursor-hook",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "diagnosis_confidence": "high",
             "ended_at": "<ts>",
@@ -173,7 +171,7 @@
             "tool_invocation_count": 0,
             "turn_id": "<id:3>",
             "turn_key": "attachment_with_extracted_entities__cursor-hooks__gpt-5.5-medium:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -190,7 +188,7 @@
       "hook": "stop",
       "exitCode": 0,
       "output": {
-        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: hook state incomplete — No reminders were injected and no tool calls were observed this turn — sessionStart/postToolUse may not be wired up. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Re-run the cursor-hooks installer (`packages/cursor-hooks/scripts/install.mjs`) and confirm `.cursor/hooks.json` references the compiled hooks. Verify NEOTOMA_HOOK_STATE_DIR is writable and that hooks are emitting JSON on stdout. Run `npm run eval:tier1` against `tests/fixtures/agentic_eval/agent_skips_store.json` to spot regressions.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique."
+        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: hook state incomplete — No reminders were injected and no tool calls were observed this turn — sessionStart/postToolUse may not be wired up. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Re-run the cursor-hooks installer (`packages/cursor-hooks/scripts/install.mjs`) and confirm `.cursor/hooks.json` references the compiled hooks. Verify NEOTOMA_HOOK_STATE_DIR is writable and that hooks are emitting JSON on stdout. Run `npm run eval:tier1` against `tests/fixtures/agentic_eval/agent_skips_store.json` to spot regressions.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nForbidden: reusing the user-phase conversation_message `turn_key` for the closing assistant store (must use `{conversation_id}:{turn_id}:assistant`, not the bare `{conversation_id}:{turn_id}`)."
       }
     }
   ]

--- a/tests/__snapshots__/agentic_eval/multi_tool_then_reply__cursor-hooks__claude-haiku-4.snap.json
+++ b/tests/__snapshots__/agentic_eval/multi_tool_then_reply__cursor-hooks__claude-haiku-4.snap.json
@@ -8,22 +8,21 @@
           {
             "client_name": "Cursor",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation",
             "harness": "cursor-hook",
             "hook_event": "beforeSubmitPrompt",
-            "repository_name": "neotoma",
-            "repository_remote": "git@github.com:markmhendrickson/neotoma.git",
-            "repository_root": "/Users/markmhendrickson/repos/neotoma",
-            "scope_summary": "Cursor session in git repository neotoma.",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "scope_summary": "<env>",
             "thread_kind": "human_agent",
-            "title": "Cursor session neotoma",
-            "workspace_kind": "git_repository"
+            "title": "<env>",
+            "workspace_kind": "<env>"
           },
           {
             "content": "Find the auth flow in this repo.",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_message",
             "harness": "cursor",
@@ -51,7 +50,7 @@
           {
             "context_source": "cursor-hook",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -65,7 +64,7 @@
             "started_at": "<ts>",
             "turn_id": "<id:3>",
             "turn_key": "multi_tool_then_reply__cursor-hooks__claude-haiku-4:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -77,7 +76,7 @@
       "body": {
         "entities": [
           {
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "tool_invocation",
             "harness": "cursor",
@@ -101,7 +100,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -118,7 +117,7 @@
             "tool_invocation_count": 1,
             "turn_id": "<id:3>",
             "turn_key": "multi_tool_then_reply__cursor-hooks__claude-haiku-4:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -130,7 +129,7 @@
       "body": {
         "entities": [
           {
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "tool_invocation",
             "harness": "cursor",
@@ -154,7 +153,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -171,7 +170,7 @@
             "tool_invocation_count": 2,
             "turn_id": "<id:3>",
             "turn_key": "multi_tool_then_reply__cursor-hooks__claude-haiku-4:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -184,7 +183,7 @@
         "entities": [
           {
             "content": "Found 3 references to createSession across src/auth/.",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_message",
             "harness": "cursor",
@@ -206,18 +205,17 @@
           {
             "client_name": "Cursor",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation",
             "harness": "cursor-hook",
             "hook_event": "stop_backfill",
-            "repository_name": "neotoma",
-            "repository_remote": "git@github.com:markmhendrickson/neotoma.git",
-            "repository_root": "/Users/markmhendrickson/repos/neotoma",
-            "scope_summary": "Cursor session in git repository neotoma.",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "scope_summary": "<env>",
             "thread_kind": "human_agent",
-            "title": "Cursor session neotoma",
-            "workspace_kind": "git_repository"
+            "title": "<env>",
+            "workspace_kind": "<env>"
           }
         ],
         "idempotency_key": "<id:8>"
@@ -231,7 +229,7 @@
           {
             "context_source": "cursor-hook",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "diagnosis_confidence": "high",
             "ended_at": "<ts>",
@@ -281,7 +279,7 @@
             "tool_invocation_count": 2,
             "turn_id": "<id:3>",
             "turn_key": "multi_tool_then_reply__cursor-hooks__claude-haiku-4:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -298,21 +296,21 @@
       "hook": "postToolUse",
       "exitCode": 0,
       "output": {
-        "additional_context": "Neotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nNote: this client (claude-haiku-4) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial."
+        "additional_context": "Neotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nForbidden: reusing the user-phase conversation_message `turn_key` for the closing assistant store (must use `{conversation_id}:{turn_id}:assistant`, not the bare `{conversation_id}:{turn_id}`).\nNote: this client (claude-haiku-4) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial."
       }
     },
     {
       "hook": "postToolUse",
       "exitCode": 0,
       "output": {
-        "additional_context": "Neotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nNote: this client (claude-haiku-4) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial."
+        "additional_context": "Neotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nForbidden: reusing the user-phase conversation_message `turn_key` for the closing assistant store (must use `{conversation_id}:{turn_id}:assistant`, not the bare `{conversation_id}:{turn_id}`).\nNote: this client (claude-haiku-4) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial."
       }
     },
     {
       "hook": "stop",
       "exitCode": 0,
       "output": {
-        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: agent ignored available instructions — Compact reminder was injected and Neotoma tooling was reachable, but the agent did not call **`store`**. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Add or extend a Tier 1 fixture in `tests/fixtures/agentic_eval/` that asserts the `agent_ignored_available_instructions` classification for this model. Check the postToolUse reminder gate so wrapped host tool calls still receive the compact Neotoma reminder. Investigate whether the MCP `[COMPACT MODE]` block omits a contract this model needs; expand `docs/developer/mcp/instructions.md` accordingly.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nNote: this client (claude-haiku-4) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial."
+        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: agent ignored available instructions — Compact reminder was injected and Neotoma tooling was reachable, but the agent did not call **`store`**. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Add or extend a Tier 1 fixture in `tests/fixtures/agentic_eval/` that asserts the `agent_ignored_available_instructions` classification for this model. Check the postToolUse reminder gate so wrapped host tool calls still receive the compact Neotoma reminder. Investigate whether the MCP `[COMPACT MODE]` block omits a contract this model needs; expand `docs/developer/mcp/instructions.md` accordingly.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nForbidden: reusing the user-phase conversation_message `turn_key` for the closing assistant store (must use `{conversation_id}:{turn_id}:assistant`, not the bare `{conversation_id}:{turn_id}`).\nNote: this client (claude-haiku-4) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial."
       }
     }
   ]

--- a/tests/__snapshots__/agentic_eval/multi_tool_then_reply__cursor-hooks__claude-sonnet-4.5.snap.json
+++ b/tests/__snapshots__/agentic_eval/multi_tool_then_reply__cursor-hooks__claude-sonnet-4.5.snap.json
@@ -8,22 +8,21 @@
           {
             "client_name": "Cursor",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation",
             "harness": "cursor-hook",
             "hook_event": "beforeSubmitPrompt",
-            "repository_name": "neotoma",
-            "repository_remote": "git@github.com:markmhendrickson/neotoma.git",
-            "repository_root": "/Users/markmhendrickson/repos/neotoma",
-            "scope_summary": "Cursor session in git repository neotoma.",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "scope_summary": "<env>",
             "thread_kind": "human_agent",
-            "title": "Cursor session neotoma",
-            "workspace_kind": "git_repository"
+            "title": "<env>",
+            "workspace_kind": "<env>"
           },
           {
             "content": "Find the auth flow in this repo.",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_message",
             "harness": "cursor",
@@ -51,7 +50,7 @@
           {
             "context_source": "cursor-hook",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -65,7 +64,7 @@
             "started_at": "<ts>",
             "turn_id": "<id:3>",
             "turn_key": "multi_tool_then_reply__cursor-hooks__claude-sonnet-4.5:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -77,7 +76,7 @@
       "body": {
         "entities": [
           {
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "tool_invocation",
             "harness": "cursor",
@@ -101,7 +100,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -118,7 +117,7 @@
             "tool_invocation_count": 1,
             "turn_id": "<id:3>",
             "turn_key": "multi_tool_then_reply__cursor-hooks__claude-sonnet-4.5:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -130,7 +129,7 @@
       "body": {
         "entities": [
           {
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "tool_invocation",
             "harness": "cursor",
@@ -154,7 +153,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -171,7 +170,7 @@
             "tool_invocation_count": 2,
             "turn_id": "<id:3>",
             "turn_key": "multi_tool_then_reply__cursor-hooks__claude-sonnet-4.5:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -184,7 +183,7 @@
         "entities": [
           {
             "content": "Found 3 references to createSession across src/auth/.",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_message",
             "harness": "cursor",
@@ -206,18 +205,17 @@
           {
             "client_name": "Cursor",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation",
             "harness": "cursor-hook",
             "hook_event": "stop_backfill",
-            "repository_name": "neotoma",
-            "repository_remote": "git@github.com:markmhendrickson/neotoma.git",
-            "repository_root": "/Users/markmhendrickson/repos/neotoma",
-            "scope_summary": "Cursor session in git repository neotoma.",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "scope_summary": "<env>",
             "thread_kind": "human_agent",
-            "title": "Cursor session neotoma",
-            "workspace_kind": "git_repository"
+            "title": "<env>",
+            "workspace_kind": "<env>"
           }
         ],
         "idempotency_key": "<id:8>"
@@ -231,7 +229,7 @@
           {
             "context_source": "cursor-hook",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "diagnosis_confidence": "high",
             "ended_at": "<ts>",
@@ -281,7 +279,7 @@
             "tool_invocation_count": 2,
             "turn_id": "<id:3>",
             "turn_key": "multi_tool_then_reply__cursor-hooks__claude-sonnet-4.5:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -298,21 +296,21 @@
       "hook": "postToolUse",
       "exitCode": 0,
       "output": {
-        "additional_context": "Neotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique."
+        "additional_context": "Neotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nForbidden: reusing the user-phase conversation_message `turn_key` for the closing assistant store (must use `{conversation_id}:{turn_id}:assistant`, not the bare `{conversation_id}:{turn_id}`)."
       }
     },
     {
       "hook": "postToolUse",
       "exitCode": 0,
       "output": {
-        "additional_context": "Neotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique."
+        "additional_context": "Neotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nForbidden: reusing the user-phase conversation_message `turn_key` for the closing assistant store (must use `{conversation_id}:{turn_id}:assistant`, not the bare `{conversation_id}:{turn_id}`)."
       }
     },
     {
       "hook": "stop",
       "exitCode": 0,
       "output": {
-        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: agent ignored available instructions — Compact reminder was injected and Neotoma tooling was reachable, but the agent did not call **`store`**. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Add or extend a Tier 1 fixture in `tests/fixtures/agentic_eval/` that asserts the `agent_ignored_available_instructions` classification for this model. Check the postToolUse reminder gate so wrapped host tool calls still receive the compact Neotoma reminder. Investigate whether the MCP `[COMPACT MODE]` block omits a contract this model needs; expand `docs/developer/mcp/instructions.md` accordingly.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique."
+        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: agent ignored available instructions — Compact reminder was injected and Neotoma tooling was reachable, but the agent did not call **`store`**. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Add or extend a Tier 1 fixture in `tests/fixtures/agentic_eval/` that asserts the `agent_ignored_available_instructions` classification for this model. Check the postToolUse reminder gate so wrapped host tool calls still receive the compact Neotoma reminder. Investigate whether the MCP `[COMPACT MODE]` block omits a contract this model needs; expand `docs/developer/mcp/instructions.md` accordingly.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nForbidden: reusing the user-phase conversation_message `turn_key` for the closing assistant store (must use `{conversation_id}:{turn_id}:assistant`, not the bare `{conversation_id}:{turn_id}`)."
       }
     }
   ]

--- a/tests/__snapshots__/agentic_eval/multi_tool_then_reply__cursor-hooks__composer-2.snap.json
+++ b/tests/__snapshots__/agentic_eval/multi_tool_then_reply__cursor-hooks__composer-2.snap.json
@@ -8,22 +8,21 @@
           {
             "client_name": "Cursor",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation",
             "harness": "cursor-hook",
             "hook_event": "beforeSubmitPrompt",
-            "repository_name": "neotoma",
-            "repository_remote": "git@github.com:markmhendrickson/neotoma.git",
-            "repository_root": "/Users/markmhendrickson/repos/neotoma",
-            "scope_summary": "Cursor session in git repository neotoma.",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "scope_summary": "<env>",
             "thread_kind": "human_agent",
-            "title": "Cursor session neotoma",
-            "workspace_kind": "git_repository"
+            "title": "<env>",
+            "workspace_kind": "<env>"
           },
           {
             "content": "Find the auth flow in this repo.",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_message",
             "harness": "cursor",
@@ -51,7 +50,7 @@
           {
             "context_source": "cursor-hook",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -65,7 +64,7 @@
             "started_at": "<ts>",
             "turn_id": "<id:3>",
             "turn_key": "multi_tool_then_reply__cursor-hooks__composer-2:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -77,7 +76,7 @@
       "body": {
         "entities": [
           {
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "tool_invocation",
             "harness": "cursor",
@@ -101,7 +100,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -118,7 +117,7 @@
             "tool_invocation_count": 1,
             "turn_id": "<id:3>",
             "turn_key": "multi_tool_then_reply__cursor-hooks__composer-2:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -130,7 +129,7 @@
       "body": {
         "entities": [
           {
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "tool_invocation",
             "harness": "cursor",
@@ -154,7 +153,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -171,7 +170,7 @@
             "tool_invocation_count": 2,
             "turn_id": "<id:3>",
             "turn_key": "multi_tool_then_reply__cursor-hooks__composer-2:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -184,7 +183,7 @@
         "entities": [
           {
             "content": "Found 3 references to createSession across src/auth/.",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_message",
             "harness": "cursor",
@@ -206,18 +205,17 @@
           {
             "client_name": "Cursor",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation",
             "harness": "cursor-hook",
             "hook_event": "stop_backfill",
-            "repository_name": "neotoma",
-            "repository_remote": "git@github.com:markmhendrickson/neotoma.git",
-            "repository_root": "/Users/markmhendrickson/repos/neotoma",
-            "scope_summary": "Cursor session in git repository neotoma.",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "scope_summary": "<env>",
             "thread_kind": "human_agent",
-            "title": "Cursor session neotoma",
-            "workspace_kind": "git_repository"
+            "title": "<env>",
+            "workspace_kind": "<env>"
           }
         ],
         "idempotency_key": "<id:8>"
@@ -231,7 +229,7 @@
           {
             "context_source": "cursor-hook",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "diagnosis_confidence": "high",
             "ended_at": "<ts>",
@@ -281,7 +279,7 @@
             "tool_invocation_count": 2,
             "turn_id": "<id:3>",
             "turn_key": "multi_tool_then_reply__cursor-hooks__composer-2:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -298,21 +296,21 @@
       "hook": "postToolUse",
       "exitCode": 0,
       "output": {
-        "additional_context": "Neotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nNote: this client (composer-2) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial."
+        "additional_context": "Neotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nForbidden: reusing the user-phase conversation_message `turn_key` for the closing assistant store (must use `{conversation_id}:{turn_id}:assistant`, not the bare `{conversation_id}:{turn_id}`).\nNote: this client (composer-2) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial."
       }
     },
     {
       "hook": "postToolUse",
       "exitCode": 0,
       "output": {
-        "additional_context": "Neotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nNote: this client (composer-2) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial."
+        "additional_context": "Neotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nForbidden: reusing the user-phase conversation_message `turn_key` for the closing assistant store (must use `{conversation_id}:{turn_id}:assistant`, not the bare `{conversation_id}:{turn_id}`).\nNote: this client (composer-2) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial."
       }
     },
     {
       "hook": "stop",
       "exitCode": 0,
       "output": {
-        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: agent ignored available instructions — Compact reminder was injected and Neotoma tooling was reachable, but the agent did not call **`store`**. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Add or extend a Tier 1 fixture in `tests/fixtures/agentic_eval/` that asserts the `agent_ignored_available_instructions` classification for this model. Check the postToolUse reminder gate so wrapped host tool calls still receive the compact Neotoma reminder. Investigate whether the MCP `[COMPACT MODE]` block omits a contract this model needs; expand `docs/developer/mcp/instructions.md` accordingly.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nNote: this client (composer-2) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial."
+        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: agent ignored available instructions — Compact reminder was injected and Neotoma tooling was reachable, but the agent did not call **`store`**. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Add or extend a Tier 1 fixture in `tests/fixtures/agentic_eval/` that asserts the `agent_ignored_available_instructions` classification for this model. Check the postToolUse reminder gate so wrapped host tool calls still receive the compact Neotoma reminder. Investigate whether the MCP `[COMPACT MODE]` block omits a contract this model needs; expand `docs/developer/mcp/instructions.md` accordingly.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nForbidden: reusing the user-phase conversation_message `turn_key` for the closing assistant store (must use `{conversation_id}:{turn_id}:assistant`, not the bare `{conversation_id}:{turn_id}`).\nNote: this client (composer-2) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial."
       }
     }
   ]

--- a/tests/__snapshots__/agentic_eval/multi_tool_then_reply__cursor-hooks__gpt-5.5-fast.snap.json
+++ b/tests/__snapshots__/agentic_eval/multi_tool_then_reply__cursor-hooks__gpt-5.5-fast.snap.json
@@ -8,22 +8,21 @@
           {
             "client_name": "Cursor",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation",
             "harness": "cursor-hook",
             "hook_event": "beforeSubmitPrompt",
-            "repository_name": "neotoma",
-            "repository_remote": "git@github.com:markmhendrickson/neotoma.git",
-            "repository_root": "/Users/markmhendrickson/repos/neotoma",
-            "scope_summary": "Cursor session in git repository neotoma.",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "scope_summary": "<env>",
             "thread_kind": "human_agent",
-            "title": "Cursor session neotoma",
-            "workspace_kind": "git_repository"
+            "title": "<env>",
+            "workspace_kind": "<env>"
           },
           {
             "content": "Find the auth flow in this repo.",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_message",
             "harness": "cursor",
@@ -51,7 +50,7 @@
           {
             "context_source": "cursor-hook",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -65,7 +64,7 @@
             "started_at": "<ts>",
             "turn_id": "<id:3>",
             "turn_key": "multi_tool_then_reply__cursor-hooks__gpt-5.5-fast:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -77,7 +76,7 @@
       "body": {
         "entities": [
           {
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "tool_invocation",
             "harness": "cursor",
@@ -101,7 +100,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -118,7 +117,7 @@
             "tool_invocation_count": 1,
             "turn_id": "<id:3>",
             "turn_key": "multi_tool_then_reply__cursor-hooks__gpt-5.5-fast:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -130,7 +129,7 @@
       "body": {
         "entities": [
           {
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "tool_invocation",
             "harness": "cursor",
@@ -154,7 +153,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -171,7 +170,7 @@
             "tool_invocation_count": 2,
             "turn_id": "<id:3>",
             "turn_key": "multi_tool_then_reply__cursor-hooks__gpt-5.5-fast:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -184,7 +183,7 @@
         "entities": [
           {
             "content": "Found 3 references to createSession across src/auth/.",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_message",
             "harness": "cursor",
@@ -206,18 +205,17 @@
           {
             "client_name": "Cursor",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation",
             "harness": "cursor-hook",
             "hook_event": "stop_backfill",
-            "repository_name": "neotoma",
-            "repository_remote": "git@github.com:markmhendrickson/neotoma.git",
-            "repository_root": "/Users/markmhendrickson/repos/neotoma",
-            "scope_summary": "Cursor session in git repository neotoma.",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "scope_summary": "<env>",
             "thread_kind": "human_agent",
-            "title": "Cursor session neotoma",
-            "workspace_kind": "git_repository"
+            "title": "<env>",
+            "workspace_kind": "<env>"
           }
         ],
         "idempotency_key": "<id:8>"
@@ -231,7 +229,7 @@
           {
             "context_source": "cursor-hook",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "diagnosis_confidence": "high",
             "ended_at": "<ts>",
@@ -281,7 +279,7 @@
             "tool_invocation_count": 2,
             "turn_id": "<id:3>",
             "turn_key": "multi_tool_then_reply__cursor-hooks__gpt-5.5-fast:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -298,21 +296,21 @@
       "hook": "postToolUse",
       "exitCode": 0,
       "output": {
-        "additional_context": "Neotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nNote: this client (gpt-5.5-fast) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial."
+        "additional_context": "Neotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nForbidden: reusing the user-phase conversation_message `turn_key` for the closing assistant store (must use `{conversation_id}:{turn_id}:assistant`, not the bare `{conversation_id}:{turn_id}`).\nNote: this client (gpt-5.5-fast) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial."
       }
     },
     {
       "hook": "postToolUse",
       "exitCode": 0,
       "output": {
-        "additional_context": "Neotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nNote: this client (gpt-5.5-fast) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial."
+        "additional_context": "Neotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nForbidden: reusing the user-phase conversation_message `turn_key` for the closing assistant store (must use `{conversation_id}:{turn_id}:assistant`, not the bare `{conversation_id}:{turn_id}`).\nNote: this client (gpt-5.5-fast) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial."
       }
     },
     {
       "hook": "stop",
       "exitCode": 0,
       "output": {
-        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: agent ignored available instructions — Compact reminder was injected and Neotoma tooling was reachable, but the agent did not call **`store`**. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Add or extend a Tier 1 fixture in `tests/fixtures/agentic_eval/` that asserts the `agent_ignored_available_instructions` classification for this model. Check the postToolUse reminder gate so wrapped host tool calls still receive the compact Neotoma reminder. Investigate whether the MCP `[COMPACT MODE]` block omits a contract this model needs; expand `docs/developer/mcp/instructions.md` accordingly.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nNote: this client (gpt-5.5-fast) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial."
+        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: agent ignored available instructions — Compact reminder was injected and Neotoma tooling was reachable, but the agent did not call **`store`**. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Add or extend a Tier 1 fixture in `tests/fixtures/agentic_eval/` that asserts the `agent_ignored_available_instructions` classification for this model. Check the postToolUse reminder gate so wrapped host tool calls still receive the compact Neotoma reminder. Investigate whether the MCP `[COMPACT MODE]` block omits a contract this model needs; expand `docs/developer/mcp/instructions.md` accordingly.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nForbidden: reusing the user-phase conversation_message `turn_key` for the closing assistant store (must use `{conversation_id}:{turn_id}:assistant`, not the bare `{conversation_id}:{turn_id}`).\nNote: this client (gpt-5.5-fast) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial."
       }
     }
   ]

--- a/tests/__snapshots__/agentic_eval/multi_tool_then_reply__cursor-hooks__gpt-5.5-medium.snap.json
+++ b/tests/__snapshots__/agentic_eval/multi_tool_then_reply__cursor-hooks__gpt-5.5-medium.snap.json
@@ -8,22 +8,21 @@
           {
             "client_name": "Cursor",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation",
             "harness": "cursor-hook",
             "hook_event": "beforeSubmitPrompt",
-            "repository_name": "neotoma",
-            "repository_remote": "git@github.com:markmhendrickson/neotoma.git",
-            "repository_root": "/Users/markmhendrickson/repos/neotoma",
-            "scope_summary": "Cursor session in git repository neotoma.",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "scope_summary": "<env>",
             "thread_kind": "human_agent",
-            "title": "Cursor session neotoma",
-            "workspace_kind": "git_repository"
+            "title": "<env>",
+            "workspace_kind": "<env>"
           },
           {
             "content": "Find the auth flow in this repo.",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_message",
             "harness": "cursor",
@@ -51,7 +50,7 @@
           {
             "context_source": "cursor-hook",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -65,7 +64,7 @@
             "started_at": "<ts>",
             "turn_id": "<id:3>",
             "turn_key": "multi_tool_then_reply__cursor-hooks__gpt-5.5-medium:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -77,7 +76,7 @@
       "body": {
         "entities": [
           {
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "tool_invocation",
             "harness": "cursor",
@@ -101,7 +100,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -118,7 +117,7 @@
             "tool_invocation_count": 1,
             "turn_id": "<id:3>",
             "turn_key": "multi_tool_then_reply__cursor-hooks__gpt-5.5-medium:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -130,7 +129,7 @@
       "body": {
         "entities": [
           {
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "tool_invocation",
             "harness": "cursor",
@@ -154,7 +153,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -171,7 +170,7 @@
             "tool_invocation_count": 2,
             "turn_id": "<id:3>",
             "turn_key": "multi_tool_then_reply__cursor-hooks__gpt-5.5-medium:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -184,7 +183,7 @@
         "entities": [
           {
             "content": "Found 3 references to createSession across src/auth/.",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_message",
             "harness": "cursor",
@@ -206,18 +205,17 @@
           {
             "client_name": "Cursor",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation",
             "harness": "cursor-hook",
             "hook_event": "stop_backfill",
-            "repository_name": "neotoma",
-            "repository_remote": "git@github.com:markmhendrickson/neotoma.git",
-            "repository_root": "/Users/markmhendrickson/repos/neotoma",
-            "scope_summary": "Cursor session in git repository neotoma.",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "scope_summary": "<env>",
             "thread_kind": "human_agent",
-            "title": "Cursor session neotoma",
-            "workspace_kind": "git_repository"
+            "title": "<env>",
+            "workspace_kind": "<env>"
           }
         ],
         "idempotency_key": "<id:8>"
@@ -231,7 +229,7 @@
           {
             "context_source": "cursor-hook",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "diagnosis_confidence": "high",
             "ended_at": "<ts>",
@@ -281,7 +279,7 @@
             "tool_invocation_count": 2,
             "turn_id": "<id:3>",
             "turn_key": "multi_tool_then_reply__cursor-hooks__gpt-5.5-medium:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -298,21 +296,21 @@
       "hook": "postToolUse",
       "exitCode": 0,
       "output": {
-        "additional_context": "Neotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique."
+        "additional_context": "Neotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nForbidden: reusing the user-phase conversation_message `turn_key` for the closing assistant store (must use `{conversation_id}:{turn_id}:assistant`, not the bare `{conversation_id}:{turn_id}`)."
       }
     },
     {
       "hook": "postToolUse",
       "exitCode": 0,
       "output": {
-        "additional_context": "Neotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique."
+        "additional_context": "Neotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nForbidden: reusing the user-phase conversation_message `turn_key` for the closing assistant store (must use `{conversation_id}:{turn_id}:assistant`, not the bare `{conversation_id}:{turn_id}`)."
       }
     },
     {
       "hook": "stop",
       "exitCode": 0,
       "output": {
-        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: agent ignored available instructions — Compact reminder was injected and Neotoma tooling was reachable, but the agent did not call **`store`**. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Add or extend a Tier 1 fixture in `tests/fixtures/agentic_eval/` that asserts the `agent_ignored_available_instructions` classification for this model. Check the postToolUse reminder gate so wrapped host tool calls still receive the compact Neotoma reminder. Investigate whether the MCP `[COMPACT MODE]` block omits a contract this model needs; expand `docs/developer/mcp/instructions.md` accordingly.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique."
+        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: agent ignored available instructions — Compact reminder was injected and Neotoma tooling was reachable, but the agent did not call **`store`**. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Add or extend a Tier 1 fixture in `tests/fixtures/agentic_eval/` that asserts the `agent_ignored_available_instructions` classification for this model. Check the postToolUse reminder gate so wrapped host tool calls still receive the compact Neotoma reminder. Investigate whether the MCP `[COMPACT MODE]` block omits a contract this model needs; expand `docs/developer/mcp/instructions.md` accordingly.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nForbidden: reusing the user-phase conversation_message `turn_key` for the closing assistant store (must use `{conversation_id}:{turn_id}:assistant`, not the bare `{conversation_id}:{turn_id}`)."
       }
     }
   ]

--- a/tests/__snapshots__/agentic_eval/single_turn_with_extracted_entity__cursor-hooks__claude-haiku-4.snap.json
+++ b/tests/__snapshots__/agentic_eval/single_turn_with_extracted_entity__cursor-hooks__claude-haiku-4.snap.json
@@ -8,22 +8,21 @@
           {
             "client_name": "Cursor",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation",
             "harness": "cursor-hook",
             "hook_event": "beforeSubmitPrompt",
-            "repository_name": "neotoma",
-            "repository_remote": "git@github.com:markmhendrickson/neotoma.git",
-            "repository_root": "/Users/markmhendrickson/repos/neotoma",
-            "scope_summary": "Cursor session in git repository neotoma.",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "scope_summary": "<env>",
             "thread_kind": "human_agent",
-            "title": "Cursor session neotoma",
-            "workspace_kind": "git_repository"
+            "title": "<env>",
+            "workspace_kind": "<env>"
           },
           {
             "content": "Sara Lee said the proposal looks great.",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_message",
             "harness": "cursor",
@@ -51,7 +50,7 @@
           {
             "context_source": "cursor-hook",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -65,7 +64,7 @@
             "started_at": "<ts>",
             "turn_id": "<id:3>",
             "turn_key": "single_turn_with_extracted_entity__cursor-hooks__claude-haiku-4:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -78,7 +77,7 @@
         "entities": [
           {
             "content": "Got it — I will note Sara Lee's feedback.",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_message",
             "harness": "cursor",
@@ -100,18 +99,17 @@
           {
             "client_name": "Cursor",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation",
             "harness": "cursor-hook",
             "hook_event": "stop_backfill",
-            "repository_name": "neotoma",
-            "repository_remote": "git@github.com:markmhendrickson/neotoma.git",
-            "repository_root": "/Users/markmhendrickson/repos/neotoma",
-            "scope_summary": "Cursor session in git repository neotoma.",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "scope_summary": "<env>",
             "thread_kind": "human_agent",
-            "title": "Cursor session neotoma",
-            "workspace_kind": "git_repository"
+            "title": "<env>",
+            "workspace_kind": "<env>"
           }
         ],
         "idempotency_key": "<id:6>"
@@ -125,7 +123,7 @@
           {
             "context_source": "cursor-hook",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "diagnosis_confidence": "high",
             "ended_at": "<ts>",
@@ -173,7 +171,7 @@
             "tool_invocation_count": 0,
             "turn_id": "<id:3>",
             "turn_key": "single_turn_with_extracted_entity__cursor-hooks__claude-haiku-4:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -190,7 +188,7 @@
       "hook": "stop",
       "exitCode": 0,
       "output": {
-        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: hook state incomplete — No reminders were injected and no tool calls were observed this turn — sessionStart/postToolUse may not be wired up. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Re-run the cursor-hooks installer (`packages/cursor-hooks/scripts/install.mjs`) and confirm `.cursor/hooks.json` references the compiled hooks. Verify NEOTOMA_HOOK_STATE_DIR is writable and that hooks are emitting JSON on stdout. Run `npm run eval:tier1` against `tests/fixtures/agentic_eval/agent_skips_store.json` to spot regressions.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nNote: this client (claude-haiku-4) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial."
+        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: hook state incomplete — No reminders were injected and no tool calls were observed this turn — sessionStart/postToolUse may not be wired up. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Re-run the cursor-hooks installer (`packages/cursor-hooks/scripts/install.mjs`) and confirm `.cursor/hooks.json` references the compiled hooks. Verify NEOTOMA_HOOK_STATE_DIR is writable and that hooks are emitting JSON on stdout. Run `npm run eval:tier1` against `tests/fixtures/agentic_eval/agent_skips_store.json` to spot regressions.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nForbidden: reusing the user-phase conversation_message `turn_key` for the closing assistant store (must use `{conversation_id}:{turn_id}:assistant`, not the bare `{conversation_id}:{turn_id}`).\nNote: this client (claude-haiku-4) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial."
       }
     }
   ]

--- a/tests/__snapshots__/agentic_eval/single_turn_with_extracted_entity__cursor-hooks__claude-sonnet-4.5.snap.json
+++ b/tests/__snapshots__/agentic_eval/single_turn_with_extracted_entity__cursor-hooks__claude-sonnet-4.5.snap.json
@@ -8,22 +8,21 @@
           {
             "client_name": "Cursor",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation",
             "harness": "cursor-hook",
             "hook_event": "beforeSubmitPrompt",
-            "repository_name": "neotoma",
-            "repository_remote": "git@github.com:markmhendrickson/neotoma.git",
-            "repository_root": "/Users/markmhendrickson/repos/neotoma",
-            "scope_summary": "Cursor session in git repository neotoma.",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "scope_summary": "<env>",
             "thread_kind": "human_agent",
-            "title": "Cursor session neotoma",
-            "workspace_kind": "git_repository"
+            "title": "<env>",
+            "workspace_kind": "<env>"
           },
           {
             "content": "Sara Lee said the proposal looks great.",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_message",
             "harness": "cursor",
@@ -51,7 +50,7 @@
           {
             "context_source": "cursor-hook",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -65,7 +64,7 @@
             "started_at": "<ts>",
             "turn_id": "<id:3>",
             "turn_key": "single_turn_with_extracted_entity__cursor-hooks__claude-sonnet-4.5:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -78,7 +77,7 @@
         "entities": [
           {
             "content": "Got it — I will note Sara Lee's feedback.",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_message",
             "harness": "cursor",
@@ -100,18 +99,17 @@
           {
             "client_name": "Cursor",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation",
             "harness": "cursor-hook",
             "hook_event": "stop_backfill",
-            "repository_name": "neotoma",
-            "repository_remote": "git@github.com:markmhendrickson/neotoma.git",
-            "repository_root": "/Users/markmhendrickson/repos/neotoma",
-            "scope_summary": "Cursor session in git repository neotoma.",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "scope_summary": "<env>",
             "thread_kind": "human_agent",
-            "title": "Cursor session neotoma",
-            "workspace_kind": "git_repository"
+            "title": "<env>",
+            "workspace_kind": "<env>"
           }
         ],
         "idempotency_key": "<id:6>"
@@ -125,7 +123,7 @@
           {
             "context_source": "cursor-hook",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "diagnosis_confidence": "high",
             "ended_at": "<ts>",
@@ -173,7 +171,7 @@
             "tool_invocation_count": 0,
             "turn_id": "<id:3>",
             "turn_key": "single_turn_with_extracted_entity__cursor-hooks__claude-sonnet-4.5:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -190,7 +188,7 @@
       "hook": "stop",
       "exitCode": 0,
       "output": {
-        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: hook state incomplete — No reminders were injected and no tool calls were observed this turn — sessionStart/postToolUse may not be wired up. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Re-run the cursor-hooks installer (`packages/cursor-hooks/scripts/install.mjs`) and confirm `.cursor/hooks.json` references the compiled hooks. Verify NEOTOMA_HOOK_STATE_DIR is writable and that hooks are emitting JSON on stdout. Run `npm run eval:tier1` against `tests/fixtures/agentic_eval/agent_skips_store.json` to spot regressions.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique."
+        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: hook state incomplete — No reminders were injected and no tool calls were observed this turn — sessionStart/postToolUse may not be wired up. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Re-run the cursor-hooks installer (`packages/cursor-hooks/scripts/install.mjs`) and confirm `.cursor/hooks.json` references the compiled hooks. Verify NEOTOMA_HOOK_STATE_DIR is writable and that hooks are emitting JSON on stdout. Run `npm run eval:tier1` against `tests/fixtures/agentic_eval/agent_skips_store.json` to spot regressions.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nForbidden: reusing the user-phase conversation_message `turn_key` for the closing assistant store (must use `{conversation_id}:{turn_id}:assistant`, not the bare `{conversation_id}:{turn_id}`)."
       }
     }
   ]

--- a/tests/__snapshots__/agentic_eval/single_turn_with_extracted_entity__cursor-hooks__composer-2.snap.json
+++ b/tests/__snapshots__/agentic_eval/single_turn_with_extracted_entity__cursor-hooks__composer-2.snap.json
@@ -8,22 +8,21 @@
           {
             "client_name": "Cursor",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation",
             "harness": "cursor-hook",
             "hook_event": "beforeSubmitPrompt",
-            "repository_name": "neotoma",
-            "repository_remote": "git@github.com:markmhendrickson/neotoma.git",
-            "repository_root": "/Users/markmhendrickson/repos/neotoma",
-            "scope_summary": "Cursor session in git repository neotoma.",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "scope_summary": "<env>",
             "thread_kind": "human_agent",
-            "title": "Cursor session neotoma",
-            "workspace_kind": "git_repository"
+            "title": "<env>",
+            "workspace_kind": "<env>"
           },
           {
             "content": "Sara Lee said the proposal looks great.",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_message",
             "harness": "cursor",
@@ -51,7 +50,7 @@
           {
             "context_source": "cursor-hook",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -65,7 +64,7 @@
             "started_at": "<ts>",
             "turn_id": "<id:3>",
             "turn_key": "single_turn_with_extracted_entity__cursor-hooks__composer-2:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -78,7 +77,7 @@
         "entities": [
           {
             "content": "Got it — I will note Sara Lee's feedback.",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_message",
             "harness": "cursor",
@@ -100,18 +99,17 @@
           {
             "client_name": "Cursor",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation",
             "harness": "cursor-hook",
             "hook_event": "stop_backfill",
-            "repository_name": "neotoma",
-            "repository_remote": "git@github.com:markmhendrickson/neotoma.git",
-            "repository_root": "/Users/markmhendrickson/repos/neotoma",
-            "scope_summary": "Cursor session in git repository neotoma.",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "scope_summary": "<env>",
             "thread_kind": "human_agent",
-            "title": "Cursor session neotoma",
-            "workspace_kind": "git_repository"
+            "title": "<env>",
+            "workspace_kind": "<env>"
           }
         ],
         "idempotency_key": "<id:6>"
@@ -125,7 +123,7 @@
           {
             "context_source": "cursor-hook",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "diagnosis_confidence": "high",
             "ended_at": "<ts>",
@@ -173,7 +171,7 @@
             "tool_invocation_count": 0,
             "turn_id": "<id:3>",
             "turn_key": "single_turn_with_extracted_entity__cursor-hooks__composer-2:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -190,7 +188,7 @@
       "hook": "stop",
       "exitCode": 0,
       "output": {
-        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: hook state incomplete — No reminders were injected and no tool calls were observed this turn — sessionStart/postToolUse may not be wired up. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Re-run the cursor-hooks installer (`packages/cursor-hooks/scripts/install.mjs`) and confirm `.cursor/hooks.json` references the compiled hooks. Verify NEOTOMA_HOOK_STATE_DIR is writable and that hooks are emitting JSON on stdout. Run `npm run eval:tier1` against `tests/fixtures/agentic_eval/agent_skips_store.json` to spot regressions.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nNote: this client (composer-2) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial."
+        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: hook state incomplete — No reminders were injected and no tool calls were observed this turn — sessionStart/postToolUse may not be wired up. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Re-run the cursor-hooks installer (`packages/cursor-hooks/scripts/install.mjs`) and confirm `.cursor/hooks.json` references the compiled hooks. Verify NEOTOMA_HOOK_STATE_DIR is writable and that hooks are emitting JSON on stdout. Run `npm run eval:tier1` against `tests/fixtures/agentic_eval/agent_skips_store.json` to spot regressions.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nForbidden: reusing the user-phase conversation_message `turn_key` for the closing assistant store (must use `{conversation_id}:{turn_id}:assistant`, not the bare `{conversation_id}:{turn_id}`).\nNote: this client (composer-2) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial."
       }
     }
   ]

--- a/tests/__snapshots__/agentic_eval/single_turn_with_extracted_entity__cursor-hooks__gpt-5.5-fast.snap.json
+++ b/tests/__snapshots__/agentic_eval/single_turn_with_extracted_entity__cursor-hooks__gpt-5.5-fast.snap.json
@@ -8,22 +8,21 @@
           {
             "client_name": "Cursor",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation",
             "harness": "cursor-hook",
             "hook_event": "beforeSubmitPrompt",
-            "repository_name": "neotoma",
-            "repository_remote": "git@github.com:markmhendrickson/neotoma.git",
-            "repository_root": "/Users/markmhendrickson/repos/neotoma",
-            "scope_summary": "Cursor session in git repository neotoma.",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "scope_summary": "<env>",
             "thread_kind": "human_agent",
-            "title": "Cursor session neotoma",
-            "workspace_kind": "git_repository"
+            "title": "<env>",
+            "workspace_kind": "<env>"
           },
           {
             "content": "Sara Lee said the proposal looks great.",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_message",
             "harness": "cursor",
@@ -51,7 +50,7 @@
           {
             "context_source": "cursor-hook",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -65,7 +64,7 @@
             "started_at": "<ts>",
             "turn_id": "<id:3>",
             "turn_key": "single_turn_with_extracted_entity__cursor-hooks__gpt-5.5-fast:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -78,7 +77,7 @@
         "entities": [
           {
             "content": "Got it — I will note Sara Lee's feedback.",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_message",
             "harness": "cursor",
@@ -100,18 +99,17 @@
           {
             "client_name": "Cursor",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation",
             "harness": "cursor-hook",
             "hook_event": "stop_backfill",
-            "repository_name": "neotoma",
-            "repository_remote": "git@github.com:markmhendrickson/neotoma.git",
-            "repository_root": "/Users/markmhendrickson/repos/neotoma",
-            "scope_summary": "Cursor session in git repository neotoma.",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "scope_summary": "<env>",
             "thread_kind": "human_agent",
-            "title": "Cursor session neotoma",
-            "workspace_kind": "git_repository"
+            "title": "<env>",
+            "workspace_kind": "<env>"
           }
         ],
         "idempotency_key": "<id:6>"
@@ -125,7 +123,7 @@
           {
             "context_source": "cursor-hook",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "diagnosis_confidence": "high",
             "ended_at": "<ts>",
@@ -173,7 +171,7 @@
             "tool_invocation_count": 0,
             "turn_id": "<id:3>",
             "turn_key": "single_turn_with_extracted_entity__cursor-hooks__gpt-5.5-fast:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -190,7 +188,7 @@
       "hook": "stop",
       "exitCode": 0,
       "output": {
-        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: hook state incomplete — No reminders were injected and no tool calls were observed this turn — sessionStart/postToolUse may not be wired up. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Re-run the cursor-hooks installer (`packages/cursor-hooks/scripts/install.mjs`) and confirm `.cursor/hooks.json` references the compiled hooks. Verify NEOTOMA_HOOK_STATE_DIR is writable and that hooks are emitting JSON on stdout. Run `npm run eval:tier1` against `tests/fixtures/agentic_eval/agent_skips_store.json` to spot regressions.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nNote: this client (gpt-5.5-fast) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial."
+        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: hook state incomplete — No reminders were injected and no tool calls were observed this turn — sessionStart/postToolUse may not be wired up. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Re-run the cursor-hooks installer (`packages/cursor-hooks/scripts/install.mjs`) and confirm `.cursor/hooks.json` references the compiled hooks. Verify NEOTOMA_HOOK_STATE_DIR is writable and that hooks are emitting JSON on stdout. Run `npm run eval:tier1` against `tests/fixtures/agentic_eval/agent_skips_store.json` to spot regressions.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nForbidden: reusing the user-phase conversation_message `turn_key` for the closing assistant store (must use `{conversation_id}:{turn_id}:assistant`, not the bare `{conversation_id}:{turn_id}`).\nNote: this client (gpt-5.5-fast) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial."
       }
     }
   ]

--- a/tests/__snapshots__/agentic_eval/single_turn_with_extracted_entity__cursor-hooks__gpt-5.5-medium.snap.json
+++ b/tests/__snapshots__/agentic_eval/single_turn_with_extracted_entity__cursor-hooks__gpt-5.5-medium.snap.json
@@ -8,22 +8,21 @@
           {
             "client_name": "Cursor",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation",
             "harness": "cursor-hook",
             "hook_event": "beforeSubmitPrompt",
-            "repository_name": "neotoma",
-            "repository_remote": "git@github.com:markmhendrickson/neotoma.git",
-            "repository_root": "/Users/markmhendrickson/repos/neotoma",
-            "scope_summary": "Cursor session in git repository neotoma.",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "scope_summary": "<env>",
             "thread_kind": "human_agent",
-            "title": "Cursor session neotoma",
-            "workspace_kind": "git_repository"
+            "title": "<env>",
+            "workspace_kind": "<env>"
           },
           {
             "content": "Sara Lee said the proposal looks great.",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_message",
             "harness": "cursor",
@@ -51,7 +50,7 @@
           {
             "context_source": "cursor-hook",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -65,7 +64,7 @@
             "started_at": "<ts>",
             "turn_id": "<id:3>",
             "turn_key": "single_turn_with_extracted_entity__cursor-hooks__gpt-5.5-medium:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -78,7 +77,7 @@
         "entities": [
           {
             "content": "Got it — I will note Sara Lee's feedback.",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_message",
             "harness": "cursor",
@@ -100,18 +99,17 @@
           {
             "client_name": "Cursor",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation",
             "harness": "cursor-hook",
             "hook_event": "stop_backfill",
-            "repository_name": "neotoma",
-            "repository_remote": "git@github.com:markmhendrickson/neotoma.git",
-            "repository_root": "/Users/markmhendrickson/repos/neotoma",
-            "scope_summary": "Cursor session in git repository neotoma.",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "scope_summary": "<env>",
             "thread_kind": "human_agent",
-            "title": "Cursor session neotoma",
-            "workspace_kind": "git_repository"
+            "title": "<env>",
+            "workspace_kind": "<env>"
           }
         ],
         "idempotency_key": "<id:6>"
@@ -125,7 +123,7 @@
           {
             "context_source": "cursor-hook",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "diagnosis_confidence": "high",
             "ended_at": "<ts>",
@@ -173,7 +171,7 @@
             "tool_invocation_count": 0,
             "turn_id": "<id:3>",
             "turn_key": "single_turn_with_extracted_entity__cursor-hooks__gpt-5.5-medium:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -190,7 +188,7 @@
       "hook": "stop",
       "exitCode": 0,
       "output": {
-        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: hook state incomplete — No reminders were injected and no tool calls were observed this turn — sessionStart/postToolUse may not be wired up. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Re-run the cursor-hooks installer (`packages/cursor-hooks/scripts/install.mjs`) and confirm `.cursor/hooks.json` references the compiled hooks. Verify NEOTOMA_HOOK_STATE_DIR is writable and that hooks are emitting JSON on stdout. Run `npm run eval:tier1` against `tests/fixtures/agentic_eval/agent_skips_store.json` to spot regressions.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique."
+        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: hook state incomplete — No reminders were injected and no tool calls were observed this turn — sessionStart/postToolUse may not be wired up. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Re-run the cursor-hooks installer (`packages/cursor-hooks/scripts/install.mjs`) and confirm `.cursor/hooks.json` references the compiled hooks. Verify NEOTOMA_HOOK_STATE_DIR is writable and that hooks are emitting JSON on stdout. Run `npm run eval:tier1` against `tests/fixtures/agentic_eval/agent_skips_store.json` to spot regressions.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nForbidden: reusing the user-phase conversation_message `turn_key` for the closing assistant store (must use `{conversation_id}:{turn_id}:assistant`, not the bare `{conversation_id}:{turn_id}`)."
       }
     }
   ]

--- a/tests/__snapshots__/agentic_eval/tool_failure_recovery__cursor-hooks__claude-haiku-4.snap.json
+++ b/tests/__snapshots__/agentic_eval/tool_failure_recovery__cursor-hooks__claude-haiku-4.snap.json
@@ -8,22 +8,21 @@
           {
             "client_name": "Cursor",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation",
             "harness": "cursor-hook",
             "hook_event": "beforeSubmitPrompt",
-            "repository_name": "neotoma",
-            "repository_remote": "git@github.com:markmhendrickson/neotoma.git",
-            "repository_root": "/Users/markmhendrickson/repos/neotoma",
-            "scope_summary": "Cursor session in git repository neotoma.",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "scope_summary": "<env>",
             "thread_kind": "human_agent",
-            "title": "Cursor session neotoma",
-            "workspace_kind": "git_repository"
+            "title": "<env>",
+            "workspace_kind": "<env>"
           },
           {
             "content": "Read /does/not/exist.txt",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_message",
             "harness": "cursor",
@@ -51,7 +50,7 @@
           {
             "context_source": "cursor-hook",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -65,7 +64,7 @@
             "started_at": "<ts>",
             "turn_id": "<id:3>",
             "turn_key": "tool_failure_recovery__cursor-hooks__claude-haiku-4:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -78,7 +77,7 @@
         "entities": [
           {
             "content": "That file does not exist; please check the path.",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_message",
             "harness": "cursor",
@@ -100,18 +99,17 @@
           {
             "client_name": "Cursor",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation",
             "harness": "cursor-hook",
             "hook_event": "stop_backfill",
-            "repository_name": "neotoma",
-            "repository_remote": "git@github.com:markmhendrickson/neotoma.git",
-            "repository_root": "/Users/markmhendrickson/repos/neotoma",
-            "scope_summary": "Cursor session in git repository neotoma.",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "scope_summary": "<env>",
             "thread_kind": "human_agent",
-            "title": "Cursor session neotoma",
-            "workspace_kind": "git_repository"
+            "title": "<env>",
+            "workspace_kind": "<env>"
           }
         ],
         "idempotency_key": "<id:6>"
@@ -125,7 +123,7 @@
           {
             "context_source": "cursor-hook",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "diagnosis_confidence": "high",
             "ended_at": "<ts>",
@@ -173,7 +171,7 @@
             "tool_invocation_count": 0,
             "turn_id": "<id:3>",
             "turn_key": "tool_failure_recovery__cursor-hooks__claude-haiku-4:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -195,7 +193,7 @@
       "hook": "stop",
       "exitCode": 0,
       "output": {
-        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: hook state incomplete — No reminders were injected and no tool calls were observed this turn — sessionStart/postToolUse may not be wired up. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Re-run the cursor-hooks installer (`packages/cursor-hooks/scripts/install.mjs`) and confirm `.cursor/hooks.json` references the compiled hooks. Verify NEOTOMA_HOOK_STATE_DIR is writable and that hooks are emitting JSON on stdout. Run `npm run eval:tier1` against `tests/fixtures/agentic_eval/agent_skips_store.json` to spot regressions.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nNote: this client (claude-haiku-4) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial."
+        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: hook state incomplete — No reminders were injected and no tool calls were observed this turn — sessionStart/postToolUse may not be wired up. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Re-run the cursor-hooks installer (`packages/cursor-hooks/scripts/install.mjs`) and confirm `.cursor/hooks.json` references the compiled hooks. Verify NEOTOMA_HOOK_STATE_DIR is writable and that hooks are emitting JSON on stdout. Run `npm run eval:tier1` against `tests/fixtures/agentic_eval/agent_skips_store.json` to spot regressions.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nForbidden: reusing the user-phase conversation_message `turn_key` for the closing assistant store (must use `{conversation_id}:{turn_id}:assistant`, not the bare `{conversation_id}:{turn_id}`).\nNote: this client (claude-haiku-4) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial."
       }
     }
   ]

--- a/tests/__snapshots__/agentic_eval/tool_failure_recovery__cursor-hooks__claude-sonnet-4.5.snap.json
+++ b/tests/__snapshots__/agentic_eval/tool_failure_recovery__cursor-hooks__claude-sonnet-4.5.snap.json
@@ -8,22 +8,21 @@
           {
             "client_name": "Cursor",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation",
             "harness": "cursor-hook",
             "hook_event": "beforeSubmitPrompt",
-            "repository_name": "neotoma",
-            "repository_remote": "git@github.com:markmhendrickson/neotoma.git",
-            "repository_root": "/Users/markmhendrickson/repos/neotoma",
-            "scope_summary": "Cursor session in git repository neotoma.",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "scope_summary": "<env>",
             "thread_kind": "human_agent",
-            "title": "Cursor session neotoma",
-            "workspace_kind": "git_repository"
+            "title": "<env>",
+            "workspace_kind": "<env>"
           },
           {
             "content": "Read /does/not/exist.txt",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_message",
             "harness": "cursor",
@@ -51,7 +50,7 @@
           {
             "context_source": "cursor-hook",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -65,7 +64,7 @@
             "started_at": "<ts>",
             "turn_id": "<id:3>",
             "turn_key": "tool_failure_recovery__cursor-hooks__claude-sonnet-4.5:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -78,7 +77,7 @@
         "entities": [
           {
             "content": "That file does not exist; please check the path.",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_message",
             "harness": "cursor",
@@ -100,18 +99,17 @@
           {
             "client_name": "Cursor",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation",
             "harness": "cursor-hook",
             "hook_event": "stop_backfill",
-            "repository_name": "neotoma",
-            "repository_remote": "git@github.com:markmhendrickson/neotoma.git",
-            "repository_root": "/Users/markmhendrickson/repos/neotoma",
-            "scope_summary": "Cursor session in git repository neotoma.",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "scope_summary": "<env>",
             "thread_kind": "human_agent",
-            "title": "Cursor session neotoma",
-            "workspace_kind": "git_repository"
+            "title": "<env>",
+            "workspace_kind": "<env>"
           }
         ],
         "idempotency_key": "<id:6>"
@@ -125,7 +123,7 @@
           {
             "context_source": "cursor-hook",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "diagnosis_confidence": "high",
             "ended_at": "<ts>",
@@ -173,7 +171,7 @@
             "tool_invocation_count": 0,
             "turn_id": "<id:3>",
             "turn_key": "tool_failure_recovery__cursor-hooks__claude-sonnet-4.5:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -195,7 +193,7 @@
       "hook": "stop",
       "exitCode": 0,
       "output": {
-        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: hook state incomplete — No reminders were injected and no tool calls were observed this turn — sessionStart/postToolUse may not be wired up. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Re-run the cursor-hooks installer (`packages/cursor-hooks/scripts/install.mjs`) and confirm `.cursor/hooks.json` references the compiled hooks. Verify NEOTOMA_HOOK_STATE_DIR is writable and that hooks are emitting JSON on stdout. Run `npm run eval:tier1` against `tests/fixtures/agentic_eval/agent_skips_store.json` to spot regressions.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique."
+        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: hook state incomplete — No reminders were injected and no tool calls were observed this turn — sessionStart/postToolUse may not be wired up. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Re-run the cursor-hooks installer (`packages/cursor-hooks/scripts/install.mjs`) and confirm `.cursor/hooks.json` references the compiled hooks. Verify NEOTOMA_HOOK_STATE_DIR is writable and that hooks are emitting JSON on stdout. Run `npm run eval:tier1` against `tests/fixtures/agentic_eval/agent_skips_store.json` to spot regressions.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nForbidden: reusing the user-phase conversation_message `turn_key` for the closing assistant store (must use `{conversation_id}:{turn_id}:assistant`, not the bare `{conversation_id}:{turn_id}`)."
       }
     }
   ]

--- a/tests/__snapshots__/agentic_eval/tool_failure_recovery__cursor-hooks__composer-2.snap.json
+++ b/tests/__snapshots__/agentic_eval/tool_failure_recovery__cursor-hooks__composer-2.snap.json
@@ -8,22 +8,21 @@
           {
             "client_name": "Cursor",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation",
             "harness": "cursor-hook",
             "hook_event": "beforeSubmitPrompt",
-            "repository_name": "neotoma",
-            "repository_remote": "git@github.com:markmhendrickson/neotoma.git",
-            "repository_root": "/Users/markmhendrickson/repos/neotoma",
-            "scope_summary": "Cursor session in git repository neotoma.",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "scope_summary": "<env>",
             "thread_kind": "human_agent",
-            "title": "Cursor session neotoma",
-            "workspace_kind": "git_repository"
+            "title": "<env>",
+            "workspace_kind": "<env>"
           },
           {
             "content": "Read /does/not/exist.txt",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_message",
             "harness": "cursor",
@@ -51,7 +50,7 @@
           {
             "context_source": "cursor-hook",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -65,7 +64,7 @@
             "started_at": "<ts>",
             "turn_id": "<id:3>",
             "turn_key": "tool_failure_recovery__cursor-hooks__composer-2:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -78,7 +77,7 @@
         "entities": [
           {
             "content": "That file does not exist; please check the path.",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_message",
             "harness": "cursor",
@@ -100,18 +99,17 @@
           {
             "client_name": "Cursor",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation",
             "harness": "cursor-hook",
             "hook_event": "stop_backfill",
-            "repository_name": "neotoma",
-            "repository_remote": "git@github.com:markmhendrickson/neotoma.git",
-            "repository_root": "/Users/markmhendrickson/repos/neotoma",
-            "scope_summary": "Cursor session in git repository neotoma.",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "scope_summary": "<env>",
             "thread_kind": "human_agent",
-            "title": "Cursor session neotoma",
-            "workspace_kind": "git_repository"
+            "title": "<env>",
+            "workspace_kind": "<env>"
           }
         ],
         "idempotency_key": "<id:6>"
@@ -125,7 +123,7 @@
           {
             "context_source": "cursor-hook",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "diagnosis_confidence": "high",
             "ended_at": "<ts>",
@@ -173,7 +171,7 @@
             "tool_invocation_count": 0,
             "turn_id": "<id:3>",
             "turn_key": "tool_failure_recovery__cursor-hooks__composer-2:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -195,7 +193,7 @@
       "hook": "stop",
       "exitCode": 0,
       "output": {
-        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: hook state incomplete — No reminders were injected and no tool calls were observed this turn — sessionStart/postToolUse may not be wired up. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Re-run the cursor-hooks installer (`packages/cursor-hooks/scripts/install.mjs`) and confirm `.cursor/hooks.json` references the compiled hooks. Verify NEOTOMA_HOOK_STATE_DIR is writable and that hooks are emitting JSON on stdout. Run `npm run eval:tier1` against `tests/fixtures/agentic_eval/agent_skips_store.json` to spot regressions.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nNote: this client (composer-2) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial."
+        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: hook state incomplete — No reminders were injected and no tool calls were observed this turn — sessionStart/postToolUse may not be wired up. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Re-run the cursor-hooks installer (`packages/cursor-hooks/scripts/install.mjs`) and confirm `.cursor/hooks.json` references the compiled hooks. Verify NEOTOMA_HOOK_STATE_DIR is writable and that hooks are emitting JSON on stdout. Run `npm run eval:tier1` against `tests/fixtures/agentic_eval/agent_skips_store.json` to spot regressions.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nForbidden: reusing the user-phase conversation_message `turn_key` for the closing assistant store (must use `{conversation_id}:{turn_id}:assistant`, not the bare `{conversation_id}:{turn_id}`).\nNote: this client (composer-2) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial."
       }
     }
   ]

--- a/tests/__snapshots__/agentic_eval/tool_failure_recovery__cursor-hooks__gpt-5.5-fast.snap.json
+++ b/tests/__snapshots__/agentic_eval/tool_failure_recovery__cursor-hooks__gpt-5.5-fast.snap.json
@@ -8,22 +8,21 @@
           {
             "client_name": "Cursor",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation",
             "harness": "cursor-hook",
             "hook_event": "beforeSubmitPrompt",
-            "repository_name": "neotoma",
-            "repository_remote": "git@github.com:markmhendrickson/neotoma.git",
-            "repository_root": "/Users/markmhendrickson/repos/neotoma",
-            "scope_summary": "Cursor session in git repository neotoma.",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "scope_summary": "<env>",
             "thread_kind": "human_agent",
-            "title": "Cursor session neotoma",
-            "workspace_kind": "git_repository"
+            "title": "<env>",
+            "workspace_kind": "<env>"
           },
           {
             "content": "Read /does/not/exist.txt",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_message",
             "harness": "cursor",
@@ -51,7 +50,7 @@
           {
             "context_source": "cursor-hook",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -65,7 +64,7 @@
             "started_at": "<ts>",
             "turn_id": "<id:3>",
             "turn_key": "tool_failure_recovery__cursor-hooks__gpt-5.5-fast:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -78,7 +77,7 @@
         "entities": [
           {
             "content": "That file does not exist; please check the path.",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_message",
             "harness": "cursor",
@@ -100,18 +99,17 @@
           {
             "client_name": "Cursor",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation",
             "harness": "cursor-hook",
             "hook_event": "stop_backfill",
-            "repository_name": "neotoma",
-            "repository_remote": "git@github.com:markmhendrickson/neotoma.git",
-            "repository_root": "/Users/markmhendrickson/repos/neotoma",
-            "scope_summary": "Cursor session in git repository neotoma.",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "scope_summary": "<env>",
             "thread_kind": "human_agent",
-            "title": "Cursor session neotoma",
-            "workspace_kind": "git_repository"
+            "title": "<env>",
+            "workspace_kind": "<env>"
           }
         ],
         "idempotency_key": "<id:6>"
@@ -125,7 +123,7 @@
           {
             "context_source": "cursor-hook",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "diagnosis_confidence": "high",
             "ended_at": "<ts>",
@@ -173,7 +171,7 @@
             "tool_invocation_count": 0,
             "turn_id": "<id:3>",
             "turn_key": "tool_failure_recovery__cursor-hooks__gpt-5.5-fast:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -195,7 +193,7 @@
       "hook": "stop",
       "exitCode": 0,
       "output": {
-        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: hook state incomplete — No reminders were injected and no tool calls were observed this turn — sessionStart/postToolUse may not be wired up. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Re-run the cursor-hooks installer (`packages/cursor-hooks/scripts/install.mjs`) and confirm `.cursor/hooks.json` references the compiled hooks. Verify NEOTOMA_HOOK_STATE_DIR is writable and that hooks are emitting JSON on stdout. Run `npm run eval:tier1` against `tests/fixtures/agentic_eval/agent_skips_store.json` to spot regressions.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nNote: this client (gpt-5.5-fast) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial."
+        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: hook state incomplete — No reminders were injected and no tool calls were observed this turn — sessionStart/postToolUse may not be wired up. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Re-run the cursor-hooks installer (`packages/cursor-hooks/scripts/install.mjs`) and confirm `.cursor/hooks.json` references the compiled hooks. Verify NEOTOMA_HOOK_STATE_DIR is writable and that hooks are emitting JSON on stdout. Run `npm run eval:tier1` against `tests/fixtures/agentic_eval/agent_skips_store.json` to spot regressions.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nForbidden: reusing the user-phase conversation_message `turn_key` for the closing assistant store (must use `{conversation_id}:{turn_id}:assistant`, not the bare `{conversation_id}:{turn_id}`).\nNote: this client (gpt-5.5-fast) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial."
       }
     }
   ]

--- a/tests/__snapshots__/agentic_eval/tool_failure_recovery__cursor-hooks__gpt-5.5-medium.snap.json
+++ b/tests/__snapshots__/agentic_eval/tool_failure_recovery__cursor-hooks__gpt-5.5-medium.snap.json
@@ -8,22 +8,21 @@
           {
             "client_name": "Cursor",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation",
             "harness": "cursor-hook",
             "hook_event": "beforeSubmitPrompt",
-            "repository_name": "neotoma",
-            "repository_remote": "git@github.com:markmhendrickson/neotoma.git",
-            "repository_root": "/Users/markmhendrickson/repos/neotoma",
-            "scope_summary": "Cursor session in git repository neotoma.",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "scope_summary": "<env>",
             "thread_kind": "human_agent",
-            "title": "Cursor session neotoma",
-            "workspace_kind": "git_repository"
+            "title": "<env>",
+            "workspace_kind": "<env>"
           },
           {
             "content": "Read /does/not/exist.txt",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_message",
             "harness": "cursor",
@@ -51,7 +50,7 @@
           {
             "context_source": "cursor-hook",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -65,7 +64,7 @@
             "started_at": "<ts>",
             "turn_id": "<id:3>",
             "turn_key": "tool_failure_recovery__cursor-hooks__gpt-5.5-medium:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -78,7 +77,7 @@
         "entities": [
           {
             "content": "That file does not exist; please check the path.",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_message",
             "harness": "cursor",
@@ -100,18 +99,17 @@
           {
             "client_name": "Cursor",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation",
             "harness": "cursor-hook",
             "hook_event": "stop_backfill",
-            "repository_name": "neotoma",
-            "repository_remote": "git@github.com:markmhendrickson/neotoma.git",
-            "repository_root": "/Users/markmhendrickson/repos/neotoma",
-            "scope_summary": "Cursor session in git repository neotoma.",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "scope_summary": "<env>",
             "thread_kind": "human_agent",
-            "title": "Cursor session neotoma",
-            "workspace_kind": "git_repository"
+            "title": "<env>",
+            "workspace_kind": "<env>"
           }
         ],
         "idempotency_key": "<id:6>"
@@ -125,7 +123,7 @@
           {
             "context_source": "cursor-hook",
             "conversation_id": "<id:1>",
-            "cwd": "/Users/markmhendrickson/repos/neotoma",
+            "cwd": "<env>",
             "data_source": "cursor-hook",
             "diagnosis_confidence": "high",
             "ended_at": "<ts>",
@@ -173,7 +171,7 @@
             "tool_invocation_count": 0,
             "turn_id": "<id:3>",
             "turn_key": "tool_failure_recovery__cursor-hooks__gpt-5.5-medium:turn-1",
-            "working_directory": "/Users/markmhendrickson/repos/neotoma"
+            "working_directory": "<env>"
           }
         ],
         "idempotency_key": "<id:4>"
@@ -195,7 +193,7 @@
       "hook": "stop",
       "exitCode": 0,
       "output": {
-        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: hook state incomplete — No reminders were injected and no tool calls were observed this turn — sessionStart/postToolUse may not be wired up. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Re-run the cursor-hooks installer (`packages/cursor-hooks/scripts/install.mjs`) and confirm `.cursor/hooks.json` references the compiled hooks. Verify NEOTOMA_HOOK_STATE_DIR is writable and that hooks are emitting JSON on stdout. Run `npm run eval:tier1` against `tests/fixtures/agentic_eval/agent_skips_store.json` to spot regressions.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique."
+        "followup_message": "Neotoma compliance pass: the previous turn skipped the required Neotoma writes. Please re-run this turn now using one batched **`store`** MCP call: (1) bounded retrieval if the user message implied known entities, (2) user-phase store with conversation + user conversation_message + extracted entities + PART_OF/REFERS_TO links, (3) closing assistant store with the exact reply text. Reply with a one-line summary noting the entity_ids stored. Likely cause: hook state incomplete — No reminders were injected and no tool calls were observed this turn — sessionStart/postToolUse may not be wired up. Because this is a Neotoma source checkout, do not stop after backfilling the turn; proactively resolve the repo-owned root cause now when safe. Recommended repairs: Re-run the cursor-hooks installer (`packages/cursor-hooks/scripts/install.mjs`) and confirm `.cursor/hooks.json` references the compiled hooks. Verify NEOTOMA_HOOK_STATE_DIR is writable and that hooks are emitting JSON on stdout. Run `npm run eval:tier1` against `tests/fixtures/agentic_eval/agent_skips_store.json` to spot regressions.\n\nNeotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nForbidden: reusing the user-phase conversation_message `turn_key` for the closing assistant store (must use `{conversation_id}:{turn_id}:assistant`, not the bare `{conversation_id}:{turn_id}`)."
       }
     }
   ]

--- a/tests/helpers/agentic_eval/snapshot.ts
+++ b/tests/helpers/agentic_eval/snapshot.ts
@@ -46,7 +46,17 @@ const ID_KEYS = new Set([
   "idempotency_key",
 ]);
 
-const ENVIRONMENT_KEYS = new Set(["git_branch"]);
+const ENVIRONMENT_KEYS = new Set([
+  "git_branch",
+  "cwd",
+  "repository_root",
+  "repository_remote",
+  "repository_name",
+  "scope_summary",
+  "title",
+  "working_directory",
+  "workspace_kind",
+]);
 
 function scrubValue(value: unknown, ctx: { idMap: Map<string, string>; nextId: { n: number } }): unknown {
   if (value == null) return value;


### PR DESCRIPTION
## Summary

- **opencode-plugin build missing in CI**: Added `npm ci` + `npm run build` steps for `packages/opencode-plugin` to the baseline job; changed dependency from `^0.1.0` (registry) to `file:../client` and added a `package-lock.json` so `npm ci` has a lockfile to work with.

- **inspector submodule pin stale**: Advanced the inspector pin from `4d3125d` to `206e14e`. The new commit adds `--config vite.config.ts` to all four vite scripts (`dev:vite`, `build:vite`, `build:watch`, `preview`). The `package_scripts.test.ts` contract assertion was failing because CI checked out the old pin which lacked the flag.

- **processes_command platform leak**: `buildNeotomaServerSummaries` called `inferLaunchAgentLabel(process.platform, ...)` directly instead of using `options.platform`. On Linux CI, `process.platform` is `"linux"`, so `inferLaunchAgentLabel` returned `"-"` even when the test fixture passed `platform: "darwin"`. Fixed by adding `platform` to the options type and passing it through.

- **agentic_eval snapshot path sensitivity**: Snapshot serializer didn't normalize `cwd`, `repository_root`, `repository_remote`, `repository_name`, `scope_summary`, `title`, `workspace_kind`, or `working_directory`. These recorded machine-local paths and names, causing CI (different path, repo name) to diverge. Added all 8 to `ENVIRONMENT_KEYS` and regenerated all 30 snapshot files.

## Test plan

- [ ] CI `baseline` job passes: `opencode_plugin.test.ts`, `package_scripts.test.ts`, `processes_command.test.ts`, `agentic_eval_matrix.test.ts` all green
- [ ] `inferLaunchAgentLabel` receives `"darwin"` in the test fixture → `launchagent` column shows `"com.neotoma.dev-server"` ✓
- [ ] Snapshot files contain `"<env>"` for all machine-specific fields ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)