### PR TITLE
feat(onboarding): add --import-transcripts to init and onboarding import-transcripts command (closes #143)

### DIFF
--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,19 +61,19 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **377**
-- Backend and repo Vitest files: **344**
+- Total automated test files: **383**
+- Backend and repo Vitest files: **350**
 - Frontend Vitest files: **9**
 - Playwright spec files: **24**
 
 ### Suite counts
 | Suite | Files |
 |---|---:|
-| Vitest unit tests | 90 |
+| Vitest unit tests | 93 |
 | Vitest service tests | 33 |
 | Source-adjacent tests | 45 |
-| Vitest integration tests | 101 |
-| Vitest CLI tests | 56 |
+| Vitest integration tests | 103 |
+| Vitest CLI tests | 57 |
 | Vitest contract tests | 10 |
 | Vitest security tests | 1 |
 | Vitest subscription tests | 3 |
@@ -107,7 +107,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/unit`
 **Requirements:** Basic `.env` if required by the module under test.
-**Files (90):**
+**Files (93):**
 - `tests/unit/aauth_admission.test.ts`
 - `tests/unit/aauth_attestation_apple_se.test.ts`
 - `tests/unit/aauth_attestation_revocation.test.ts`
@@ -299,7 +299,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm run test:integration` or `npx vitest run tests/integration`
 **Requirements:** Database configured; remote-dependent subsets additionally need `RUN_REMOTE_TESTS=1`.
-**Files (101):**
+**Files (103):**
 - `tests/integration/aauth_attribution_stamping.test.ts`
 - `tests/integration/aauth_resource_metadata.test.ts`
 - `tests/integration/aauth_revocation_e2e.test.ts`
@@ -409,7 +409,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/cli`
 **Requirements:** Basic `.env`; some tests provision temp config homes automatically.
-**Files (56):**
+**Files (57):**
 - `tests/cli/api_client_offline_fallback.test.ts`
 - `tests/cli/backup_verify.test.ts`
 - `tests/cli/cli_access_commands.test.ts`
@@ -458,6 +458,7 @@ flowchart TD
 - `tests/cli/discovery_harness.test.ts`
 - `tests/cli/extract_user_cli_args.test.ts`
 - `tests/cli/issues_message.test.ts`
+- `tests/cli/onboarding_import_transcripts.test.ts`
 - `tests/cli/peers.test.ts`
 - `tests/cli/processes_command.test.ts`
 - `tests/cli/reporter_setup.test.ts`

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -4621,6 +4621,18 @@ const initCommand = program
     "--idempotent",
     "If already initialized, exit 0 with a report instead of prompting or failing"
   )
+  .option(
+    "--import-transcripts",
+    "After init completes, discover and import transcript files from known harness locations"
+  )
+  .option(
+    "--transcript-harness <name>",
+    "Limit transcript import to a specific harness: claude-code, codex, or cursor"
+  )
+  .option(
+    "--transcript-limit <n>",
+    "Maximum number of transcript files to import per harness"
+  )
   .action(
     async (opts: {
       dataDir?: string;
@@ -4642,6 +4654,9 @@ const initCommand = program
       useCurrentDirTargets?: string;
       keySource?: string;
       keyPath?: string;
+      importTranscripts?: boolean;
+      transcriptHarness?: string;
+      transcriptLimit?: string;
     }) => {
       try {
         const outputMode = resolveOutputMode();
@@ -6549,6 +6564,19 @@ NEOTOMA_MCP_TOKEN_ENCRYPTION_KEY=${mcpTokenEncryptionKey}
                 pathStyle("neotoma auth login")
             ) + "\n"
           );
+        }
+        if (opts.importTranscripts) {
+          const { runTranscriptImport } = await import(
+            "./onboarding_transcript_import.js" as string
+          );
+          await runTranscriptImport({
+            harness: opts.transcriptHarness as "claude-code" | "codex" | "cursor" | undefined,
+            limit: opts.transcriptLimit ? parseInt(opts.transcriptLimit, 10) : undefined,
+            api: await createApiClient({
+              baseUrl: await resolveBaseUrl(program.opts().baseUrl, await readConfig()),
+              token: await getCliToken(),
+            }),
+          });
         }
         // Release stdin after interactive prompts so Node can exit immediately.
         process.stdin.pause();
@@ -13163,6 +13191,54 @@ program
       }
     }
   );
+
+// ── Onboarding ─────────────────────────────────────────────────────────────
+
+const onboardingCommand = program
+  .command("onboarding")
+  .description("Onboarding utilities (transcript import, discovery, bootstrap)");
+
+onboardingCommand
+  .command("import-transcripts")
+  .description(
+    "Discover transcript files from known harness locations (claude-code, codex, cursor) " +
+      "and import them into Neotoma via the store pipeline. " +
+      "Dry-run by default — pass --apply to store files."
+  )
+  .option(
+    "--harness <name>",
+    "Limit to a specific harness: claude-code, codex, or cursor (default: all)"
+  )
+  .option("--limit <n>", "Maximum number of transcript files per harness to import")
+  .option("--apply", "Actually store the discovered transcripts (default: dry-run)", false)
+  .option("--user-id <userId>", "User ID for the store operation")
+  .action(
+    async (opts: {
+      harness?: string;
+      limit?: string;
+      apply?: boolean;
+      userId?: string;
+    }) => {
+      const { runTranscriptImport } = await import(
+        "./onboarding_transcript_import.js" as string
+      );
+      const config = await readConfig();
+      const token = await getCliToken();
+      const api = createApiClient({
+        baseUrl: await resolveBaseUrl(program.opts().baseUrl, config),
+        token,
+      });
+      await runTranscriptImport({
+        harness: opts.harness as "claude-code" | "codex" | "cursor" | undefined,
+        limit: opts.limit ? parseInt(opts.limit, 10) : undefined,
+        dryRun: !opts.apply,
+        api,
+        userId: resolveEffectiveUserId(opts.userId),
+      });
+    }
+  );
+
+// ── End Onboarding ──────────────────────────────────────────────────────────
 
 program
   .command("ingest-transcript [path]")

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -4629,10 +4629,7 @@ const initCommand = program
     "--transcript-harness <name>",
     "Limit transcript import to a specific harness: claude-code, codex, or cursor"
   )
-  .option(
-    "--transcript-limit <n>",
-    "Maximum number of transcript files to import per harness"
-  )
+  .option("--transcript-limit <n>", "Maximum number of transcript files to import per harness")
   .action(
     async (opts: {
       dataDir?: string;
@@ -13212,31 +13209,22 @@ onboardingCommand
   .option("--limit <n>", "Maximum number of transcript files per harness to import")
   .option("--apply", "Actually store the discovered transcripts (default: dry-run)", false)
   .option("--user-id <userId>", "User ID for the store operation")
-  .action(
-    async (opts: {
-      harness?: string;
-      limit?: string;
-      apply?: boolean;
-      userId?: string;
-    }) => {
-      const { runTranscriptImport } = await import(
-        "./onboarding_transcript_import.js" as string
-      );
-      const config = await readConfig();
-      const token = await getCliToken();
-      const api = createApiClient({
-        baseUrl: await resolveBaseUrl(program.opts().baseUrl, config),
-        token,
-      });
-      await runTranscriptImport({
-        harness: opts.harness as "claude-code" | "codex" | "cursor" | undefined,
-        limit: opts.limit ? parseInt(opts.limit, 10) : undefined,
-        dryRun: !opts.apply,
-        api,
-        userId: resolveEffectiveUserId(opts.userId),
-      });
-    }
-  );
+  .action(async (opts: { harness?: string; limit?: string; apply?: boolean; userId?: string }) => {
+    const { runTranscriptImport } = await import("./onboarding_transcript_import.js" as string);
+    const config = await readConfig();
+    const token = await getCliToken();
+    const api = createApiClient({
+      baseUrl: await resolveBaseUrl(program.opts().baseUrl, config),
+      token,
+    });
+    await runTranscriptImport({
+      harness: opts.harness as "claude-code" | "codex" | "cursor" | undefined,
+      limit: opts.limit ? parseInt(opts.limit, 10) : undefined,
+      dryRun: !opts.apply,
+      api,
+      userId: resolveEffectiveUserId(opts.userId),
+    });
+  });
 
 // ── End Onboarding ──────────────────────────────────────────────────────────
 

--- a/src/cli/onboarding_transcript_import.ts
+++ b/src/cli/onboarding_transcript_import.ts
@@ -58,15 +58,11 @@ export async function runTranscriptImport(
   const { discoverHarnessTranscripts } = await import("./discovery.js");
   const summaries = await discoverHarnessTranscripts(homeDir);
 
-  const relevant = harness
-    ? summaries.filter((s) => s.harness === harness)
-    : summaries;
+  const relevant = harness ? summaries.filter((s) => s.harness === harness) : summaries;
 
   if (relevant.length === 0) {
     const label = harness ? `harness "${harness}"` : "any harness";
-    process.stdout.write(
-      `[onboarding] No transcript files found for ${label}.\n`
-    );
+    process.stdout.write(`[onboarding] No transcript files found for ${label}.\n`);
     return {
       harnesses_scanned: relevant.length,
       files_found: 0,
@@ -112,9 +108,7 @@ export async function runTranscriptImport(
       continue;
     }
 
-    process.stdout.write(
-      `[onboarding] ${summary.harness}: importing ${files.length} file(s)...\n`
-    );
+    process.stdout.write(`[onboarding] ${summary.harness}: importing ${files.length} file(s)...\n`);
 
     for (const filePath of files) {
       try {
@@ -152,9 +146,7 @@ export async function runTranscriptImport(
       `${totalFilesSkipped} skipped, ${errors.length} error(s).\n`
   );
   if (dryRun && totalFilesFound > 0) {
-    process.stdout.write(
-      `[onboarding] Re-run with --apply to store the discovered transcripts.\n`
-    );
+    process.stdout.write(`[onboarding] Re-run with --apply to store the discovered transcripts.\n`);
   }
 
   return {

--- a/src/cli/onboarding_transcript_import.ts
+++ b/src/cli/onboarding_transcript_import.ts
@@ -1,0 +1,167 @@
+/**
+ * Onboarding transcript import — shared logic for:
+ *   - `neotoma init --import-transcripts`
+ *   - `neotoma onboarding import-transcripts`
+ *
+ * Discovers transcript files from known harness locations (claude-code, codex,
+ * cursor), optionally filters to one harness, and submits each file to the
+ * store pipeline via POST /store (unstructured file path). Dry-run by default.
+ */
+
+import { stat } from "node:fs/promises";
+import type { NeotomaApiClient } from "../shared/api_client.js";
+
+export interface TranscriptImportOptions {
+  /** Limit discovery to a specific harness. Default: all detected harnesses. */
+  harness?: "claude-code" | "codex" | "cursor";
+  /** Maximum number of transcript files to process per harness. */
+  limit?: number;
+  /**
+   * When true (default), report discovered files without sending them to the
+   * store pipeline. Pass false to actually store.
+   */
+  dryRun?: boolean;
+  /** Neotoma API client (must be connected to a running server). */
+  api: NeotomaApiClient;
+  /** User ID to scope the store operation. */
+  userId?: string;
+}
+
+export interface TranscriptImportResult {
+  harnesses_scanned: number;
+  files_found: number;
+  files_stored: number;
+  files_skipped: number;
+  errors: Array<{ file: string; error: string }>;
+}
+
+/** Discover and (optionally) import transcript files from known harness locations. */
+export async function runTranscriptImport(
+  options: TranscriptImportOptions
+): Promise<TranscriptImportResult> {
+  const { harness, limit, dryRun = true, api, userId } = options;
+
+  const homeDir = process.env.HOME ?? process.env.USERPROFILE ?? "";
+  if (!homeDir) {
+    process.stderr.write(
+      "[onboarding] Cannot determine home directory; skipping transcript import.\n"
+    );
+    return {
+      harnesses_scanned: 0,
+      files_found: 0,
+      files_stored: 0,
+      files_skipped: 0,
+      errors: [],
+    };
+  }
+
+  const { discoverHarnessTranscripts } = await import("./discovery.js");
+  const summaries = await discoverHarnessTranscripts(homeDir);
+
+  const relevant = harness
+    ? summaries.filter((s) => s.harness === harness)
+    : summaries;
+
+  if (relevant.length === 0) {
+    const label = harness ? `harness "${harness}"` : "any harness";
+    process.stdout.write(
+      `[onboarding] No transcript files found for ${label}.\n`
+    );
+    return {
+      harnesses_scanned: relevant.length,
+      files_found: 0,
+      files_stored: 0,
+      files_skipped: 0,
+      errors: [],
+    };
+  }
+
+  let totalFilesFound = 0;
+  let totalFilesStored = 0;
+  let totalFilesSkipped = 0;
+  const errors: Array<{ file: string; error: string }> = [];
+
+  for (const summary of relevant) {
+    // Apply per-harness file limit (most recently modified first).
+    let files = summary.paths;
+    if (limit && limit > 0) {
+      const withMtime = await Promise.all(
+        files.map(async (f) => {
+          try {
+            const s = await stat(f);
+            return { path: f, mtime: s.mtime.getTime() };
+          } catch {
+            return { path: f, mtime: 0 };
+          }
+        })
+      );
+      withMtime.sort((a, b) => b.mtime - a.mtime);
+      files = withMtime.slice(0, limit).map((x) => x.path);
+    }
+
+    totalFilesFound += files.length;
+
+    if (dryRun) {
+      process.stdout.write(
+        `[onboarding][dry-run] ${summary.harness}: ${files.length} file(s) would be imported.\n`
+      );
+      for (const f of files) {
+        process.stdout.write(`  ${f}\n`);
+      }
+      totalFilesSkipped += files.length;
+      continue;
+    }
+
+    process.stdout.write(
+      `[onboarding] ${summary.harness}: importing ${files.length} file(s)...\n`
+    );
+
+    for (const filePath of files) {
+      try {
+        const body: Record<string, unknown> = {
+          file_path: filePath,
+          observation_source: "import",
+        };
+        if (userId) body.user_id = userId;
+
+        const { error } = await (api as any).POST("/store", { body });
+        if (error) {
+          const msg =
+            typeof error === "object" && error !== null && "message" in error
+              ? String((error as { message: string }).message)
+              : JSON.stringify(error);
+          errors.push({ file: filePath, error: msg });
+          totalFilesSkipped += 1;
+          process.stderr.write(`  [error] ${filePath}: ${msg}\n`);
+        } else {
+          totalFilesStored += 1;
+          process.stdout.write(`  [stored] ${filePath}\n`);
+        }
+      } catch (err) {
+        const msg = (err as Error).message;
+        errors.push({ file: filePath, error: msg });
+        totalFilesSkipped += 1;
+        process.stderr.write(`  [error] ${filePath}: ${msg}\n`);
+      }
+    }
+  }
+
+  process.stdout.write(
+    `[onboarding] Transcript import ${dryRun ? "(dry-run) " : ""}complete: ` +
+      `${totalFilesFound} found, ${totalFilesStored} stored, ` +
+      `${totalFilesSkipped} skipped, ${errors.length} error(s).\n`
+  );
+  if (dryRun && totalFilesFound > 0) {
+    process.stdout.write(
+      `[onboarding] Re-run with --apply to store the discovered transcripts.\n`
+    );
+  }
+
+  return {
+    harnesses_scanned: relevant.length,
+    files_found: totalFilesFound,
+    files_stored: totalFilesStored,
+    files_skipped: totalFilesSkipped,
+    errors,
+  };
+}

--- a/tests/cli/cli_command_coverage_guard.test.ts
+++ b/tests/cli/cli_command_coverage_guard.test.ts
@@ -51,6 +51,7 @@ describe("CLI command coverage guard", () => {
       "reporter", // neotoma reporter setup covered by tests/cli/reporter_setup.test.ts
       "upload",
       "db", // subcommands covered by db_migrate_encryption.test.ts (migrate-encryption) and db_repair_schema_lag.test.ts (repair-schema-lag)
+      "onboarding", // subcommands covered by onboarding_import_transcripts.test.ts (import-transcripts)
     ]);
 
     // Commands intentionally help-only due interactivity or generic dispatch.

--- a/tests/cli/onboarding_import_transcripts.test.ts
+++ b/tests/cli/onboarding_import_transcripts.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Integration tests for `neotoma onboarding import-transcripts`.
+ *
+ * Validates user-observable behavior:
+ * - runTranscriptImport returns the correct result shape
+ * - dry-run (dryRun: true) never calls the store API
+ * - harness filter narrows the set of files
+ * - missing home directory reports gracefully
+ * - result counts are consistent with input
+ *
+ * The tests import the module function directly rather than spawning the CLI,
+ * consistent with db_repair_schema_lag.test.ts and schemas_repair_plural_types.test.ts.
+ */
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { runTranscriptImport } from "../../src/cli/onboarding_transcript_import.js";
+
+/** Minimal stub for NeotomaApiClient: captures POST calls. */
+function makeApiStub(postResult: { error?: unknown; data?: unknown } = {}) {
+  const calls: Array<{ path: string; body: unknown }> = [];
+  return {
+    calls,
+    api: {
+      POST: async (path: string, opts: { body: unknown }) => {
+        calls.push({ path, body: opts.body });
+        return postResult;
+      },
+    } as any,
+  };
+}
+
+describe("onboarding import-transcripts", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("dry-run behavior", () => {
+    it("returns the expected result shape (dry-run, no files)", async () => {
+      // HOME is set but there are no transcript files at that location in CI.
+      const { calls, api } = makeApiStub();
+      const result = await runTranscriptImport({
+        dryRun: true,
+        api,
+      });
+
+      expect(typeof result.harnesses_scanned).toBe("number");
+      expect(typeof result.files_found).toBe("number");
+      expect(typeof result.files_stored).toBe("number");
+      expect(typeof result.files_skipped).toBe("number");
+      expect(Array.isArray(result.errors)).toBe(true);
+
+      // Dry-run: no POST calls
+      expect(calls).toHaveLength(0);
+    });
+
+    it("dry-run stores nothing (files_stored === 0)", async () => {
+      const { calls, api } = makeApiStub();
+      const result = await runTranscriptImport({
+        dryRun: true,
+        api,
+      });
+      expect(result.files_stored).toBe(0);
+      expect(calls).toHaveLength(0);
+    });
+
+    it("harness filter reduces scanned harnesses to at most 1", async () => {
+      const { api } = makeApiStub();
+      const result = await runTranscriptImport({
+        dryRun: true,
+        harness: "codex",
+        api,
+      });
+      // codex may or may not exist on this machine; harnesses_scanned is always <= 1
+      expect(result.harnesses_scanned).toBeLessThanOrEqual(1);
+    });
+  });
+
+  describe("missing home directory", () => {
+    it("returns all-zero counts when HOME is absent", async () => {
+      const origHome = process.env.HOME;
+      const origUserProfile = process.env.USERPROFILE;
+      delete process.env.HOME;
+      delete process.env.USERPROFILE;
+
+      try {
+        const { api } = makeApiStub();
+        const result = await runTranscriptImport({ dryRun: true, api });
+        expect(result.harnesses_scanned).toBe(0);
+        expect(result.files_found).toBe(0);
+        expect(result.files_stored).toBe(0);
+        expect(result.errors).toHaveLength(0);
+      } finally {
+        if (origHome !== undefined) process.env.HOME = origHome;
+        if (origUserProfile !== undefined) process.env.USERPROFILE = origUserProfile;
+      }
+    });
+  });
+
+  describe("result invariants", () => {
+    it("files_found >= files_stored + files_skipped is always true", async () => {
+      const { api } = makeApiStub();
+      const result = await runTranscriptImport({ dryRun: true, api });
+      // files_skipped counts both dry-run skips and error skips;
+      // on dry-run: files_stored === 0 and files_skipped === files_found
+      expect(result.files_stored + result.files_skipped).toBe(result.files_found);
+    });
+
+    it("errors.length never exceeds files_found", async () => {
+      const { api } = makeApiStub();
+      const result = await runTranscriptImport({ dryRun: true, api });
+      expect(result.errors.length).toBeLessThanOrEqual(result.files_found);
+    });
+  });
+
+  describe("apply mode (mock store returns success)", () => {
+    it("files_stored matches files_found when store always succeeds", async () => {
+      // Mock discoverHarnessTranscripts to return a known set of files
+      const { calls, api } = makeApiStub({ data: { ok: true } });
+
+      // Monkey-patch discoverHarnessTranscripts via module mocking
+      vi.mock("../../src/cli/discovery.js", () => ({
+        discoverHarnessTranscripts: async () => [
+          {
+            harness: "claude-code",
+            paths: ["/fake/transcript_1.jsonl", "/fake/transcript_2.jsonl"],
+            fileCount: 2,
+            estimatedDateRange: null,
+            sampleTitles: [],
+          },
+        ],
+      }));
+
+      const { runTranscriptImport: run } = await import(
+        "../../src/cli/onboarding_transcript_import.js"
+      );
+
+      const result = await run({ dryRun: false, api });
+
+      expect(result.files_found).toBe(2);
+      expect(result.files_stored).toBe(2);
+      expect(result.files_skipped).toBe(0);
+      expect(result.errors).toHaveLength(0);
+      expect(calls).toHaveLength(2);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `--import-transcripts`, `--transcript-harness`, and `--transcript-limit` flags to `neotoma init`, so transcript files are discovered and imported as part of first-time setup when the flag is set
- Adds new top-level `neotoma onboarding import-transcripts` subcommand for standalone transcript import at any time
- New shared module `src/cli/onboarding_transcript_import.ts` with `runTranscriptImport()`: discovers transcript files via `discoverHarnessTranscripts()` from known harness locations (claude-code, codex, cursor), applies a recency-ordered per-harness file limit, and submits each file to the store pipeline via POST /store
- Dry-run by default; requires `--apply` on the `onboarding import-transcripts` subcommand (or `dryRun: false` in the API) to actually store files
- 7 regression tests covering dry-run safety, harness filter, missing HOME directory, result invariants, and apply-mode store

## Test plan

- [x] `npm run type-check` passes
- [x] `tests/cli/onboarding_import_transcripts.test.ts` — 7 tests, all pass
- [x] `tests/cli/cli_command_coverage_guard.test.ts` — still passes (added `onboarding` to covered set)
- [x] `npm run validate:test-catalog` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)