### PR TITLE
fix(ci): pass CLAUDE_CODE_OAUTH_TOKEN as claude_code_oauth_token not anthropic_api_key

### DIFF
--- a/.github/workflows/claude_pr_review.yml
+++ b/.github/workflows/claude_pr_review.yml
@@ -80,7 +80,7 @@ jobs:
       - uses: anthropics/claude-code-action@beta
         if: steps.diff_check.outputs.substantial == 'true'
         with:
-          anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           model: claude-opus-4-7
           timeout_minutes: 30


### PR DESCRIPTION
## Summary

- The OAuth token stored in `CLAUDE_CODE_OAUTH_TOKEN` was being passed to the `anthropic_api_key` input of `claude-code-action`, not to `claude_code_oauth_token`
- OAuth tokens and API keys are incompatible formats; this caused every review run to fail immediately with "Invalid API key" and output only the placeholder comment
- One-line fix: rename the input key

## Test plan

- [ ] Merge this PR; push a commit to any open non-draft PR and verify the review workflow posts a substantive Opus review comment
- [ ] Or trigger manually with `@claude review` on any open PR after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)