### PR TITLE
fix(test): add @neotoma/client alias to vitest resolver

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -45,6 +45,7 @@ export default defineConfig({
     alias: {
       "@": path.resolve(__dirname, "./frontend/src"),
       "@shared": path.resolve(__dirname, "./src/shared"),
+      "@neotoma/client": path.resolve(__dirname, "./packages/client/src/index.ts"),
     },
   },
   test: {


### PR DESCRIPTION
## Summary

- Adds `@neotoma/client` to `resolve.alias` in `vitest.config.ts`, pointing to `packages/client/src/index.ts`
- Fixes the sole failure in the `baseline` CI job for PR #104 ([run 25900149162](https://github.com/markmhendrickson/neotoma/actions/runs/25900149162/job/76121596245))

## Root cause

`tests/unit/opencode_plugin.test.ts` imports `packages/opencode-plugin/src/index.ts` directly (TS source). That source imports `@neotoma/client` by package name. Vitest's module resolver had aliases for `@` and `@shared` but not `@neotoma/client`, so it failed to resolve the package — even though the CI "Build @neotoma/client" step ran successfully (it only produced the dist; Vitest resolves from source via aliases, not `node_modules` symlinks for workspace `file:` deps).

## What changed

`vitest.config.ts` — one line added to `resolve.alias`:

```ts
"@neotoma/client": path.resolve(__dirname, "./packages/client/src/index.ts"),
```

## Test plan

- [ ] `npx vitest run tests/unit/opencode_plugin.test.ts` passes (4/4 locally verified)
- [ ] Baseline CI job passes on this PR