### PR TITLE
feat(cursor-hooks): add --global flag to install into ~/.cursor/hooks.json

### DIFF
--- a/packages/cursor-hooks/README.md
+++ b/packages/cursor-hooks/README.md
@@ -16,13 +16,28 @@ No LLM-based extraction runs in the hook layer — that stays with the agent via
 
 ## Install
 
+**Global install** (recommended — applies to every Cursor workspace):
+
 ```bash
-# From the project where you want Cursor to use Neotoma
+npm install --save-dev @neotoma/cursor-hooks @neotoma/client
+npx @neotoma/cursor-hooks install --global
+```
+
+This merges Neotoma entries into `~/.cursor/hooks.json`, which Cursor loads for every project. To remove:
+
+```bash
+npx @neotoma/cursor-hooks --uninstall --global
+```
+
+**Per-project install** (add hooks only to the current workspace):
+
+```bash
+# From the project root
 npm install --save-dev @neotoma/cursor-hooks @neotoma/client
 npx @neotoma/cursor-hooks install
 ```
 
-This writes Neotoma entries into `.cursor/hooks.json` in the current directory, merging with anything already there. To remove:
+This writes to `.cursor/hooks.json` in the current directory. To remove:
 
 ```bash
 npx @neotoma/cursor-hooks --uninstall
@@ -38,7 +53,7 @@ npx @neotoma/cursor-hooks --uninstall
 | Env var | Default | Purpose |
 | --- | --- | --- |
 | `NEOTOMA_BASE_URL` | `http://127.0.0.1:3080` | Neotoma API root. |
-| `NEOTOMA_TOKEN` | `dev-local` | Auth token. |
+| `NEOTOMA_TOKEN` | (unset) | Auth token. Omit for anonymous access to a local dev server; set to a registered Bearer token for authenticated instances. |
 | `NEOTOMA_LOG_LEVEL` | `warn` | `debug` \| `info` \| `warn` \| `error` \| `silent`. |
 | `NEOTOMA_HOOK_FEEDBACK_HINT` | `on` | Set to `off` to disable the one-shot failure hint surfaced by `postToolUse`. |
 | `NEOTOMA_HOOK_FEEDBACK_HINT_THRESHOLD` | `2` | Minimum repeated-failure count for `(tool, error_class)` before a hint is surfaced. |

--- a/packages/cursor-hooks/scripts/install.mjs
+++ b/packages/cursor-hooks/scripts/install.mjs
@@ -1,11 +1,13 @@
 #!/usr/bin/env node
 /**
- * Installs or removes Neotoma hooks in a Cursor project.
+ * Installs or removes Neotoma hooks in a Cursor project or globally.
  *
  * Usage:
- *   npx @neotoma/cursor-hooks install         # add to .cursor/hooks.json in cwd
- *   npx @neotoma/cursor-hooks install --path  # custom project root
+ *   npx @neotoma/cursor-hooks install           # add to .cursor/hooks.json in cwd
+ *   npx @neotoma/cursor-hooks install --global  # add to ~/.cursor/hooks.json
+ *   npx @neotoma/cursor-hooks install --path <dir>  # custom project root
  *   npx @neotoma/cursor-hooks --uninstall
+ *   npx @neotoma/cursor-hooks --uninstall --global
  *
  * The script merges Neotoma's hook entries into any existing hooks.json
  * so it plays nicely with hooks another tool may have installed.
@@ -13,6 +15,7 @@
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
+import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -20,11 +23,13 @@ const packageRoot = resolve(__dirname, "..");
 const templatePath = join(packageRoot, "hooks.template.json");
 
 function parseArgs(argv) {
-  const args = { uninstall: false, projectRoot: process.cwd() };
+  const args = { uninstall: false, global: false, projectRoot: process.cwd() };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === "--uninstall" || arg === "uninstall") {
       args.uninstall = true;
+    } else if (arg === "--global" || arg === "-g") {
+      args.global = true;
     } else if (arg === "--path" && argv[i + 1]) {
       args.projectRoot = resolve(argv[i + 1]);
       i += 1;
@@ -39,10 +44,12 @@ function parseArgs(argv) {
 }
 
 function printHelp() {
-  console.log(`Usage: neotoma-cursor-hooks [install|--uninstall] [--path <dir>]
+  console.log(`Usage: neotoma-cursor-hooks [install|--uninstall] [--global] [--path <dir>]
 
-Installs Neotoma hooks into .cursor/hooks.json in the target project.
-Defaults to the current directory.`);
+Installs Neotoma hooks into .cursor/hooks.json.
+  --global   Target ~/.cursor/hooks.json (Cursor's global config) instead of the project directory.
+  --path     Custom project root (ignored when --global is set).
+Defaults to the current working directory.`);
 }
 
 function loadExistingHooks(hooksFile) {
@@ -116,8 +123,9 @@ function removeNeotoma(existing) {
 
 function main() {
   const args = parseArgs(process.argv.slice(2));
-  const projectRoot = args.projectRoot;
-  const cursorDir = join(projectRoot, ".cursor");
+  const cursorDir = args.global
+    ? join(homedir(), ".cursor")
+    : join(args.projectRoot, ".cursor");
   const hooksFile = join(cursorDir, "hooks.json");
 
   mkdirSync(cursorDir, { recursive: true });


### PR DESCRIPTION
## Summary

- Adds `--global` / `-g` flag to `install.mjs` so users can install Neotoma hooks into `~/.cursor/hooks.json` (Cursor's global config that applies to every workspace) rather than only per-project
- Updates README to recommend `--global` as the primary install path, with per-project as the secondary option
- Fixes stale `NEOTOMA_TOKEN` default in README docs (was documented as `dev-local`; the server rejects that token — correct default is unset/anonymous)

## Motivation

The root cause of a user's Cursor hooks being incomplete: `stop` was wired manually into `~/.cursor/hooks.json` early on, the other hooks were added to the package later, and there was no way to re-run the installer against the global file without hand-editing it. The `--global` flag closes that gap.

## Test plan

- [ ] `node scripts/install.mjs --help` shows `--global` in usage
- [ ] `node scripts/install.mjs install --global` writes all hooks to `~/.cursor/hooks.json`
- [ ] `node scripts/install.mjs --uninstall --global` removes Neotoma entries from `~/.cursor/hooks.json`
- [ ] `node scripts/install.mjs install --global --path /some/ignored/path` ignores `--path` and writes to global
- [ ] Running install twice is idempotent (existing Neotoma entries replaced, not duplicated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)