### PR TITLE
chore(standards): PR template, CODEOWNERS, format scripts, severity-mapping docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,55 @@
+# Code ownership and review routing.
+#
+# Lines lower in the file take precedence over earlier lines for the same path.
+# All entries currently route to @markmhendrickson; split out as additional
+# maintainers join. The point today is to make high-risk surfaces visible at
+# PR-open time and to give GitHub a hook for branch-protection required reviews.
+#
+# See .claude/rules/change_guardrails_rules.md § "Touchpoint matrix" for the
+# canonical mapping from surface → constraint doc.
+
+# Default owner for everything not otherwise matched.
+*                                            @markmhendrickson
+
+# Security: auth, proxy/loopback trust, local-dev shortcuts, semgrep, manifests.
+/src/actions.ts                              @markmhendrickson
+/src/services/local_auth.ts                  @markmhendrickson
+/src/services/access_policy.ts               @markmhendrickson
+/src/services/root_landing/                  @markmhendrickson
+/scripts/security/                           @markmhendrickson
+/tests/security/                             @markmhendrickson
+/docs/security/                              @markmhendrickson
+
+# API contract: OpenAPI is the source of truth; mappings + types are generated
+# or hand-maintained companions.
+/openapi.yaml                                @markmhendrickson
+/src/shared/openapi_types.ts                 @markmhendrickson
+/src/shared/openapi_schema.ts                @markmhendrickson
+/src/shared/openapi_file.ts                  @markmhendrickson
+/src/shared/contract_mappings.ts             @markmhendrickson
+/src/shared/action_schemas.ts                @markmhendrickson
+/tests/contract/                             @markmhendrickson
+
+# Schema registry & bootstrap: per-type behavior must stay schema-driven.
+/src/services/schema_registry.ts             @markmhendrickson
+/src/services/schema_bootstrap.ts            @markmhendrickson
+
+# Foundation, architecture, and the change guardrails themselves.
+/docs/foundation/                            @markmhendrickson
+/docs/architecture/                          @markmhendrickson
+/docs/NEOTOMA_MANIFEST.md                    @markmhendrickson
+/.claude/rules/                              @markmhendrickson
+
+# Release tooling and process. Skills are mirrored across .cursor/ and .claude/;
+# both paths route to the same reviewer.
+/.cursor/skills/release/                     @markmhendrickson
+/.cursor/skills/create-release/              @markmhendrickson
+/.claude/skills/release/                     @markmhendrickson
+/.claude/skills/create-release/              @markmhendrickson
+/docs/developer/github_release_process.md    @markmhendrickson
+/docs/releases/                              @markmhendrickson
+
+# CI configuration: changing what runs on PR is itself a high-risk change.
+/.github/workflows/                          @markmhendrickson
+/.github/CODEOWNERS                          @markmhendrickson
+/.github/pull_request_template.md            @markmhendrickson

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,80 @@
+<!--
+This template mirrors the Pre-PR checklist from .claude/rules/change_guardrails_rules.md,
+trimmed to items a reviewer can verify from a diff. The full Touchpoint Matrix and
+canonical doc index live in that rule; consult it when unsure.
+
+Delete sections that don't apply to this change.
+-->
+
+## Summary
+
+<!-- 1-3 sentences: what changes and why. Link to issue/discussion if applicable. -->
+
+## Touchpoints
+
+<!-- Tick every surface this PR touches. Each surface has a canonical doc in
+.claude/rules/change_guardrails_rules.md § "Canonical doc index". -->
+
+- [ ] HTTP endpoint / request / response field
+- [ ] MCP tool definition or behavior
+- [ ] CLI command, flag, or runtime override
+- [ ] Error envelope / hint / validation tightening
+- [ ] Auth / user-id resolution / proxy trust / local-dev shortcut
+- [ ] Schema registry, entity type, or per-type behavior
+- [ ] Ingestion / store / correction path
+- [ ] Source / observation lifecycle (immutability)
+- [ ] Reducer / merge / snapshot
+- [ ] Relationships
+- [ ] Timeline / events
+- [ ] Release supplement or release tooling
+- [ ] Logging, metrics, events, traces
+- [ ] File / folder rename, npm script rename
+- [ ] None — pure docs / tests / internal refactor
+
+## Pre-PR checklist
+
+### API & contract
+
+- [ ] `openapi.yaml` edited first; `npm run openapi:generate` output committed alongside
+- [ ] `src/shared/contract_mappings.ts` updated for any new `operationId`, MCP tool, or CLI command
+- [ ] `npm test -- tests/contract/` passes
+- [ ] New top-level CLI commands listed in `tests/cli/cli_command_coverage_guard.test.ts`
+- [ ] MCP and CLI agent-instruction parity confirmed
+- [ ] Runtime overrides follow `flag > env > default` and appear in the cli_reference Runtime overrides table
+- [ ] New env vars are `NEOTOMA_`-prefixed and read in `preAction`
+- [ ] Error hints emitted as structured `hint` / `details` fields, not concatenated into `message`
+- [ ] If this PR causes previously-accepted input to be rejected, a structured `hint` is populated and a `tests/contract/legacy_payloads/` fixture is updated
+- [ ] New top-level request bodies in `openapi.yaml` declare `additionalProperties: false` (unless implicit tolerance is intentional and documented in the schema `description`)
+
+### Data layer
+
+- [ ] Data-layer changes preserve determinism (reproducible IDs, stable ordering, canonicalized LLM output)
+- [ ] Mutating ops honor `idempotency_key`; ingestion writes are transactional
+- [ ] No mutation of sources or observations after creation (reinterpretation = new observation)
+- [ ] No new PII in logs, metric labels, event payloads, or error messages
+- [ ] Per-type behavior expressed as a `SchemaDefinition` declaration rather than a code branch (per `.claude/rules/schema_agnostic_design_rules.md`)
+
+### Security
+
+- [ ] `npm run security:classify-diff` recorded; if `sensitive=true`, all of:
+  - [ ] `npm run security:lint` clean
+  - [ ] `npm run security:manifest:check` passes
+  - [ ] `npm run test:security:auth-matrix` passes
+  - [ ] `docs/releases/in_progress/<TAG>/security_review.md` exists with a sign-off verdict
+- [ ] New Express routes registered in `protected_routes_manifest.json` (or runtime unauth allow-list with a `reason`); manifest regenerated via `npm run security:manifest:write` when needed
+- [ ] No bare `req.socket.remoteAddress`, `X-Forwarded-For`, or `Host` reads outside `src/actions.ts` / `src/services/root_landing/**`; auth-local fallbacks gated through `assertExplicitlyTrusted`
+
+### Release & process
+
+- [ ] For release PRs: `npm run openapi:bc-diff` output reviewed; any "Breaking" entries named in the supplement's "Breaking changes" section (or supplement contains `No breaking changes.`)
+- [ ] `tests/contract/legacy_payloads/replay.test.ts` passes; outcome flips paired with a new entry in `CHANGES.md`
+- [ ] Release-visible changes documented in a supplement under `docs/releases/in_progress/<TAG>/`; historical supplements untouched
+- [ ] Renamed files are `snake_case` and `foundation_config.yaml` + `.claude/rules/` symlinks updated
+
+## Test plan
+
+<!-- What you ran. What a reviewer should re-run. Include relevant npm scripts. -->
+
+## Notes for reviewer
+
+<!-- Anything non-obvious: design tradeoffs, follow-ups, risks. -->

--- a/docs/research/determinism_immutability_lint_landscape.md
+++ b/docs/research/determinism_immutability_lint_landscape.md
@@ -1,0 +1,209 @@
+# Determinism and immutability: lint/static-enforcement landscape
+
+**Status:** Research note. Input to a follow-up plan deciding whether to add
+domain-specific lint rules in Neotoma. Not a decision document.
+
+**Scope:** Survey of how comparable OSS projects statically enforce (a)
+deterministic ID/event derivation and (b) immutability of source/observation
+records, plus an assessment of TypeScript-side tooling Neotoma could adopt
+cheaply today.
+
+## 1. Event-sourcing and append-only stores
+
+The headline finding: none of the major event-sourced or bitemporal stores
+expose anything resembling a custom linter that enforces "no mutation after
+write" on their *own* implementation code. Immutability is enforced at the
+storage-engine and protocol layer, then the implementation language's normal
+type system carries it the rest of the way. The closer a system sits to a
+functional language (Clojure, Rust, F#), the less it needs lint pressure.
+
+- **Datomic** and **XTDB** treat facts as the unit of truth. In Datomic a
+  Datom (`entity, attribute, value, tx, op`) is conceptually frozen by the
+  transactor and broadcast as novelty to peers
+  ([InfoQ architecture overview](https://www.infoq.com/articles/Architecture-Datomic/),
+  [Datomic internals — tonsky.me](https://tonsky.me/blog/unofficial-guide-to-datomic-internals/)).
+  XTDB pushes the same idea further: the "transactor" role is just a passive,
+  pluggable log (Kafka, Postgres, filesystem), and the engine deliberately does
+  not enforce schema or mutation rules — the log being append-only is the
+  enforcement ([XTDB FAQ](https://v1-docs.xtdb.com/resources/faq/),
+  [Biffweb comparison](https://biffweb.com/p/xtdb-compared-to-other-databases/)).
+  Both projects are Clojure: persistent data structures are the default, so
+  there is no analog of "did someone mutate this struct?" to lint against.
+- **EventStoreDB** (now Kurrent) enforces append-only at the stream-storage
+  layer, not via linters in its C#/.NET source. No public custom analyzer
+  bans mutation in its own codebase. The contract is structural: streams
+  expose append + read, not update.
+- **Materialize** (Rust) leans on Rust's ownership/borrow system; immutability
+  is a language-level default, not a lint concern.
+- **Kafka Streams / Marten**: same pattern. Storage layer is the enforcer;
+  implementation discipline is enforced by code review and tests, not custom
+  static analysis.
+
+Generalizable takeaway: **no comparable project found that ships a custom
+domain lint rule enforcing "no mutation of stored facts" in its own source.**
+The pattern is "make the wrong thing structurally impossible (append-only API,
+sealed structs, persistent data structures), then trust the host language."
+
+For Neotoma in TypeScript this matters because TS has no equivalent of
+Clojure's persistent defaults or Rust's borrow checker. The structural
+prevention some of these systems get for free has to be either typed
+(`readonly`, branded/opaque types, `Object.freeze` at boundaries) or linted.
+That is closer to a real gap than the survey first suggests.
+
+## 2. MCP servers
+
+The MCP TypeScript SDK does have a relevant convention, but it is advisory
+only. `registerTool` accepts an `annotations.idempotentHint` boolean (and
+`destructiveHint`, `readOnlyHint`), and the docs explicitly say handlers
+should be designed for safe retries
+([typescript-sdk/docs/server.md](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/docs/server.md)).
+The annotation is a hint to *clients* about how to render/retry — it does not
+alter execution and there is no static check that a tool flagged
+`idempotentHint: true` actually behaves idempotently. Per the SDK docs: "these
+annotations are hints only."
+
+A scan of well-maintained community MCP servers (filesystem, git, sqlite
+reference servers under `modelcontextprotocol/servers`, plus a sample of
+third-party servers) surfaces no convention for:
+
+- deterministic tool-result IDs,
+- idempotency-key handling at the SDK level,
+- immutable response shapes (responses are plain `content: [...]` arrays,
+  typically constructed mutably with `push`).
+
+**Plainly: nothing standardized.** There is no MCP-ecosystem precedent to
+borrow. Neotoma's `idempotency_key` contract on `ingest` / `store` / `correct`
+is already ahead of where the SDK conventions sit.
+
+## 3. TypeScript tooling assessment
+
+### `eslint-plugin-functional`
+
+The relevant rule is `immutable-data`, which bans property assignment,
+`delete`, `Object.assign`, and mutating array methods (`push`, `sort`, etc.)
+([rule docs](https://github.com/eslint-functional/eslint-plugin-functional/blob/main/docs/rules/immutable-data.md)).
+Escape hatches matter: `ignoreImmediateMutation` permits builder-style
+construction on freshly created locals (`const x = []; x.push(...); return x;`),
+`ignoreNonConstDeclarations` confines the check to `const` bindings, and
+`ignoreIdentifierPattern` allows targeted carve-outs.
+
+**Fit for Neotoma:** The plugin's own guidance recommends the "Lite" preset
+when converting an existing codebase. Applied broadly to a TS-strict server
+codebase that uses normal accumulator/builder patterns in handlers, reducers,
+and bootstrap code, the false-positive rate is high enough that the plugin is
+almost always adopted scoped — e.g. only on `src/services/reducer/**` or
+`src/services/observation/**` rather than repo-wide. The `prefer-readonly`
+and `prefer-readonly-parameter-types` rules from `typescript-eslint`
+([prefer-readonly](https://typescript-eslint.io/rules/prefer-readonly/),
+[prefer-readonly-parameter-types](https://typescript-eslint.io/rules/prefer-readonly-parameter-types/))
+are cheaper wins and probably the right first step before considering
+`immutable-data`.
+
+`eslint-plugin-immutable` / `tslint-immutable` are predecessor projects
+([tslint-immutable](https://github.com/jonaskello/tslint-immutable)) — both
+folded into `eslint-plugin-functional`. Not separately useful.
+
+### Semgrep
+
+There is no off-the-shelf semgrep rule pack targeting determinism (no
+`Math.random` / `Date.now` / unstable-sort detector aimed at business logic).
+The existing rules at
+[semgrep/semgrep-rules](https://github.com/semgrep/semgrep-rules) and
+[fullstorydev/semgrep-rules math-random](https://github.com/fullstorydev/semgrep-rules/blob/main/optimizations/math-random-used.yaml)
+target `Math.random` from a *security* angle (crypto misuse), not a
+determinism angle. Writing the rules Neotoma needs is straightforward —
+semgrep's pattern syntax handles `Date.now()` / `Math.random()` / `new Date()`
+trivially, and path-scoping (`paths: include: ["src/services/entity_resolution/**"]`)
+lets us confine them to the ID-derivation and reducer code paths where they
+matter, avoiding noise in logging/metrics code where `Date.now()` is fine.
+
+### Plain ESLint `no-restricted-syntax`
+
+The lowest-cost option: AST-selector bans via the core
+[`no-restricted-syntax`](https://eslint.org/docs/latest/rules/no-restricted-syntax)
+rule. A two-rule config bans `Date.now()` and `Math.random()` at specific
+call-site shapes with custom messages, no plugin needed
+([example](https://christopher.xyz/2021/05/16/eslint-ban-syntax.html)). Pairs
+well with ESLint `overrides` to scope to specific directories. Likely the best
+first instrument because it's plugin-free and review-trivial.
+
+## Recommendation
+
+Five candidate checks. All are scoped, not repo-wide; "trivial" means one
+config block, "small" means an afternoon, "medium" means a short FU.
+
+- **`no-date-now-in-id-derivation`** — flags `Date.now()`, `new Date()`,
+  `performance.now()` in `src/services/entity_resolution/**`,
+  `src/services/observation/**`, and any module that exports an `*Id` /
+  `derive*Id` function. Tool: ESLint `no-restricted-syntax` with `overrides`.
+  Effort: **trivial**. Justification: the v0.x determinism invariants name
+  exactly this anti-pattern; catching it at lint time costs nothing and is the
+  single highest-signal check on the list.
+
+- **`no-math-random-in-business-logic`** — bans `Math.random()` everywhere
+  under `src/services/**` except a small allowlist (jitter/backoff in retry
+  helpers). Tool: ESLint `no-restricted-syntax` + `overrides` allowlist, or
+  semgrep with `paths:`. Effort: **trivial**. Justification: pairs with the
+  above; the existing `scripts/security/run_semgrep.js` pipeline can host it
+  as a WARNING that becomes ERROR after a one-pass cleanup.
+
+- **`unstable-sort-without-tiebreaker`** — semgrep pattern that flags
+  `.sort((a, b) => …)` where the comparator body returns from a single field
+  comparison with no secondary key, scoped to reducer / snapshot projection
+  paths. Tool: semgrep. Effort: **small**. Justification: matches the
+  documented `observed_at DESC, id ASC` stable-ordering invariant; the failure
+  mode (snapshot reorder churn on equal `observed_at`) is exactly the kind of
+  bug code review misses. Expect some false positives on cosmetic sorts — ship
+  as WARNING.
+
+- **`readonly-on-observation-and-source-types`** — enable
+  `typescript-eslint/prefer-readonly` and add a targeted rule (custom or
+  semgrep) that requires `Readonly<…>` or `readonly` on the `Observation`,
+  `Source`, and `TimelineEvent` type declarations and their return-position
+  uses. Tool: typescript-eslint + a small custom rule or semgrep guard on the
+  type declaration files. Effort: **small**. Justification: pushes the
+  immutability invariant into the type system at the seam where it actually
+  matters, instead of relying on a broad `eslint-plugin-functional` pass that
+  would generate noise across handlers and bootstrap code.
+
+- **`no-in-place-mutation-of-observation`** — semgrep pattern banning
+  property assignment (`obs.x = …`, `Object.assign(obs, …)`) and mutating
+  array methods on parameters typed `Observation` / `Source` /
+  `ObservationProjection`. Tool: semgrep with type-tag matching, or a small
+  custom ESLint rule using the TS type checker. Effort: **medium** (semgrep's
+  TS type awareness is limited; getting low false-positive rate likely needs a
+  custom ESLint rule that reads the TS type). Justification: directly encodes
+  the "observations are immutable; reinterpretation = new observation"
+  invariant. Only worth the medium effort if the first three rules don't
+  already catch the regressions we actually see in PR review — revisit after
+  six months of data on the cheaper rules.
+
+**What to skip:** repo-wide `eslint-plugin-functional` adoption, and any
+attempt to enforce idempotency of tool handlers via lint. The first has too
+much noise; the second is a property of behavior that lint cannot see, and the
+MCP ecosystem itself treats `idempotentHint` as a hint, not a checked
+property.
+
+The first three bullets together are roughly half a day of work, sit on
+infra Neotoma already runs (ESLint + the semgrep CI gate), and target the
+exact regression modes the invariants exist to prevent. That is the
+recommendation: ship those three; defer the readonly type push and the
+in-place-mutation rule until there is concrete PR-review evidence they would
+have caught a real regression.
+
+## Sources
+
+- [Datomic architecture (InfoQ)](https://www.infoq.com/articles/Architecture-Datomic/)
+- [Unofficial guide to Datomic internals — tonsky.me](https://tonsky.me/blog/unofficial-guide-to-datomic-internals/)
+- [XTDB FAQ](https://v1-docs.xtdb.com/resources/faq/)
+- [XTDB vs other databases (Biffweb)](https://biffweb.com/p/xtdb-compared-to-other-databases/)
+- [MCP TypeScript SDK — server docs](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/docs/server.md)
+- [MCP TypeScript SDK repo](https://github.com/modelcontextprotocol/typescript-sdk)
+- [eslint-plugin-functional — immutable-data rule](https://github.com/eslint-functional/eslint-plugin-functional/blob/main/docs/rules/immutable-data.md)
+- [typescript-eslint — prefer-readonly](https://typescript-eslint.io/rules/prefer-readonly/)
+- [typescript-eslint — prefer-readonly-parameter-types](https://typescript-eslint.io/rules/prefer-readonly-parameter-types/)
+- [tslint-immutable (predecessor, archived)](https://github.com/jonaskello/tslint-immutable)
+- [ESLint `no-restricted-syntax` rule](https://eslint.org/docs/latest/rules/no-restricted-syntax)
+- [Using `no-restricted-syntax` — Christopher Dignam](https://christopher.xyz/2021/05/16/eslint-ban-syntax.html)
+- [semgrep-rules repo](https://github.com/semgrep/semgrep-rules)
+- [fullstorydev semgrep math-random rule](https://github.com/fullstorydev/semgrep-rules/blob/main/optimizations/math-random-used.yaml)

--- a/docs/security/threat_model.md
+++ b/docs/security/threat_model.md
@@ -78,6 +78,16 @@ The attribution contract (`docs/subsystems/agent_attribution_integration.md`) tr
 - **Supply-chain attacks.** `npm audit`, Socket.dev, and the package lockfile policy stay the canonical defense (see `docs/developer/pre_release_checklist.md` § 1.8).
 - **Social engineering and phishing.** Out of scope; covered by the operator runbook.
 
+## Static-rule severity → gate behavior
+
+The G2 static-rule runner (`scripts/security/run_semgrep.js`, wired into `npm run security:lint`) maps each rule's declared `severity` to CI gate behavior. The mapping is intentional, not a side effect of how Semgrep happens to exit:
+
+- **`ERROR` — blocking.** A single hit fails `npm run security:lint` (exit 1) and therefore fails the `security_gates` CI lane. Reserved for rules that guard a MUST / MUST NOT in `.claude/rules/change_guardrails_rules.md` (e.g. `no-auth-local-fallback`, `loopback-trust-in-production`, `forwarded-for-trust`). New `ERROR` rules MUST cite the constraint they enforce in the rule message.
+- **`WARNING` — advisory.** Findings are annotated in the run report and surfaced in PR security review (`security_review.md`) but do not fail CI. Reserved for hygiene rules and "confirm this is intentional" checks (e.g. `local-dev-user-widening`, `unauth-route-without-allowlist-marker`). The intent is to force a written rationale in review, not to block.
+- **`INFO`** — currently unused. If adopted, treat as advisory-only with no required reviewer response.
+
+The runner's `--fail-on <warning|error>` flag lets local development tighten the gate temporarily; CI runs the default (`error`). Promoting a rule from `WARNING` to `ERROR` is itself a guardrail change — it MUST land with at least one cited incident or design rationale in `docs/security/advisories/` and a `security_review.md` sign-off on the same PR.
+
 ## Versioning & escape hatches
 
 - **`assertExplicitlyTrusted("<reason>")`** in `src/services/access_policy.ts` is the only sanctioned bypass for the auth-local-fallback rule. Every call site MUST cite the reason in the same string the helper records.

--- a/package.json
+++ b/package.json
@@ -99,6 +99,8 @@
     "recover:db:prod": "node scripts/recover_sqlite_database.js --env production",
     "lint": "eslint src --ext .ts",
     "lint:site-copy": "tsx scripts/lint_site_copy_style.ts",
+    "format": "prettier --write 'src/**/*.{ts,tsx,js,json}'",
+    "format:check": "prettier --check 'src/**/*.{ts,tsx,js,json}'",
     "type-check": "tsc --noEmit",
     "start:server": "node dist/actions.js",
     "start:server:prod": "npm run build:server && node scripts/pick-port.js 3180 -- cross-env NEOTOMA_ENV=production npm run start:server",

--- a/scripts/security/run_semgrep.js
+++ b/scripts/security/run_semgrep.js
@@ -12,7 +12,9 @@
  * delegates to it (`semgrep --config scripts/security/semgrep_auth_rules.yml`).
  * Otherwise it walks every `*.ts` file under src/ and applies regex
  * equivalents of each rule, with the same severities (ERROR fails CI,
- * WARNING annotates).
+ * WARNING annotates). The severity → gate mapping is documented canonically
+ * in `docs/security/threat_model.md` § "Static-rule severity → gate behavior";
+ * promoting a rule from WARNING to ERROR is itself a guardrail change.
  *
  * Escape hatches:
  *   - `// neotoma:security-allow:<rule-id> <reason>` on the *previous* line

--- a/scripts/security/semgrep_auth_rules.yml
+++ b/scripts/security/semgrep_auth_rules.yml
@@ -10,6 +10,17 @@
 # a short rationale + suggested fix in the rule message so PR reviewers and
 # agents see them without having to follow a link.
 #
+# Severity → gate mapping (canonical: docs/security/threat_model.md
+# § "Static-rule severity → gate behavior"):
+#   ERROR   — blocking. Fails `npm run security:lint` and the security_gates
+#             CI lane. Reserved for rules guarding a MUST / MUST NOT in
+#             .claude/rules/change_guardrails_rules.md.
+#   WARNING — advisory. Annotated in the run report and surfaced in
+#             security_review.md; does not fail CI.
+#   INFO    — unused.
+# Promoting WARNING → ERROR requires a cited incident or design rationale in
+# docs/security/advisories/ and a security_review.md sign-off on the same PR.
+#
 # Escape hatches (intentional and bounded):
 #   - `assertExplicitlyTrusted("<reason>")` from src/services/access_policy.ts
 #     marks a deliberate exception; the rule's metavariable check filters it.


### PR DESCRIPTION
## Summary

Closes the visible PR-review gaps identified in an audit of repo-wide coding-standards enforcement. Adds scaffolding only — no behavior change, no new lint or test gates enabled yet. Two follow-up PRs are queued:

- **PR B**: mass `npm run format` on `src/` (227 files of pre-existing Prettier drift)
- **PR C**: wire `format:check` into Husky pre-commit and the CI baseline lane

## What changes

- [.github/pull_request_template.md](https://github.com/markmhendrickson/neotoma/blob/chore/standards-scaffolding/.github/pull_request_template.md) mirrors the trimmed Pre-PR checklist from `.claude/rules/change_guardrails_rules.md`, sectioned by Touchpoint Matrix. That checklist is thorough but invisible at PR-open time today.
- [.github/CODEOWNERS](https://github.com/markmhendrickson/neotoma/blob/chore/standards-scaffolding/.github/CODEOWNERS) routes auth, OpenAPI/contract, schema, foundation, release, and CI paths. All entries go to `@markmhendrickson` initially; refactor as the team grows.
- [package.json](https://github.com/markmhendrickson/neotoma/blob/chore/standards-scaffolding/package.json): adds `format` and `format:check` scripts. **Not yet wired into pre-commit or CI** — PR C does that after PR B clears the existing drift.
- [docs/security/threat_model.md](https://github.com/markmhendrickson/neotoma/blob/chore/standards-scaffolding/docs/security/threat_model.md): adds a canonical "Static-rule severity → gate behavior" section documenting that ERROR-severity semgrep rules block CI and WARNING-severity rules advise. The runner (`scripts/security/run_semgrep.js`) already implements this; this PR documents the contract and the promotion process.
- [scripts/security/semgrep_auth_rules.yml](https://github.com/markmhendrickson/neotoma/blob/chore/standards-scaffolding/scripts/security/semgrep_auth_rules.yml) and [scripts/security/run_semgrep.js](https://github.com/markmhendrickson/neotoma/blob/chore/standards-scaffolding/scripts/security/run_semgrep.js): header comments cite the canonical doc.
- [docs/research/determinism_immutability_lint_landscape.md](https://github.com/markmhendrickson/neotoma/blob/chore/standards-scaffolding/docs/research/determinism_immutability_lint_landscape.md): input to a follow-up plan for adding targeted determinism/immutability lint checks. Recommends 0–5 specific rules; top 3 are trivial-effort additions to the existing semgrep gate.

## Test plan

- [x] `npm run security:lint` clean (0 errors, 110 advisory warnings — matches documented mapping)
- [x] `npm run format:check` works as a no-op verification script
- [x] `npm run lint` and `npm run type-check` pass (pre-commit hook)
- [x] Full `npm test` passes (2848 passed; one unrelated worker-pool warning from OpenAI test fixture, not a regression)
- [ ] Reviewer: confirm the PR template renders correctly on this very PR after merge
- [ ] Reviewer: confirm CODEOWNERS routes you as expected when touching one of the listed paths