### PR TITLE
feat(ci): add Claude PR review GitHub Action

### DIFF
--- a/.github/workflows/ci_test_lanes.yml
+++ b/.github/workflows/ci_test_lanes.yml
@@ -40,6 +40,10 @@ jobs:
           npm run build --prefix packages/client
           npm ci --prefix packages/cursor-hooks
           npm run build --prefix packages/cursor-hooks
+          # opencode-plugin imports @neotoma/client via "file:../client" — its
+          # tests import src/ directly so no build step is needed, but the
+          # node_modules symlink must exist for ESM resolution.
+          npm ci --prefix packages/opencode-plugin
 
       - name: Type check
         run: npm run type-check

--- a/.github/workflows/claude_pr_review.yml
+++ b/.github/workflows/claude_pr_review.yml
@@ -1,0 +1,41 @@
+name: Claude PR Review
+
+on:
+  pull_request:
+    types:
+      - ready_for_review
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  review:
+    if: |
+      (github.event_name == 'pull_request' && github.event.pull_request.draft == false) ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request != null &&
+       contains(github.event.comment.body, '@claude review'))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: anthropics/claude-code-action@beta
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          model: claude-opus-4-7
+          trigger_phrase: "@claude review"
+          direct_prompt: |
+            Review this pull request thoroughly. Focus on:
+            - Correctness and logic errors
+            - Architectural boundary violations (State Layer constraints, no strategy/execution logic in Neotoma)
+            - Determinism violations (random IDs, unstable sorts, Date.now() in business logic)
+            - Immutability violations (mutating observations or sources after creation)
+            - Security issues (auth bypasses, PII in logs, unprotected routes)
+            - Missing idempotency_key on mutating operations
+            - Contract surface changes without matching openapi.yaml edits
+            - Test coverage gaps for new behavior
+            - Breaking changes that should be named in a release supplement
+            Be direct and specific. Cite file and line numbers. Skip praise.

--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,8 +61,8 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **344**
-- Backend and repo Vitest files: **311**
+- Total automated test files: **346**
+- Backend and repo Vitest files: **313**
 - Frontend Vitest files: **9**
 - Playwright spec files: **24**
 
@@ -72,7 +72,7 @@ flowchart TD
 | Vitest unit tests | 81 |
 | Vitest service tests | 33 |
 | Source-adjacent tests | 39 |
-| Vitest integration tests | 90 |
+| Vitest integration tests | 92 |
 | Vitest CLI tests | 49 |
 | Vitest contract tests | 10 |
 | Vitest security tests | 1 |
@@ -281,7 +281,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm run test:integration` or `npx vitest run tests/integration`
 **Requirements:** Database configured; remote-dependent subsets additionally need `RUN_REMOTE_TESTS=1`.
-**Files (90):**
+**Files (92):**
 - `tests/integration/aauth_attribution_stamping.test.ts`
 - `tests/integration/aauth_resource_metadata.test.ts`
 - `tests/integration/aauth_revocation_e2e.test.ts`


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/claude_pr_review.yml` using `anthropics/claude-code-action@beta`
- Triggers on `pull_request: ready_for_review` (draft → ready transition) and on `@claude review` comment
- Uses `claude-opus-4-7` — most capable model for catching mistakes from less capable LLMs
- Advisory only: posts review as a PR comment, does not block merge
- Review prompt tuned to Neotoma-specific constraints (State Layer, determinism, immutability, security, contract surfaces)

## Test plan

- [ ] Open a draft PR, flip to ready — confirm Claude posts a review comment
- [ ] Comment `@claude review` on an existing open PR — confirm Claude posts a review comment
- [ ] Confirm the action does NOT trigger on every push to an open PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)