### PR TITLE
fix(ci): install opencode-plugin deps so @neotoma/client resolves (#107)

### DIFF
--- a/.github/workflows/ci_test_lanes.yml
+++ b/.github/workflows/ci_test_lanes.yml
@@ -40,6 +40,10 @@ jobs:
           npm run build --prefix packages/client
           npm ci --prefix packages/cursor-hooks
           npm run build --prefix packages/cursor-hooks
+          # opencode-plugin imports @neotoma/client via "file:../client" — its
+          # tests import src/ directly so no build step is needed, but the
+          # node_modules symlink must exist for ESM resolution.
+          npm ci --prefix packages/opencode-plugin
 
       - name: Type check
         run: npm run type-check

--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,8 +61,8 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **344**
-- Backend and repo Vitest files: **311**
+- Total automated test files: **346**
+- Backend and repo Vitest files: **313**
 - Frontend Vitest files: **9**
 - Playwright spec files: **24**
 
@@ -72,7 +72,7 @@ flowchart TD
 | Vitest unit tests | 81 |
 | Vitest service tests | 33 |
 | Source-adjacent tests | 39 |
-| Vitest integration tests | 90 |
+| Vitest integration tests | 92 |
 | Vitest CLI tests | 49 |
 | Vitest contract tests | 10 |
 | Vitest security tests | 1 |
@@ -281,7 +281,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm run test:integration` or `npx vitest run tests/integration`
 **Requirements:** Database configured; remote-dependent subsets additionally need `RUN_REMOTE_TESTS=1`.
-**Files (90):**
+**Files (92):**
 - `tests/integration/aauth_attribution_stamping.test.ts`
 - `tests/integration/aauth_resource_metadata.test.ts`
 - `tests/integration/aauth_revocation_e2e.test.ts`


### PR DESCRIPTION
## Summary

- Adds `npm ci --prefix packages/opencode-plugin` to the `baseline` job's existing build step so the `@neotoma/client` `file:` dependency symlink gets created
- Unblocks `tests/unit/opencode_plugin.test.ts`, which has been failing on `main` and on every open PR with: `Cannot find package '@neotoma/client' imported from packages/opencode-plugin/src/index.ts`
- No build step needed — the test imports `src/` directly, only the `node_modules` symlink

Closes #107

## Test plan

- [ ] CI `baseline` job passes (currently the only failing check on open PRs)
- [ ] No new failures introduced in other lanes

🤖 Generated with [Claude Code](https://claude.com/claude-code)