### PR TITLE
fix(reducer): use active schema version for field projection (#142)

### DIFF
--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,15 +61,15 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **348**
-- Backend and repo Vitest files: **315**
+- Total automated test files: **349**
+- Backend and repo Vitest files: **316**
 - Frontend Vitest files: **9**
 - Playwright spec files: **24**
 
 ### Suite counts
 | Suite | Files |
 |---|---:|
-| Vitest unit tests | 82 |
+| Vitest unit tests | 83 |
 | Vitest service tests | 33 |
 | Source-adjacent tests | 39 |
 | Vitest integration tests | 93 |
@@ -107,7 +107,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/unit`
 **Requirements:** Basic `.env` if required by the module under test.
-**Files (82):**
+**Files (83):**
 - `tests/unit/aauth_admission.test.ts`
 - `tests/unit/aauth_attestation_apple_se.test.ts`
 - `tests/unit/aauth_attestation_revocation.test.ts`
@@ -181,6 +181,7 @@ flowchart TD
 - `tests/unit/sandbox_reset.test.ts`
 - `tests/unit/schema_agent_instructions.test.ts`
 - `tests/unit/schema_inference.test.ts`
+- `tests/unit/schema_projection_lag.test.ts`
 - `tests/unit/security_hardening.test.ts`
 - `tests/unit/seo_metadata.test.ts`
 - `tests/unit/session_info.test.ts`

--- a/src/services/schema_registry.ts
+++ b/src/services/schema_registry.ts
@@ -548,6 +548,39 @@ export class SchemaRegistryService {
 
     const registeredSchema = data as SchemaRegistryEntry;
 
+    // When activating a new schema version, deactivate all previously active
+    // versions for the same entity_type and scope so only one row ever has
+    // active = true. Without this, `loadGlobalSchema` / `loadUserSpecificSchema`
+    // use `.single()` which errors (or non-deterministically returns the old
+    // version) when multiple active rows exist, causing new fields to be routed
+    // to raw_fragments instead of the top-level snapshot. (Fixes #142)
+    if (config.activate) {
+      let deactivateQuery = db
+        .from("schema_registry")
+        .update({ active: false })
+        .eq("entity_type", config.entity_type)
+        .eq("active", true)
+        .not("id", "eq", registeredSchema.id);
+
+      if (scope === "user" && config.user_specific && config.user_id) {
+        deactivateQuery = deactivateQuery
+          .eq("scope", "user")
+          .eq("user_id", config.user_id);
+      } else {
+        deactivateQuery = deactivateQuery
+          .eq("scope", "global")
+          .is("user_id", null);
+      }
+
+      const { error: deactivateError } = await deactivateQuery;
+      if (deactivateError) {
+        logSchemaRegistryInfo(
+          `[SCHEMA_REGISTRY] Warning: failed to deactivate prior active schemas for ` +
+          `${config.entity_type}: ${deactivateError.message}`,
+        );
+      }
+    }
+
     // Auto-generate icon if not provided (non-blocking)
     this.generateIconAsync(registeredSchema.entity_type, config.metadata);
 

--- a/tests/services/schema_registry_incremental.test.ts
+++ b/tests/services/schema_registry_incremental.test.ts
@@ -32,6 +32,7 @@ describe("SchemaRegistryService - Incremental Updates", () => {
       range: vi.fn(),
       is: vi.fn(), // For .is("user_id", null)
       or: vi.fn(), // For .or("user_id.is.null,user_id.eq....")
+      not: vi.fn(), // For .not("id", "eq", id) used in register() deactivation
     };
     // Make each method return the mock so chaining works
     Object.keys(mock).forEach((key) => {
@@ -65,8 +66,8 @@ describe("SchemaRegistryService - Incremental Updates", () => {
       }
     });
     
-    // Ensure update/insert/select/eq/is/range still return mock for chaining (unless overridden)
-    ['update', 'insert', 'select', 'eq', 'is', 'range'].forEach((method) => {
+    // Ensure update/insert/select/eq/is/range/not still return mock for chaining (unless overridden)
+    ['update', 'insert', 'select', 'eq', 'is', 'range', 'not'].forEach((method) => {
       if (!methods[method] || typeof methods[method] !== 'function') {
         // Only set if not already a function that returns something
         if (typeof mock[method] === 'function' && !mock[method].mock) {
@@ -1173,7 +1174,13 @@ describe("SchemaRegistryService - Incremental Updates", () => {
         }),
       });
 
-      mockFrom.mockReturnValueOnce(mockInsert);
+      // When activate: true, register() also calls db.from("schema_registry").update(...)
+      // to deactivate prior active schemas. Provide a mock for that call.
+      const mockDeactivate = createChainableQuery({});
+
+      mockFrom
+        .mockReturnValueOnce(mockInsert)     // insert call
+        .mockReturnValueOnce(mockDeactivate); // deactivate prior active versions
 
       const result = await service.register({
         entity_type: "transaction",
@@ -1185,6 +1192,8 @@ describe("SchemaRegistryService - Incremental Updates", () => {
 
       const insertedData = mockInsert.insert.mock.calls[0][0];
       expect(insertedData.active).toBe(true);
+      // Verify deactivation was attempted for prior active schemas
+      expect(mockDeactivate.update).toHaveBeenCalledWith({ active: false });
     });
 
     it("should not activate by default", async () => {

--- a/tests/unit/schema_projection_lag.test.ts
+++ b/tests/unit/schema_projection_lag.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Unit tests for schema projection lag fix (issue #142).
+ *
+ * Verifies that when a schema version is bumped via register_schema with
+ * activate: true, subsequent store calls that include the new fields produce
+ * them in the top-level snapshot rather than raw_fragments.
+ *
+ * Root cause: register() with activate: true did not deactivate the prior
+ * active schema version. loadGlobalSchema uses .single() which behaves
+ * non-deterministically when multiple active rows exist (SQLite returns first
+ * row = old schema; PostgREST errors). The fix: deactivate prior active rows
+ * in register() when activate: true.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { SchemaRegistryService } from "../../src/services/schema_registry.js";
+import { ObservationReducer } from "../../src/reducers/observation_reducer.js";
+import { db } from "../../src/db.js";
+
+const TEST_ENTITY_TYPE = "schema_projection_lag_test_entity";
+const TEST_USER_ID = "00000000-0000-0000-0000-000000000000";
+
+async function cleanupTestData(): Promise<void> {
+  await db.from("raw_fragments").delete().eq("entity_type", TEST_ENTITY_TYPE);
+  await db.from("entity_snapshots").delete().eq("entity_type", TEST_ENTITY_TYPE);
+  await db.from("observations").delete().eq("entity_type", TEST_ENTITY_TYPE);
+  const { data: entities } = await db
+    .from("entities")
+    .select("id")
+    .eq("entity_type", TEST_ENTITY_TYPE);
+  if (entities && entities.length > 0) {
+    await db
+      .from("entities")
+      .delete()
+      .in("id", entities.map((e: { id: string }) => e.id));
+  }
+  await db.from("schema_registry").delete().eq("entity_type", TEST_ENTITY_TYPE);
+}
+
+describe("Schema projection lag fix (#142)", () => {
+  const registry = new SchemaRegistryService();
+  const reducer = new ObservationReducer();
+
+  beforeEach(async () => {
+    await cleanupTestData();
+  });
+
+  it("register() with activate:true deactivates the prior active schema version", async () => {
+    // Register v1.0 with activate: true
+    await registry.register({
+      entity_type: TEST_ENTITY_TYPE,
+      schema_version: "1.0",
+      schema_definition: {
+        fields: {
+          name: { type: "string" },
+          value: { type: "number" },
+        },
+        identity_opt_out: "heuristic_canonical_name",
+      },
+      reducer_config: {
+        merge_policies: {
+          name: { strategy: "last_write" },
+          value: { strategy: "last_write" },
+        },
+      },
+      activate: true,
+    });
+
+    // Verify v1.0 is active
+    const schemaV1 = await registry.loadActiveSchema(TEST_ENTITY_TYPE);
+    expect(schemaV1?.schema_version).toBe("1.0");
+
+    // Register v1.1 with activate: true (adds extra_field)
+    await registry.register({
+      entity_type: TEST_ENTITY_TYPE,
+      schema_version: "1.1",
+      schema_definition: {
+        fields: {
+          name: { type: "string" },
+          value: { type: "number" },
+          extra_field: { type: "string" },
+        },
+        identity_opt_out: "heuristic_canonical_name",
+      },
+      reducer_config: {
+        merge_policies: {
+          name: { strategy: "last_write" },
+          value: { strategy: "last_write" },
+          extra_field: { strategy: "last_write" },
+        },
+      },
+      activate: true,
+    });
+
+    // Only one schema should be active, and it should be v1.1
+    const { data: activeRows } = await db
+      .from("schema_registry")
+      .select("schema_version, active")
+      .eq("entity_type", TEST_ENTITY_TYPE)
+      .eq("active", true);
+
+    expect(activeRows).toBeDefined();
+    expect(activeRows!.length).toBe(1);
+    expect(activeRows![0].schema_version).toBe("1.1");
+  });
+
+  it("loadActiveSchema returns v1.1 (not v1.0) after a schema version bump", async () => {
+    await registry.register({
+      entity_type: TEST_ENTITY_TYPE,
+      schema_version: "1.0",
+      schema_definition: {
+        fields: {
+          name: { type: "string" },
+          value: { type: "number" },
+        },
+        identity_opt_out: "heuristic_canonical_name",
+      },
+      reducer_config: {
+        merge_policies: {
+          name: { strategy: "last_write" },
+          value: { strategy: "last_write" },
+        },
+      },
+      activate: true,
+    });
+
+    await registry.register({
+      entity_type: TEST_ENTITY_TYPE,
+      schema_version: "1.1",
+      schema_definition: {
+        fields: {
+          name: { type: "string" },
+          value: { type: "number" },
+          extra_field: { type: "string" },
+        },
+        identity_opt_out: "heuristic_canonical_name",
+      },
+      reducer_config: {
+        merge_policies: {
+          name: { strategy: "last_write" },
+          value: { strategy: "last_write" },
+          extra_field: { strategy: "last_write" },
+        },
+      },
+      activate: true,
+    });
+
+    // loadActiveSchema must return v1.1 — if it returned v1.0, extra_field
+    // would be missing from the schema and new observations would route it
+    // to raw_fragments instead of validFields.
+    const activeSchema = await registry.loadActiveSchema(TEST_ENTITY_TYPE, TEST_USER_ID);
+    expect(activeSchema).not.toBeNull();
+    expect(activeSchema!.schema_version).toBe("1.1");
+    expect(activeSchema!.schema_definition.fields).toHaveProperty("extra_field");
+  });
+
+  it("reducer projects extra_field to top-level snapshot using the active schema after version bump", async () => {
+    // Register v1.0 and bump to v1.1 (adds extra_field)
+    await registry.register({
+      entity_type: TEST_ENTITY_TYPE,
+      schema_version: "1.0",
+      schema_definition: {
+        fields: {
+          name: { type: "string" },
+          value: { type: "number" },
+        },
+        identity_opt_out: "heuristic_canonical_name",
+      },
+      reducer_config: {
+        merge_policies: {
+          name: { strategy: "last_write" },
+          value: { strategy: "last_write" },
+        },
+      },
+      activate: true,
+    });
+
+    await registry.register({
+      entity_type: TEST_ENTITY_TYPE,
+      schema_version: "1.1",
+      schema_definition: {
+        fields: {
+          name: { type: "string" },
+          value: { type: "number" },
+          extra_field: { type: "string" },
+        },
+        identity_opt_out: "heuristic_canonical_name",
+      },
+      reducer_config: {
+        merge_policies: {
+          name: { strategy: "last_write" },
+          value: { strategy: "last_write" },
+          extra_field: { strategy: "last_write" },
+        },
+      },
+      activate: true,
+    });
+
+    // Simulate observations — first observation (before bump), second after bump.
+    // The reducer uses the *currently active* schema, so extra_field from the
+    // second observation should appear in the top-level snapshot.
+    const observations = [
+      {
+        id: "obs-v10-001",
+        entity_id: "ent-lag-test-001",
+        entity_type: TEST_ENTITY_TYPE,
+        schema_version: "1.0",
+        source_id: "src-001",
+        observed_at: "2025-01-01T00:00:00Z",
+        specificity_score: 1.0,
+        source_priority: 100,
+        fields: { name: "Alice", value: 42 },
+        created_at: "2025-01-01T00:00:00Z",
+        user_id: TEST_USER_ID,
+      },
+      {
+        id: "obs-v11-001",
+        entity_id: "ent-lag-test-001",
+        entity_type: TEST_ENTITY_TYPE,
+        schema_version: "1.1",
+        source_id: "src-001",
+        observed_at: "2025-01-02T00:00:00Z",
+        specificity_score: 1.0,
+        source_priority: 100,
+        fields: { name: "Alice", value: 42, extra_field: "hello" },
+        created_at: "2025-01-02T00:00:00Z",
+        user_id: TEST_USER_ID,
+      },
+    ];
+
+    const snapshot = await reducer.computeSnapshot("ent-lag-test-001", observations);
+
+    expect(snapshot).not.toBeNull();
+    // extra_field must appear in the top-level snapshot, not be absent
+    expect(snapshot!.snapshot).toHaveProperty("extra_field", "hello");
+    // name and value must still be present
+    expect(snapshot!.snapshot).toHaveProperty("name", "Alice");
+    expect(snapshot!.snapshot).toHaveProperty("value", 42);
+    // schema_version on the snapshot should reflect the current active schema
+    expect(snapshot!.schema_version).toBe("1.1");
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes schema projection lag where new fields added in a schema version bump land in `raw_fragments` on existing entities instead of projecting to the top-level snapshot
- Root cause: `register()` with `activate: true` inserted the new schema row as active but never deactivated the previously-active version. `loadGlobalSchema` uses `.single()` — in SQLite this non-deterministically returns the first (old) row; in PostgREST it errors on multiple active rows. Either way, the old schema (without the new fields) was used by `validateFieldsWithConverters` at write time, routing new fields to `raw_fragments` instead of `validFields`.
- Fix: after inserting the new schema row with `activate: true`, immediately deactivate all other active rows for the same `entity_type` + `scope` so exactly one row has `active = true` at all times — matching the invariant already maintained by `updateSchemaIncremental()`/`activate()`.
- Adds unit tests verifying that schema bumps via `register_schema` immediately affect field projection on subsequent observations

## Test plan
- [x] Unit tests pass: `register()` with `activate: true` leaves exactly one active row after version bump
- [x] Unit tests pass: `loadActiveSchema` returns the new version (not the old) after `register()` bump
- [x] Unit tests pass: reducer projects `extra_field` to top-level snapshot after schema v1.0 → v1.1 bump
- [x] Existing `schema_registry_incremental.test.ts` updated to mock the additional deactivate `db.from()` call — all 34 tests still pass
- [x] Test catalog regenerated and validates
- [x] No regressions in `tests/unit` or `tests/services` (same 2 pre-existing failures unrelated to schemas)

Fixes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)