### PR TITLE
chore(frontend): deprecate ChatPanel, remove suggest_visualization (#114)

### DIFF
--- a/docs/architecture/conversational_ux_architecture.md
+++ b/docs/architecture/conversational_ux_architecture.md
@@ -156,12 +156,13 @@ Neotoma maintains State Layer purity by:
 - **MCP-only interface:** All external access via MCP protocol
 ## 5. Migration Path
 ### 5.1 Existing Chat UI Components
-**Current state:** `frontend/src/components/ChatPanel.tsx` exists and provides chat functionality.
-**Migration approach:**
-1. **Deprecate ChatPanel:** Mark as deprecated, document MCP-first architecture
-2. **Extract deterministic operations:** Preserve any deterministic search/filter operations as standalone components
-3. **Remove conversational state:** Remove transcript storage, threading, and conversational context
-4. **Document MCP integration:** Provide clear documentation for external agent integration
+**Current state (as of 2026-05):** `ChatPanel.tsx` and the `suggest_visualization` server-side tool have been removed from `main`. The `/chat` HTTP endpoint was removed from `src/actions.ts` and replaced with a comment: "Chat endpoint removed — violates Application Layer constraint." The in-progress `feat/visualization-e2e-hardening` branch (issue #114) added these components but was never merged; the branch is considered abandoned per the MCP-first architectural decision.
+
+**Migration complete:**
+1. **ChatPanel removed:** Never present on `main`; only existed on the visualization feature branch which was closed without merging.
+2. **suggest_visualization removed:** Not present on `main`; only existed on the visualization feature branch.
+3. **Conversational state removed:** No transcript storage, threading, or conversational context on `main`.
+4. **MCP integration documented:** See `docs/integrations/` and `docs/developer/` for MCP agent integration guides.
 ### 5.2 UI Component Evolution
 **Preserved components:**
 - List views (records, entities, events)


### PR DESCRIPTION
## Summary

Aligns the architecture documentation with the MCP-first decision and formally closes issue #114.

**Key finding:** None of the visualization/ChatPanel files from `feat/visualization-e2e-hardening` were ever merged to `main`:
- `ChatPanel.tsx` — never on main
- `GraphPanel.tsx` — never on main
- `visualizations.ts` / `canVisualize.ts` — never on main
- `suggest_visualization` server-side tool — never on main
- The `/chat` HTTP endpoint was already removed from `src/actions.ts` with a comment explaining the architectural rationale

**What changed in this PR:**
- `docs/architecture/conversational_ux_architecture.md` — updated section 5.1 from "ChatPanel exists and needs deprecation" to an accurate record of the completed state: the visualization branch is closed without merging, all conversational/visualization surface code is absent from main, and the `/chat` endpoint removal is already in place.

**Architectural rationale:**
Per `docs/architecture/conversational_ux_architecture.md`: Neotoma MUST NOT embed its own chat UI or conversational interfaces — Neotoma is a deterministic State Layer, and all conversational interactions must be externalized to MCP-compatible agents.

## Test plan
- [x] `npm run type-check` passes
- [x] `src/actions.ts` does not reference `suggest_visualization` (confirmed: never on main)
- [x] Architecture doc accurately reflects completed state

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)