### PR TITLE
ci(baseline): install opencode-plugin deps to fix @neotoma/client resolution (#107)

### DIFF
--- a/.github/workflows/ci_test_lanes.yml
+++ b/.github/workflows/ci_test_lanes.yml
@@ -40,6 +40,7 @@ jobs:
           npm run build --prefix packages/client
           npm ci --prefix packages/cursor-hooks
           npm run build --prefix packages/cursor-hooks
+          npm ci --prefix packages/opencode-plugin
 
       - name: Type check
         run: npm run type-check


### PR DESCRIPTION
## Summary

- Adds `npm ci --prefix packages/opencode-plugin` to the "Build @neotoma/client and cursor-hooks" step in `.github/workflows/ci_test_lanes.yml`
- The missing install caused the `@neotoma/client` symlink to never be created inside `packages/opencode-plugin/node_modules`, so `opencode_plugin.test.ts` failed with `Cannot find package '@neotoma/client'` on every PR

## Test plan

- [ ] CI `baseline` job passes on this PR
- [ ] Verify `opencode_plugin.test.ts` runs successfully in the baseline job

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)