### PR TITLE
fix: surface raw_fragments recovery hint when store drops unknown fields (closes #187)

### DIFF
--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,8 +61,8 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **385**
-- Backend and repo Vitest files: **352**
+- Total automated test files: **386**
+- Backend and repo Vitest files: **353**
 - Frontend Vitest files: **9**
 - Playwright spec files: **24**
 
@@ -72,7 +72,7 @@ flowchart TD
 | Vitest unit tests | 93 |
 | Vitest service tests | 33 |
 | Source-adjacent tests | 45 |
-| Vitest integration tests | 103 |
+| Vitest integration tests | 104 |
 | Vitest CLI tests | 59 |
 | Vitest contract tests | 10 |
 | Vitest security tests | 1 |
@@ -299,7 +299,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm run test:integration` or `npx vitest run tests/integration`
 **Requirements:** Database configured; remote-dependent subsets additionally need `RUN_REMOTE_TESTS=1`.
-**Files (103):**
+**Files (104):**
 - `tests/integration/aauth_attribution_stamping.test.ts`
 - `tests/integration/aauth_resource_metadata.test.ts`
 - `tests/integration/aauth_revocation_e2e.test.ts`
@@ -366,6 +366,7 @@ flowchart TD
 - `tests/integration/mcp_store_canonical_name_unknown_fields.test.ts`
 - `tests/integration/mcp_store_intra_batch_relationships.test.ts`
 - `tests/integration/mcp_store_parquet.test.ts`
+- `tests/integration/mcp_store_raw_fragments_hint.test.ts`
 - `tests/integration/mcp_store_unknown_fields_names.test.ts`
 - `tests/integration/mcp_store_unstructured.test.ts`
 - `tests/integration/mcp_store_variations.test.ts`

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1221,6 +1221,14 @@ components:
             the entity's active schema. Present when `unknown_fields_count > 0`.
             Use `update_schema_incremental` or `register_schema` to add these
             fields before re-storing.
+        hint:
+          type: string
+          description: |
+            Actionable guidance when fields were dropped to `raw_fragments`.
+            Present only when `unknown_fields_count > 0`. Directs the caller
+            to use `update_schema_incremental` with `migrate_existing: true`
+            to promote the unknown fields into the schema and backfill existing
+            data.
         relationships_created:
           type: array
           items:
@@ -1654,6 +1662,20 @@ components:
             types had an active schema and were processed normally. When this list
             is non-empty, run `register_schema` for each type to create a schema
             so future ingestion produces observations instead of fragments.
+        unknown_fields_count:
+          type: integer
+          description: |
+            Number of entity fields that were dropped because they are not
+            declared in the entity's active schema. These fields were stored in
+            `raw_fragments` and can be recovered.
+        hint:
+          type: string
+          description: |
+            Actionable guidance when fields were dropped to `raw_fragments`.
+            Present only when `unknown_fields_count > 0`. Directs the caller
+            to use `update_schema_incremental` with `migrate_existing: true`
+            to promote the unknown fields into the schema and backfill existing
+            data.
     ResolverWarning:
       type: object
       description: |

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -5473,6 +5473,7 @@ app.post("/interpretations/create", async (req, res) => {
       observations_created: interpretationResult.observationsCreated,
       unknown_fields_count: interpretationResult.unknownFieldsCount,
       unknown_fields: interpretationResult.unknownFieldNames,
+      ...(interpretationResult.hint ? { hint: interpretationResult.hint } : {}),
       relationships_created: relationshipsCreated,
       ...(interpretationResult.noSchemaEntityTypes &&
       interpretationResult.noSchemaEntityTypes.length > 0

--- a/src/server.ts
+++ b/src/server.ts
@@ -3719,6 +3719,7 @@ export class NeotomaServer {
       observations_created: result.observationsCreated,
       unknown_fields_count: result.unknownFieldsCount,
       unknown_fields: result.unknownFieldNames,
+      ...(result.hint ? { hint: result.hint } : {}),
       relationships_created: relationshipsCreated,
       ...(result.noSchemaEntityTypes && result.noSchemaEntityTypes.length > 0
         ? { no_schema_entity_types: result.noSchemaEntityTypes }
@@ -4419,6 +4420,7 @@ export class NeotomaServer {
         ...(result.noSchemaEntityTypes && result.noSchemaEntityTypes.length > 0
           ? { no_schema_entity_types: result.noSchemaEntityTypes }
           : {}),
+        ...(result.hint ? { hint: result.hint } : {}),
       });
     }
 
@@ -5126,6 +5128,14 @@ export class NeotomaServer {
       })),
       unknown_fields_count: unknownFieldsCount,
       unknown_fields: Array.from(unknownFieldNamesSet).sort(),
+      ...(unknownFieldsCount > 0
+        ? {
+            hint:
+              "Unknown fields were stored in raw_fragments. " +
+              "Call update_schema_incremental to promote them to schema fields, " +
+              "then set migrate_existing: true to backfill existing data.",
+          }
+        : {}),
       related_entities: relatedData.entities,
       related_relationships: relatedData.relationships,
       ...(schemaStoreWarnings.length > 0 ? { store_warnings: schemaStoreWarnings } : {}),

--- a/src/services/interpretation.ts
+++ b/src/services/interpretation.ts
@@ -57,12 +57,19 @@ export interface InterpretationOptions {
   config: InterpretationConfig;
 }
 
+export const UNKNOWN_FIELDS_HINT =
+  "Unknown fields were stored in raw_fragments. " +
+  "Call update_schema_incremental to promote them to schema fields, " +
+  "then set migrate_existing: true to backfill existing data.";
+
 export interface InterpretationResult {
   interpretationId: string;
   observationsCreated: number;
   unknownFieldsCount: number;
   /** The field names that were not recognized by the schema. */
   unknownFieldNames: string[];
+  /** Actionable guidance surfaced when unknownFieldsCount > 0. */
+  hint?: string;
   observationsDeduplicated?: number; // Count of observations that already existed
   fixedPointReached?: boolean; // Whether fixed-point convergence was achieved
   convergenceIterations?: number; // Number of iterations to reach convergence
@@ -831,6 +838,7 @@ export async function runInterpretation(
       observationsCreated,
       unknownFieldsCount,
       unknownFieldNames: Array.from(unknownFieldNamesSet).sort(),
+      hint: unknownFieldsCount > 0 ? UNKNOWN_FIELDS_HINT : undefined,
       entities,
       refinement_debug: refinementDebug.length > 0 ? refinementDebug : undefined,
       noSchemaEntityTypes: noSchemaEntityTypes.length > 0 ? noSchemaEntityTypes : undefined,

--- a/src/shared/openapi_types.ts
+++ b/src/shared/openapi_types.ts
@@ -2671,6 +2671,21 @@ export interface components {
       }[];
       observations_created?: number;
       unknown_fields_count?: number;
+      /**
+       * @description Names of fields that were dropped because they are not declared in
+       *     the entity's active schema. Present when `unknown_fields_count > 0`.
+       *     Use `update_schema_incremental` or `register_schema` to add these
+       *     fields before re-storing.
+       */
+      unknown_fields?: string[];
+      /**
+       * @description Actionable guidance when fields were dropped to `raw_fragments`.
+       *     Present only when `unknown_fields_count > 0`. Directs the caller
+       *     to use `update_schema_incremental` with `migrate_existing: true`
+       *     to promote the unknown fields into the schema and backfill existing
+       *     data.
+       */
+      hint?: string;
       relationships_created?: {
         [key: string]: unknown;
       }[];
@@ -3094,6 +3109,13 @@ export interface components {
       /** @description Interpretation row linked to observations when the request supplied an explicit interpretation block. */
       interpretation_id?: string | null;
       /**
+       * @description Names of fields that were dropped because they are not declared in
+       *     the entity's active schema. Present when `unknown_fields_count > 0`.
+       *     Use `update_schema_incremental` or `register_schema` to add these
+       *     fields before re-storing.
+       */
+      unknown_fields?: string[];
+      /**
        * @description Entity types whose payloads were routed to raw_fragments because no
        *     schema could be found or auto-registered. Each element is a distinct
        *     entity_type string. An empty array (or absent field) means all entity
@@ -3102,6 +3124,20 @@ export interface components {
        *     so future ingestion produces observations instead of fragments.
        */
       no_schema_entity_types?: string[];
+      /**
+       * @description Number of entity fields that were dropped because they are not
+       *     declared in the entity's active schema. These fields were stored in
+       *     `raw_fragments` and can be recovered.
+       */
+      unknown_fields_count?: number;
+      /**
+       * @description Actionable guidance when fields were dropped to `raw_fragments`.
+       *     Present only when `unknown_fields_count > 0`. Directs the caller
+       *     to use `update_schema_incremental` with `migrate_existing: true`
+       *     to promote the unknown fields into the schema and backfill existing
+       *     data.
+       */
+      hint?: string;
     };
     /**
      * @description Non-fatal warning emitted by entity resolution when a schema declares

--- a/tests/integration/mcp_store_raw_fragments_hint.test.ts
+++ b/tests/integration/mcp_store_raw_fragments_hint.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Regression tests for issue #187:
+ * store response MUST surface a `hint` directing callers to the raw_fragments
+ * recovery path when unknown fields are present.
+ *
+ * This test exercises:
+ * - `hint` string present in response when `unknown_fields_count > 0`
+ * - Hint references `update_schema_incremental` and `migrate_existing`
+ * - `hint` absent when all fields are schema-declared (clean payload)
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { NeotomaServer } from "../../src/server.js";
+import { db } from "../../src/db.js";
+
+const TEST_USER_ID = "00000000-0000-0000-0000-000000000187";
+const ENTITY_TYPE = "issue_187_regression_plan";
+
+async function seedNarrowSchema(): Promise<void> {
+  await db.from("schema_registry").delete().eq("entity_type", ENTITY_TYPE);
+  const { error } = await db.from("schema_registry").insert({
+    entity_type: ENTITY_TYPE,
+    schema_version: "1.0",
+    schema_definition: {
+      fields: {
+        title: { type: "string" },
+      },
+      canonical_name_fields: ["title"],
+    },
+    reducer_config: {
+      merge_policies: {
+        title: { strategy: "last_write", tie_breaker: "observed_at" },
+      },
+    },
+    active: true,
+    scope: "global",
+    user_id: null,
+  });
+  if (error) throw new Error(`Failed to seed schema: ${error.message}`);
+}
+
+async function cleanupTestData(): Promise<void> {
+  await db.from("raw_fragments").delete().eq("entity_type", ENTITY_TYPE).eq("user_id", TEST_USER_ID);
+  await db.from("schema_registry").delete().eq("entity_type", ENTITY_TYPE);
+
+  const { data: entities } = await db
+    .from("entities")
+    .select("id")
+    .eq("entity_type", ENTITY_TYPE);
+  if (entities && entities.length > 0) {
+    const ids = entities.map((e) => e.id);
+    await db.from("observations").delete().in("entity_id", ids);
+    await db.from("entity_snapshots").delete().in("entity_id", ids);
+    await db.from("entities").delete().in("id", ids);
+  }
+}
+
+describe("MCP store: raw_fragments recovery hint surfaced (issue #187)", () => {
+  let server: NeotomaServer;
+
+  beforeAll(async () => {
+    await cleanupTestData();
+    await seedNarrowSchema();
+    server = new NeotomaServer();
+    (server as unknown as Record<string, unknown>).authenticatedUserId = TEST_USER_ID;
+  });
+
+  afterAll(async () => {
+    await cleanupTestData();
+  });
+
+  it("includes a hint when unknown fields are present", async () => {
+    const result = await (server as unknown as {
+      store: (params: Record<string, unknown>) => Promise<{ content: Array<{ text: string }> }>;
+    }).store({
+      user_id: TEST_USER_ID,
+      idempotency_key: `issue-187-hint-present-${Date.now()}`,
+      commit: true,
+      entities: [
+        {
+          entity_type: ENTITY_TYPE,
+          title: "My Plan",
+          goals: "Launch product",
+          architecture: "Microservices",
+          cost_estimate: "50000",
+        },
+      ],
+    });
+
+    const body = JSON.parse(result.content[0].text) as {
+      unknown_fields_count?: number;
+      hint?: string;
+      entities?: Array<{ entity_id: string }>;
+      error?: { code?: string };
+    };
+
+    expect(body.error).toBeUndefined();
+    expect(body.unknown_fields_count).toBe(3);
+
+    // Hint must be present and reference the recovery path.
+    expect(typeof body.hint).toBe("string");
+    expect(body.hint).toContain("raw_fragments");
+    expect(body.hint).toContain("update_schema_incremental");
+    expect(body.hint).toContain("migrate_existing");
+  });
+
+  it("omits the hint when all fields are schema-declared", async () => {
+    const result = await (server as unknown as {
+      store: (params: Record<string, unknown>) => Promise<{ content: Array<{ text: string }> }>;
+    }).store({
+      user_id: TEST_USER_ID,
+      idempotency_key: `issue-187-hint-absent-${Date.now()}`,
+      commit: true,
+      entities: [
+        {
+          entity_type: ENTITY_TYPE,
+          title: "Clean Plan",
+        },
+      ],
+    });
+
+    const body = JSON.parse(result.content[0].text) as {
+      unknown_fields_count?: number;
+      hint?: string;
+      entities?: Array<{ entity_id: string }>;
+      error?: { code?: string };
+    };
+
+    expect(body.error).toBeUndefined();
+    expect(body.unknown_fields_count ?? 0).toBe(0);
+    // No hint when there are no unknown fields.
+    expect(body.hint).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a `hint` string to the MCP `store` and HTTP `/interpretations/create` responses when `unknown_fields_count > 0`
- Hint reads: "Unknown fields were stored in raw_fragments. Call update_schema_incremental to promote them to schema fields, then set migrate_existing: true to backfill existing data."
- `hint` is absent when all fields match the schema (clean payloads)
- Updated `openapi.yaml` and regenerated `openapi_types.ts` for both `StoreStructuredResponse` and `CreateInterpretationResponse`

## Test plan

- [ ] `tests/integration/mcp_store_raw_fragments_hint.test.ts` — 2 regression tests pass
  - Verifies hint is present and references recovery path when unknown fields exist
  - Verifies hint is absent for clean payloads
- [ ] Full test suite: 293 passed, 6 pre-existing failures (unrelated to this change)
- [ ] TypeScript type-check: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)