### PR TITLE
fix: schema canonical_name_fields, unknown_fields list, idempotency mismatch detection

### DIFF
--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,8 +61,8 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **369**
-- Backend and repo Vitest files: **336**
+- Total automated test files: **373**
+- Backend and repo Vitest files: **340**
 - Frontend Vitest files: **9**
 - Playwright spec files: **24**
 
@@ -72,7 +72,7 @@ flowchart TD
 | Vitest unit tests | 88 |
 | Vitest service tests | 33 |
 | Source-adjacent tests | 45 |
-| Vitest integration tests | 96 |
+| Vitest integration tests | 100 |
 | Vitest CLI tests | 55 |
 | Vitest contract tests | 10 |
 | Vitest security tests | 1 |
@@ -294,7 +294,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm run test:integration` or `npx vitest run tests/integration`
 **Requirements:** Database configured; remote-dependent subsets additionally need `RUN_REMOTE_TESTS=1`.
-**Files (96):**
+**Files (100):**
 - `tests/integration/aauth_attribution_stamping.test.ts`
 - `tests/integration/aauth_resource_metadata.test.ts`
 - `tests/integration/aauth_revocation_e2e.test.ts`
@@ -329,10 +329,12 @@ flowchart TD
 - `tests/integration/guest_token_isolation.test.ts`
 - `tests/integration/guest_write_rate_limit.test.ts`
 - `tests/integration/hook_failure_hint.test.ts`
+- `tests/integration/idempotency_key_content_mismatch.test.ts`
 - `tests/integration/inspector_bundled_mount.test.ts`
 - `tests/integration/interpretation_fragment_ordering.test.ts`
 - `tests/integration/interpretation_no_schema_fallback.test.ts`
 - `tests/integration/interpretation_store.test.ts`
+- `tests/integration/issue_207_list_timeline_events_unknown_type.test.ts`
 - `tests/integration/issue_37_event_schema_projection.test.ts`
 - `tests/integration/lexical_search.test.ts`
 - `tests/integration/live_issues_tooling.test.ts`
@@ -380,10 +382,12 @@ flowchart TD
 - `tests/integration/session_introspection.test.ts`
 - `tests/integration/store_builtin_identity_opt_out_schemas.test.ts`
 - `tests/integration/store_conversation_message_role_conflict.test.ts`
+- `tests/integration/store_exercise_log_device_schema.test.ts`
 - `tests/integration/store_explicit_canonical_name.test.ts`
 - `tests/integration/store_external_link_schema.test.ts`
 - `tests/integration/store_registered_schema_alias_precedence.test.ts`
 - `tests/integration/store_resolution_attributes_hint.test.ts`
+- `tests/integration/store_unknown_fields_list.test.ts`
 - `tests/integration/submit_issue_advisory_alias.test.ts`
 - `tests/integration/subscription_list.test.ts`
 - `tests/integration/subscription_unsubscribe.test.ts`

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1550,9 +1550,12 @@ components:
           type: boolean
           description: |
             True when the response is an idempotency replay (no new observations
-            or entities were written for this request). Consumers can use this
-            to distinguish a genuine fresh commit from a replayed earlier result
-            when `entities_created_count` is 0.
+            or entities were written for this request). The key was already used
+            with identical content so the original result is returned. Consumers
+            can use this to distinguish a genuine fresh commit from a replayed
+            earlier result when `entities_created_count` is 0. If the same key
+            is reused with *different* content the request is rejected with
+            `ERR_IDEMPOTENCY_MISMATCH` (HTTP 400).
         entities:
           type: array
           items:
@@ -3694,8 +3697,10 @@ paths:
         '400':
           description: |
             Request rejected. `ERR_STORE_RESOLUTION_FAILED` uses the richer
-            `StoreResolutionErrorEnvelope` shape; other validation errors fall
-            back to the generic `ErrorEnvelope`.
+            `StoreResolutionErrorEnvelope` shape. `ERR_IDEMPOTENCY_MISMATCH` is
+            returned when the same `idempotency_key` is reused with materially
+            different content — use a new key for a different payload. Other
+            validation errors fall back to the generic `ErrorEnvelope`.
           content:
             application/json:
               schema:

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -5472,6 +5472,7 @@ app.post("/interpretations/create", async (req, res) => {
       })),
       observations_created: interpretationResult.observationsCreated,
       unknown_fields_count: interpretationResult.unknownFieldsCount,
+      unknown_fields: interpretationResult.unknownFieldNames,
       relationships_created: relationshipsCreated,
       ...(interpretationResult.noSchemaEntityTypes && interpretationResult.noSchemaEntityTypes.length > 0
         ? { no_schema_entity_types: interpretationResult.noSchemaEntityTypes }
@@ -5835,9 +5836,20 @@ export async function storeStructuredForApi(params: {
     }
   }
 
+  // Compute hash of incoming content before querying so we can detect
+  // idempotency-key reuse with different content (issue #186).
+  const incomingJsonContent = JSON.stringify(entities, (key, value) => {
+    if (typeof value === "bigint") {
+      return Number(value);
+    }
+    return value;
+  });
+  const { computeContentHash: _computeContentHash } = await import("./services/raw_storage.js");
+  const incomingContentHash = _computeContentHash(Buffer.from(incomingJsonContent, "utf-8"));
+
   const { data: existingSource, error: existingSourceError } = await db
     .from("sources")
-    .select("id")
+    .select("id, content_hash")
     .eq("user_id", userId)
     .eq("idempotency_key", idempotencyKey)
     .maybeSingle();
@@ -5847,6 +5859,21 @@ export async function storeStructuredForApi(params: {
   }
 
   if (existingSource) {
+    // If content hash differs, the caller reused an idempotency_key with
+    // materially different content. Reject with a clear error rather than
+    // silently skipping the write. See docs/architecture/idempotence_pattern.md.
+    if (existingSource.content_hash && existingSource.content_hash !== incomingContentHash) {
+      const mismatchErr = new Error(
+        `Idempotency key "${idempotencyKey}" was already used with different content. ` +
+          "Use a new idempotency_key for a different payload."
+      ) as Error & { code: string; hint: string };
+      mismatchErr.code = "ERR_IDEMPOTENCY_MISMATCH";
+      mismatchErr.hint =
+        "Each unique payload must use a unique idempotency_key. " +
+        "To update an entity, omit the idempotency_key or use a new one.";
+      throw mismatchErr;
+    }
+
     const { listObservationsForSource } = await import("./services/observation_storage.js");
     const existingObs = await listObservationsForSource(existingSource.id, userId);
 
@@ -5857,9 +5884,10 @@ export async function storeStructuredForApi(params: {
     }));
 
     // Idempotency replay: the source row already exists for
-    // (user_id, idempotency_key). No new observations or entities were
-    // written. Callers distinguish this from a zero-commit fresh write via the
-    // `replayed: true` flag (v0.5.1+). See docs/architecture/idempotence_pattern.md.
+    // (user_id, idempotency_key) with identical content. No new observations
+    // or entities were written. Callers distinguish this from a zero-commit
+    // fresh write via the `replayed: true` flag (v0.5.1+).
+    // See docs/architecture/idempotence_pattern.md.
     return {
       success: true,
       replayed: true,
@@ -5872,12 +5900,7 @@ export async function storeStructuredForApi(params: {
 
   const { createObservation } = await import("./services/observation_storage.js");
 
-  const jsonContent = JSON.stringify(entities, (key, value) => {
-    if (typeof value === "bigint") {
-      return Number(value);
-    }
-    return value;
-  });
+  const jsonContent = incomingJsonContent;
   const filenameForStorage = originalFilename?.trim() || undefined;
   const storageResult = await storeRawContent({
     userId,
@@ -6682,6 +6705,18 @@ async function handleStorePost(
       const message = error instanceof Error ? error.message : String(error);
       logWarn("EntityTypeGuardError:store", req, { code: errCode, message });
       return sendError(res, 400, errCode, message);
+    }
+    if (errCode === "ERR_IDEMPOTENCY_MISMATCH") {
+      const message = error instanceof Error ? error.message : "Idempotency key mismatch";
+      const hint = (error as { hint?: string }).hint;
+      logWarn("IdempotencyMismatch:store", req, { message });
+      return res.status(400).json({
+        error: {
+          code: "ERR_IDEMPOTENCY_MISMATCH",
+          message,
+          hint: hint ?? "Use a new idempotency_key for a different payload.",
+        },
+      });
     }
     if (error && typeof error === "object" && errCode === "ERR_STORE_RESOLUTION_FAILED") {
       const err = error as {

--- a/src/server.ts
+++ b/src/server.ts
@@ -4210,15 +4210,19 @@ export class NeotomaServer {
         entities: planEntities,
         entity_snapshots_after: planEntities.map(() => null),
         unknown_fields_count: 0,
+        unknown_fields: [],
         related_entities: [],
         related_relationships: [],
       });
     }
 
     if (idempotencyKey) {
+      const incomingContentHash = createHash("sha256")
+        .update(JSON.stringify(entities, null, 2))
+        .digest("hex");
       const { data: existingSource, error: existingSourceError } = await db
         .from("sources")
-        .select("id")
+        .select("id, content_hash")
         .eq("user_id", userId)
         .eq("idempotency_key", idempotencyKey)
         .maybeSingle();
@@ -4228,6 +4232,15 @@ export class NeotomaServer {
       }
 
       if (existingSource) {
+        if (existingSource.content_hash && existingSource.content_hash !== incomingContentHash) {
+          const mismatchErr = new McpError(
+            ErrorCode.InvalidParams,
+            `ERR_IDEMPOTENCY_MISMATCH: idempotency_key "${idempotencyKey}" was already used with different content. ` +
+            `Use a unique idempotency_key for each distinct write.`
+          );
+          throw mismatchErr;
+        }
+
         const { data: existingObservations, error: obsError } = await db
           .from("observations")
           .select("id, entity_id, entity_type")
@@ -4243,11 +4256,12 @@ export class NeotomaServer {
             (obs: { id: string; entity_id: string; entity_type: string }) => obs.entity_id
           ) ?? [];
         const relatedData = await this.getRelatedEntitiesAndRelationships(existingEntityIds);
-        const { count: unknownFieldsCount } = await db
+        const { data: fragmentRows } = await db
           .from("raw_fragments")
-          .select("id", { count: "exact", head: true })
+          .select("fragment_key")
           .eq("source_id", existingSource.id)
           .eq("user_id", userId);
+        const replayUnknownFieldNames = [...new Set((fragmentRows ?? []).map((r: { fragment_key: string }) => r.fragment_key))].sort();
 
         return this.buildTextResponse({
           source_id: existingSource.id,
@@ -4259,7 +4273,8 @@ export class NeotomaServer {
                 observation_id: obs.id,
               })
             ) ?? [],
-          unknown_fields_count: unknownFieldsCount || 0,
+          unknown_fields_count: replayUnknownFieldNames.length,
+          unknown_fields: replayUnknownFieldNames,
           related_entities: relatedData.entities,
           related_relationships: relatedData.relationships,
         });
@@ -4353,6 +4368,7 @@ export class NeotomaServer {
           observation_id: entity.observationId,
         })),
         unknown_fields_count: result.unknownFieldsCount,
+        unknown_fields: result.unknownFieldNames,
         ...(result.noSchemaEntityTypes && result.noSchemaEntityTypes.length > 0
           ? { no_schema_entity_types: result.noSchemaEntityTypes }
           : {}),
@@ -4372,6 +4388,7 @@ export class NeotomaServer {
     }> = [];
     const insertedObservationIds = new Set<string>();
     let unknownFieldsCount = 0;
+    const unknownFieldNamesSet = new Set<string>();
 
     for (const entityData of entities) {
       // Extract entity_type (support both 'entity_type' and 'type' fields)
@@ -4645,7 +4662,7 @@ export class NeotomaServer {
         validFields,
       });
 
-      unknownFieldsCount += await storeUnknownFields({
+      const unknownFieldsResult = await storeUnknownFields({
         sourceId: storageResult.sourceId,
         userId,
         entityId,
@@ -4653,6 +4670,8 @@ export class NeotomaServer {
         schemaVersion: schemaVer,
         unknownFields,
       });
+      unknownFieldsCount += unknownFieldsResult.count;
+      for (const f of unknownFieldsResult.fields) unknownFieldNamesSet.add(f);
 
       // If this store produced unknown fields, lazily check whether any of them
       // are already declared in the active schema — a sign of schema-lag misrouting
@@ -4963,6 +4982,7 @@ export class NeotomaServer {
         entity_snapshot_after: snapshotByEntityId.get(e.entityId) ?? null,
       })),
       unknown_fields_count: unknownFieldsCount,
+      unknown_fields: Array.from(unknownFieldNamesSet).sort(),
       related_entities: relatedData.entities,
       related_relationships: relatedData.relationships,
     });

--- a/src/services/interpretation.ts
+++ b/src/services/interpretation.ts
@@ -61,6 +61,8 @@ export interface InterpretationResult {
   interpretationId: string;
   observationsCreated: number;
   unknownFieldsCount: number;
+  /** The field names that were not recognized by the schema. */
+  unknownFieldNames: string[];
   observationsDeduplicated?: number; // Count of observations that already existed
   fixedPointReached?: boolean; // Whether fixed-point convergence was achieved
   convergenceIterations?: number; // Number of iterations to reach convergence
@@ -325,6 +327,7 @@ export async function runInterpretation(
   const interpretationId = run.id;
   let observationsCreated = 0;
   let unknownFieldsCount = 0;
+  const unknownFieldNamesSet = new Set<string>();
   const entities: Array<{
     entityId: string;
     entityType: string;
@@ -526,6 +529,7 @@ export async function runInterpretation(
       for (const [key, value] of Object.entries(unknownFields)) {
         if (value === null || value === undefined) continue;
         pendingUnknownFragments.push({ key, value });
+        unknownFieldNamesSet.add(key);
       }
 
       const validFieldKeys = Object.keys(validFields).filter((key) => key !== "schema_version");
@@ -793,6 +797,7 @@ export async function runInterpretation(
       interpretationId,
       observationsCreated,
       unknownFieldsCount,
+      unknownFieldNames: Array.from(unknownFieldNamesSet).sort(),
       entities,
       refinement_debug: refinementDebug.length > 0 ? refinementDebug : undefined,
       noSchemaEntityTypes: noSchemaEntityTypes.length > 0 ? noSchemaEntityTypes : undefined,

--- a/src/services/raw_fragments.ts
+++ b/src/services/raw_fragments.ts
@@ -205,7 +205,7 @@ export async function storeUnknownFields(params: {
   entityType: string;
   schemaVersion: string;
   unknownFields: Record<string, unknown>;
-}): Promise<number> {
+}): Promise<{ count: number; fields: string[] }> {
   const { sourceId, userId, entityId, entityType, schemaVersion, unknownFields } = params;
 
   const nonNullEntries = Object.entries(unknownFields).filter(
@@ -218,7 +218,7 @@ export async function storeUnknownFields(params: {
     );
   }
 
-  let count = 0;
+  const storedFields: string[] = [];
   for (const [key, value] of nonNullEntries) {
     const stored = await storeFragment({
       sourceId,
@@ -230,8 +230,8 @@ export async function storeUnknownFields(params: {
       value,
       reason: "unknown_field",
     });
-    if (stored) count++;
+    if (stored) storedFields.push(key);
   }
 
-  return count;
+  return { count: storedFields.length, fields: storedFields };
 }

--- a/src/services/schema_definitions.ts
+++ b/src/services/schema_definitions.ts
@@ -1502,6 +1502,52 @@ export const ENTITY_SCHEMAS: Record<string, EntitySchema> = {
     },
   },
 
+  exercise_log: {
+    entity_type: "exercise_log",
+    schema_version: "1.0",
+    metadata: {
+      label: "Exercise Log",
+      description:
+        "A single logged exercise set — one atomic entry in a workout (e.g. Bench Press, Set 1, 60 kg × 10 reps, 2026-05-16).",
+      category: "health",
+      aliases: ["exercise_set", "workout_set", "exercise_entry"],
+    },
+    schema_definition: {
+      fields: {
+        schema_version: { type: "string", required: true },
+        exercise: { type: "string", required: true },
+        date: { type: "date", required: true },
+        set_number: { type: "number", required: false },
+        set_type: { type: "string", required: false },
+        reps: { type: "number", required: false },
+        weight_kg: { type: "number", required: false },
+        weight_lbs: { type: "number", required: false },
+        duration_seconds: { type: "number", required: false },
+        distance_meters: { type: "number", required: false },
+        notes: { type: "string", required: false },
+        import_date: { type: "date", required: false },
+        import_source_file: { type: "string", required: false },
+      },
+      // Composite identity: exercise name + date + set_number uniquely identifies
+      // a single logged set. Falls back to exercise + date when set_number is absent
+      // (e.g. for cardio or untimed drills with no per-set breakdown).
+      canonical_name_fields: [
+        { composite: ["exercise", "date", "set_number"] },
+        { composite: ["exercise", "date"] },
+      ],
+    },
+    reducer_config: {
+      merge_policies: {
+        date: { strategy: "last_write" },
+        reps: { strategy: "last_write" },
+        weight_kg: { strategy: "last_write" },
+        weight_lbs: { strategy: "last_write" },
+        duration_seconds: { strategy: "last_write" },
+        distance_meters: { strategy: "last_write" },
+      },
+    },
+  },
+
   meal: {
     entity_type: "meal",
     schema_version: "1.0",
@@ -2831,6 +2877,52 @@ export const ENTITY_SCHEMAS: Record<string, EntitySchema> = {
         applied_fix: { strategy: "last_write" },
         proactive_remediation_required: { strategy: "last_write" },
         remediation_status: { strategy: "last_write" },
+      },
+    },
+  },
+
+  device: {
+    entity_type: "device",
+    schema_version: "1.0",
+    metadata: {
+      label: "Device",
+      description:
+        "A hardware device or IoT/smart-home unit (compute hardware, sensors, appliances). Identified by name; additional metadata such as brand, protocol, and location can be stored as optional fields.",
+      category: "knowledge",
+      aliases: ["hardware", "iot_device", "smart_device", "appliance"],
+    },
+    schema_definition: {
+      fields: {
+        schema_version: { type: "string", required: true },
+        name: { type: "string", required: true },
+        brand: { type: "string", required: false },
+        device_type: { type: "string", required: false },
+        model: { type: "string", required: false },
+        protocol: { type: "string", required: false },
+        location_in_home: { type: "string", required: false },
+        floor: { type: "string", required: false },
+        local_api_available: { type: "boolean", required: false },
+        cloud_dependent: { type: "boolean", required: false },
+        cpu_cores: { type: "number", required: false },
+        gpu_cores: { type: "number", required: false },
+        memory_gb: { type: "number", required: false },
+        notes: { type: "string", required: false },
+        import_date: { type: "date", required: false },
+        import_source_file: { type: "string", required: false },
+      },
+      // Devices are identified by name — "Nest Thermostat", "MacBook Pro", etc.
+      canonical_name_fields: ["name"],
+    },
+    reducer_config: {
+      merge_policies: {
+        brand: { strategy: "last_write" },
+        device_type: { strategy: "last_write" },
+        model: { strategy: "last_write" },
+        protocol: { strategy: "last_write" },
+        location_in_home: { strategy: "last_write" },
+        floor: { strategy: "last_write" },
+        local_api_available: { strategy: "last_write" },
+        cloud_dependent: { strategy: "last_write" },
       },
     },
   },

--- a/tests/cli/cli_store_commands.test.ts
+++ b/tests/cli/cli_store_commands.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeAll, afterEach } from "vitest";
 import { exec } from "child_process";
 import { promisify } from "util";
+import { randomUUID } from "crypto";
 import { TestIdTracker } from "../helpers/cleanup_helpers.js";
 import { writeFile, mkdir } from "fs/promises";
 import { join } from "path";
@@ -192,7 +193,7 @@ describe("CLI store commands", () => {
     });
 
     it("should be replay-safe with idempotency key", async () => {
-      const key = `store-turn-idem-${Date.now()}`;
+      const key = `store-turn-idem-${randomUUID()}`;
       const cmd =
         `${CLI_PATH} store-turn --conversation-title "CLI Turn Idem" ` +
         `--message "User said hello twice" --idempotency-key "${key}" --user-id "${TEST_USER_ID}" --json`;
@@ -203,6 +204,7 @@ describe("CLI store commands", () => {
       expect(first.source_id).toBeDefined();
       expect(second.source_id).toBe(first.source_id);
 
+      if (first.source_id) tracker.trackSource(first.source_id);
       if (Array.isArray(first.entities)) {
         for (const entity of first.entities) {
           if (entity?.id) tracker.trackEntity(entity.id);

--- a/tests/integration/idempotency_key_content_mismatch.test.ts
+++ b/tests/integration/idempotency_key_content_mismatch.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Regression test for GitHub issue #186:
+ * Idempotency key reused with different content should produce a clear error,
+ * not silently succeed while skipping the write.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import { db } from "../../src/db.js";
+import { storeStructuredForApi } from "../../src/actions.js";
+import { NeotomaServer } from "../../src/server.js";
+
+const TEST_USER_ID = "00000000-0000-4000-8000-000000000099";
+const ENTITY_TYPE = "idempotency_mismatch_test_note";
+
+async function cleanup() {
+  const { data: observations } = await db
+    .from("observations")
+    .select("entity_id, source_id")
+    .eq("user_id", TEST_USER_ID);
+  const entityIds = Array.from(
+    new Set((observations ?? []).map((obs: { entity_id: string }) => obs.entity_id).filter(Boolean))
+  );
+  const sourceIds = Array.from(
+    new Set((observations ?? []).map((obs: { source_id: string }) => obs.source_id).filter(Boolean))
+  );
+
+  await db.from("timeline_events").delete().eq("user_id", TEST_USER_ID);
+  if (entityIds.length > 0) {
+    await db.from("entity_snapshots").delete().in("entity_id", entityIds);
+  }
+  await db.from("observations").delete().eq("user_id", TEST_USER_ID);
+  if (sourceIds.length > 0) {
+    await db.from("raw_fragments").delete().in("source_id", sourceIds);
+    await db.from("sources").delete().in("id", sourceIds);
+  }
+  if (entityIds.length > 0) {
+    await db.from("entities").delete().in("id", entityIds);
+  }
+}
+
+describe("Idempotency key reuse with different content (issue #186)", () => {
+  afterEach(cleanup);
+
+  describe("storeStructuredForApi (HTTP API path)", () => {
+    it("returns replayed:true when same idempotency_key is reused with identical content", async () => {
+      const key = `replay-same-${randomUUID()}`;
+      const entities = [
+        {
+          entity_type: ENTITY_TYPE,
+          title: "Original entity",
+          description: "First write",
+        },
+      ];
+
+      const first = await storeStructuredForApi({
+        userId: TEST_USER_ID,
+        entities,
+        sourcePriority: 100,
+        idempotencyKey: key,
+      });
+      expect(first.replayed).toBeFalsy();
+      expect(first.entities.length).toBe(1);
+
+      // Second call with identical payload — should replay successfully
+      const second = await storeStructuredForApi({
+        userId: TEST_USER_ID,
+        entities,
+        sourcePriority: 100,
+        idempotencyKey: key,
+      });
+      expect(second.replayed).toBe(true);
+      expect(second.entities.length).toBe(1);
+      expect(second.entities[0].entity_id).toBe(first.entities[0].entity_id);
+    });
+
+    it("throws ERR_IDEMPOTENCY_MISMATCH when same key is reused with different content", async () => {
+      const key = `replay-diff-${randomUUID()}`;
+
+      const firstEntities = [
+        {
+          entity_type: ENTITY_TYPE,
+          title: "Original entity",
+          description: "First write",
+        },
+      ];
+      const secondEntities = [
+        {
+          entity_type: ENTITY_TYPE,
+          title: "Different entity",
+          description: "This has different content",
+        },
+      ];
+
+      // Store the first payload
+      await storeStructuredForApi({
+        userId: TEST_USER_ID,
+        entities: firstEntities,
+        sourcePriority: 100,
+        idempotencyKey: key,
+      });
+
+      // Attempt to reuse the same key with different content — must throw
+      await expect(
+        storeStructuredForApi({
+          userId: TEST_USER_ID,
+          entities: secondEntities,
+          sourcePriority: 100,
+          idempotencyKey: key,
+        })
+      ).rejects.toMatchObject({
+        code: "ERR_IDEMPOTENCY_MISMATCH",
+        message: expect.stringContaining(key),
+      });
+    });
+
+    it("does NOT write the new entity when the mismatch error is thrown", async () => {
+      const key = `no-write-${randomUUID()}`;
+
+      const firstEntities = [
+        {
+          entity_type: ENTITY_TYPE,
+          title: "Original entity stable",
+          description: "First write stable",
+        },
+      ];
+      const secondEntities = [
+        {
+          entity_type: ENTITY_TYPE,
+          title: "Should not be stored",
+          description: "This entity should never appear in the DB",
+        },
+      ];
+
+      const first = await storeStructuredForApi({
+        userId: TEST_USER_ID,
+        entities: firstEntities,
+        sourcePriority: 100,
+        idempotencyKey: key,
+      });
+      const originalEntityId = first.entities[0].entity_id;
+
+      // Attempt with different content (should error)
+      await expect(
+        storeStructuredForApi({
+          userId: TEST_USER_ID,
+          entities: secondEntities,
+          sourcePriority: 100,
+          idempotencyKey: key,
+        })
+      ).rejects.toMatchObject({ code: "ERR_IDEMPOTENCY_MISMATCH" });
+
+      // Verify no additional observations were written for this user
+      const { data: observations } = await db
+        .from("observations")
+        .select("entity_id")
+        .eq("user_id", TEST_USER_ID);
+
+      const entityIds = new Set((observations ?? []).map((o: { entity_id: string }) => o.entity_id));
+      // Only the original entity should be present; "should not be stored" entity must not exist
+      expect(entityIds.has(originalEntityId)).toBe(true);
+
+      // Confirm there is exactly one source for this idempotency key (no second source created)
+      const { data: sources } = await db
+        .from("sources")
+        .select("id")
+        .eq("user_id", TEST_USER_ID)
+        .eq("idempotency_key", key);
+      expect(sources?.length).toBe(1);
+    });
+  });
+
+  describe("MCP store path (storeStructuredInternal)", () => {
+    let server: NeotomaServer;
+
+    it("throws ERR_IDEMPOTENCY_MISMATCH on key reuse with different content via MCP store", async () => {
+      server = new NeotomaServer();
+      (server as unknown as { authenticatedUserId: string }).authenticatedUserId = TEST_USER_ID;
+
+      const key = `mcp-diff-${randomUUID()}`;
+
+      const firstEntities = [
+        {
+          entity_type: ENTITY_TYPE,
+          title: "MCP original entity",
+          description: "First MCP write",
+        },
+      ];
+      const secondEntities = [
+        {
+          entity_type: ENTITY_TYPE,
+          title: "MCP different entity",
+          description: "Different content via MCP",
+        },
+      ];
+
+      // First write
+      await (server as unknown as { store: (p: unknown) => Promise<unknown> }).store({
+        user_id: TEST_USER_ID,
+        entities: firstEntities,
+        idempotency_key: key,
+      });
+
+      // Second write with different content must throw an MCP error containing the code
+      await expect(
+        (server as unknown as { store: (p: unknown) => Promise<unknown> }).store({
+          user_id: TEST_USER_ID,
+          entities: secondEntities,
+          idempotency_key: key,
+        })
+      ).rejects.toMatchObject({
+        message: expect.stringContaining(key),
+      });
+    });
+
+    it("returns replayed result when same key is reused with identical content via MCP store", async () => {
+      server = new NeotomaServer();
+      (server as unknown as { authenticatedUserId: string }).authenticatedUserId = TEST_USER_ID;
+
+      const key = `mcp-same-${randomUUID()}`;
+      const entities = [
+        {
+          entity_type: ENTITY_TYPE,
+          title: "MCP replay entity",
+          description: "Content for replay test",
+        },
+      ];
+
+      const firstResponse = await (server as unknown as { store: (p: unknown) => Promise<{ content: Array<{ text: string }> }> }).store({
+        user_id: TEST_USER_ID,
+        entities,
+        idempotency_key: key,
+      });
+      const firstParsed = JSON.parse((firstResponse as { content: Array<{ text: string }> }).content[0].text);
+      expect(firstParsed.source_id).toBeDefined();
+
+      // Replay with identical content
+      const secondResponse = await (server as unknown as { store: (p: unknown) => Promise<{ content: Array<{ text: string }> }> }).store({
+        user_id: TEST_USER_ID,
+        entities,
+        idempotency_key: key,
+      });
+      const secondParsed = JSON.parse((secondResponse as { content: Array<{ text: string }> }).content[0].text);
+
+      // Same source_id should be returned on replay
+      expect(secondParsed.source_id).toBe(firstParsed.source_id);
+    });
+  });
+});

--- a/tests/integration/issue_207_list_timeline_events_unknown_type.test.ts
+++ b/tests/integration/issue_207_list_timeline_events_unknown_type.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Regression test for issue #207:
+ * list_timeline_events returns a generic error instead of an empty result set
+ * when called with an unknown event_type (e.g. event_type: "workout").
+ *
+ * Expected: { events: [], total: 0 }
+ * Before fix: generic tool execution error
+ */
+
+import { describe, it, expect, beforeAll } from "vitest";
+import { NeotomaServer } from "../../src/server.js";
+
+describe("issue 207 — list_timeline_events with unknown event_type", () => {
+  let server: NeotomaServer;
+  const testUserId = "00000000-0000-0000-0000-000000000207";
+
+  beforeAll(() => {
+    server = new NeotomaServer();
+    // Set authenticated user directly — avoids needing a real MCP initialize handshake.
+    (server as any).authenticatedUserId = testUserId;
+  });
+
+  it("returns empty events array (not an error) for a nonexistent event_type", async () => {
+    // Calling list_timeline_events with an event_type that has no stored events
+    // must return {events: [], total: 0} rather than throwing or returning an
+    // error envelope.
+    const result = await (server as any).listTimelineEvents({
+      event_type: "workout",
+    });
+
+    expect(result).toHaveProperty("content");
+    expect(Array.isArray(result.content)).toBe(true);
+    expect(result.content.length).toBeGreaterThan(0);
+    expect(result.content[0].type).toBe("text");
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed).toHaveProperty("events");
+    expect(parsed).toHaveProperty("total");
+    expect(Array.isArray(parsed.events)).toBe(true);
+    expect(parsed.events).toHaveLength(0);
+    expect(parsed.total).toBe(0);
+  });
+
+  it("returns empty events array for another nonexistent event_type variant", async () => {
+    const result = await (server as any).listTimelineEvents({
+      event_type: "nonexistent_event_type_xyz_12345",
+    });
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.events).toHaveLength(0);
+    expect(parsed.total).toBe(0);
+  });
+
+  it("executeTool dispatch also returns empty results for unknown event_type (regression: issue #207)", async () => {
+    // Exercise the full executeTool → listTimelineEvents path used by the MCP
+    // CallToolRequestSchema handler so any regression in the dispatch layer is caught.
+    const result = await server.executeToolForCli(
+      "list_timeline_events",
+      { event_type: "workout" },
+      testUserId,
+    );
+
+    expect(result).toHaveProperty("content");
+    const parsed = JSON.parse(result.content[0].text);
+    // Must not be an error object
+    expect(parsed).not.toHaveProperty("error");
+    expect(Array.isArray(parsed.events)).toBe(true);
+    expect(parsed.events).toHaveLength(0);
+    expect(parsed.total).toBe(0);
+  });
+});

--- a/tests/integration/store_exercise_log_device_schema.test.ts
+++ b/tests/integration/store_exercise_log_device_schema.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Regression tests for issues #204 and #188:
+ *
+ * #204 — `exercise_log` schema missing `canonical_name_fields` — storing an
+ *        exercise_log entity without an explicit `name` field caused a hard
+ *        "Cannot derive canonical_name" error. Fixed by adding a built-in
+ *        `exercise_log` schema to ENTITY_SCHEMAS with
+ *        `canonical_name_fields: [{ composite: ["exercise", "date", "set_number"] }, { composite: ["exercise", "date"] }]`.
+ *
+ * #188 — `device` schema blocked incremental field extension because it had no
+ *        `canonical_name_fields` or `identity_opt_out` declaration. Fixed by
+ *        adding a built-in `device` schema to ENTITY_SCHEMAS with
+ *        `canonical_name_fields: ["name"]`.
+ */
+
+import { describe, it, expect } from "vitest";
+import { NeotomaServer } from "../../src/server.js";
+import { randomUUID } from "crypto";
+import { getSchemaDefinition } from "../../src/services/schema_definitions.js";
+
+const TEST_USER_ID = "00000000-0000-0000-0000-000000000000";
+
+describe("store: exercise_log canonical_name_fields (#204)", () => {
+  const server = new NeotomaServer();
+  (server as any).authenticatedUserId = TEST_USER_ID;
+
+  it("stores an exercise_log entity without an explicit name field (#204)", async () => {
+    const result = await (server as any).store({
+      user_id: TEST_USER_ID,
+      idempotency_key: `test-204-${randomUUID()}`,
+      entities: [
+        {
+          entity_type: "exercise_log",
+          schema_version: "1.0",
+          exercise: "Bench Press",
+          reps: 10,
+          set_number: 1,
+          set_type: "warmup",
+          weight_kg: 60,
+          date: "2026-05-16",
+        },
+      ],
+    });
+
+    const response = JSON.parse(result.content[0].text);
+    expect(response.error).toBeUndefined();
+    expect(response.entities).toHaveLength(1);
+    expect(response.entities[0].entity_id).toBeTruthy();
+  });
+
+  it("stores an exercise_log entity without set_number using the exercise+date fallback rule (#204)", async () => {
+    const result = await (server as any).store({
+      user_id: TEST_USER_ID,
+      idempotency_key: `test-204-no-set-${randomUUID()}`,
+      entities: [
+        {
+          entity_type: "exercise_log",
+          schema_version: "1.0",
+          exercise: "5k Run",
+          date: "2026-05-16",
+          duration_seconds: 1800,
+          distance_meters: 5000,
+        },
+      ],
+    });
+
+    const response = JSON.parse(result.content[0].text);
+    expect(response.error).toBeUndefined();
+    expect(response.entities).toHaveLength(1);
+    expect(response.entities[0].entity_id).toBeTruthy();
+  });
+
+  it("exercise_log schema has canonical_name_fields declared in ENTITY_SCHEMAS (#204)", () => {
+    const schema = getSchemaDefinition("exercise_log");
+    expect(schema).not.toBeNull();
+    expect(schema!.schema_definition.canonical_name_fields).toBeDefined();
+    expect(schema!.schema_definition.identity_opt_out).toBeUndefined();
+  });
+});
+
+describe("store: device canonical_name_fields (#188)", () => {
+  const server = new NeotomaServer();
+  (server as any).authenticatedUserId = TEST_USER_ID;
+
+  it("stores a device entity without error (#188)", async () => {
+    const result = await (server as any).store({
+      user_id: TEST_USER_ID,
+      idempotency_key: `test-188-${randomUUID()}`,
+      entities: [
+        {
+          entity_type: "device",
+          schema_version: "1.0",
+          name: "Nest Thermostat",
+          brand: "Google",
+          device_type: "thermostat",
+          protocol: "wifi",
+          local_api_available: false,
+          cloud_dependent: true,
+          floor: "1",
+          location_in_home: "hallway",
+        },
+      ],
+    });
+
+    const response = JSON.parse(result.content[0].text);
+    expect(response.error).toBeUndefined();
+    expect(response.entities).toHaveLength(1);
+    expect(response.entities[0].entity_id).toBeTruthy();
+  });
+
+  it("device schema has canonical_name_fields declared in ENTITY_SCHEMAS (#188)", () => {
+    const schema = getSchemaDefinition("device");
+    expect(schema).not.toBeNull();
+    expect(schema!.schema_definition.canonical_name_fields).toBeDefined();
+    expect(schema!.schema_definition.identity_opt_out).toBeUndefined();
+  });
+});

--- a/tests/integration/store_unknown_fields_list.test.ts
+++ b/tests/integration/store_unknown_fields_list.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Tests for issues #185 and #190: store response should include
+ * `unknown_fields: string[]` alongside `unknown_fields_count: number`
+ * so agents can self-correct without fetching the schema separately.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { NeotomaServer } from "../../src/server.js";
+import { cleanupEntityType } from "../helpers/cleanup_helpers.js";
+
+const TEST_USER_ID = "00000000-0000-0000-0000-000000000001";
+
+type StoreResponse = {
+  entities?: Array<{ entity_id: string; entity_type: string }>;
+  unknown_fields_count?: number;
+  unknown_fields?: string[];
+  source_id?: string;
+  error?: unknown;
+};
+
+describe("store response: unknown_fields list (issues #185, #190)", () => {
+  let server: NeotomaServer;
+
+  beforeAll(async () => {
+    server = new NeotomaServer();
+    (server as unknown as Record<string, unknown>).authenticatedUserId = TEST_USER_ID;
+  });
+
+  afterAll(async () => {
+    await cleanupEntityType("note", TEST_USER_ID);
+    await cleanupEntityType("generic", TEST_USER_ID);
+  });
+
+  it("returns unknown_fields: [] and unknown_fields_count: 0 when all fields are schema-known", async () => {
+    const result = await (
+      server as unknown as {
+        store: (params: Record<string, unknown>) => Promise<{ content: Array<{ text: string }> }>;
+      }
+    ).store({
+      user_id: TEST_USER_ID,
+      idempotency_key: `unknown-fields-known-${Date.now()}`,
+      commit: true,
+      entities: [
+        {
+          entity_type: "note",
+          title: "Meeting notes",
+          content: "Discussed roadmap",
+        },
+      ],
+    });
+
+    const body = JSON.parse(result.content[0].text) as StoreResponse;
+
+    expect(body.error).toBeUndefined();
+    expect(body.unknown_fields_count).toBeDefined();
+    expect(body.unknown_fields).toBeDefined();
+    expect(Array.isArray(body.unknown_fields)).toBe(true);
+    // Note may have no unknown fields if title/content are declared schema fields,
+    // but the response shape must always be present.
+    expect(typeof body.unknown_fields_count).toBe("number");
+  });
+
+  it("returns unknown_fields list naming each unrecognized field when unknown fields are stored", async () => {
+    // Use a note entity (has title/content in schema) but include extra unknown fields
+    const result = await (
+      server as unknown as {
+        store: (params: Record<string, unknown>) => Promise<{ content: Array<{ text: string }> }>;
+      }
+    ).store({
+      user_id: TEST_USER_ID,
+      idempotency_key: `unknown-fields-present-${Date.now()}`,
+      commit: true,
+      entities: [
+        {
+          entity_type: "note",
+          title: "Unknown fields test note",
+          content: "Testing unknown field reporting",
+          // These are not declared in the note schema
+          custom_tag_xyzzy: "some-value",
+          internal_ref_plugh: "another-value",
+        },
+      ],
+    });
+
+    const body = JSON.parse(result.content[0].text) as StoreResponse;
+
+    expect(body.error).toBeUndefined();
+    expect(Array.isArray(body.unknown_fields)).toBe(true);
+    expect(typeof body.unknown_fields_count).toBe("number");
+
+    // The count and list must be consistent
+    expect(body.unknown_fields_count).toBe(body.unknown_fields!.length);
+
+    // The unknown field names must be present in the list if they were stored as raw_fragments
+    // (null/undefined values are filtered out, so non-null unknown fields must appear)
+    const unknownFieldNames = body.unknown_fields!;
+    if (body.unknown_fields_count! > 0) {
+      expect(unknownFieldNames.length).toBeGreaterThan(0);
+      // Each entry must be a string
+      for (const name of unknownFieldNames) {
+        expect(typeof name).toBe("string");
+        expect(name.length).toBeGreaterThan(0);
+      }
+      // Both custom fields (if stored as unknown) should be present
+      // They are non-null so they should appear in the list
+      expect(unknownFieldNames).toContain("custom_tag_xyzzy");
+      expect(unknownFieldNames).toContain("internal_ref_plugh");
+    }
+  });
+
+  it("unknown_fields list contains exactly the unrecognized field names for a generic entity", async () => {
+    // Use entity_type generic so every field is treated as unknown
+    const result = await (
+      server as unknown as {
+        store: (params: Record<string, unknown>) => Promise<{ content: Array<{ text: string }> }>;
+      }
+    ).store({
+      user_id: TEST_USER_ID,
+      idempotency_key: `unknown-fields-generic-${Date.now()}`,
+      commit: true,
+      entities: [
+        {
+          entity_type: "generic",
+          canonical_name: "Test Generic Entity",
+          field_alpha: "value-alpha",
+          field_beta: "value-beta",
+          field_gamma: "value-gamma",
+        },
+      ],
+    });
+
+    const body = JSON.parse(result.content[0].text) as StoreResponse;
+
+    expect(body.error).toBeUndefined();
+    expect(Array.isArray(body.unknown_fields)).toBe(true);
+    expect(typeof body.unknown_fields_count).toBe("number");
+    // Count and list length must match
+    expect(body.unknown_fields_count).toBe(body.unknown_fields!.length);
+    // The list must be sorted
+    const sorted = [...body.unknown_fields!].sort();
+    expect(body.unknown_fields).toEqual(sorted);
+  });
+});


### PR DESCRIPTION
## Summary

- **exercise_log schema** (`#204`): adds `canonical_name_fields` composite rules so storing without explicit name no longer throws
- **device schema** (`#188`): adds `canonical_name_fields: ["name"]` so `update_schema_incremental` no longer fails the R2 check
- **store response** (`#185`, `#190`): adds `unknown_fields: string[]` alongside `unknown_fields_count` so agents can self-correct schema mismatches without a separate schema lookup
- **idempotency mismatch** (`#186`): detects content hash divergence on key reuse and returns `ERR_IDEMPOTENCY_MISMATCH` (HTTP 400 / `McpError InvalidParams`) instead of silently replaying
- **list_timeline_events** (`#207`): already returns empty for unknown event types; regression tests added to lock that behavior

## Test plan

- [ ] `tests/integration/store_exercise_log_device_schema.test.ts` — 5 tests, exercise_log and device schema identity resolution
- [ ] `tests/integration/store_unknown_fields_list.test.ts` — 3 tests, unknown_fields array in store response
- [ ] `tests/integration/idempotency_key_content_mismatch.test.ts` — 5 tests, HTTP and MCP mismatch paths
- [ ] `tests/integration/issue_207_list_timeline_events_unknown_type.test.ts` — 3 tests, empty results for unknown event type

All 16 tests pass locally. Type check and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)