### PR TITLE
feat: add neotoma reporter setup command (closes #199)

### DIFF
--- a/docs/developer/cli_reference.md
+++ b/docs/developer/cli_reference.md
@@ -369,6 +369,20 @@ After the JSON report, `neotoma setup` always emits two plain-text lines to stdo
 
 Use `neotoma setup --tool <harness> --yes` for the normal greenfield path. Use `neotoma mcp config` or `neotoma cli config` when only one layer needs repair.
 
+### Reporter
+
+One-shot onboarding for friction reporters (testers or user agents who file issues via Neotoma):
+
+- `neotoma reporter setup`: Orchestrate the full reporter setup in one command.
+  - `--tool <tool>`: Target harness (`claude-code|cursor|codex|openclaw|claude-desktop`). Auto-detected from cwd when omitted.
+  - `--git-sha <sha>`: Default `reporter_git_sha` embedded in every submitted issue.
+  - `--app-version <version>`: Default `reporter_app_version` embedded in every submitted issue.
+  - `--default-visibility <public|private>`: Default issue visibility (default: `public`).
+  - `--dry-run`: Plan the setup without writing files or applying changes.
+  - `--print-block`: Print a copy-pastable env-var block instead of writing the project config file.
+
+The command runs four steps in sequence: (1) version check — warns when the installed CLI is older than the minimum required version; (2) preflight — applies harness permission-file allowlist entries via `neotoma preflight --apply`; (3) config write — persists the reporter defaults to `.neotoma/reporter.json` in the project root so subsequent `neotoma issues create` calls pick them up automatically; (4) smoke-test hint — prints a ready-to-run dry-run command. The structured JSON report includes `tool`, `dry_run`, `installed_version`, `version_ok`, `steps[]`, `reporter_config`, `reporter_config_path`, `smoke_test_command`, `overall_ok`, and `summary`.
+
 ### Preflight
 
 - `neotoma preflight`: Check or apply harness permission-file entries for Neotoma.

--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,8 +61,8 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **375**
-- Backend and repo Vitest files: **342**
+- Total automated test files: **377**
+- Backend and repo Vitest files: **344**
 - Frontend Vitest files: **9**
 - Playwright spec files: **24**
 
@@ -73,7 +73,7 @@ flowchart TD
 | Vitest service tests | 33 |
 | Source-adjacent tests | 45 |
 | Vitest integration tests | 101 |
-| Vitest CLI tests | 55 |
+| Vitest CLI tests | 56 |
 | Vitest contract tests | 10 |
 | Vitest security tests | 1 |
 | Vitest subscription tests | 3 |
@@ -404,7 +404,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/cli`
 **Requirements:** Basic `.env`; some tests provision temp config homes automatically.
-**Files (55):**
+**Files (56):**
 - `tests/cli/api_client_offline_fallback.test.ts`
 - `tests/cli/backup_verify.test.ts`
 - `tests/cli/cli_access_commands.test.ts`
@@ -455,6 +455,7 @@ flowchart TD
 - `tests/cli/issues_message.test.ts`
 - `tests/cli/peers.test.ts`
 - `tests/cli/processes_command.test.ts`
+- `tests/cli/reporter_setup.test.ts`
 - `tests/cli/run_neotoma_mcp_launchers_bash_syntax.test.ts`
 - `tests/cli/schemas_describe.test.ts`
 - `tests/cli/test_command_detection.test.ts`

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -9255,10 +9255,20 @@ reporterCommand
     "One-shot reporter onboarding: version check + harness allowlist + project-local reporter config. " +
       "Run once per project to enable agents to file issues automatically."
   )
-  .option("--tool <tool>", "Target harness (claude-code|cursor|codex|openclaw|claude-desktop). Auto-detected when omitted.")
+  .option(
+    "--tool <tool>",
+    "Target harness (claude-code|cursor|codex|openclaw|claude-desktop). Auto-detected when omitted."
+  )
   .option("--git-sha <sha>", "Default reporter_git_sha to embed in every submitted issue")
-  .option("--app-version <version>", "Default reporter_app_version to embed in every submitted issue")
-  .option("--default-visibility <visibility>", "Default issue visibility: public (default) or private", "public")
+  .option(
+    "--app-version <version>",
+    "Default reporter_app_version to embed in every submitted issue"
+  )
+  .option(
+    "--default-visibility <visibility>",
+    "Default issue visibility: public (default) or private",
+    "public"
+  )
   .option("--dry-run", "Plan the setup without writing files or applying changes", false)
   .option(
     "--print-block",
@@ -9274,8 +9284,7 @@ reporterCommand
       cwd: process.cwd(),
       gitSha: opts.gitSha,
       appVersion: opts.appVersion,
-      defaultVisibility:
-        opts.defaultVisibility === "private" ? "private" : "public",
+      defaultVisibility: opts.defaultVisibility === "private" ? "private" : "public",
       printBlock: Boolean(opts.printBlock),
     });
 
@@ -9298,7 +9307,9 @@ reporterCommand
       }
       if (opts.printBlock) {
         process.stdout.write("\n");
-        process.stdout.write(buildEnvBlock(report.reporter_config, report.reporter_config_path) + "\n");
+        process.stdout.write(
+          buildEnvBlock(report.reporter_config, report.reporter_config_path) + "\n"
+        );
       }
     }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -9244,6 +9244,67 @@ program
     process.exitCode = exitCode;
   });
 
+// ─── Reporter commands ────────────────────────────────────────────────────
+const reporterCommand = program
+  .command("reporter")
+  .description("Reporter-side commands for agents that file friction issues via Neotoma.");
+
+reporterCommand
+  .command("setup")
+  .description(
+    "One-shot reporter onboarding: version check + harness allowlist + project-local reporter config. " +
+      "Run once per project to enable agents to file issues automatically."
+  )
+  .option("--tool <tool>", "Target harness (claude-code|cursor|codex|openclaw|claude-desktop). Auto-detected when omitted.")
+  .option("--git-sha <sha>", "Default reporter_git_sha to embed in every submitted issue")
+  .option("--app-version <version>", "Default reporter_app_version to embed in every submitted issue")
+  .option("--default-visibility <visibility>", "Default issue visibility: public (default) or private", "public")
+  .option("--dry-run", "Plan the setup without writing files or applying changes", false)
+  .option(
+    "--print-block",
+    "Print a copy-pastable env-var block instead of writing the project config file",
+    false
+  )
+  .action(async (opts) => {
+    const outputMode = resolveOutputMode();
+    const { runReporterSetup, buildEnvBlock } = await import("./reporter_setup.js");
+    const report = await runReporterSetup({
+      tool: opts.tool ?? null,
+      dryRun: Boolean(opts.dryRun),
+      cwd: process.cwd(),
+      gitSha: opts.gitSha,
+      appVersion: opts.appVersion,
+      defaultVisibility:
+        opts.defaultVisibility === "private" ? "private" : "public",
+      printBlock: Boolean(opts.printBlock),
+    });
+
+    if (outputMode === "json") {
+      writeOutput(report, outputMode);
+    } else {
+      // Emit a step-by-step status block.
+      for (const step of report.steps) {
+        const status = step.ok ? "ok" : "FAIL";
+        const skipped = step.skipped ? " (skipped)" : step.changed ? " (changed)" : "";
+        process.stdout.write(`[${status}] ${step.step}${skipped}`);
+        if (step.reason) process.stdout.write(`: ${step.reason}`);
+        process.stdout.write("\n");
+      }
+      process.stdout.write("\n");
+      process.stdout.write(`${report.summary}\n`);
+      if (report.overall_ok) {
+        process.stdout.write("\n");
+        process.stdout.write(`Smoke test: ${report.smoke_test_command}\n`);
+      }
+      if (opts.printBlock) {
+        process.stdout.write("\n");
+        process.stdout.write(buildEnvBlock(report.reporter_config, report.reporter_config_path) + "\n");
+      }
+    }
+
+    process.exitCode = report.overall_ok ? 0 : 1;
+  });
+
 program
   .command("preflight")
   .description(

--- a/src/cli/reporter_setup.ts
+++ b/src/cli/reporter_setup.ts
@@ -111,7 +111,10 @@ export async function readReporterConfig(configPath: string): Promise<ReporterCo
 }
 
 /** Write reporter config JSON, creating the .neotoma/ directory if needed. */
-export async function writeReporterConfig(configPath: string, config: ReporterConfig): Promise<void> {
+export async function writeReporterConfig(
+  configPath: string,
+  config: ReporterConfig
+): Promise<void> {
   await fs.mkdir(path.dirname(configPath), { recursive: true });
   await fs.writeFile(configPath, JSON.stringify(config, null, 2) + "\n", "utf8");
 }
@@ -233,8 +236,7 @@ export async function runReporterSetup(
     Object.entries(newConfig).filter(([, v]) => v !== undefined)
   ) as ReporterConfig;
 
-  const configChanged =
-    JSON.stringify(cleanConfig) !== JSON.stringify(existingConfig);
+  const configChanged = JSON.stringify(cleanConfig) !== JSON.stringify(existingConfig);
 
   if (options.printBlock) {
     steps.push({
@@ -281,7 +283,8 @@ export async function runReporterSetup(
   }
 
   // ── Build outputs ─────────────────────────────────────────────────────────
-  const smokeTestCommand = "neotoma issues create --dry-run --title \"test\" --body \"Reporter setup smoke test\"";
+  const smokeTestCommand =
+    'neotoma issues create --dry-run --title "test" --body "Reporter setup smoke test"';
 
   const overallOk = steps.every((s) => s.ok);
 

--- a/src/cli/reporter_setup.ts
+++ b/src/cli/reporter_setup.ts
@@ -1,0 +1,324 @@
+/**
+ * `neotoma reporter setup` — one-shot reporter onboarding command.
+ *
+ * Orchestrates the steps a new friction-reporter (tester / user agent) needs:
+ *   1. Version check: warns when the installed Neotoma CLI is older than the
+ *      minimum version required for stable issue reporting.
+ *   2. Preflight: applies harness permission-file allowlist entries so agents
+ *      can call `neotoma` without per-command approval prompts.
+ *   3. Config write: persists default reporter fields (reporter_git_sha,
+ *      reporter_app_version, default_visibility) to project-local
+ *      `.neotoma/reporter.json` so subsequent `neotoma issues create` calls
+ *      pick them up automatically.
+ *   4. Smoke-test hint: prints a ready-to-run dry-run command the user can
+ *      copy to verify the wiring.
+ */
+
+import { existsSync } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+
+import type { ToolId } from "./doctor.js";
+import { detectCurrentToolHint } from "./doctor.js";
+import { runPreflight } from "./preflight.js";
+
+/** Minimum neotoma version required for stable reporter usage. */
+export const REPORTER_MIN_VERSION = "0.12.0";
+
+/** Config file path relative to the project root (cwd). */
+export const REPORTER_CONFIG_FILENAME = ".neotoma/reporter.json";
+
+export interface ReporterConfig {
+  reporter_git_sha?: string;
+  reporter_app_version?: string;
+  default_visibility?: "public" | "private";
+}
+
+export interface ReporterSetupStepResult {
+  step: string;
+  ok: boolean;
+  skipped?: boolean;
+  changed?: boolean;
+  reason?: string;
+  details?: unknown;
+}
+
+export interface ReporterSetupReport {
+  tool: ToolId | null;
+  dry_run: boolean;
+  installed_version: string | null;
+  version_ok: boolean;
+  steps: ReporterSetupStepResult[];
+  reporter_config: ReporterConfig;
+  reporter_config_path: string;
+  smoke_test_command: string;
+  overall_ok: boolean;
+  summary: string;
+}
+
+export interface RunReporterSetupOptions {
+  tool?: string | ToolId | null;
+  dryRun?: boolean;
+  cwd?: string;
+  /** Pre-supply git SHA; skips prompt when set. */
+  gitSha?: string;
+  /** Pre-supply app/CLI version; skips prompt when set. */
+  appVersion?: string;
+  /** Default visibility for submitted issues. */
+  defaultVisibility?: "public" | "private";
+  /** When true, emit a copy-paste env-var block instead of writing the file. */
+  printBlock?: boolean;
+}
+
+/** Detect the installed neotoma version from the CLI binary. */
+function detectInstalledVersion(): string | null {
+  try {
+    const out = execFileSync("neotoma", ["--version"], {
+      encoding: "utf8",
+      timeout: 5000,
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    // Output is typically "0.13.0" or "neotoma/0.13.0 node/v20.x.x"
+    const match = /(\d+\.\d+\.\d+)/.exec(out);
+    return match?.[1] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/** Semver comparison: returns true when `installed` >= `required`. */
+export function semverGte(installed: string, required: string): boolean {
+  const parse = (v: string): [number, number, number] => {
+    const parts = v.split(".").map((p) => parseInt(p, 10));
+    return [parts[0] ?? 0, parts[1] ?? 0, parts[2] ?? 0];
+  };
+  const [ia, ib, ic] = parse(installed);
+  const [ra, rb, rc] = parse(required);
+  if (ia !== ra) return ia > ra;
+  if (ib !== rb) return ib > rb;
+  return ic >= rc;
+}
+
+/** Read existing reporter config, merging over defaults. */
+export async function readReporterConfig(configPath: string): Promise<ReporterConfig> {
+  try {
+    const raw = await fs.readFile(configPath, "utf8");
+    return JSON.parse(raw) as ReporterConfig;
+  } catch {
+    return {};
+  }
+}
+
+/** Write reporter config JSON, creating the .neotoma/ directory if needed. */
+export async function writeReporterConfig(configPath: string, config: ReporterConfig): Promise<void> {
+  await fs.mkdir(path.dirname(configPath), { recursive: true });
+  await fs.writeFile(configPath, JSON.stringify(config, null, 2) + "\n", "utf8");
+}
+
+/** Build the copy-paste env-var block for --print-block mode. */
+export function buildEnvBlock(config: ReporterConfig, configPath: string): string {
+  const lines: string[] = [
+    "# Reporter environment variables (add to your shell profile or CI env):",
+  ];
+  if (config.reporter_git_sha) {
+    lines.push(`export NEOTOMA_REPORTER_GIT_SHA="${config.reporter_git_sha}"`);
+  }
+  if (config.reporter_app_version) {
+    lines.push(`export NEOTOMA_REPORTER_APP_VERSION="${config.reporter_app_version}"`);
+  }
+  if (config.default_visibility) {
+    lines.push(`export NEOTOMA_REPORTER_DEFAULT_VISIBILITY="${config.default_visibility}"`);
+  }
+  lines.push("");
+  lines.push(`# Or persist these to ${configPath} using: neotoma reporter setup`);
+  return lines.join("\n");
+}
+
+export async function runReporterSetup(
+  options: RunReporterSetupOptions = {}
+): Promise<ReporterSetupReport> {
+  const cwd = options.cwd ?? process.cwd();
+  const dryRun = options.dryRun ?? false;
+  const configPath = path.join(cwd, REPORTER_CONFIG_FILENAME);
+
+  const steps: ReporterSetupStepResult[] = [];
+
+  // ── Step 1: Version check ─────────────────────────────────────────────────
+  const installedVersion = detectInstalledVersion();
+  let versionOk = true;
+  if (!installedVersion) {
+    steps.push({
+      step: "version_check",
+      ok: false,
+      reason: `Could not detect installed neotoma version. Install with: npm install -g neotoma`,
+      details: { required: REPORTER_MIN_VERSION },
+    });
+    versionOk = false;
+  } else if (!semverGte(installedVersion, REPORTER_MIN_VERSION)) {
+    steps.push({
+      step: "version_check",
+      ok: false,
+      reason: `Installed version ${installedVersion} is below minimum ${REPORTER_MIN_VERSION}. Upgrade with: npm install -g neotoma@latest`,
+      details: { installed: installedVersion, required: REPORTER_MIN_VERSION },
+    });
+    versionOk = false;
+  } else {
+    steps.push({
+      step: "version_check",
+      ok: true,
+      details: { installed: installedVersion, required: REPORTER_MIN_VERSION },
+    });
+  }
+
+  // ── Step 2: Detect harness and run preflight ──────────────────────────────
+  const toolInput = options.tool ?? detectCurrentToolHint(cwd);
+  const tool: ToolId | null =
+    typeof toolInput === "string" && toolInput.length > 0 ? (toolInput as ToolId) : null;
+
+  if (!tool) {
+    steps.push({
+      step: "preflight",
+      ok: false,
+      skipped: false,
+      reason:
+        "Could not detect a harness automatically. Re-run with --tool <claude-code|cursor|codex|openclaw|claude-desktop>.",
+    });
+  } else {
+    try {
+      const preflightReport = await runPreflight({
+        tool,
+        apply: !dryRun,
+        dryRun,
+        cwd,
+        scope: "both",
+      });
+      const changed = preflightReport.patches.some((p) => p.changed);
+      steps.push({
+        step: "preflight",
+        ok: preflightReport.overall_ok,
+        changed,
+        skipped: preflightReport.already_ok,
+        reason: preflightReport.already_ok
+          ? "Permission entries already present."
+          : changed
+            ? `Applied ${preflightReport.patches.length} permission patch(es).`
+            : undefined,
+        details: { tool, patches: preflightReport.patches },
+      });
+    } catch (err) {
+      steps.push({
+        step: "preflight",
+        ok: false,
+        reason: (err as Error).message,
+      });
+    }
+  }
+
+  // ── Step 3: Write reporter config ─────────────────────────────────────────
+  const existingConfig = await readReporterConfig(configPath);
+  const newConfig: ReporterConfig = {
+    ...existingConfig,
+    ...(options.gitSha !== undefined ? { reporter_git_sha: options.gitSha || undefined } : {}),
+    ...(options.appVersion !== undefined
+      ? { reporter_app_version: options.appVersion || undefined }
+      : {}),
+    ...(options.defaultVisibility !== undefined
+      ? { default_visibility: options.defaultVisibility }
+      : {}),
+  };
+
+  // Remove undefined keys so JSON.stringify doesn't emit them.
+  const cleanConfig: ReporterConfig = Object.fromEntries(
+    Object.entries(newConfig).filter(([, v]) => v !== undefined)
+  ) as ReporterConfig;
+
+  const configChanged =
+    JSON.stringify(cleanConfig) !== JSON.stringify(existingConfig);
+
+  if (options.printBlock) {
+    steps.push({
+      step: "config_write",
+      ok: true,
+      skipped: true,
+      reason: "--print-block mode: config not written; env-var block printed instead.",
+      details: { config: cleanConfig },
+    });
+  } else if (dryRun) {
+    steps.push({
+      step: "config_write",
+      ok: true,
+      skipped: true,
+      changed: configChanged,
+      reason: `Dry run: would ${existsSync(configPath) ? "update" : "create"} ${configPath}`,
+      details: { config: cleanConfig },
+    });
+  } else if (!configChanged && existsSync(configPath)) {
+    steps.push({
+      step: "config_write",
+      ok: true,
+      skipped: true,
+      changed: false,
+      reason: "Reporter config already up to date.",
+      details: { config: cleanConfig },
+    });
+  } else {
+    try {
+      await writeReporterConfig(configPath, cleanConfig);
+      steps.push({
+        step: "config_write",
+        ok: true,
+        changed: configChanged,
+        details: { config: cleanConfig, path: configPath },
+      });
+    } catch (err) {
+      steps.push({
+        step: "config_write",
+        ok: false,
+        reason: (err as Error).message,
+      });
+    }
+  }
+
+  // ── Build outputs ─────────────────────────────────────────────────────────
+  const smokeTestCommand = "neotoma issues create --dry-run --title \"test\" --body \"Reporter setup smoke test\"";
+
+  const overallOk = steps.every((s) => s.ok);
+
+  const summaryParts: string[] = [
+    `Reporter setup ${overallOk ? "complete" : "completed with issues"}.`,
+    `Your agents in this project will file issues with:`,
+  ];
+  if (cleanConfig.reporter_git_sha) {
+    summaryParts.push(`  git_sha=${cleanConfig.reporter_git_sha}`);
+  }
+  if (cleanConfig.reporter_app_version) {
+    summaryParts.push(`  app_version=${cleanConfig.reporter_app_version}`);
+  }
+  if (cleanConfig.default_visibility) {
+    summaryParts.push(`  default_visibility=${cleanConfig.default_visibility}`);
+  }
+  if (tool) {
+    summaryParts.push(`  harness=${tool}`);
+  }
+  if (!overallOk) {
+    summaryParts.push("");
+    summaryParts.push("Issues to resolve:");
+    for (const s of steps.filter((s) => !s.ok)) {
+      summaryParts.push(`  [${s.step}] ${s.reason ?? "unknown error"}`);
+    }
+  }
+
+  return {
+    tool,
+    dry_run: dryRun,
+    installed_version: installedVersion,
+    version_ok: versionOk,
+    steps,
+    reporter_config: cleanConfig,
+    reporter_config_path: configPath,
+    smoke_test_command: smokeTestCommand,
+    overall_ok: overallOk,
+    summary: summaryParts.join("\n"),
+  };
+}

--- a/tests/cli/cli_command_coverage_guard.test.ts
+++ b/tests/cli/cli_command_coverage_guard.test.ts
@@ -48,6 +48,7 @@ describe("CLI command coverage guard", () => {
       "issues",
       "plans",
       "preflight",
+      "reporter", // neotoma reporter setup covered by tests/cli/reporter_setup.test.ts
       "upload",
       "db", // subcommands covered by db_migrate_encryption.test.ts (migrate-encryption) and db_repair_schema_lag.test.ts (repair-schema-lag)
     ]);

--- a/tests/cli/reporter_setup.test.ts
+++ b/tests/cli/reporter_setup.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import path from "node:path";
+import os from "node:os";
+import fs from "node:fs/promises";
+
+// We import the module under test directly so we can test logic without
+// spawning a child process for every assertion.
+import {
+  semverGte,
+  readReporterConfig,
+  writeReporterConfig,
+  buildEnvBlock,
+  runReporterSetup,
+  REPORTER_CONFIG_FILENAME,
+  REPORTER_MIN_VERSION,
+} from "../../src/cli/reporter_setup.js";
+
+// ── semverGte ──────────────────────────────────────────────────────────────
+
+describe("semverGte", () => {
+  it("returns true when installed equals required", () => {
+    expect(semverGte("0.12.0", "0.12.0")).toBe(true);
+  });
+
+  it("returns true when installed is greater (patch)", () => {
+    expect(semverGte("0.12.1", "0.12.0")).toBe(true);
+  });
+
+  it("returns true when installed is greater (minor)", () => {
+    expect(semverGte("0.13.0", "0.12.0")).toBe(true);
+  });
+
+  it("returns true when installed is greater (major)", () => {
+    expect(semverGte("1.0.0", "0.12.0")).toBe(true);
+  });
+
+  it("returns false when installed is below required (patch)", () => {
+    expect(semverGte("0.11.9", "0.12.0")).toBe(false);
+  });
+
+  it("returns false when installed is below required (minor)", () => {
+    expect(semverGte("0.11.0", "0.12.0")).toBe(false);
+  });
+
+  it("returns false when installed is below required (major)", () => {
+    expect(semverGte("0.0.1", "0.12.0")).toBe(false);
+  });
+});
+
+// ── readReporterConfig / writeReporterConfig ───────────────────────────────
+
+describe("readReporterConfig", () => {
+  it("returns empty object when file does not exist", async () => {
+    const result = await readReporterConfig("/nonexistent/.neotoma/reporter.json");
+    expect(result).toEqual({});
+  });
+
+  it("returns parsed config when file exists", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "neotoma-reporter-test-"));
+    try {
+      const p = path.join(dir, "reporter.json");
+      await fs.writeFile(p, JSON.stringify({ reporter_git_sha: "abc123", default_visibility: "public" }), "utf8");
+      const result = await readReporterConfig(p);
+      expect(result.reporter_git_sha).toBe("abc123");
+      expect(result.default_visibility).toBe("public");
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("writeReporterConfig", () => {
+  it("creates parent directories and writes JSON", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "neotoma-reporter-test-"));
+    try {
+      const p = path.join(dir, ".neotoma", "reporter.json");
+      await writeReporterConfig(p, { reporter_git_sha: "sha-abc", default_visibility: "private" });
+      const raw = await fs.readFile(p, "utf8");
+      const parsed = JSON.parse(raw) as Record<string, unknown>;
+      expect(parsed.reporter_git_sha).toBe("sha-abc");
+      expect(parsed.default_visibility).toBe("private");
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ── buildEnvBlock ──────────────────────────────────────────────────────────
+
+describe("buildEnvBlock", () => {
+  it("includes export lines for configured fields", () => {
+    const block = buildEnvBlock(
+      { reporter_git_sha: "abc", reporter_app_version: "1.2.3", default_visibility: "public" },
+      ".neotoma/reporter.json"
+    );
+    expect(block).toContain("NEOTOMA_REPORTER_GIT_SHA");
+    expect(block).toContain("abc");
+    expect(block).toContain("NEOTOMA_REPORTER_APP_VERSION");
+    expect(block).toContain("1.2.3");
+    expect(block).toContain("NEOTOMA_REPORTER_DEFAULT_VISIBILITY");
+    expect(block).toContain("public");
+  });
+
+  it("omits lines for unconfigured fields", () => {
+    const block = buildEnvBlock({}, ".neotoma/reporter.json");
+    expect(block).not.toContain("NEOTOMA_REPORTER_GIT_SHA");
+    expect(block).not.toContain("NEOTOMA_REPORTER_APP_VERSION");
+  });
+});
+
+// ── runReporterSetup ───────────────────────────────────────────────────────
+
+describe("runReporterSetup", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("emits a version_check step", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "neotoma-reporter-test-"));
+    try {
+      const report = await runReporterSetup({ cwd: dir, dryRun: true });
+      const versionStep = report.steps.find((s) => s.step === "version_check");
+      expect(versionStep).toBeDefined();
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("emits a config_write step with skipped=true in dry-run mode", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "neotoma-reporter-test-"));
+    try {
+      const report = await runReporterSetup({
+        cwd: dir,
+        dryRun: true,
+        gitSha: "test-sha",
+        appVersion: "1.0.0",
+        defaultVisibility: "public",
+        tool: "claude-code",
+      });
+      const configStep = report.steps.find((s) => s.step === "config_write");
+      expect(configStep).toBeDefined();
+      expect(configStep?.skipped).toBe(true);
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("writes reporter.json when not dry-run", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "neotoma-reporter-test-"));
+    try {
+      await runReporterSetup({
+        cwd: dir,
+        dryRun: false,
+        gitSha: "sha-xyz",
+        appVersion: "0.13.0",
+        defaultVisibility: "private",
+        // No tool to avoid running preflight against real filesystem
+        tool: null,
+      });
+      const configPath = path.join(dir, REPORTER_CONFIG_FILENAME);
+      const raw = await fs.readFile(configPath, "utf8");
+      const parsed = JSON.parse(raw) as Record<string, unknown>;
+      expect(parsed.reporter_git_sha).toBe("sha-xyz");
+      expect(parsed.reporter_app_version).toBe("0.13.0");
+      expect(parsed.default_visibility).toBe("private");
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("skips config_write when nothing changed", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "neotoma-reporter-test-"));
+    try {
+      const configPath = path.join(dir, REPORTER_CONFIG_FILENAME);
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      await fs.writeFile(
+        configPath,
+        JSON.stringify({ reporter_git_sha: "sha-abc", default_visibility: "public" }) + "\n",
+        "utf8"
+      );
+      const report = await runReporterSetup({
+        cwd: dir,
+        dryRun: false,
+        gitSha: "sha-abc",
+        defaultVisibility: "public",
+        tool: null,
+      });
+      const configStep = report.steps.find((s) => s.step === "config_write");
+      expect(configStep?.skipped).toBe(true);
+      expect(configStep?.changed).toBe(false);
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("reports smoke_test_command in output", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "neotoma-reporter-test-"));
+    try {
+      const report = await runReporterSetup({ cwd: dir, dryRun: true, tool: null });
+      expect(report.smoke_test_command).toContain("issues create --dry-run");
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("reports min_version constant in version check details on version failure", async () => {
+    // When installed version is not detectable, version_ok should be false.
+    // The step details should reference REPORTER_MIN_VERSION.
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "neotoma-reporter-test-"));
+    try {
+      const report = await runReporterSetup({ cwd: dir, dryRun: true, tool: null });
+      const versionStep = report.steps.find((s) => s.step === "version_check");
+      // Whether ok or not, details always carry the required version.
+      expect(versionStep?.details).toMatchObject({ required: REPORTER_MIN_VERSION });
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("sets print-block mode: config_write skipped=true, details contain config", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "neotoma-reporter-test-"));
+    try {
+      const report = await runReporterSetup({
+        cwd: dir,
+        dryRun: false,
+        printBlock: true,
+        gitSha: "sha-print",
+        tool: null,
+      });
+      const configStep = report.steps.find((s) => s.step === "config_write");
+      expect(configStep?.skipped).toBe(true);
+      const details = configStep?.details as Record<string, unknown> | undefined;
+      const config = details?.config as Record<string, unknown> | undefined;
+      expect(config?.reporter_git_sha).toBe("sha-print");
+      // File should NOT have been written
+      await expect(
+        fs.access(path.join(dir, REPORTER_CONFIG_FILENAME))
+      ).rejects.toThrow();
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `neotoma reporter setup` as a single orchestrator command that collapses 4+ manual onboarding steps into one
- Implements four sequential steps: version check, preflight (harness allowlist), project-local config write, smoke-test hint
- Persists reporter defaults (`reporter_git_sha`, `reporter_app_version`, `default_visibility`) to `.neotoma/reporter.json`
- Supports `--print-block` to emit a copy-pastable env-var block instead of writing the config file
- Auto-detects harness via `detectCurrentToolHint`; accepts `--tool` override
- New module `src/cli/reporter_setup.ts` is pure (no side effects on import) and fully testable
- 19 unit tests covering `semverGte`, config read/write, env block generation, and `runReporterSetup` step logic
- CLI coverage guard updated to include `reporter`
- `docs/developer/cli_reference.md` documents the new Reporter section

## Test plan

- [x] `npm run type-check` passes
- [x] `npm test -- tests/cli/reporter_setup.test.ts tests/cli/cli_command_coverage_guard.test.ts` — 20 tests pass
- [x] `npm run lint:site-copy` passes
- [x] `npm run validate:doc-deps` passes
- Manual smoke: `neotoma reporter setup --dry-run --tool claude-code --git-sha abc123 --app-version 0.13.0` should print step results and summary without writing files

🤖 Generated with [Claude Code](https://claude.com/claude-code)