### PR TITLE
docs: add retrieval routing rule for named entity-type queries (closes #228)

### DIFF
--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,8 +61,8 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **383**
-- Backend and repo Vitest files: **350**
+- Total automated test files: **385**
+- Backend and repo Vitest files: **352**
 - Frontend Vitest files: **9**
 - Playwright spec files: **24**
 
@@ -73,7 +73,7 @@ flowchart TD
 | Vitest service tests | 33 |
 | Source-adjacent tests | 45 |
 | Vitest integration tests | 103 |
-| Vitest CLI tests | 57 |
+| Vitest CLI tests | 59 |
 | Vitest contract tests | 10 |
 | Vitest security tests | 1 |
 | Vitest subscription tests | 3 |
@@ -409,7 +409,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/cli`
 **Requirements:** Basic `.env`; some tests provision temp config homes automatically.
-**Files (57):**
+**Files (59):**
 - `tests/cli/api_client_offline_fallback.test.ts`
 - `tests/cli/backup_verify.test.ts`
 - `tests/cli/cli_access_commands.test.ts`


### PR DESCRIPTION
## Summary

- Adds a `Named entity-type routing` rule to the MCP instructions fenced block (`docs/developer/mcp/instructions.md`): when the user asks about "newest plans", "my tasks", etc., agents MUST call `retrieve_entities` with the matching `entity_type` directly rather than searching conversation history first.
- Mirrors the same rule in `docs/developer/cli_agent_instructions.md` (CLI backup quick reference) to maintain MCP↔CLI parity per the agent instructions sync rules.

## Test plan

- [x] Doc-only change; no TypeScript modified; type-check passes
- [x] `npm run lint` passes (0 errors)
- [x] `npm run validate:doc-deps` passes

Closes #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)