### PR TITLE
fix: workout session snapshot does not consolidate exercise observations (closes #209)

### DIFF
--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,15 +61,15 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **356**
-- Backend and repo Vitest files: **323**
+- Total automated test files: **357**
+- Backend and repo Vitest files: **324**
 - Frontend Vitest files: **9**
 - Playwright spec files: **24**
 
 ### Suite counts
 | Suite | Files |
 |---|---:|
-| Vitest unit tests | 84 |
+| Vitest unit tests | 85 |
 | Vitest service tests | 33 |
 | Source-adjacent tests | 39 |
 | Vitest integration tests | 93 |
@@ -107,7 +107,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/unit`
 **Requirements:** Basic `.env` if required by the module under test.
-**Files (84):**
+**Files (85):**
 - `tests/unit/aauth_admission.test.ts`
 - `tests/unit/aauth_attestation_apple_se.test.ts`
 - `tests/unit/aauth_attestation_revocation.test.ts`
@@ -192,6 +192,7 @@ flowchart TD
 - `tests/unit/substrate_event_bus.test.ts`
 - `tests/unit/timeline_events.test.ts`
 - `tests/unit/unknown_fields_guard.test.ts`
+- `tests/unit/workout_session_schema.test.ts`
 
 ### Vitest service tests
 **Directory:** `tests/services/`

--- a/src/services/schema_definitions.ts
+++ b/src/services/schema_definitions.ts
@@ -2847,6 +2847,61 @@ export const ENTITY_SCHEMAS: Record<string, EntitySchema> = {
       },
     },
   },
+
+  workout_session: {
+    entity_type: "workout_session",
+    schema_version: "1.0",
+    metadata: {
+      label: "Workout Session",
+      description:
+        "A single workout session container. Exercises performed during the session are accumulated incrementally via the `exercises` array field using the merge_array reducer strategy, so each logged exercise observation appends to the consolidated list.",
+      category: "health",
+      aliases: ["training_session", "gym_session", "workout_log"],
+    },
+    schema_definition: {
+      fields: {
+        schema_version: { type: "string", required: true },
+        // Caller-supplied stable identifier linking all observations in this
+        // session. Required for deterministic identity; callers (e.g. the
+        // Telegram bot) should pass a stable session token each turn.
+        session_id: { type: "string", required: false },
+        name: { type: "string", required: false, preserveCase: true },
+        date: { type: "date", required: false },
+        started_at: { type: "date", required: false },
+        ended_at: { type: "date", required: false },
+        duration_minutes: { type: "number", required: false },
+        // Accumulated list of exercises performed. Each observation may
+        // push one or more exercise objects (name, sets, reps, weight).
+        // The merge_array reducer strategy unions all values across
+        // observations so incremental logging converges into a full list.
+        exercises: { type: "array", required: false },
+        notes: { type: "string", required: false, preserveCase: true },
+        location: { type: "string", required: false },
+        import_date: { type: "date", required: false },
+        import_source_file: { type: "string", required: false },
+      },
+      // session_id is the primary stable identity key. Falls back to
+      // name + date for sessions created without an explicit session_id.
+      canonical_name_fields: [
+        "session_id",
+        { composite: ["name", "date"] },
+      ],
+    },
+    reducer_config: {
+      merge_policies: {
+        // exercises accumulates across observations — each new log appends.
+        exercises: { strategy: "merge_array" },
+        // Scalar fields use last_write so mid-session corrections propagate.
+        name: { strategy: "last_write" },
+        date: { strategy: "last_write" },
+        started_at: { strategy: "last_write" },
+        ended_at: { strategy: "last_write" },
+        duration_minutes: { strategy: "last_write" },
+        notes: { strategy: "last_write" },
+        location: { strategy: "last_write" },
+      },
+    },
+  },
 };
 
 /**

--- a/tests/unit/workout_session_schema.test.ts
+++ b/tests/unit/workout_session_schema.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Unit tests for workout_session schema definition (issue #209).
+ *
+ * Verifies that the workout_session entity type is registered with:
+ *   - exercises field declared as array type with merge_array reducer strategy
+ *   - canonical_name_fields covering session_id and name+date composite
+ *   - all expected scalar fields
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  ENTITY_SCHEMAS,
+  getSchemaDefinition,
+} from "../../src/services/schema_definitions.js";
+
+describe("workout_session schema (#209)", () => {
+  const schema = ENTITY_SCHEMAS["workout_session"];
+
+  it("is registered in ENTITY_SCHEMAS", () => {
+    expect(schema).toBeDefined();
+    expect(schema.entity_type).toBe("workout_session");
+  });
+
+  it("is retrievable via getSchemaDefinition", () => {
+    const result = getSchemaDefinition("workout_session");
+    expect(result).not.toBeNull();
+    expect(result?.entity_type).toBe("workout_session");
+  });
+
+  it("has exercises declared as array field", () => {
+    const { fields } = schema.schema_definition;
+    expect(fields.exercises).toBeDefined();
+    expect(fields.exercises.type).toBe("array");
+  });
+
+  it("uses merge_array strategy for exercises", () => {
+    const { merge_policies } = schema.reducer_config;
+    expect(merge_policies.exercises).toBeDefined();
+    expect(merge_policies.exercises.strategy).toBe("merge_array");
+  });
+
+  it("declares canonical_name_fields with session_id as primary rule", () => {
+    const { canonical_name_fields } = schema.schema_definition;
+    expect(canonical_name_fields).toBeDefined();
+    expect(Array.isArray(canonical_name_fields)).toBe(true);
+    // First rule: scalar session_id
+    const rules = canonical_name_fields as Array<string | { composite: string[] }>;
+    expect(rules[0]).toBe("session_id");
+  });
+
+  it("includes name+date composite as fallback canonical_name rule", () => {
+    const rules = schema.schema_definition
+      .canonical_name_fields as Array<string | { composite: string[] }>;
+    const compositeRule = rules.find(
+      (r): r is { composite: string[] } =>
+        typeof r === "object" && "composite" in r,
+    );
+    expect(compositeRule).toBeDefined();
+    expect(compositeRule?.composite).toContain("name");
+    expect(compositeRule?.composite).toContain("date");
+  });
+
+  it("has expected scalar fields with correct types", () => {
+    const { fields } = schema.schema_definition;
+    expect(fields.session_id?.type).toBe("string");
+    expect(fields.name?.type).toBe("string");
+    expect(fields.date?.type).toBe("date");
+    expect(fields.duration_minutes?.type).toBe("number");
+    expect(fields.notes?.type).toBe("string");
+  });
+
+  it("uses last_write for all scalar merge policies", () => {
+    const { merge_policies } = schema.reducer_config;
+    for (const field of ["name", "date", "started_at", "ended_at", "duration_minutes", "notes", "location"] as const) {
+      expect(merge_policies[field]?.strategy).toBe("last_write");
+    }
+  });
+
+  it("has health category metadata", () => {
+    expect(schema.metadata?.category).toBe("health");
+  });
+});


### PR DESCRIPTION
## Summary

- Registers `workout_session` in `ENTITY_SCHEMAS` with an `exercises` field using `merge_array` reducer strategy, so repeated store calls (one observation per exercise) accumulate into a single consolidated snapshot rather than overwriting.
- Adds `session_id` as the primary canonical identity field and `{ composite: ["name", "date"] }` as fallback, enabling reliable entity identity resolution across sources.
- Scalar fields (`name`, `date`, `started_at`, `ended_at`, `duration_minutes`, `notes`, `location`) use `last_write` so mid-session corrections propagate.

## Test plan

- [ ] `tests/unit/workout_session_schema.test.ts` (9 unit tests) — verifies schema structure, field declarations, `exercises` merge policy, and `canonical_name_fields` without requiring a database connection
- [ ] `npm run type-check` — passes
- [ ] All 9 schema unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)