### PR TITLE
chore(deploy): rename Fly.io app to neotoma-sandbox, add data volume mount (#117)

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -3,7 +3,7 @@
 # See https://fly.io/docs/reference/configuration/ for information about how to use this file.
 #
 
-app = 'neotoma'
+app = 'neotoma-sandbox'
 primary_region = 'lhr'
 
 [build]
@@ -28,9 +28,6 @@ primary_region = 'lhr'
   cpu_kind = 'shared'
   cpus = 1
 
-# Scheduled importers
-# Fly.io doesn't support cron directly. Use one of:
-# 1. Fly Machines with scheduled tasks (flyctl machines run --schedule)
-# 2. External cron service (GitHub Actions, cron-job.org) calling HTTP endpoint
-# 3. Always-on machine running internal scheduler
-# See docs/importers.md for scheduling options
+[[mounts]]
+  source = "data"
+  destination = "/app/data"


### PR DESCRIPTION
## Summary
- Renames the Fly.io app from `neotoma` to `neotoma-sandbox`
- Adds `[[mounts]]` section with `source = "data"`, `destination = "/app/data"` for persistent SQLite storage
- Removes stale scheduler comments that no longer apply

## Test plan
- [ ] `fly config validate` passes against `neotoma-sandbox` app
- [ ] Confirm `/app/data` mount is available after `fly deploy`

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)