### PR TITLE
fix(mcp): honor store_structured and store_unstructured aliases in executeTool dispatch

### DIFF
--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,15 +61,15 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **356**
-- Backend and repo Vitest files: **323**
+- Total automated test files: **357**
+- Backend and repo Vitest files: **324**
 - Frontend Vitest files: **9**
 - Playwright spec files: **24**
 
 ### Suite counts
 | Suite | Files |
 |---|---:|
-| Vitest unit tests | 84 |
+| Vitest unit tests | 85 |
 | Vitest service tests | 33 |
 | Source-adjacent tests | 39 |
 | Vitest integration tests | 93 |
@@ -107,7 +107,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/unit`
 **Requirements:** Basic `.env` if required by the module under test.
-**Files (84):**
+**Files (85):**
 - `tests/unit/aauth_admission.test.ts`
 - `tests/unit/aauth_attestation_apple_se.test.ts`
 - `tests/unit/aauth_attestation_revocation.test.ts`
@@ -188,6 +188,7 @@ flowchart TD
 - `tests/unit/session_info.test.ts`
 - `tests/unit/site_page_markdown.test.ts`
 - `tests/unit/spa_path.test.ts`
+- `tests/unit/store_alias_dispatch.test.ts`
 - `tests/unit/subscription_types.test.ts`
 - `tests/unit/substrate_event_bus.test.ts`
 - `tests/unit/timeline_events.test.ts`

--- a/src/server.ts
+++ b/src/server.ts
@@ -1733,6 +1733,8 @@ export class NeotomaServer {
       case "list_interpretations":
         return await this.listInterpretations(args);
       case "store":
+      case "store_structured":
+      case "store_unstructured":
         return await this.store(args);
       case "parse_file":
         return await this.parseFile(args);

--- a/tests/unit/store_alias_dispatch.test.ts
+++ b/tests/unit/store_alias_dispatch.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Regression test for issue ent_016798e974737e4d7044bb31:
+ * store_structured and store_unstructured are documented as deprecated aliases
+ * for store, but were missing from the executeTool dispatch switch, causing
+ * MethodNotFound errors when invoked via MCP.
+ */
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const serverSrc = readFileSync(join(__dirname, "../../src/server.ts"), "utf-8");
+
+describe("executeTool dispatch — store alias coverage", () => {
+  it("handles store_structured so callers do not receive MethodNotFound", () => {
+    // Verify the switch contains a case for store_structured that falls through to store.
+    // The expected pattern is one or both aliases appearing as case statements before "store":
+    expect(serverSrc).toMatch(/case\s+"store_structured"\s*:/);
+  });
+
+  it("handles store_unstructured so callers do not receive MethodNotFound", () => {
+    expect(serverSrc).toMatch(/case\s+"store_unstructured"\s*:/);
+  });
+
+  it("alias cases lead to the same handler as 'store'", () => {
+    // Verify that store_structured and store_unstructured fall through to the store
+    // handler — they appear before the 'store' case with no intervening return/throw,
+    // or immediately after grouped together.
+    const storeBlock = serverSrc.match(
+      /case\s+"store(?:_structured|_unstructured)?"\s*:[\s\S]*?case\s+"parse_file"\s*:/
+    );
+    expect(storeBlock).not.toBeNull();
+    const block = storeBlock![0];
+    // All three cases appear; only one return statement (the handler)
+    const caseCount = (block.match(/case\s+"store/g) ?? []).length;
+    expect(caseCount).toBeGreaterThanOrEqual(3);
+    const returnCount = (block.match(/\breturn\s+await\s+this\.store\(/g) ?? []).length;
+    expect(returnCount).toBe(1);
+  });
+
+  it("contract_mappings.ts defines the same aliases", () => {
+    const contractMappings = readFileSync(
+      join(__dirname, "../../src/shared/contract_mappings.ts"),
+      "utf-8"
+    );
+    expect(contractMappings).toContain('store_structured: "store"');
+    expect(contractMappings).toContain('store_unstructured: "store"');
+  });
+});


### PR DESCRIPTION
## Summary

- `store_structured` and `store_unstructured` were documented as deprecated aliases that route to the same handler as `store`, but the `executeTool` dispatch switch had no `case` for either. Any MCP client invoking one of these aliases received `ErrorCode.MethodNotFound` instead of being handled.
- Adds `case "store_structured":` and `case "store_unstructured":` as fallthrough cases in the `executeTool` switch, so both aliases delegate to `this.store(args)`.
- Adds a regression test (`tests/unit/store_alias_dispatch.test.ts`) that statically asserts all three case labels are present in the switch and collapse to a single handler, and that `contract_mappings.ts` declares both aliases.

## What changed

| File | Change |
|------|--------|
| `src/server.ts` | +2 fallthrough case labels before `case "store":` |
| `tests/unit/store_alias_dispatch.test.ts` | New regression test (4 assertions) |
| `docs/testing/automated_test_catalog.md` | Regenerated (new test file picked up) |

## Why

Fixes issue `ent_016798e974737e4d7044bb31` — reported from Telegram: agents using `store_structured` (the name still cited in the MCP interaction instructions as a deprecated alias) received `MethodNotFound` and had to fall back to the unified `store` tool manually.

The instructions at `docs/developer/mcp/instructions.md:51` explicitly state: *"Deprecated MCP aliases `store_structured` and `store_unstructured` call the same handler as `store` until removed"*. The fix makes that promise true.

## Reviewer notes

- No behavior change for callers already using `store` — the new cases purely add alias coverage.
- The regression test is static (reads `server.ts` as text) to avoid the full server instantiation overhead; this matches the pattern used in `mcp_instructions_fallback_invariants.test.ts` and `mcp_instruction_doc.test.ts`.
- Pre-existing integration test failures (port conflicts in the test environment) are unrelated to this change and were present on `main` before this branch.

## Test plan

- [x] `npm run type-check` — clean
- [x] `npx vitest run tests/unit/store_alias_dispatch.test.ts tests/unit/mcp_instructions_fallback_invariants.test.ts` — 19/19 pass
- [x] `npm run validate:test-catalog` — up to date

🤖 Generated with [Claude Code](https://claude.com/claude-code)