### PR TITLE
fix(site): include neotoma-wordmark.svg in site_pages build output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ public/
 site_pages/assets/
 site_pages/neotoma-hero.png
 site_pages/neotoma-og-1200x630.png
+site_pages/neotoma-wordmark.svg
 .cursor/mcp.json
 .cursor/error_reports/
 docs/developer/mcp.json.example

--- a/scripts/build_github_pages_site.tsx
+++ b/scripts/build_github_pages_site.tsx
@@ -43,6 +43,8 @@ const heroImageSrc = path.join(repoRoot, "frontend", "public", "neotoma-hero.png
 const heroImageDest = path.join(outputDir, "neotoma-hero.png");
 const ogImageSrc = path.join(repoRoot, "frontend", "public", "neotoma-og-1200x630.png");
 const ogImageDest = path.join(outputDir, "neotoma-og-1200x630.png");
+const wordmarkSrc = path.join(repoRoot, "frontend", "public", "neotoma-wordmark.svg");
+const wordmarkDest = path.join(outputDir, "neotoma-wordmark.svg");
 const robotsFile = path.join(outputDir, "robots.txt");
 const sitemapFile = path.join(outputDir, "sitemap.xml");
 const llmsTxtSrc = path.join(repoRoot, "frontend", "public", "llms.txt");
@@ -278,6 +280,10 @@ async function main() {
   if (fs.existsSync(ogImageSrc)) {
     fs.copyFileSync(ogImageSrc, ogImageDest);
     console.log(`Copied OG image: ${path.relative(repoRoot, ogImageDest)}`);
+  }
+  if (fs.existsSync(wordmarkSrc)) {
+    fs.copyFileSync(wordmarkSrc, wordmarkDest);
+    console.log(`Copied wordmark: ${path.relative(repoRoot, wordmarkDest)}`);
   }
   fs.writeFileSync(robotsFile, buildRobotsTxt(), "utf-8");
   fs.writeFileSync(sitemapFile, buildSitemapXml(), "utf-8");

--- a/site_pages/neotoma-wordmark.svg
+++ b/site_pages/neotoma-wordmark.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 224 40" role="img" aria-labelledby="wordmark-title" fill="none">
+  <title id="wordmark-title">Neotoma</title>
+  <text
+    x="0"
+    y="32"
+    font-family="Inter, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+    font-size="36"
+    font-weight="500"
+    letter-spacing="-0.5"
+    fill="#2d3748"
+  >neotoma</text>
+</svg>


### PR DESCRIPTION
## Summary

- The build script (`scripts/build_github_pages_site.tsx`) explicitly copies individual assets from `frontend/public/` to `site_pages/`, but `neotoma-wordmark.svg` was never listed — causing a 404 for `/neotoma-wordmark.svg` on neotoma.io and breaking the nav/footer logo.
- Added `wordmarkSrc`/`wordmarkDest` constants and a `fs.copyFileSync` block alongside the other named image copies so future builds include it automatically.
- Added `site_pages/neotoma-wordmark.svg` directly to fix the currently deployed site immediately on merge.

## Test plan

- [ ] Verify `neotoma.io` logo renders after merge (no broken image icon in nav)
- [ ] Run `npm run build:site:pages` locally and confirm `site_pages/neotoma-wordmark.svg` is present in the output

🤖 Generated with [Claude Code](https://claude.com/claude-code)