### PR TITLE
feat(issues): add entity_ids_to_link to submit_issue and add_issue_message for server-side REFERS_TO linking (#131)

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4189,6 +4189,14 @@ paths:
                   description: |
                     Soft requirement on public issue threads (server emits a warning when both
                     `reporter_git_sha` and `reporter_app_version` are missing).
+                entity_ids_to_link:
+                  type: array
+                  items:
+                    type: string
+                    minLength: 1
+                  description: >
+                    Entity IDs to link to the issue entity via REFERS_TO relationships.
+                    Created server-side in the same operation as the message is stored.
                 user_id:
                   type: string
               description: |
@@ -4298,6 +4306,14 @@ paths:
                 submission_timestamp:
                   type: string
                   description: Guest submitter timestamp used for deterministic local thread identity.
+                entity_ids_to_link:
+                  type: array
+                  items:
+                    type: string
+                    minLength: 1
+                  description: >
+                    Entity IDs to link to this issue via REFERS_TO relationships.
+                    Created server-side in the same operation as issue creation.
                 user_id:
                   type: string
       responses:

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -7996,6 +7996,7 @@ const handleIssuesAddMessageHttp: express.RequestHandler = async (req, res) => {
               ...(parsed.data.reporter_git_ref ? { reporter_git_ref: parsed.data.reporter_git_ref } : {}),
               ...(parsed.data.reporter_channel ? { reporter_channel: parsed.data.reporter_channel } : {}),
               ...(parsed.data.reporter_app_version ? { reporter_app_version: parsed.data.reporter_app_version } : {}),
+              ...(parsed.data.entity_ids_to_link ? { entity_ids_to_link: parsed.data.entity_ids_to_link } : {}),
             });
       logDebug("Success:issues_add_message", req, { message_entity_id: result.message_entity_id });
       return res.json(result);
@@ -8083,6 +8084,7 @@ const handleIssuesSubmitHttp: express.RequestHandler = async (req, res) => {
           reporter_app_version: parsed.data.reporter_app_version,
           reporter_ci_run_id: parsed.data.reporter_ci_run_id,
           reporter_patch_source_id: parsed.data.reporter_patch_source_id,
+          ...(parsed.data.entity_ids_to_link ? { entity_ids_to_link: parsed.data.entity_ids_to_link } : {}),
         });
       })();
       logDebug("Success:issues_submit", req, { entity_id: result.entity_id });

--- a/src/server.ts
+++ b/src/server.ts
@@ -980,6 +980,7 @@ export class NeotomaServer {
       reporter_app_version: z.string().optional(),
       reporter_ci_run_id: z.string().optional(),
       reporter_patch_source_id: z.string().optional(),
+      entity_ids_to_link: z.array(z.string().min(1)).optional(),
     });
     const parsed = schema.parse(args ?? {});
 
@@ -1002,6 +1003,7 @@ export class NeotomaServer {
         reporter_app_version: parsed.reporter_app_version,
         reporter_ci_run_id: parsed.reporter_ci_run_id,
         reporter_patch_source_id: parsed.reporter_patch_source_id,
+        ...(parsed.entity_ids_to_link ? { entity_ids_to_link: parsed.entity_ids_to_link } : {}),
       });
 
       return this.buildTextResponse({
@@ -1169,6 +1171,7 @@ export class NeotomaServer {
         reporter_git_ref: z.string().optional(),
         reporter_channel: z.string().optional(),
         reporter_app_version: z.string().optional(),
+        entity_ids_to_link: z.array(z.string().min(1)).optional(),
       })
       .refine(
         (v) =>
@@ -1193,6 +1196,7 @@ export class NeotomaServer {
         ...(parsed.reporter_git_ref ? { reporter_git_ref: parsed.reporter_git_ref } : {}),
         ...(parsed.reporter_channel ? { reporter_channel: parsed.reporter_channel } : {}),
         ...(parsed.reporter_app_version ? { reporter_app_version: parsed.reporter_app_version } : {}),
+        ...(parsed.entity_ids_to_link ? { entity_ids_to_link: parsed.entity_ids_to_link } : {}),
       });
       return this.buildTextResponse(result);
     } catch (err: any) {

--- a/src/services/issues/issue_operations.test.ts
+++ b/src/services/issues/issue_operations.test.ts
@@ -307,6 +307,66 @@ describe("Issue Operations (Neotoma-canonical)", () => {
       expect(result.submitted_to_neotoma).toBe(false);
       expect(result.pushed_to_github).toBe(true);
     });
+
+    it("creates REFERS_TO relationships when entity_ids_to_link is provided", async () => {
+      mockCreateIssue.mockResolvedValue({
+        number: 77,
+        html_url: "https://github.com/test/repo/issues/77",
+        user: { login: "tester" },
+        created_at: "2026-05-01T00:00:00Z",
+      });
+      mockSubmitIssueToRemote.mockResolvedValue({
+        entity_ids: ["remote-issue-1", "remote-conv-1"],
+        issue_entity_id: "remote-issue-1",
+        conversation_id: "remote-conv-1",
+        access_token: "tok",
+      });
+
+      const mockCreateRelationships = vi.fn().mockResolvedValue({});
+      ops = { ...ops, createRelationships: mockCreateRelationships } as unknown as typeof ops;
+
+      await submitIssue(ops, {
+        title: "Linked Issue",
+        body: "Issue body",
+        visibility: "public",
+        reporter_git_sha: "abc1234",
+        entity_ids_to_link: ["entity-a", "entity-b"],
+      });
+
+      expect(mockCreateRelationships).toHaveBeenCalledWith({
+        relationships: [
+          { relationship_type: "REFERS_TO", source_entity_id: "local-issue-1", target_entity_id: "entity-a" },
+          { relationship_type: "REFERS_TO", source_entity_id: "local-issue-1", target_entity_id: "entity-b" },
+        ],
+      });
+    });
+
+    it("does not call createRelationships when entity_ids_to_link is absent", async () => {
+      mockCreateIssue.mockResolvedValue({
+        number: 78,
+        html_url: "https://github.com/test/repo/issues/78",
+        user: { login: "tester" },
+        created_at: "2026-05-01T00:00:00Z",
+      });
+      mockSubmitIssueToRemote.mockResolvedValue({
+        entity_ids: ["remote-issue-2"],
+        issue_entity_id: "remote-issue-2",
+        conversation_id: "remote-conv-2",
+      });
+
+      const mockCreateRelationships = vi.fn().mockResolvedValue({});
+      ops = { ...ops, createRelationships: mockCreateRelationships } as unknown as typeof ops;
+
+      const result = await submitIssue(ops, {
+        title: "No Link Issue",
+        body: "Issue body",
+        visibility: "public",
+        reporter_git_sha: "abc1234",
+      });
+
+      expect(mockCreateRelationships).not.toHaveBeenCalled();
+      expect(result.entity_id).toBeTruthy();
+    });
   });
 
   describe("submitGuestIssue", () => {
@@ -535,6 +595,34 @@ describe("Issue Operations (Neotoma-canonical)", () => {
       expect(result.remote_submission_error).toMatch(
         /Remote issue message submission to https:\/\/neotoma\.example\.com failed: ECONNREFUSED/,
       );
+    });
+
+    it("creates REFERS_TO relationships when entity_ids_to_link is provided (local store path)", async () => {
+      mockLoadIssuesConfig.mockResolvedValue({ ...defaultIssuesConfig, target_url: "" });
+      mockAddIssueComment.mockResolvedValue({
+        id: 999,
+        body: "test",
+        user: { login: "tester" },
+        created_at: "2026-05-01T00:00:00Z",
+        updated_at: "2026-05-01T00:00:00Z",
+        html_url: "https://github.com/test/repo/issues/1#issuecomment-999",
+      });
+
+      const mockCreateRelationships = vi.fn().mockResolvedValue({});
+      ops = { ...ops, createRelationships: mockCreateRelationships } as unknown as typeof ops;
+
+      await addIssueMessage(ops, {
+        entity_id: "local-issue-1",
+        body: "Test message",
+        entity_ids_to_link: ["target-entity-x", "target-entity-y"],
+      });
+
+      expect(mockCreateRelationships).toHaveBeenCalledWith({
+        relationships: [
+          { relationship_type: "REFERS_TO", source_entity_id: "local-issue-1", target_entity_id: "target-entity-x" },
+          { relationship_type: "REFERS_TO", source_entity_id: "local-issue-1", target_entity_id: "target-entity-y" },
+        ],
+      });
     });
   });
 

--- a/src/services/issues/issue_operations.ts
+++ b/src/services/issues/issue_operations.ts
@@ -912,6 +912,21 @@ export async function submitIssue(
   const entityId = structuredEntityIdAt(storeResult, 0);
   const conversationId = structuredEntityIdAt(storeResult, 1);
 
+  // Create REFERS_TO relationships from the issue entity to caller-provided entity IDs.
+  const entityIdsToLink = Array.isArray(params.entity_ids_to_link)
+    ? params.entity_ids_to_link.filter((id): id is string => typeof id === "string" && id.trim().length > 0)
+    : [];
+  if (entityId && entityIdsToLink.length > 0) {
+    const relationships: import("../../core/operations.js").CreateRelationshipInput[] = entityIdsToLink.map(
+      (targetId) => ({
+        relationship_type: "REFERS_TO" as const,
+        source_entity_id: entityId,
+        target_entity_id: targetId.trim(),
+      }),
+    );
+    await ops.createRelationships({ relationships });
+  }
+
   let remoteSubmissionErrorMessage: string | null = null;
   if (remoteSubmissionAttempted && !submittedToNeotoma) {
     const cause = remoteSubmissionError?.message ?? "unknown error";
@@ -1052,6 +1067,22 @@ export async function addIssueMessage(
       author: "remote",
       idempotencyKey: `issue-shadow-message-activity-${issueEntityId}-${remoteMessageEntityId || now}`,
     });
+
+    // Create REFERS_TO relationships from the issue entity to caller-provided entity IDs.
+    const entityIdsToLinkRemote = Array.isArray(params.entity_ids_to_link)
+      ? params.entity_ids_to_link.filter((id): id is string => typeof id === "string" && id.trim().length > 0)
+      : [];
+    if (entityIdsToLinkRemote.length > 0) {
+      const rels: import("../../core/operations.js").CreateRelationshipInput[] = entityIdsToLinkRemote.map(
+        (targetId) => ({
+          relationship_type: "REFERS_TO" as const,
+          source_entity_id: issueEntityId,
+          target_entity_id: targetId.trim(),
+        }),
+      );
+      await ops.createRelationships({ relationships: rels });
+    }
+
     return {
       github_comment_id: null,
       message_entity_id: remoteMessageEntityId,
@@ -1115,6 +1146,21 @@ export async function addIssueMessage(
       idempotencyKey: `issue-message-activity-${issueEntityId}-${commentKey}`,
     }),
   );
+
+  // Create REFERS_TO relationships from the issue entity to caller-provided entity IDs.
+  const entityIdsToLink = Array.isArray(params.entity_ids_to_link)
+    ? params.entity_ids_to_link.filter((id): id is string => typeof id === "string" && id.trim().length > 0)
+    : [];
+  if (entityIdsToLink.length > 0) {
+    const rels: import("../../core/operations.js").CreateRelationshipInput[] = entityIdsToLink.map(
+      (targetId) => ({
+        relationship_type: "REFERS_TO" as const,
+        source_entity_id: issueEntityId,
+        target_entity_id: targetId.trim(),
+      }),
+    );
+    await ops.createRelationships({ relationships: rels });
+  }
 
   const remoteSubmissionErrorMessage =
     remoteSubmissionAttempted && !submittedToNeotoma

--- a/src/services/issues/types.ts
+++ b/src/services/issues/types.ts
@@ -31,6 +31,11 @@ export interface IssueCreateParams {
   reporter_app_version?: string;
   reporter_ci_run_id?: string;
   reporter_patch_source_id?: string;
+  /**
+   * Optional entity IDs to link to the created issue entity via REFERS_TO relationships.
+   * Created server-side in the same operation as issue creation.
+   */
+  entity_ids_to_link?: string[];
 }
 
 export interface IssueMessageParams {
@@ -56,6 +61,11 @@ export interface IssueMessageParams {
   reporter_git_ref?: string;
   reporter_channel?: string;
   reporter_app_version?: string;
+  /**
+   * Optional entity IDs to link to the issue entity via REFERS_TO relationships.
+   * Created server-side in the same operation as the message is stored.
+   */
+  entity_ids_to_link?: string[];
 }
 
 export interface IssueSyncParams {

--- a/src/shared/action_schemas.ts
+++ b/src/shared/action_schemas.ts
@@ -645,6 +645,7 @@ export const IssuesAddMessageRequestSchema = z
     reporter_git_ref: z.string().optional(),
     reporter_channel: z.string().optional(),
     reporter_app_version: z.string().optional(),
+    entity_ids_to_link: z.array(z.string().min(1)).optional(),
     user_id: z.string().optional(),
   })
   .refine(
@@ -671,6 +672,7 @@ export const IssuesSubmitRequestSchema = z.object({
   author: z.string().optional(),
   local_issue_id: z.string().optional(),
   submission_timestamp: z.string().optional(),
+  entity_ids_to_link: z.array(z.string().min(1)).optional(),
   user_id: z.string().optional(),
 });
 

--- a/src/shared/openapi_types.ts
+++ b/src/shared/openapi_types.ts
@@ -5192,6 +5192,8 @@ export interface operations {
                      *     `reporter_git_sha` and `reporter_app_version` are missing).
                      */
                     reporter_app_version?: string;
+                    /** @description Entity IDs to link to the issue entity via REFERS_TO relationships. Created server-side in the same operation as the message is stored. */
+                    entity_ids_to_link?: string[];
                     user_id?: string;
                 };
             };
@@ -5251,6 +5253,8 @@ export interface operations {
                     local_issue_id?: string;
                     /** @description Guest submitter timestamp used for deterministic local thread identity. */
                     submission_timestamp?: string;
+                    /** @description Entity IDs to link to this issue via REFERS_TO relationships. Created server-side in the same operation as issue creation. */
+                    entity_ids_to_link?: string[];
                     user_id?: string;
                 };
             };


### PR DESCRIPTION
## Summary

- Adds optional `entity_ids_to_link` parameter (array of entity ID strings) to both `submit_issue` and `add_issue_message` MCP tools and their HTTP counterparts (`POST /issues/submit`, `POST /issues/add_message`).
- When provided, the server creates `REFERS_TO` relationships from the issue entity to each listed entity ID immediately after the primary store operation, in the same request — no second round-trip needed.
- Implemented OpenAPI-first: `openapi.yaml` edited first, types regenerated with `npm run openapi:generate`, then handlers updated.
- Parameter is fully optional; all existing callers are unaffected.

## Key files changed

- `openapi.yaml` — new `entity_ids_to_link` field on `issuesSubmit` and `issuesAddMessage` request schemas
- `src/shared/openapi_types.ts` — regenerated
- `src/services/issues/types.ts` — field added to `IssueCreateParams` and `IssueMessageParams`
- `src/services/issues/issue_operations.ts` — `ops.createRelationships` called after store in both `submitIssue` and `addIssueMessage` (both the remote-only early-return path and the local store path)
- `src/shared/action_schemas.ts` — Zod validation schemas updated for HTTP layer
- `src/actions.ts` — HTTP handler passes field through
- `src/server.ts` — MCP tool schemas updated for both tools

## Test plan

- [x] `npm run type-check` passes
- [x] All 30 tests in `src/services/issues/issue_operations.test.ts` pass
- [x] 3 new unit tests added:
  - `submitIssue` with `entity_ids_to_link` calls `createRelationships` with correct REFERS_TO edges
  - `submitIssue` without `entity_ids_to_link` does not call `createRelationships` (no regression)
  - `addIssueMessage` with `entity_ids_to_link` calls `createRelationships` with correct edges

Fixes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)