### PR TITLE
feat(schema): add feedback_source discriminator and identity validation to product_feedback (#136 #137)

### DIFF
--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,15 +61,15 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **367**
-- Backend and repo Vitest files: **334**
+- Total automated test files: **369**
+- Backend and repo Vitest files: **336**
 - Frontend Vitest files: **9**
 - Playwright spec files: **24**
 
 ### Suite counts
 | Suite | Files |
 |---|---:|
-| Vitest unit tests | 88 |
+| Vitest unit tests | 89 |
 | Vitest service tests | 33 |
 | Source-adjacent tests | 45 |
 | Vitest integration tests | 95 |
@@ -107,7 +107,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/unit`
 **Requirements:** Basic `.env` if required by the module under test.
-**Files (88):**
+**Files (89):**
 - `tests/unit/aauth_admission.test.ts`
 - `tests/unit/aauth_attestation_apple_se.test.ts`
 - `tests/unit/aauth_attestation_revocation.test.ts`
@@ -173,6 +173,7 @@ flowchart TD
 - `tests/unit/observation_reducer_provenance.test.ts`
 - `tests/unit/opencode_plugin.test.ts`
 - `tests/unit/parquet_reader.test.ts`
+- `tests/unit/product_feedback_schema.test.ts`
 - `tests/unit/protected_entity_types.test.ts`
 - `tests/unit/relationship_batch_schemas.test.ts`
 - `tests/unit/relationship_reducer.test.ts`

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -6459,6 +6459,44 @@ export async function storeStructuredForApi(params: {
     }
   }
 
+  // Schema-driven store_warnings: emit non-blocking warnings declared in the
+  // schema when none of the listed fields are present in the observation payload.
+  // These are schema-agnostic — no per-type branches here; the schema drives it.
+  const schemaStoreWarnings: Array<{
+    code: string;
+    message: string;
+    observation_index: number;
+    entity_type: string;
+    entity_id: string;
+  }> = [];
+  {
+    const { schemaRegistry } = await import("./services/schema_registry.js");
+    for (const r of resolved) {
+      let schemaEntry;
+      try {
+        schemaEntry = await schemaRegistry.loadActiveSchema(r.entity_type, userId);
+      } catch {
+        // Best-effort; never block store on registry IO failure.
+      }
+      const storeWarningRules = schemaEntry?.schema_definition?.store_warnings;
+      if (!storeWarningRules?.length) continue;
+      for (const rule of storeWarningRules) {
+        const hasIdentityField = rule.fields.some(
+          (f) => r.fields[f] !== undefined && r.fields[f] !== null && r.fields[f] !== "",
+        );
+        if (!hasIdentityField) {
+          schemaStoreWarnings.push({
+            code: rule.code,
+            message: rule.message,
+            observation_index: r.observation_index,
+            entity_type: r.entity_type,
+            entity_id: r.entity_id,
+          });
+        }
+      }
+    }
+  }
+
   if (commit && interpretationId) {
     await completeInterpretationRun({
       interpretationId,
@@ -6482,6 +6520,7 @@ export async function storeStructuredForApi(params: {
     entities: createdEntities,
     relationships_created: relationshipsCreated,
     ...(aggregatedWarnings.length > 0 ? { warnings: aggregatedWarnings } : {}),
+    ...(schemaStoreWarnings.length > 0 ? { store_warnings: schemaStoreWarnings } : {}),
   };
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -4364,6 +4364,8 @@ export class NeotomaServer {
       identityRule: string;
       action: string;
     }> = [];
+    // Track the resolved fields per observation index for schema-driven store_warnings.
+    const resolvedFieldsByIndex = new Map<number, Record<string, unknown>>();
     const insertedObservationIds = new Set<string>();
     let unknownFieldsCount = 0;
 
@@ -4715,6 +4717,7 @@ export class NeotomaServer {
         insertedObservationIds.add(observationId);
       }
 
+      resolvedFieldsByIndex.set(createdEntities.length, fieldsToValidate as Record<string, unknown>);
       createdEntities.push({
         entityId,
         entityType,
@@ -4942,6 +4945,43 @@ export class NeotomaServer {
       createdEntities.map((e) => e.entityId)
     );
 
+    // Schema-driven store_warnings: non-blocking warnings declared in the schema
+    // when none of the listed fields are present in the observation payload.
+    // Schema-agnostic — no per-type branches; the schema drives it.
+    const schemaStoreWarnings: Array<{
+      code: string;
+      message: string;
+      observation_index: number;
+      entity_type: string;
+      entity_id: string;
+    }> = [];
+    for (let i = 0; i < createdEntities.length; i++) {
+      const e = createdEntities[i];
+      const entityFields = resolvedFieldsByIndex.get(i) ?? {};
+      let schemaEntry;
+      try {
+        schemaEntry = await schemaRegistry.loadActiveSchema(e.entityType, userId);
+      } catch {
+        // Best-effort; never block store on registry IO failure.
+      }
+      const storeWarningRules = schemaEntry?.schema_definition?.store_warnings;
+      if (!storeWarningRules?.length) continue;
+      for (const rule of storeWarningRules) {
+        const hasIdentityField = rule.fields.some(
+          (f) => entityFields[f] !== undefined && entityFields[f] !== null && entityFields[f] !== "",
+        );
+        if (!hasIdentityField) {
+          schemaStoreWarnings.push({
+            code: rule.code,
+            message: rule.message,
+            observation_index: i,
+            entity_type: e.entityType,
+            entity_id: e.entityId,
+          });
+        }
+      }
+    }
+
     return this.buildTextResponse({
       source_id: storageResult.sourceId,
       entities: createdEntities.map((e, idx) => ({
@@ -4959,6 +4999,7 @@ export class NeotomaServer {
       unknown_fields_count: unknownFieldsCount,
       related_entities: relatedData.entities,
       related_relationships: relatedData.relationships,
+      ...(schemaStoreWarnings.length > 0 ? { store_warnings: schemaStoreWarnings } : {}),
     });
   }
 

--- a/src/services/schema_definitions.ts
+++ b/src/services/schema_definitions.ts
@@ -2921,6 +2921,84 @@ export const ENTITY_SCHEMAS: Record<string, EntitySchema> = {
       },
     },
   },
+
+  product_feedback: {
+    entity_type: "product_feedback",
+    schema_version: "1.0",
+    metadata: {
+      label: "Product Feedback",
+      description:
+        "User-reported or internally-filed feedback about product features, bugs, or UX. " +
+        "Use feedback_source to distinguish internal engineering observations from external " +
+        "user reports so they can be queried and triaged independently.",
+      category: "knowledge",
+      aliases: ["feedback", "user_feedback", "feature_request", "bug_report"],
+    },
+    schema_definition: {
+      fields: {
+        schema_version: { type: "string", required: false },
+        // Discriminator — distinguishes internal engineering notes from external user reports.
+        // Allowed values: "internal" | "external"
+        feedback_source: {
+          type: "string",
+          required: false,
+          description: 'Discriminator for feedback origin. Use "internal" for engineering/team ' +
+            'observations and "external" for reports from end users or beta testers.',
+        },
+        title: { type: "string", required: false, preserveCase: true },
+        content: { type: "string", required: false, preserveCase: true },
+        // External-actor identity fields. At least one should be present for external feedback.
+        reporter_email: { type: "string", required: false },
+        reporter_name: { type: "string", required: false },
+        reporter_id: { type: "string", required: false },
+        // Categorisation and routing
+        category: { type: "string", required: false },
+        severity: { type: "string", required: false },
+        status: { type: "string", required: false },
+        product_area: { type: "string", required: false },
+        // Timestamps
+        submitted_at: { type: "date", required: false },
+        resolved_at: { type: "date", required: false },
+      },
+      // R2: feedback items are identified by a combination of reporter and title
+      // when both are present; title alone is the fallback for anonymous submissions.
+      canonical_name_fields: [
+        { composite: ["reporter_email", "title"] },
+        { composite: ["reporter_id", "title"] },
+        { composite: ["reporter_name", "title"] },
+        "title",
+      ],
+      agent_instructions:
+        "product_feedback entities carry a `feedback_source` discriminator field.\n" +
+        '- `"internal"` — filed by the engineering team or internal stakeholders.\n' +
+        '- `"external"` — submitted by an end user or beta tester.\n' +
+        "Always surface `feedback_source` when presenting or summarising feedback so that " +
+        "internal observations are not confused with user-reported issues. " +
+        "For external feedback, also surface `reporter_email`, `reporter_name`, or " +
+        "`reporter_id` when present to preserve attribution.",
+      // Emit a non-blocking warning when feedback is stored without any identity or
+      // source discriminator — this is the most common cause of internal artifacts
+      // being mixed with external user reports in queries (#136 / #137).
+      store_warnings: [
+        {
+          code: "MISSING_IDENTITY_FIELDS",
+          fields: ["feedback_source", "reporter_email", "reporter_name", "reporter_id"],
+          message:
+            "product_feedback stored without identity fields " +
+            "(feedback_source, reporter_email, reporter_name, reporter_id); " +
+            "consider adding at least one to distinguish internal from external feedback",
+        },
+      ],
+    },
+    reducer_config: {
+      merge_policies: {
+        status: { strategy: "last_write" },
+        severity: { strategy: "last_write" },
+        resolved_at: { strategy: "last_write" },
+        content: { strategy: "highest_priority" },
+      },
+    },
+  },
 };
 
 /**

--- a/src/services/schema_registry.ts
+++ b/src/services/schema_registry.ts
@@ -223,6 +223,34 @@ export interface SchemaDefinition {
    * Must be a non-empty string when present.
    */
   agent_instructions?: string;
+
+  /**
+   * Declarative store-time warnings emitted when an observation payload is
+   * missing expected fields. Each entry describes one warning: if none of the
+   * listed `fields` are present in the stored payload, the `message` is
+   * appended to the response `warnings` array. The store operation is NOT
+   * blocked — warnings are non-fatal and informational only.
+   *
+   * Example: require at least one identity field on `product_feedback`:
+   * ```ts
+   * store_warnings: [{
+   *   code: "MISSING_IDENTITY_FIELDS",
+   *   fields: ["feedback_source", "reporter_email", "reporter_name", "reporter_id"],
+   *   message: "product_feedback stored without identity fields ...",
+   * }]
+   * ```
+   */
+  store_warnings?: Array<{
+    /** Machine-readable warning code surfaced in the response. */
+    code: string;
+    /**
+     * At least one of these fields must be present in the payload to suppress
+     * the warning. If none are found the warning fires.
+     */
+    fields: string[];
+    /** Human-readable warning message included in the response. */
+    message: string;
+  }>;
 }
 
 /** Known opt-out tokens for {@link SchemaDefinition.identity_opt_out}. */

--- a/tests/unit/product_feedback_schema.test.ts
+++ b/tests/unit/product_feedback_schema.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Unit tests for the product_feedback schema and store-time identity validation.
+ *
+ * Covers:
+ * - #136: product_feedback schema has a feedback_source discriminator field
+ * - #137: store_warnings fires when no identity fields are present
+ * - #137: no warning when feedback_source is supplied
+ * - #137: no warning when reporter_email / reporter_name / reporter_id is supplied
+ */
+
+import { describe, it, expect } from "vitest";
+import { ENTITY_SCHEMAS } from "../../src/services/schema_definitions.js";
+
+// ---------------------------------------------------------------------------
+// #136 – schema shape
+// ---------------------------------------------------------------------------
+
+describe("product_feedback schema (#136)", () => {
+  const schema = ENTITY_SCHEMAS["product_feedback"];
+
+  it("is registered in ENTITY_SCHEMAS", () => {
+    expect(schema).toBeDefined();
+  });
+
+  it("has entity_type 'product_feedback'", () => {
+    expect(schema.entity_type).toBe("product_feedback");
+  });
+
+  it("has a feedback_source field", () => {
+    expect(schema.schema_definition.fields).toHaveProperty("feedback_source");
+  });
+
+  it("feedback_source is typed as string", () => {
+    expect(schema.schema_definition.fields["feedback_source"].type).toBe("string");
+  });
+
+  it("feedback_source has a description mentioning 'internal' and 'external'", () => {
+    const desc = schema.schema_definition.fields["feedback_source"].description ?? "";
+    expect(desc).toMatch(/internal/i);
+    expect(desc).toMatch(/external/i);
+  });
+
+  it("has reporter_email as an optional identity field", () => {
+    expect(schema.schema_definition.fields).toHaveProperty("reporter_email");
+    expect(schema.schema_definition.fields["reporter_email"].required).toBeFalsy();
+  });
+
+  it("has reporter_name as an optional identity field", () => {
+    expect(schema.schema_definition.fields).toHaveProperty("reporter_name");
+    expect(schema.schema_definition.fields["reporter_name"].required).toBeFalsy();
+  });
+
+  it("has reporter_id as an optional identity field", () => {
+    expect(schema.schema_definition.fields).toHaveProperty("reporter_id");
+    expect(schema.schema_definition.fields["reporter_id"].required).toBeFalsy();
+  });
+
+  it("has agent_instructions mentioning feedback_source discriminator", () => {
+    const instructions = schema.schema_definition.agent_instructions ?? "";
+    expect(instructions).toMatch(/feedback_source/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #137 – store_warnings rule: helper that mirrors the actions.ts logic
+// ---------------------------------------------------------------------------
+
+/**
+ * Evaluate store_warnings rules from the schema against a payload.
+ * Returns the list of warning objects that fire.
+ *
+ * This mirrors the check in storeStructuredForApi / storeStructuredInternal so
+ * we can unit-test the rule logic without a running server or DB.
+ */
+function evaluateStoreWarnings(
+  fields: Record<string, unknown>,
+  entityType: string = "product_feedback",
+): Array<{ code: string; message: string }> {
+  const schema = ENTITY_SCHEMAS[entityType];
+  const rules = schema?.schema_definition?.store_warnings ?? [];
+  const fired: Array<{ code: string; message: string }> = [];
+  for (const rule of rules) {
+    const hasIdentityField = rule.fields.some(
+      (f) => fields[f] !== undefined && fields[f] !== null && fields[f] !== "",
+    );
+    if (!hasIdentityField) {
+      fired.push({ code: rule.code, message: rule.message });
+    }
+  }
+  return fired;
+}
+
+describe("product_feedback store_warnings rule (#137)", () => {
+  it("fires when none of the identity fields are present", () => {
+    const warnings = evaluateStoreWarnings({ title: "Bug: crash on login", content: "Repro: ..." });
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].code).toBe("MISSING_IDENTITY_FIELDS");
+    expect(warnings[0].message).toMatch(/feedback_source/);
+    expect(warnings[0].message).toMatch(/reporter_email/);
+  });
+
+  it("does NOT fire when feedback_source is 'internal'", () => {
+    const warnings = evaluateStoreWarnings({
+      title: "Sprint retro note",
+      content: "We should improve test coverage.",
+      feedback_source: "internal",
+    });
+    expect(warnings).toHaveLength(0);
+  });
+
+  it("does NOT fire when feedback_source is 'external'", () => {
+    const warnings = evaluateStoreWarnings({
+      title: "Login page broken on mobile",
+      feedback_source: "external",
+    });
+    expect(warnings).toHaveLength(0);
+  });
+
+  it("does NOT fire when reporter_email is supplied", () => {
+    const warnings = evaluateStoreWarnings({
+      title: "Feature request: dark mode",
+      reporter_email: "alice@example.com",
+    });
+    expect(warnings).toHaveLength(0);
+  });
+
+  it("does NOT fire when reporter_name is supplied", () => {
+    const warnings = evaluateStoreWarnings({
+      title: "Onboarding confusion",
+      reporter_name: "Bob Smith",
+    });
+    expect(warnings).toHaveLength(0);
+  });
+
+  it("does NOT fire when reporter_id is supplied", () => {
+    const warnings = evaluateStoreWarnings({
+      title: "Pagination bug",
+      reporter_id: "usr_abc123",
+    });
+    expect(warnings).toHaveLength(0);
+  });
+
+  it("does NOT fire when feedback_source is empty string (treats as missing)", () => {
+    // An empty string value is treated the same as absent — must have a real value.
+    const warnings = evaluateStoreWarnings({
+      title: "Vague report",
+      feedback_source: "",
+    });
+    expect(warnings).toHaveLength(1);
+  });
+
+  it("warning message mentions all four identity fields", () => {
+    const warnings = evaluateStoreWarnings({ title: "No identity" });
+    const msg = warnings[0]?.message ?? "";
+    expect(msg).toMatch(/feedback_source/);
+    expect(msg).toMatch(/reporter_email/);
+    expect(msg).toMatch(/reporter_name/);
+    expect(msg).toMatch(/reporter_id/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Verify store_warnings is declared on the schema itself
+// ---------------------------------------------------------------------------
+
+describe("product_feedback schema store_warnings declaration", () => {
+  const schema = ENTITY_SCHEMAS["product_feedback"];
+
+  it("declares store_warnings on schema_definition", () => {
+    expect(schema.schema_definition.store_warnings).toBeDefined();
+    expect(Array.isArray(schema.schema_definition.store_warnings)).toBe(true);
+    expect(schema.schema_definition.store_warnings!.length).toBeGreaterThan(0);
+  });
+
+  it("MISSING_IDENTITY_FIELDS rule covers all four identity fields", () => {
+    const rule = schema.schema_definition.store_warnings!.find(
+      (r) => r.code === "MISSING_IDENTITY_FIELDS",
+    );
+    expect(rule).toBeDefined();
+    expect(rule!.fields).toContain("feedback_source");
+    expect(rule!.fields).toContain("reporter_email");
+    expect(rule!.fields).toContain("reporter_name");
+    expect(rule!.fields).toContain("reporter_id");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `feedback_source` discriminator field (`"internal"` | `"external"`) to the `product_feedback` schema
- Adds optional identity fields: `reporter_email`, `reporter_name`, `reporter_id`
- Emits a structured warning when `product_feedback` is stored without any identity or source discriminator
- Adds unit tests for schema structure and warning behavior

## Test plan
- [ ] Unit tests pass (`npx vitest run tests/unit/product_feedback_schema.test.ts`)
- [ ] Storing product_feedback with `feedback_source: "internal"` → no warning
- [ ] Storing product_feedback without any identity fields → `store_warnings` in response
- [ ] Storing product_feedback with `reporter_email` → no warning

Fixes #136
Fixes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)