### PR TITLE
fix: buffer raw_fragment writes until after entity resolution (closes #163)

### DIFF
--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,8 +61,8 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **366**
-- Backend and repo Vitest files: **333**
+- Total automated test files: **367**
+- Backend and repo Vitest files: **334**
 - Frontend Vitest files: **9**
 - Playwright spec files: **24**
 
@@ -72,7 +72,7 @@ flowchart TD
 | Vitest unit tests | 87 |
 | Vitest service tests | 33 |
 | Source-adjacent tests | 45 |
-| Vitest integration tests | 94 |
+| Vitest integration tests | 95 |
 | Vitest CLI tests | 55 |
 | Vitest contract tests | 10 |
 | Vitest security tests | 1 |
@@ -293,7 +293,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm run test:integration` or `npx vitest run tests/integration`
 **Requirements:** Database configured; remote-dependent subsets additionally need `RUN_REMOTE_TESTS=1`.
-**Files (94):**
+**Files (95):**
 - `tests/integration/aauth_attribution_stamping.test.ts`
 - `tests/integration/aauth_resource_metadata.test.ts`
 - `tests/integration/aauth_revocation_e2e.test.ts`
@@ -329,6 +329,7 @@ flowchart TD
 - `tests/integration/guest_write_rate_limit.test.ts`
 - `tests/integration/hook_failure_hint.test.ts`
 - `tests/integration/inspector_bundled_mount.test.ts`
+- `tests/integration/interpretation_fragment_ordering.test.ts`
 - `tests/integration/interpretation_store.test.ts`
 - `tests/integration/issue_37_event_schema_projection.test.ts`
 - `tests/integration/lexical_search.test.ts`

--- a/src/services/interpretation.ts
+++ b/src/services/interpretation.ts
@@ -105,6 +105,176 @@ function validateAgainstSchema(
 }
 
 /**
+ * Write buffered raw_fragments for a single entity after entity resolution and
+ * observation creation have both succeeded (issue #163: do not write fragments
+ * before entity resolution).
+ */
+async function flushPendingFragments(opts: {
+  db: unknown; // unused; kept for call-site symmetry — module-level db is used
+  sourceId: string;
+  interpretationId: string;
+  userId: string;
+  entityType: string;
+  effectiveSchemaVersion: string;
+  validFields: Record<string, unknown>;
+  pendingConvertedFragments: Array<{ key: string; value: unknown }>;
+  pendingUnknownFragments: Array<{ key: string; value: unknown }>;
+}): Promise<void> {
+  const {
+    sourceId, interpretationId, userId, entityType,
+    effectiveSchemaVersion, validFields,
+    pendingConvertedFragments, pendingUnknownFragments,
+  } = opts;
+
+  // Write converted-value originals (preserves zero data loss for converter fields).
+  for (const { key, value } of pendingConvertedFragments) {
+    const { data: existing } = await db
+      .from("raw_fragments")
+      .select("id, frequency_count")
+      .eq("source_id", sourceId)
+      .eq("fragment_key", key)
+      .eq("user_id", userId)
+      .maybeSingle();
+
+    if (existing) {
+      await db
+        .from("raw_fragments")
+        .update({
+          fragment_value: value,
+          fragment_envelope: {
+            reason: "converted_value_original",
+            entity_type: entityType,
+            schema_version: effectiveSchemaVersion,
+            converted_to: validFields[key],
+          },
+          frequency_count: (existing.frequency_count || 1) + 1,
+          last_seen: new Date().toISOString(),
+        })
+        .eq("id", existing.id);
+    } else {
+      await db.from("raw_fragments").insert({
+        id: randomUUID(),
+        source_id: sourceId,
+        interpretation_id: interpretationId,
+        user_id: userId,
+        entity_type: entityType,
+        fragment_key: key,
+        fragment_value: value,
+        fragment_envelope: {
+          reason: "converted_value_original",
+          entity_type: entityType,
+          schema_version: effectiveSchemaVersion,
+          converted_to: validFields[key],
+        },
+      });
+    }
+  }
+
+  // Write unknown-field fragments.
+  for (const { key, value } of pendingUnknownFragments) {
+    const { data: existing } = await db
+      .from("raw_fragments")
+      .select("id, frequency_count")
+      .eq("source_id", sourceId)
+      .eq("fragment_key", key)
+      .eq("user_id", userId)
+      .maybeSingle();
+
+    if (existing) {
+      const newFreq = (existing.frequency_count || 1) + 1;
+      await db
+        .from("raw_fragments")
+        .update({
+          fragment_value: value,
+          fragment_envelope: {
+            reason: "unknown_field",
+            entity_type: entityType,
+            schema_version: effectiveSchemaVersion,
+          },
+          frequency_count: newFreq,
+          last_seen: new Date().toISOString(),
+        })
+        .eq("id", existing.id);
+      try {
+        const { schemaRecommendationService } = await import("./schema_recommendation.js");
+        await schemaRecommendationService.queueAutoEnhancementCheck({
+          entity_type: entityType, fragment_key: key, user_id: userId, frequency_count: newFreq,
+        });
+      } catch (queueError: unknown) {
+        logger.warn(
+          `[Interpretation] Failed to queue auto-enhancement for ${entityType}.${key}:`,
+          queueError instanceof Error ? queueError.message : String(queueError)
+        );
+      }
+    } else {
+      const { error: insertError } = await db.from("raw_fragments").insert({
+        id: randomUUID(),
+        source_id: sourceId,
+        interpretation_id: interpretationId,
+        user_id: userId,
+        entity_type: entityType,
+        fragment_key: key,
+        fragment_value: value,
+        fragment_envelope: {
+          reason: "unknown_field",
+          entity_type: entityType,
+          schema_version: effectiveSchemaVersion,
+        },
+      });
+      if (insertError?.code === "23505") {
+        // Race condition: another process inserted the same fragment concurrently.
+        const { data: retryExisting } = await db
+          .from("raw_fragments")
+          .select("id, frequency_count")
+          .eq("source_id", sourceId)
+          .eq("fragment_key", key)
+          .eq("user_id", userId)
+          .maybeSingle();
+        if (retryExisting) {
+          const retryFreq = (retryExisting.frequency_count || 1) + 1;
+          await db
+            .from("raw_fragments")
+            .update({
+              fragment_value: value,
+              fragment_envelope: {
+                reason: "unknown_field",
+                entity_type: entityType,
+                schema_version: effectiveSchemaVersion,
+              },
+              frequency_count: retryFreq,
+              last_seen: new Date().toISOString(),
+            })
+            .eq("id", retryExisting.id);
+          try {
+            const { schemaRecommendationService } = await import("./schema_recommendation.js");
+            await schemaRecommendationService.queueAutoEnhancementCheck({
+              entity_type: entityType, fragment_key: key, user_id: userId, frequency_count: retryFreq,
+            });
+          } catch (queueError: unknown) {
+            logger.warn(
+              `[Interpretation] Failed to queue auto-enhancement for ${entityType}.${key}:`,
+              queueError instanceof Error ? queueError.message : String(queueError)
+            );
+          }
+        }
+      } else if (!insertError) {
+        try {
+          const { schemaRecommendationService } = await import("./schema_recommendation.js");
+          await schemaRecommendationService.queueAutoEnhancementCheck({
+            entity_type: entityType, fragment_key: key, user_id: userId, frequency_count: 1,
+          });
+        } catch (queueError: unknown) {
+          logger.warn(
+            `[Interpretation] Failed to queue auto-enhancement for ${entityType}.${key}:`,
+            queueError instanceof Error ? queueError.message : String(queueError)
+          );
+        }
+      }
+    }
+  }
+}
+
+/**
  * Run interpretation on extracted data
  * Creates interpretation run, validates fields, resolves entities, creates observations
  */
@@ -327,185 +497,19 @@ export async function runInterpretation(
         delete (unknownFields as Record<string, unknown>)["canonical_name"];
       }
 
-      // Store original values in raw_fragments for converted fields (preserves zero data loss)
+      // Buffer fragment writes: collect all raw_fragments for this entity so they
+      // can be written AFTER entity resolution succeeds. If resolution fails the
+      // fragments are discarded and no orphaned rows are created (issue #163).
+      const pendingConvertedFragments: Array<{ key: string; value: unknown }> = [];
       for (const [key, value] of Object.entries(originalValues)) {
-        // Skip null or undefined values (database constraint)
-        if (value === null || value === undefined) {
-          continue;
-        }
-
-        // Check if fragment already exists (for idempotence)
-        const { data: existing } = await db
-          .from("raw_fragments")
-          .select("id, frequency_count")
-          .eq("source_id", sourceId)
-          .eq("fragment_key", key)
-          .eq("user_id", userId)
-          .maybeSingle();
-
-        if (existing) {
-          // Update existing fragment
-          await db
-            .from("raw_fragments")
-            .update({
-              fragment_value: value,
-              fragment_envelope: {
-                reason: "converted_value_original",
-                entity_type: entityType,
-                schema_version: effectiveSchemaVersion,
-                converted_to: validFields[key],
-              },
-              frequency_count: (existing.frequency_count || 1) + 1,
-              last_seen: new Date().toISOString(),
-            })
-            .eq("id", existing.id);
-        } else {
-          // Insert new fragment
-          const fragmentId = randomUUID();
-          await db.from("raw_fragments").insert({
-            id: fragmentId,
-            source_id: sourceId,
-            interpretation_id: interpretationId,
-            user_id: userId,
-            entity_type: entityType,
-            fragment_key: key,
-            fragment_value: value,
-            fragment_envelope: {
-              reason: "converted_value_original",
-              entity_type: entityType,
-              schema_version: effectiveSchemaVersion,
-              converted_to: validFields[key],
-            },
-          });
-        }
+        if (value === null || value === undefined) continue;
+        pendingConvertedFragments.push({ key, value });
       }
 
-      // Store unknown fields in raw_fragments (with idempotence)
-      // Filter out null/undefined values before storing
+      const pendingUnknownFragments: Array<{ key: string; value: unknown }> = [];
       for (const [key, value] of Object.entries(unknownFields)) {
-        // Skip null or undefined values (database constraint)
-        if (value === null || value === undefined) {
-          continue;
-        }
-        // Check if fragment already exists (for idempotence)
-        const { data: existing } = await db
-          .from("raw_fragments")
-          .select("id, frequency_count")
-          .eq("source_id", sourceId)
-          .eq("fragment_key", key)
-          .eq("user_id", userId)
-          .maybeSingle();
-
-        if (existing) {
-          // Update existing fragment (increment frequency, update last_seen)
-          const newFreq = (existing.frequency_count || 1) + 1;
-          await db
-            .from("raw_fragments")
-            .update({
-              fragment_value: value,
-              fragment_envelope: {
-                reason: "unknown_field",
-                entity_type: entityType,
-                schema_version: effectiveSchemaVersion,
-              },
-              frequency_count: newFreq,
-              last_seen: new Date().toISOString(),
-            })
-            .eq("id", existing.id);
-          unknownFieldsCount++;
-          // Queue auto-enhancement so raw_fragments can promote to schema
-          try {
-            const { schemaRecommendationService } = await import("./schema_recommendation.js");
-            await schemaRecommendationService.queueAutoEnhancementCheck({
-              entity_type: entityType,
-              fragment_key: key,
-              user_id: userId,
-              frequency_count: newFreq,
-            });
-          } catch (queueError: unknown) {
-            logger.warn(
-              `[Interpretation] Failed to queue auto-enhancement for ${entityType}.${key}:`,
-              queueError instanceof Error ? queueError.message : String(queueError)
-            );
-          }
-        } else {
-          // Insert new fragment
-          const fragmentId = randomUUID();
-          const { error: insertError } = await db.from("raw_fragments").insert({
-            id: fragmentId,
-            source_id: sourceId,
-            interpretation_id: interpretationId,
-            user_id: userId,
-            entity_type: entityType,
-            fragment_key: key,
-            fragment_value: value,
-            fragment_envelope: {
-              reason: "unknown_field",
-              entity_type: entityType,
-              schema_version: effectiveSchemaVersion,
-            },
-          });
-
-          // Handle race condition (unique constraint violation)
-          if (insertError?.code === "23505") {
-            // Another process inserted it, retry as update
-            const { data: retryExisting } = await db
-              .from("raw_fragments")
-              .select("id, frequency_count")
-              .eq("source_id", sourceId)
-              .eq("fragment_key", key)
-              .eq("user_id", userId)
-              .maybeSingle();
-
-            if (retryExisting) {
-              const retryFreq = (retryExisting.frequency_count || 1) + 1;
-              await db
-                .from("raw_fragments")
-                .update({
-                  fragment_value: value,
-                  fragment_envelope: {
-                    reason: "unknown_field",
-                    entity_type: entityType,
-                    schema_version: effectiveSchemaVersion,
-                  },
-                  frequency_count: retryFreq,
-                  last_seen: new Date().toISOString(),
-                })
-                .eq("id", retryExisting.id);
-              try {
-                const { schemaRecommendationService } = await import("./schema_recommendation.js");
-                await schemaRecommendationService.queueAutoEnhancementCheck({
-                  entity_type: entityType,
-                  fragment_key: key,
-                  user_id: userId,
-                  frequency_count: retryFreq,
-                });
-              } catch (queueError: unknown) {
-                logger.warn(
-                  `[Interpretation] Failed to queue auto-enhancement for ${entityType}.${key}:`,
-                  queueError instanceof Error ? queueError.message : String(queueError)
-                );
-              }
-            }
-          } else if (!insertError) {
-            // New fragment inserted successfully; queue auto-enhancement
-            try {
-              const { schemaRecommendationService } = await import("./schema_recommendation.js");
-              await schemaRecommendationService.queueAutoEnhancementCheck({
-                entity_type: entityType,
-                fragment_key: key,
-                user_id: userId,
-                frequency_count: 1,
-              });
-            } catch (queueError: unknown) {
-              logger.warn(
-                `[Interpretation] Failed to queue auto-enhancement for ${entityType}.${key}:`,
-                queueError instanceof Error ? queueError.message : String(queueError)
-              );
-            }
-          }
-          unknownFieldsCount++;
-        }
+        if (value === null || value === undefined) continue;
+        pendingUnknownFragments.push({ key, value });
       }
 
       const validFieldKeys = Object.keys(validFields).filter((key) => key !== "schema_version");
@@ -567,7 +571,14 @@ export async function runInterpretation(
       );
 
       if (existingObservation) {
-        // Observation already exists - don't create duplicate
+        // Observation already exists - don't create duplicate.
+        // Still flush buffered fragments so they are kept current on replay.
+        await flushPendingFragments({
+          db, sourceId, interpretationId, userId, entityType,
+          effectiveSchemaVersion, validFields,
+          pendingConvertedFragments, pendingUnknownFragments,
+        });
+        unknownFieldsCount += pendingUnknownFragments.length;
         entities.push({
           entityId,
           entityType,
@@ -623,6 +634,15 @@ export async function runInterpretation(
         entityType,
         observationId,
       });
+
+      // Flush buffered raw_fragments now that entity resolution and observation
+      // creation have both succeeded (issue #163).
+      await flushPendingFragments({
+        db, sourceId, interpretationId, userId, entityType,
+        effectiveSchemaVersion, validFields,
+        pendingConvertedFragments, pendingUnknownFragments,
+      });
+      unknownFieldsCount += pendingUnknownFragments.length;
     }
 
     // Compute snapshots for all entities

--- a/tests/integration/interpretation_fragment_ordering.test.ts
+++ b/tests/integration/interpretation_fragment_ordering.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Regression tests for issue #163:
+ * raw_fragments MUST NOT be written before entity resolution succeeds.
+ *
+ * When resolveEntity throws CanonicalNameUnresolvedError (e.g. the required
+ * canonical_name_fields value is absent from the payload), the interpretation
+ * loop must discard buffered fragments and write nothing to raw_fragments.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import { db } from "../../src/db.js";
+import { runInterpretation } from "../../src/services/interpretation.js";
+import type { InterpretationConfig } from "../../src/services/interpretation.js";
+import {
+  cleanupTestEntityType,
+  countRawFragments,
+} from "../helpers/test_schema_helpers.js";
+
+const TEST_USER_ID = "00000000-0000-0000-0000-000000000163";
+const ENTITY_TYPE = "fragment_ordering_regression_test";
+
+const CONFIG: InterpretationConfig = {
+  provider: "test",
+  model_id: "test-model",
+  temperature: 0.0,
+  prompt_hash: "test_hash_163",
+  code_version: "1.0.0",
+};
+
+async function insertSource(): Promise<string> {
+  const { data, error } = await db
+    .from("sources")
+    .insert({
+      user_id: TEST_USER_ID,
+      original_filename: "regression163.json",
+      mime_type: "application/json",
+      file_size: 42,
+      content_hash: `hash_163_${randomUUID()}`,
+    })
+    .select("id")
+    .single();
+  if (error || !data) throw new Error(`Failed to insert source: ${error?.message}`);
+  return data.id;
+}
+
+async function seedSchema(): Promise<void> {
+  // Schema requires "required_name" via canonical_name_fields.
+  // "numeric_field" is a number — excluded from heuristic string-fallback.
+  // When "required_name" is absent AND only numeric fields remain, resolveEntity
+  // throws CanonicalNameUnresolvedError, causing the loop to skip the entity.
+  await db.from("schema_registry").delete().eq("entity_type", ENTITY_TYPE);
+  const { error } = await db.from("schema_registry").insert({
+    entity_type: ENTITY_TYPE,
+    schema_version: "1.0",
+    schema_definition: {
+      fields: {
+        required_name: { type: "string" },
+        numeric_field: { type: "number" },
+      },
+      canonical_name_fields: ["required_name"],
+    },
+    reducer_config: {
+      merge_policies: {
+        required_name: { strategy: "last_write", tie_breaker: "observed_at" },
+        numeric_field: { strategy: "last_write", tie_breaker: "observed_at" },
+      },
+    },
+    active: true,
+    scope: "global",
+    user_id: null,
+  });
+  if (error) throw new Error(`Failed to seed schema: ${error.message}`);
+}
+
+describe("interpretation fragment ordering (issue #163)", () => {
+  let sourceId: string;
+
+  beforeEach(async () => {
+    await cleanupTestEntityType(ENTITY_TYPE, TEST_USER_ID);
+    await seedSchema();
+    sourceId = await insertSource();
+  });
+
+  afterEach(async () => {
+    await cleanupTestEntityType(ENTITY_TYPE, TEST_USER_ID);
+    // Clean up the source created in beforeEach
+    await db.from("sources").delete().eq("id", sourceId);
+  });
+
+  it("does not write raw_fragments when entity resolution fails due to missing canonical name", async () => {
+    // Payload deliberately omits "required_name" so resolveEntity throws
+    // CanonicalNameUnresolvedError. Only a numeric field and an unknown string
+    // field are present. The heuristic last-resort skips numeric values, so no
+    // canonical name can be derived. "mystery_field" (unknown) and "numeric_field"
+    // would become raw_fragment rows if written before resolution (the bug).
+    const result = await runInterpretation({
+      userId: TEST_USER_ID,
+      sourceId,
+      extractedData: [
+        {
+          entity_type: ENTITY_TYPE,
+          numeric_field: 42,
+          mystery_field: "unknown to schema",
+          // required_name is intentionally absent — heuristic fallback will also
+          // fail because numeric_field is not a string candidate.
+        },
+      ],
+      config: CONFIG,
+    });
+
+    // Entity resolution failed — no observations should be created.
+    expect(result.observationsCreated).toBe(0);
+    expect(result.entities).toHaveLength(0);
+
+    // And critically: no raw_fragment rows should exist for this entity type.
+    const fragmentCount = await countRawFragments(ENTITY_TYPE, TEST_USER_ID);
+    expect(fragmentCount).toBe(0);
+  });
+
+  it("writes raw_fragments normally when entity resolution succeeds", async () => {
+    // Payload includes "required_name" so resolution succeeds.
+    // "mystery_field" is unknown to the schema and should be stored as a
+    // raw_fragment (the known-good path must still work after the fix).
+    const result = await runInterpretation({
+      userId: TEST_USER_ID,
+      sourceId,
+      extractedData: [
+        {
+          entity_type: ENTITY_TYPE,
+          required_name: "Alice",
+          numeric_field: 99,
+          mystery_field: "unknown value",
+        },
+      ],
+      config: CONFIG,
+    });
+
+    expect(result.observationsCreated).toBe(1);
+    expect(result.entities).toHaveLength(1);
+
+    // mystery_field is unknown to the schema → written as a raw_fragment.
+    const fragmentCount = await countRawFragments(ENTITY_TYPE, TEST_USER_ID);
+    expect(fragmentCount).toBeGreaterThan(0);
+  });
+
+  it("does not write fragments for a failing entity in a mixed batch", async () => {
+    // Two entities in the same batch: one can resolve, one cannot.
+    // Only the resolvable entity should produce raw_fragments.
+    const result = await runInterpretation({
+      userId: TEST_USER_ID,
+      sourceId,
+      extractedData: [
+        {
+          entity_type: ENTITY_TYPE,
+          required_name: "Bob",
+          mystery_field: "fragment for Bob",
+        },
+        {
+          entity_type: ENTITY_TYPE,
+          // required_name absent; only numeric known field — no string heuristic
+          numeric_field: 7,
+          mystery_field: "should NOT be stored",
+        },
+      ],
+      config: CONFIG,
+    });
+
+    // Only the first entity resolves.
+    expect(result.observationsCreated).toBe(1);
+    expect(result.entities).toHaveLength(1);
+    expect(result.entities[0].entityType).toBe(ENTITY_TYPE);
+
+    // Fragments from the failing entity must not be written.
+    // Only the mystery_field for "Bob" should be stored (1 row).
+    const fragmentCount = await countRawFragments(ENTITY_TYPE, TEST_USER_ID);
+    expect(fragmentCount).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Fragment DB writes in the interpretation loop were issued **before** `resolveEntity()`. When `CanonicalNameUnresolvedError` was thrown (missing canonical name field), the loop `continue`d to the next entity but left orphaned `raw_fragments` rows in the DB with no entity or observation link.
- Fix: collect `pendingConvertedFragments` and `pendingUnknownFragments` in-memory during field validation, then flush via `flushPendingFragments()` only after both entity resolution and observation creation succeed. On `CanonicalNameUnresolvedError` the buffers are discarded — no rows written.

## Test plan

- [ ] New regression test `tests/integration/interpretation_fragment_ordering.test.ts` — 3 cases:
  1. Missing canonical name field → `raw_fragments` count remains 0
  2. Present canonical name field → `raw_fragments` written normally (unknown field stored)
  3. Mixed batch → only the successfully resolved entity's fragments are written
- [ ] All 3 new tests pass locally
- [ ] Full unit test suite passes (pre-existing failures in cursor_hook, submit_issue_dx, external_actor_badge are unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)