### PR TITLE
fix: surface no-schema entity types in store response (closes #164)

### DIFF
--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,8 +61,8 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **367**
-- Backend and repo Vitest files: **334**
+- Total automated test files: **369**
+- Backend and repo Vitest files: **336**
 - Frontend Vitest files: **9**
 - Playwright spec files: **24**
 
@@ -72,7 +72,7 @@ flowchart TD
 | Vitest unit tests | 88 |
 | Vitest service tests | 33 |
 | Source-adjacent tests | 45 |
-| Vitest integration tests | 95 |
+| Vitest integration tests | 96 |
 | Vitest CLI tests | 55 |
 | Vitest contract tests | 10 |
 | Vitest security tests | 1 |
@@ -294,7 +294,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm run test:integration` or `npx vitest run tests/integration`
 **Requirements:** Database configured; remote-dependent subsets additionally need `RUN_REMOTE_TESTS=1`.
-**Files (95):**
+**Files (96):**
 - `tests/integration/aauth_attribution_stamping.test.ts`
 - `tests/integration/aauth_resource_metadata.test.ts`
 - `tests/integration/aauth_revocation_e2e.test.ts`
@@ -331,6 +331,7 @@ flowchart TD
 - `tests/integration/hook_failure_hint.test.ts`
 - `tests/integration/inspector_bundled_mount.test.ts`
 - `tests/integration/interpretation_fragment_ordering.test.ts`
+- `tests/integration/interpretation_no_schema_fallback.test.ts`
 - `tests/integration/interpretation_store.test.ts`
 - `tests/integration/issue_37_event_schema_projection.test.ts`
 - `tests/integration/lexical_search.test.ts`

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1622,6 +1622,17 @@ components:
           type: string
           nullable: true
           description: Interpretation row linked to observations when the request supplied an explicit interpretation block.
+        no_schema_entity_types:
+          type: array
+          items:
+            type: string
+          description: |
+            Entity types whose payloads were routed to raw_fragments because no
+            schema could be found or auto-registered. Each element is a distinct
+            entity_type string. An empty array (or absent field) means all entity
+            types had an active schema and were processed normally. When this list
+            is non-empty, run `register_schema` for each type to create a schema
+            so future ingestion produces observations instead of fragments.
     ResolverWarning:
       type: object
       description: |

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -5473,6 +5473,9 @@ app.post("/interpretations/create", async (req, res) => {
       observations_created: interpretationResult.observationsCreated,
       unknown_fields_count: interpretationResult.unknownFieldsCount,
       relationships_created: relationshipsCreated,
+      ...(interpretationResult.noSchemaEntityTypes && interpretationResult.noSchemaEntityTypes.length > 0
+        ? { no_schema_entity_types: interpretationResult.noSchemaEntityTypes }
+        : {}),
     });
   } catch (error) {
     logError("APIError:interpretations_create", req, error);

--- a/src/server.ts
+++ b/src/server.ts
@@ -3686,6 +3686,9 @@ export class NeotomaServer {
       observations_created: result.observationsCreated,
       unknown_fields_count: result.unknownFieldsCount,
       relationships_created: relationshipsCreated,
+      ...(result.noSchemaEntityTypes && result.noSchemaEntityTypes.length > 0
+        ? { no_schema_entity_types: result.noSchemaEntityTypes }
+        : {}),
     });
   }
 
@@ -4350,6 +4353,9 @@ export class NeotomaServer {
           observation_id: entity.observationId,
         })),
         unknown_fields_count: result.unknownFieldsCount,
+        ...(result.noSchemaEntityTypes && result.noSchemaEntityTypes.length > 0
+          ? { no_schema_entity_types: result.noSchemaEntityTypes }
+          : {}),
       });
     }
 

--- a/src/services/interpretation.ts
+++ b/src/services/interpretation.ts
@@ -71,6 +71,13 @@ export interface InterpretationResult {
   }>;
   /** Debug: per-entity type refinement (extracted keys, type before/after) for store responses */
   refinement_debug?: Array<{ extracted_keys: string[]; type_before: string; type_after: string }>;
+  /**
+   * Entity types for which no schema was found or could be auto-registered.
+   * Payloads for these types were written as raw_fragments (reason: "no_schema"
+   * or "no_schema_registration_failed") and will not appear in the entities array.
+   * Callers should register a schema for each listed type.
+   */
+  noSchemaEntityTypes?: string[];
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -324,11 +331,8 @@ export async function runInterpretation(
     observationId: string;
   }> = [];
   const interpretationInsertedObservationIds = new Set<string>();
-  const refinementDebug: Array<{
-    extracted_keys: string[];
-    type_before: string;
-    type_after: string;
-  }> = [];
+  const refinementDebug: Array<{ extracted_keys: string[]; type_before: string; type_after: string }> = [];
+  const noSchemaEntityTypes: string[] = [];
 
   try {
     // Build refinement candidates: DB schemas (user + global) + code-only types so dynamic schemas participate
@@ -421,7 +425,9 @@ export async function runInterpretation(
       }
 
       // When no known schema at all (neither DB nor code): optionally create a user-scoped schema from extracted fields
+      let schemaCreationAttempted = false;
       if (!schema && !codeSchema && config.create_schema_for_unknown !== false) {
+        schemaCreationAttempted = true;
         schema = await schemaRegistry.ensureSchemaForExtractedEntity(
           entityType,
           entityData,
@@ -443,10 +449,16 @@ export async function runInterpretation(
       const effectiveSchemaVersion = schema?.schema_version ?? codeSchema?.schema_version ?? "1.0";
 
       if (Object.keys(effectiveSchemaDefinition.fields).length === 0) {
-        // No schema found - route all fields to raw_fragments (helps debug: log extracted type)
+        // No schema found and auto-registration failed (or was disabled): route all fields to a
+        // raw_fragment so the payload is preserved. Use a distinct reason so callers can tell
+        // whether creation was attempted ("no_schema_registration_failed") or never tried
+        // ("no_schema" — creation disabled via config.create_schema_for_unknown=false).
+        const noSchemaReason = schemaCreationAttempted
+          ? "no_schema_registration_failed"
+          : "no_schema";
         logger.warn(
-          `[Interpretation] No schema for entity_type "${entityType}" (resolved from extracted data); routing to raw_fragments. ` +
-            `Run schema:init or add alias for this type.`
+          `[Interpretation] No schema for entity_type "${entityType}" (resolved from extracted data); ` +
+            `reason=${noSchemaReason}. Register a schema via register_schema to enable observations.`
         );
         const fragmentId = randomUUID();
         await db.from("raw_fragments").insert({
@@ -458,11 +470,15 @@ export async function runInterpretation(
           fragment_key: "full_entity",
           fragment_value: currentEntityData,
           fragment_envelope: {
-            reason: "no_schema",
+            reason: noSchemaReason,
             entity_type: entityType,
           },
         });
         unknownFieldsCount += Object.keys(currentEntityData).length;
+        // Track distinct no-schema entity types so callers can discover and fix them.
+        if (!noSchemaEntityTypes.includes(entityType)) {
+          noSchemaEntityTypes.push(entityType);
+        }
         continue;
       }
 
@@ -779,6 +795,7 @@ export async function runInterpretation(
       unknownFieldsCount,
       entities,
       refinement_debug: refinementDebug.length > 0 ? refinementDebug : undefined,
+      noSchemaEntityTypes: noSchemaEntityTypes.length > 0 ? noSchemaEntityTypes : undefined,
     };
   } catch (error) {
     // Mark interpretation as failed

--- a/tests/integration/interpretation_no_schema_fallback.test.ts
+++ b/tests/integration/interpretation_no_schema_fallback.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Regression tests for issue #164:
+ * no-schema fallback MUST surface affected entity types in the response and
+ * use a distinct fragment reason when schema auto-registration was attempted
+ * but failed.
+ *
+ * This test exercises:
+ * - `noSchemaEntityTypes` populated in InterpretationResult
+ * - Fragment reason set to "no_schema_registration_failed" when creation tried
+ * - Fragment reason set to "no_schema" when creation is disabled via config
+ * - Normal (schema-present) entities are not included in noSchemaEntityTypes
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import { db } from "../../src/db.js";
+import { runInterpretation } from "../../src/services/interpretation.js";
+import type { InterpretationConfig } from "../../src/services/interpretation.js";
+import { cleanupTestEntityType } from "../helpers/test_schema_helpers.js";
+
+// Unique test user to avoid cross-test pollution.
+const TEST_USER_ID = "00000000-0000-0000-0000-000000000164";
+
+// An entity type that will NEVER have a schema seeded in these tests.
+const UNKNOWN_TYPE = "no_schema_regression_unknown_type_164";
+
+// An entity type that has a real schema and should resolve normally.
+const KNOWN_TYPE = "no_schema_regression_known_type_164";
+
+const CONFIG: InterpretationConfig = {
+  provider: "test",
+  model_id: "test-model",
+  temperature: 0.0,
+  prompt_hash: "test_hash_164",
+  code_version: "1.0.0",
+};
+
+async function insertSource(): Promise<string> {
+  const { data, error } = await db
+    .from("sources")
+    .insert({
+      user_id: TEST_USER_ID,
+      original_filename: "regression164.json",
+      mime_type: "application/json",
+      file_size: 42,
+      content_hash: `hash_164_${randomUUID()}`,
+    })
+    .select("id")
+    .single();
+  if (error || !data) throw new Error(`Failed to insert source: ${error?.message}`);
+  return data.id;
+}
+
+async function seedKnownSchema(): Promise<void> {
+  await db.from("schema_registry").delete().eq("entity_type", KNOWN_TYPE);
+  const { error } = await db.from("schema_registry").insert({
+    entity_type: KNOWN_TYPE,
+    schema_version: "1.0",
+    schema_definition: {
+      fields: {
+        label: { type: "string" },
+      },
+      canonical_name_fields: ["label"],
+    },
+    reducer_config: {
+      merge_policies: {
+        label: { strategy: "last_write", tie_breaker: "observed_at" },
+      },
+    },
+    active: true,
+    scope: "global",
+    user_id: null,
+  });
+  if (error) throw new Error(`Failed to seed known schema: ${error.message}`);
+}
+
+describe("interpretation no-schema fallback (issue #164)", () => {
+  let sourceId: string;
+
+  beforeEach(async () => {
+    await cleanupTestEntityType(UNKNOWN_TYPE, TEST_USER_ID);
+    await cleanupTestEntityType(KNOWN_TYPE, TEST_USER_ID);
+    await seedKnownSchema();
+    sourceId = await insertSource();
+  });
+
+  afterEach(async () => {
+    await cleanupTestEntityType(UNKNOWN_TYPE, TEST_USER_ID);
+    await cleanupTestEntityType(KNOWN_TYPE, TEST_USER_ID);
+    await db.from("sources").delete().eq("id", sourceId);
+  });
+
+  it("populates noSchemaEntityTypes when an entity type has no schema and auto-registration fails", async () => {
+    // Provide only entity_type with no other fields — buildSchemaFromExtractedFields
+    // skips entity_type and produces only the default schema_version field, so
+    // fields.length === 1 and ensureSchemaForExtractedEntity returns null.
+    // Reason becomes "no_schema_registration_failed".
+    const result = await runInterpretation({
+      userId: TEST_USER_ID,
+      sourceId,
+      extractedData: [
+        {
+          entity_type: UNKNOWN_TYPE,
+          // No data fields — schema builder produces too-sparse output and refuses.
+        },
+      ],
+      config: CONFIG,
+    });
+
+    expect(result.observationsCreated).toBe(0);
+    expect(result.entities).toHaveLength(0);
+    expect(result.noSchemaEntityTypes).toBeDefined();
+    expect(result.noSchemaEntityTypes).toContain(UNKNOWN_TYPE);
+
+    // Verify the raw_fragment was written with the expected "registration_failed" reason.
+    const { data: fragments } = await db
+      .from("raw_fragments")
+      .select("fragment_key, fragment_envelope")
+      .eq("entity_type", UNKNOWN_TYPE)
+      .eq("user_id", TEST_USER_ID);
+
+    expect(fragments).toBeDefined();
+    expect(fragments!.length).toBeGreaterThan(0);
+    // The fragment_key for a no-schema fallback is "full_entity".
+    expect(fragments![0].fragment_key).toBe("full_entity");
+    // When schema registration was attempted (and failed), the envelope reason
+    // should be "no_schema_registration_failed", not the generic "no_schema".
+    expect(fragments![0].fragment_envelope?.reason).toBe("no_schema_registration_failed");
+  });
+
+  it("does not include normally-resolved entity types in noSchemaEntityTypes", async () => {
+    // KNOWN_TYPE has a schema — it should produce an observation and not appear
+    // in noSchemaEntityTypes.
+    const result = await runInterpretation({
+      userId: TEST_USER_ID,
+      sourceId,
+      extractedData: [
+        {
+          entity_type: KNOWN_TYPE,
+          label: "test entity",
+        },
+      ],
+      config: CONFIG,
+    });
+
+    expect(result.observationsCreated).toBe(1);
+    expect(result.entities).toHaveLength(1);
+    expect(result.noSchemaEntityTypes ?? []).not.toContain(KNOWN_TYPE);
+  });
+
+  it("only lists the no-schema type in noSchemaEntityTypes in a mixed batch", async () => {
+    // KNOWN_TYPE resolves normally; UNKNOWN_TYPE falls to no-schema.
+    const result = await runInterpretation({
+      userId: TEST_USER_ID,
+      sourceId,
+      extractedData: [
+        {
+          entity_type: KNOWN_TYPE,
+          label: "known entity in mixed batch",
+        },
+        {
+          entity_type: UNKNOWN_TYPE,
+          // No data fields — schema builder produces too-sparse output and refuses.
+        },
+      ],
+      config: CONFIG,
+    });
+
+    // Only KNOWN_TYPE produces an observation.
+    expect(result.observationsCreated).toBe(1);
+    expect(result.entities).toHaveLength(1);
+    expect(result.entities[0].entityType).toBe(KNOWN_TYPE);
+
+    // noSchemaEntityTypes lists UNKNOWN_TYPE but not KNOWN_TYPE.
+    expect(result.noSchemaEntityTypes).toBeDefined();
+    expect(result.noSchemaEntityTypes).toContain(UNKNOWN_TYPE);
+    expect(result.noSchemaEntityTypes).not.toContain(KNOWN_TYPE);
+  });
+
+  it("uses reason 'no_schema' when create_schema_for_unknown is disabled", async () => {
+    // With create_schema_for_unknown: false, the no-schema path fires but
+    // schema creation is never attempted — reason stays "no_schema".
+    const result = await runInterpretation({
+      userId: TEST_USER_ID,
+      sourceId,
+      extractedData: [
+        {
+          entity_type: UNKNOWN_TYPE,
+          // No data fields — schema builder would refuse anyway, but creation is also disabled.
+        },
+      ],
+      config: { ...CONFIG, create_schema_for_unknown: false },
+    });
+
+    expect(result.observationsCreated).toBe(0);
+    expect(result.noSchemaEntityTypes).toContain(UNKNOWN_TYPE);
+
+    const { data: fragments } = await db
+      .from("raw_fragments")
+      .select("fragment_envelope")
+      .eq("entity_type", UNKNOWN_TYPE)
+      .eq("user_id", TEST_USER_ID);
+
+    expect(fragments).toBeDefined();
+    expect(fragments!.length).toBeGreaterThan(0);
+    expect(fragments![0].fragment_envelope?.reason).toBe("no_schema");
+  });
+});


### PR DESCRIPTION
## Summary

- When interpretation encountered an unknown entity type with no schema, the entire payload was silently written as a `raw_fragments` row with `reason: "no_schema"`. Callers had no way to discover which entity types were affected or take corrective action.
- Add `no_schema_entity_types: string[]` to `StoreStructuredResponse` in `openapi.yaml`; regenerate types.
- Introduce `schemaCreationAttempted` flag: when `ensureSchemaForExtractedEntity` is called but returns null (too-sparse field set), the envelope reason is now `"no_schema_registration_failed"` instead of the generic `"no_schema"`.
- Collect distinct no-schema entity types into `noSchemaEntityTypes[]` in `InterpretationResult`; surface as `no_schema_entity_types` in all three store response paths (MCP `create_interpretation`, MCP `store` interpretation branch, HTTP `/interpretations/create`).

## Test plan

- [ ] 4 new regression tests in `tests/integration/interpretation_no_schema_fallback.test.ts`:
  1. `noSchemaEntityTypes` populated; reason is `"no_schema_registration_failed"` when auto-registration attempted but failed
  2. Normal entity types (with schema) not included in `noSchemaEntityTypes`
  3. Mixed batch: only the no-schema type listed
  4. `create_schema_for_unknown: false`: reason stays `"no_schema"`
- [ ] All 4 new tests pass locally
- [ ] Full test suite passes (pre-existing failures unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)