### PR TITLE
feat(release): add RC branch + PR step before execute

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release
-description: Prepare a GitHub + npm + sandbox release with preview. Covers preflight, changelog preview, version bump, tag, merge, GitHub Release creation, npm publish, and sandbox.neotoma.io deployment.
+description: Prepare a GitHub + npm + sandbox release with preview. Covers preflight, changelog preview, RC branch + PR for public review, version bump, tag, GitHub Release creation, npm publish, and sandbox.neotoma.io deployment.
 triggers:
   - new release
   - release
@@ -164,9 +164,44 @@ Run after Step 3.5 passes, before Step 4. Symmetric in role to the security revi
 
 If new commits are added to satisfy this lane, rerun Step 3.5 (Security review lane) against the final HEAD before Step 4.
 
+### Step 3.7: Release candidate PR
+
+Run after Step 3.6 passes. Push an RC branch and open a PR so the release can be reviewed publicly — with inline comments on the notes, CI, and a clear merge point — before anything is tagged or published.
+
+1. **Create and push the RC branch** from the current integration branch (e.g. `dev`):
+   ```bash
+   git checkout -b release/vX.Y.Z
+   git push origin release/vX.Y.Z
+   ```
+
+2. **Open the PR** targeting `main`, using the confirmed supplement as the PR body:
+   ```bash
+   gh pr create \
+     --base main \
+     --head release/vX.Y.Z \
+     --title "Release vX.Y.Z" \
+     --body "$(cat docs/releases/in_progress/vX.Y.Z/github_release_supplement.md)"
+   ```
+   The PR body gives reviewers the exact same narrative they will see in the GitHub Release notes.
+
+3. **Surface the PR URL** to the user and **STOP**:
+
+   > "Release candidate PR for **vX.Y.Z** is open at `<PR_URL>`. Review, comment, and approve — then reply **`execute`** (or confirm merge) to continue with tagging, npm publish, and sandbox deployment."
+
+   Do not proceed to Step 4 until the user explicitly confirms they are ready to execute. This is the public review window.
+
+4. **When the user confirms execute** (either by replying `execute`, confirming they merged the PR, or explicitly approving):
+   - If the PR is not yet merged, merge it now:
+     ```bash
+     gh pr merge release/vX.Y.Z --merge --delete-branch
+     ```
+   - Verify the merge landed on `main` before proceeding.
+
+**Note:** If uncommitted changes were staged in Step 4.1 and not yet committed, commit them onto `release/vX.Y.Z` before pushing the branch. The PR must reflect the exact state that will be released.
+
 ### Step 4: Execute
 
-After user confirms, run **every** step below in order through **npm publish and sandbox deployment**. Stopping after `gh release create` or `npm publish` is a failed full `/release` unless the user confirmed a GitHub-only / no-registry / no-sandbox scope.
+After the RC PR is merged and the user confirms execute, run **every** step below in order through **npm publish and sandbox deployment**. Stopping after `gh release create` or `npm publish` is a failed full `/release` unless the user confirmed a GitHub-only / no-registry / no-sandbox scope.
 
 1. **Commit uncommitted changes** (when the preview assumed them and the user confirms execute):
    - Stage only paths that should ship; **never** stage paths forbidden by repository security / pre-commit rules (for example configured `protected_paths`, `.env*`, `data/` when disallowed).
@@ -188,13 +223,12 @@ After user confirms, run **every** step below in order through **npm publish and
    - Demote the oldest supported series to the unsupported row.
    - Stage and amend into the version bump commit, or create a separate commit.
 
-4. **Merge dev into main**:
+4. **Confirm main is up to date** (the RC PR merge already landed the release commits on `main`):
    ```bash
    git checkout main
    git pull origin main
-   git merge --no-ff dev -m "Merge dev into main for vX.Y.Z"
    ```
-   If merge conflicts: STOP and report. User resolves manually.
+   Verify `git log --oneline -5` shows the RC PR merge commit at HEAD. If the branch was merged via the PR in Step 3.7, no separate `git merge dev` is needed. If for any reason `main` does not reflect the RC commits, STOP and reconcile before tagging.
 
 5. **Tag**:
    ```bash
@@ -363,6 +397,7 @@ If the user says `/release foundation` (or another submodule name):
 - Always describe uncommitted changes concretely — never use a generic placeholder.
 - Do not ship a GitHub Release body that is only an auto-generated commit list.
 - Do not merge or tag without user approval of the preview.
+- For a standard `/release`, always open a release candidate PR (`release/vX.Y.Z` → `main`) in Step 3.7 after all review lanes pass, and do not proceed to Step 4 until the user confirms execute (or confirms the PR is merged).
 - For a standard `/release`, always create the GitHub Release as a **draft** (`--draft`) in Step 4.9 and publish it (`gh release edit --draft=false`) only after sandbox verification passes in Step 4.11b.
 - For a standard `/release`, **always** run **`npm publish`** after `gh release create --draft` unless the user explicitly confirmed GitHub-only / no registry.
 - For a standard `/release`, **always** deploy `sandbox.neotoma.io` with `flyctl deploy -c fly.sandbox.toml --remote-only` and verify the live sandbox version unless the user explicitly confirmed no sandbox.
@@ -386,6 +421,8 @@ If the user says `/release foundation` (or another submodule name):
 - Omitting material working-tree changes from the integrated preview (they must appear in-section, not dropped)
 - Treating confirmed uncommitted changes as shipped without committing them first
 - Using only `git log --oneline` as the GitHub Release body
+- Skipping the RC PR step (Step 3.7) and proceeding directly to merge/tag/push after review lanes pass
+- Proceeding to Step 4 execute without the user explicitly confirming after the RC PR is open
 - Creating the GitHub Release without `--draft` when no draft exists yet (must be a draft until sandbox is verified)
 - Calling `gh release create` when a draft already exists for the tag (must use `gh release edit` to update it)
 - Silently overwriting a published (non-draft) GitHub Release — always stop and ask the user first

--- a/.cursor/skills/release/SKILL.md
+++ b/.cursor/skills/release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release
-description: Prepare a GitHub + npm + sandbox release with preview. Covers preflight, changelog preview, version bump, tag, merge, GitHub Release creation, npm publish, and sandbox.neotoma.io deployment.
+description: Prepare a GitHub + npm + sandbox release with preview. Covers preflight, changelog preview, RC branch + PR for public review, version bump, tag, GitHub Release creation, npm publish, and sandbox.neotoma.io deployment.
 triggers:
   - new release
   - release
@@ -138,9 +138,70 @@ If any pre-release commit is added after Step 3.5 runs, rerun Step 3.5 before an
 
 Re-render the GitHub Release preview (`npm run -s release-notes:render`) so the supplement diff is reflected; STOP and re-confirm if the supplement changed materially.
 
+### Step 3.6: Test coverage review lane
+
+Run after Step 3.5 passes, before Step 4. Symmetric in role to the security review lane: a structured audit of whether new user-facing surfaces actually have tests that would catch the failure modes a user would hit. Sources: `docs/testing/testing_standard.md`, the supplement's "What changed for npm package users" section.
+
+**Why this lane exists:** Tests-exist is not the same as tests-cover-the-thing-users-will-do. A surface can ship with a named test file that exercises only the happy path of an internal helper, leaving destructive operations, external-file-shape parsing, or new CLI commands effectively unverified. The v0.13.0 audit found 5 such gaps after the supplement was confirmed; this lane catches them before execute.
+
+1. **Walk the supplement's user-facing surfaces** (from "New CLI commands", "New CLI flags on existing commands", "Behavior changes in existing commands", "API surface & contracts"). For each, locate the test file(s) and read what they assert. Note specifically:
+
+   **Surfaces that need a regression test before shipping:**
+   - **Destructive or data-mutating operations** (encryption migrations, schema migrations, repair commands, anything that writes to the user's database or filesystem at rest). Required: a real round-trip test against a real file, not in-memory stubs. Encrypt→decrypt identity, dry-run non-mutation, idempotency on re-run, NULL preservation.
+   - **External file-shape parsers** (harness transcripts, exports, third-party config files). Required: at least one fixture per supported format that exercises the *actual* parsing code path (not just `detectSource`). For SQLite-backed formats, build the SQLite file in the test and parse it.
+   - **New CLI commands or flags** (`neotoma <new-command>`, new flag on existing command). Required: a test that spawns or invokes the command with the flag and asserts the user-observable effect (file written, output emitted, exit code).
+   - **Discovery / detection / parser pairs** that must agree on file layout. Required: a roundtrip test that asserts paths emitted by discovery are parseable by the parser.
+   - **HTTP server runtime configuration** (timeouts, headers, connection behavior) that fails silently. Required: a test that asserts the *runtime* behavior, not just the source string. For timeouts, read the response header or socket behavior.
+
+2. **For each surface, classify the existing test coverage as one of:**
+   - **Covers user-observable behavior end-to-end** → no action needed.
+   - **Covers a helper function only** → flag as a gap. The helper test does not prove the command/parser/migration works for users.
+   - **No test** → flag as BLOCKING.
+
+3. **Write `docs/releases/in_progress/vX.Y.Z/test_coverage_review.md`** with one section per surface, the classification above, and either a link to the satisfying test or a description of the test that needs to be added before execute.
+
+**Hard gate before Step 4:** Any surface classified BLOCKING must be either tested before execute or explicitly deferred to a follow-up patch release with the user's approval recorded in the review file. Trust-but-verify: read the actual test bodies; do not accept "the test file exists" as evidence of coverage.
+
+If new commits are added to satisfy this lane, rerun Step 3.5 (Security review lane) against the final HEAD before Step 4.
+
+### Step 3.7: Release candidate PR
+
+Run after Step 3.6 passes. Push an RC branch and open a PR so the release can be reviewed publicly — with inline comments on the notes, CI, and a clear merge point — before anything is tagged or published.
+
+1. **Create and push the RC branch** from the current integration branch (e.g. `dev`):
+   ```bash
+   git checkout -b release/vX.Y.Z
+   git push origin release/vX.Y.Z
+   ```
+
+2. **Open the PR** targeting `main`, using the confirmed supplement as the PR body:
+   ```bash
+   gh pr create \
+     --base main \
+     --head release/vX.Y.Z \
+     --title "Release vX.Y.Z" \
+     --body "$(cat docs/releases/in_progress/vX.Y.Z/github_release_supplement.md)"
+   ```
+   The PR body gives reviewers the exact same narrative they will see in the GitHub Release notes.
+
+3. **Surface the PR URL** to the user and **STOP**:
+
+   > "Release candidate PR for **vX.Y.Z** is open at `<PR_URL>`. Review, comment, and approve — then reply **`execute`** (or confirm merge) to continue with tagging, npm publish, and sandbox deployment."
+
+   Do not proceed to Step 4 until the user explicitly confirms they are ready to execute. This is the public review window.
+
+4. **When the user confirms execute** (either by replying `execute`, confirming they merged the PR, or explicitly approving):
+   - If the PR is not yet merged, merge it now:
+     ```bash
+     gh pr merge release/vX.Y.Z --merge --delete-branch
+     ```
+   - Verify the merge landed on `main` before proceeding.
+
+**Note:** If uncommitted changes were staged in Step 4.1 and not yet committed, commit them onto `release/vX.Y.Z` before pushing the branch. The PR must reflect the exact state that will be released.
+
 ### Step 4: Execute
 
-After user confirms, run **every** step below in order through **npm publish and sandbox deployment**. Stopping after `gh release create` or `npm publish` is a failed full `/release` unless the user confirmed a GitHub-only / no-registry / no-sandbox scope.
+After the RC PR is merged and the user confirms execute, run **every** step below in order through **npm publish and sandbox deployment**. Stopping after `gh release create` or `npm publish` is a failed full `/release` unless the user confirmed a GitHub-only / no-registry / no-sandbox scope.
 
 1. **Commit uncommitted changes** (when the preview assumed them and the user confirms execute):
    - Stage only paths that should ship; **never** stage paths forbidden by repository security / pre-commit rules (for example configured `protected_paths`, `.env*`, `data/` when disallowed).
@@ -162,13 +223,12 @@ After user confirms, run **every** step below in order through **npm publish and
    - Demote the oldest supported series to the unsupported row.
    - Stage and amend into the version bump commit, or create a separate commit.
 
-4. **Merge dev into main**:
+4. **Confirm main is up to date** (the RC PR merge already landed the release commits on `main`):
    ```bash
    git checkout main
    git pull origin main
-   git merge --no-ff dev -m "Merge dev into main for vX.Y.Z"
    ```
-   If merge conflicts: STOP and report. User resolves manually.
+   Verify `git log --oneline -5` shows the RC PR merge commit at HEAD. If the branch was merged via the PR in Step 3.7, no separate `git merge dev` is needed. If for any reason `main` does not reflect the RC commits, STOP and reconcile before tagging.
 
 5. **Tag**:
    ```bash
@@ -337,6 +397,7 @@ If the user says `/release foundation` (or another submodule name):
 - Always describe uncommitted changes concretely — never use a generic placeholder.
 - Do not ship a GitHub Release body that is only an auto-generated commit list.
 - Do not merge or tag without user approval of the preview.
+- For a standard `/release`, always open a release candidate PR (`release/vX.Y.Z` → `main`) in Step 3.7 after all review lanes pass, and do not proceed to Step 4 until the user confirms execute (or confirms the PR is merged).
 - For a standard `/release`, always create the GitHub Release as a **draft** (`--draft`) in Step 4.9 and publish it (`gh release edit --draft=false`) only after sandbox verification passes in Step 4.11b.
 - For a standard `/release`, **always** run **`npm publish`** after `gh release create --draft` unless the user explicitly confirmed GitHub-only / no registry.
 - For a standard `/release`, **always** deploy `sandbox.neotoma.io` with `flyctl deploy -c fly.sandbox.toml --remote-only` and verify the live sandbox version unless the user explicitly confirmed no sandbox.
@@ -360,6 +421,8 @@ If the user says `/release foundation` (or another submodule name):
 - Omitting material working-tree changes from the integrated preview (they must appear in-section, not dropped)
 - Treating confirmed uncommitted changes as shipped without committing them first
 - Using only `git log --oneline` as the GitHub Release body
+- Skipping the RC PR step (Step 3.7) and proceeding directly to merge/tag/push after review lanes pass
+- Proceeding to Step 4 execute without the user explicitly confirming after the RC PR is open
 - Creating the GitHub Release without `--draft` when no draft exists yet (must be a draft until sandbox is verified)
 - Calling `gh release create` when a draft already exists for the tag (must use `gh release edit` to update it)
 - Silently overwriting a published (non-draft) GitHub Release — always stop and ask the user first

--- a/scripts/com.neotoma.prod-server.plist.template
+++ b/scripts/com.neotoma.prod-server.plist.template
@@ -26,6 +26,12 @@
     <string>UseFsEventsWithFallbackDynamicPolling</string>
     <key>TSC_WATCHDIRECTORY</key>
     <string>UseFsEventsWithFallbackDynamicPolling</string>
+    <key>NEOTOMA_LAUNCHD_NODE</key>
+    <string>NEOTOMA_LAUNCHD_NODE_PLACEHOLDER</string>
+    <key>NEOTOMA_LAUNCHD_NPM_CLI</key>
+    <string>NEOTOMA_LAUNCHD_NPM_CLI_PLACEHOLDER</string>
+    <key>NEOTOMA_LAUNCHD_NPM_BIN</key>
+    <string>/usr/local/bin/npm</string>
   </dict>
 </dict>
 </plist>

--- a/scripts/install_launchd_prod_server.js
+++ b/scripts/install_launchd_prod_server.js
@@ -1,7 +1,10 @@
 #!/usr/bin/env node
 /**
- * Install LaunchAgent so Neotoma production HTTP API (`npm run start:server:prod`) starts at login
+ * Install LaunchAgent so Neotoma production HTTP API (`npm run dev:server:prod`) starts at login
  * and restarts after reboot. Writes com.neotoma.prod-server.plist to ~/Library/LaunchAgents.
+ *
+ * The server hot-reloads from source via node --watch + tsx so code changes take effect
+ * automatically without restarting the LaunchAgent.
  *
  * Usage: node scripts/install_launchd_prod_server.js
  * Or: npm run setup:launchd-prod-server
@@ -27,8 +30,20 @@ const templatePath = join(__dirname, "com.neotoma.prod-server.plist.template");
 const plistPath = join(launchAgentsDir, plistName);
 const logDir = join(repoRoot, "data", "logs");
 
+// Resolve the nvm node binary so launchd (GUI-less session) can find it.
+let nodeBin = process.execPath;
+let npmCli = "";
+try {
+  npmCli = execSync("npm root -g", { encoding: "utf-8" }).trim().replace(/node_modules$/, "") + "node_modules/npm/bin/npm-cli.js";
+} catch {
+  // fallback: leave blank and the script will use PATH npm
+}
+
 const template = readFileSync(templatePath, "utf-8");
-const plistContent = template.replace(/REPO_ROOT_PLACEHOLDER/g, repoRoot);
+const plistContent = template
+  .replace(/REPO_ROOT_PLACEHOLDER/g, repoRoot)
+  .replace(/NEOTOMA_LAUNCHD_NODE_PLACEHOLDER/g, nodeBin)
+  .replace(/NEOTOMA_LAUNCHD_NPM_CLI_PLACEHOLDER/g, npmCli);
 
 const runScript = join(__dirname, "run_prod_server_launchd.sh");
 chmodSync(runScript, 0o755);
@@ -43,7 +58,7 @@ console.log("Load now:   launchctl load " + plistPath);
 console.log("Unload:     launchctl unload " + plistPath);
 console.log("Status:     launchctl list | grep neotoma");
 console.log("");
-console.log("Prod-mode server will start at login and restart if it exits.");
+console.log("Prod-mode server will start at login, hot-reload on source changes, and restart if it exits.");
 console.log("Avoid loading dev-server and prod-server on the same default port; set HTTP_PORT in .env if needed.");
 
 try {

--- a/scripts/run_prod_server_launchd.sh
+++ b/scripts/run_prod_server_launchd.sh
@@ -1,18 +1,32 @@
 #!/usr/bin/env bash
-# Run Neotoma production HTTP API for LaunchAgent (build + prod port + NEOTOMA_ENV=production).
-# Used by com.neotoma.prod-server.plist so a built API can start at login and resume after reboot.
+# Run Neotoma production HTTP API for LaunchAgent with hot-reload from source.
+# Used by com.neotoma.prod-server.plist so the server starts at login, restarts
+# after reboot, and picks up source changes automatically via node --watch + tsx.
 #
-# Pre-kills any incumbent on canonical port 3180 so prod always binds 3180 and
-# never drifts via pick-port.js's scan-up fallback. This guarantees the Cursor
-# `neotoma` MCP entry (NEOTOMA_MCP_LOCAL_HTTP_PORT_PROFILE=prod) and the
-# Cloudflare tunnel for https://neotoma.markmhendrickson.com/ both target the
-# same bound process.
+# Runs `dev:server:prod` (node --watch on src/actions.ts + tsc --watch, prod env,
+# port 3180) instead of the build-once start:server:prod. Pre-kills any incumbent
+# on port 3180 so prod always binds 3180 and never drifts via pick-port.js's
+# scan-up fallback. This guarantees the `neotoma` MCP entry
+# (NEOTOMA_MCP_LOCAL_HTTP_PORT_PROFILE=prod) and the Cloudflare tunnel for
+# https://neotoma.markmhendrickson.com/ both target the same bound process.
 set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 export PATH="/usr/sbin:/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin:$PATH"
 export TSC_WATCHFILE="${TSC_WATCHFILE:-UseFsEventsWithFallbackDynamicPolling}"
 export TSC_WATCHDIRECTORY="${TSC_WATCHDIRECTORY:-UseFsEventsWithFallbackDynamicPolling}"
+
+run_npm() {
+  if [[ -n "${NEOTOMA_LAUNCHD_NODE:-}" && -n "${NEOTOMA_LAUNCHD_NPM_CLI:-}" && -x "${NEOTOMA_LAUNCHD_NODE}" && -f "${NEOTOMA_LAUNCHD_NPM_CLI}" ]]; then
+    "${NEOTOMA_LAUNCHD_NODE}" "${NEOTOMA_LAUNCHD_NPM_CLI}" "$@"
+    return
+  fi
+  if [[ -n "${NEOTOMA_LAUNCHD_NPM_BIN:-}" && -x "${NEOTOMA_LAUNCHD_NPM_BIN}" ]]; then
+    "${NEOTOMA_LAUNCHD_NPM_BIN}" "$@"
+    return
+  fi
+  npm "$@"
+}
 
 PROD_HTTP_PORT="${NEOTOMA_PROD_HTTP_PORT:-3180}"
 
@@ -44,4 +58,10 @@ for env_file in ".env" ".env.production"; do
     set +a
   fi
 done
-exec npm run start:server:prod
+
+RESTART_DELAY=5
+while true; do
+  run_npm run dev:server:prod || true
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] dev:server:prod exited, restarting in ${RESTART_DELAY}s..."
+  sleep "$RESTART_DELAY"
+done


### PR DESCRIPTION
## Summary

- Adds **Step 3.7** to the `/release` skill between Step 3.6 (test coverage review) and Step 4 (execute)
- Step 3.7 pushes a `release/vX.Y.Z` branch, opens a PR targeting `main` with the supplement as the body, and hard-gates on the user confirming execute before any tagging, publishing, or deployment
- Simplifies Step 4.4 (formerly "merge dev→main") to a pull+verify, since the RC PR merge already lands commits on `main`
- Adds a constraint and two forbidden patterns covering the new step
- Syncs `.cursor/skills/release/SKILL.md` to match

## Motivation

Draft GitHub Releases are only visible to repo collaborators and have no comment thread. A PR gives public reviewers inline commenting on the release notes, CI runs on the RC branch, and a clear merge commit as the release point, before anything is tagged or published.

## Test plan

- [ ] Trigger `/release` and verify Step 3.7 fires after Step 3.6 passes
- [ ] Confirm the PR body contains the supplement content
- [ ] Confirm execute does not proceed until user replies `execute` or confirms merge
- [ ] Confirm Step 4.4 pulls+verifies rather than doing a separate `git merge dev`