### PR TITLE
fix(reviews): address overlooked findings from PRs #152, #222, #223

### DIFF
--- a/docs/reference/error_codes.md
+++ b/docs/reference/error_codes.md
@@ -1,136 +1,181 @@
 # Error Codes Reference
-*(Complete Catalog of Neotoma Error Codes)*
+
+_(Complete Catalog of Neotoma Error Codes)_
+
 ## Scope
+
 This document covers:
+
 - All canonical error codes and their meanings
 - HTTP status code mappings
 - Retry eligibility
 - Common causes and solutions
-This document does NOT cover:
+  This document does NOT cover:
 - Error handling implementation (see `docs/subsystems/errors.md`)
 - Error propagation patterns (see `docs/architecture/architecture.md`)
+
 ## Error Envelope Format
+
 All errors follow this structure:
+
 ```typescript
 interface ErrorEnvelope {
-  error_code: string;              // Canonical error code
-  message: string;                 // Human-readable description
-  details?: Record<string, any>;   // Additional context (no PII)
-  trace_id?: string;               // Distributed tracing ID
-  timestamp: string;               // ISO 8601
+  error_code: string; // Canonical error code
+  message: string; // Human-readable description
+  details?: Record<string, any>; // Additional context (no PII)
+  trace_id?: string; // Distributed tracing ID
+  timestamp: string; // ISO 8601
 }
 ```
+
 ## Ingestion Errors
-| Code | HTTP | Retry? | Description |
-|------|------|--------|-------------|
-| `INGESTION_FILE_TOO_LARGE` | 400 | No | File exceeds maximum size (50MB) |
-| `INGESTION_UNSUPPORTED_TYPE` | 400 | No | File type not supported (PDF, JPG, PNG only) |
-| `INGESTION_INVALID_FILE` | 400 | No | File is corrupted or invalid format |
-| `INGESTION_OCR_FAILED` | 500 | Yes | OCR processing failed (Tesseract error) |
-| `INGESTION_EXTRACTION_FAILED` | 500 | No | Field extraction failed (schema error) |
-| `INGESTION_NORMALIZATION_FAILED` | 500 | Yes | File format conversion failed |
-| `INGESTION_SCHEMA_DETECTION_FAILED` | 500 | No | Could not detect document schema |
-| `INGESTION_STORAGE_FAILED` | 500 | Yes | Failed to store file in storage |
+
+| Code                                | HTTP | Retry? | Description                                  |
+| ----------------------------------- | ---- | ------ | -------------------------------------------- |
+| `INGESTION_FILE_TOO_LARGE`          | 400  | No     | File exceeds maximum size (50MB)             |
+| `INGESTION_UNSUPPORTED_TYPE`        | 400  | No     | File type not supported (PDF, JPG, PNG only) |
+| `INGESTION_INVALID_FILE`            | 400  | No     | File is corrupted or invalid format          |
+| `INGESTION_OCR_FAILED`              | 500  | Yes    | OCR processing failed (Tesseract error)      |
+| `INGESTION_EXTRACTION_FAILED`       | 500  | No     | Field extraction failed (schema error)       |
+| `INGESTION_NORMALIZATION_FAILED`    | 500  | Yes    | File format conversion failed                |
+| `INGESTION_SCHEMA_DETECTION_FAILED` | 500  | No     | Could not detect document schema             |
+| `INGESTION_STORAGE_FAILED`          | 500  | Yes    | Failed to store file in storage              |
+
 **Common Causes:**
+
 - `INGESTION_FILE_TOO_LARGE`: File >50MB
 - `INGESTION_UNSUPPORTED_TYPE`: File is not PDF, JPG, or PNG
 - `INGESTION_OCR_FAILED`: Image has no readable text or Tesseract error
+
 ## Authentication Errors
-| Code | HTTP | Retry? | Description |
-|------|------|--------|-------------|
-| `AUTH_REQUIRED` | 401 | No | No bearer token provided |
-| `AUTH_INVALID` | 401 | No | Bearer token is invalid |
-| `AUTH_EXPIRED` | 401 | No | Bearer token has expired |
-| `AUTH_MALFORMED` | 401 | No | Bearer token format is invalid |
-| `FORBIDDEN` | 403 | No | Insufficient permissions (RLS policy violation) |
+
+| Code             | HTTP | Retry? | Description                                     |
+| ---------------- | ---- | ------ | ----------------------------------------------- |
+| `AUTH_REQUIRED`  | 401  | No     | No bearer token provided                        |
+| `AUTH_INVALID`   | 401  | No     | Bearer token is invalid                         |
+| `AUTH_EXPIRED`   | 401  | No     | Bearer token has expired                        |
+| `AUTH_MALFORMED` | 401  | No     | Bearer token format is invalid                  |
+| `FORBIDDEN`      | 403  | No     | Insufficient permissions (RLS policy violation) |
+
 **Common Causes:**
+
 - `AUTH_REQUIRED`: Missing `Authorization: Bearer <token>` header
 - `AUTH_INVALID`: Token doesn't match `ACTIONS_BEARER_TOKEN`
 - `FORBIDDEN`: User doesn't have access to requested resource (RLS)
+
 ## Database Errors
-| Code | HTTP | Retry? | Description |
-|------|------|--------|-------------|
-| `DB_CONNECTION_FAILED` | 503 | Yes | Cannot connect to database |
-| `DB_QUERY_FAILED` | 500 | Yes | Query execution failed |
-| `DB_CONSTRAINT_VIOLATION` | 409 | No | Unique constraint violated (duplicate record) |
-| `DB_TRANSACTION_FAILED` | 500 | Yes | Transaction rollback failed |
-| `DB_TIMEOUT` | 504 | Yes | Database query timed out |
+
+| Code                      | HTTP | Retry? | Description                                   |
+| ------------------------- | ---- | ------ | --------------------------------------------- |
+| `DB_CONNECTION_FAILED`    | 503  | Yes    | Cannot connect to database                    |
+| `DB_QUERY_FAILED`         | 500  | Yes    | Query execution failed                        |
+| `DB_CONSTRAINT_VIOLATION` | 409  | No     | Unique constraint violated (duplicate record) |
+| `DB_TRANSACTION_FAILED`   | 500  | Yes    | Transaction rollback failed                   |
+| `DB_TIMEOUT`              | 504  | Yes    | Database query timed out                      |
 
 ### Resource Errors
-| Code | HTTP | Retry? | Meaning |
-|------|------|--------|---------|
-| `RESOURCE_NOT_FOUND` | 404 | No | Requested resource does not exist |
+
+| Code                 | HTTP | Retry? | Meaning                           |
+| -------------------- | ---- | ------ | --------------------------------- |
+| `RESOURCE_NOT_FOUND` | 404  | No     | Requested resource does not exist |
+
 **Common Causes:**
+
 - `DB_CONNECTION_FAILED`: Database unavailable or network issue
 - `DB_CONSTRAINT_VIOLATION`: Attempting to create duplicate record
 - `DB_TIMEOUT`: Query taking too long (large dataset or missing index)
+
 ## Entity Resolution Errors
-| Code | HTTP | Retry? | Description |
-|------|------|--------|-------------|
-| `ENTITY_NORMALIZATION_FAILED` | 500 | No | Entity name normalization failed |
-| `ENTITY_ID_GENERATION_FAILED` | 500 | No | Failed to generate canonical entity ID |
-| `ENTITY_TYPE_INVALID` | 400 | No | Invalid entity type (must be person, company, location) |
+
+| Code                          | HTTP | Retry? | Description                                             |
+| ----------------------------- | ---- | ------ | ------------------------------------------------------- |
+| `ENTITY_NORMALIZATION_FAILED` | 500  | No     | Entity name normalization failed                        |
+| `ENTITY_ID_GENERATION_FAILED` | 500  | No     | Failed to generate canonical entity ID                  |
+| `ENTITY_TYPE_INVALID`         | 400  | No     | Invalid entity type (must be person, company, location) |
+
 **Common Causes:**
+
 - `ENTITY_NORMALIZATION_FAILED`: Entity name is empty or invalid
 - `ENTITY_TYPE_INVALID`: Entity type not in allowed set
+
 ## Search Errors
-| Code | HTTP | Retry? | Description |
-|------|------|--------|-------------|
-| `SEARCH_QUERY_INVALID` | 400 | No | Search query is malformed |
-| `SEARCH_INDEX_UNAVAILABLE` | 503 | Yes | Search index is not ready (eventual consistency) |
-| `SEARCH_LIMIT_EXCEEDED` | 400 | No | Limit exceeds maximum (1000) |
+
+| Code                       | HTTP | Retry? | Description                                      |
+| -------------------------- | ---- | ------ | ------------------------------------------------ |
+| `SEARCH_QUERY_INVALID`     | 400  | No     | Search query is malformed                        |
+| `SEARCH_INDEX_UNAVAILABLE` | 503  | Yes    | Search index is not ready (eventual consistency) |
+| `SEARCH_LIMIT_EXCEEDED`    | 400  | No     | Limit exceeds maximum (1000)                     |
+
 **Common Causes:**
+
 - `SEARCH_QUERY_INVALID`: Invalid search_mode or malformed query
 - `SEARCH_INDEX_UNAVAILABLE`: Full-text index still building (max 5s delay)
+
 ## File Storage Errors
-| Code | HTTP | Retry? | Description |
-|------|------|--------|-------------|
-| `STORAGE_BUCKET_NOT_FOUND` | 404 | No | Storage bucket doesn't exist |
-| `STORAGE_UPLOAD_FAILED` | 500 | Yes | File upload to storage failed |
-| `STORAGE_DELETE_FAILED` | 500 | Yes | File deletion from storage failed |
-| `STORAGE_SIGNED_URL_FAILED` | 500 | Yes | Failed to generate signed URL |
+
+| Code                        | HTTP | Retry? | Description                       |
+| --------------------------- | ---- | ------ | --------------------------------- |
+| `STORAGE_BUCKET_NOT_FOUND`  | 404  | No     | Storage bucket doesn't exist      |
+| `STORAGE_UPLOAD_FAILED`     | 500  | Yes    | File upload to storage failed     |
+| `STORAGE_DELETE_FAILED`     | 500  | Yes    | File deletion from storage failed |
+| `STORAGE_SIGNED_URL_FAILED` | 500  | Yes    | Failed to generate signed URL     |
+
 **Common Causes:**
+
 - `STORAGE_BUCKET_NOT_FOUND`: Storage bucket not configured
 - `STORAGE_UPLOAD_FAILED`: Network issue or storage quota exceeded
+
 ## Integration Errors
+
 ### Plaid Errors
-| Code | HTTP | Retry? | Description |
-|------|------|--------|-------------|
-| `PLAID_LINK_TOKEN_EXPIRED` | 400 | No | Link token has expired (4 hours) |
-| `PLAID_ITEM_NOT_FOUND` | 404 | No | Plaid item doesn't exist |
-| `PLAID_SYNC_FAILED` | 500 | Yes | Transaction sync failed |
-| `PLAID_RATE_LIMIT_EXCEEDED` | 429 | Yes | Plaid API rate limit exceeded |
-| `PLAID_INVALID_CREDENTIALS` | 401 | No | Plaid client_id or secret invalid |
+
+| Code                        | HTTP | Retry? | Description                       |
+| --------------------------- | ---- | ------ | --------------------------------- |
+| `PLAID_LINK_TOKEN_EXPIRED`  | 400  | No     | Link token has expired (4 hours)  |
+| `PLAID_ITEM_NOT_FOUND`      | 404  | No     | Plaid item doesn't exist          |
+| `PLAID_SYNC_FAILED`         | 500  | Yes    | Transaction sync failed           |
+| `PLAID_RATE_LIMIT_EXCEEDED` | 429  | Yes    | Plaid API rate limit exceeded     |
+| `PLAID_INVALID_CREDENTIALS` | 401  | No     | Plaid client_id or secret invalid |
+
 **Common Causes:**
+
 - `PLAID_LINK_TOKEN_EXPIRED`: Token older than 4 hours
 - `PLAID_RATE_LIMIT_EXCEEDED`: Too many API calls (500/min sandbox)
+
 ### External Provider Errors
-| Code | HTTP | Retry? | Description |
-|------|------|--------|-------------|
-| `PROVIDER_OAUTH_FAILED` | 500 | Yes | OAuth flow failed |
-| `PROVIDER_TOKEN_EXPIRED` | 401 | No | OAuth token expired (refresh required) |
-| `PROVIDER_RATE_LIMIT_EXCEEDED` | 429 | Yes | Provider API rate limit exceeded |
-| `PROVIDER_CONNECTOR_NOT_FOUND` | 404 | No | Connector doesn't exist |
-| `PROVIDER_SYNC_FAILED` | 500 | Yes | Provider sync failed |
+
+| Code                           | HTTP | Retry? | Description                            |
+| ------------------------------ | ---- | ------ | -------------------------------------- |
+| `PROVIDER_OAUTH_FAILED`        | 500  | Yes    | OAuth flow failed                      |
+| `PROVIDER_TOKEN_EXPIRED`       | 401  | No     | OAuth token expired (refresh required) |
+| `PROVIDER_RATE_LIMIT_EXCEEDED` | 429  | Yes    | Provider API rate limit exceeded       |
+| `PROVIDER_CONNECTOR_NOT_FOUND` | 404  | No     | Connector doesn't exist                |
+| `PROVIDER_SYNC_FAILED`         | 500  | Yes    | Provider sync failed                   |
+
 **Common Causes:**
+
 - `PROVIDER_TOKEN_EXPIRED`: OAuth token needs refresh
 - `PROVIDER_RATE_LIMIT_EXCEEDED`: Exceeded provider's rate limits
+
 ### MCP OAuth Errors
-| Code | HTTP | Retry? | Description |
-|------|------|--------|-------------|
-| `OAUTH_CLIENT_REGISTRATION_FAILED` | 500 | No | Dynamic OAuth client registration failed |
-| `OAUTH_STATE_INVALID` | 400 | No | Invalid or missing OAuth state token |
-| `OAUTH_STATE_EXPIRED` | 400 | No | OAuth state token expired (10 minute limit) |
-| `OAUTH_TOKEN_EXCHANGE_FAILED` | 500 | Yes | Failed to exchange authorization code for tokens |
-| `OAUTH_TOKEN_REFRESH_FAILED` | 401 | Yes | Failed to refresh access token |
-| `OAUTH_CONNECTION_NOT_FOUND` | 404 | No | MCP OAuth connection not found |
-| `OAUTH_CONNECTION_REVOKED` | 403 | No | Connection has been revoked by user |
-| `OAUTH_ENCRYPTION_KEY_MISSING` | 500 | No | Token encryption key not configured |
-| `OAUTH_ENCRYPTION_KEY_INVALID` | 500 | No | Encryption key format is invalid (must be 64 hex chars) |
-| `OAUTH_INVALID_REDIRECT_URI` | 400 | No | Redirect URI format validation failed |
-| `OAUTH_DECRYPTION_FAILED` | 500 | No | Failed to decrypt refresh token |
-| `OAUTH_USER_INFO_FAILED` | 500 | Yes | Failed to get user info from access token |
+
+| Code                               | HTTP | Retry? | Description                                             |
+| ---------------------------------- | ---- | ------ | ------------------------------------------------------- |
+| `OAUTH_CLIENT_REGISTRATION_FAILED` | 500  | No     | Dynamic OAuth client registration failed                |
+| `OAUTH_STATE_INVALID`              | 400  | No     | Invalid or missing OAuth state token                    |
+| `OAUTH_STATE_EXPIRED`              | 400  | No     | OAuth state token expired (10 minute limit)             |
+| `OAUTH_TOKEN_EXCHANGE_FAILED`      | 500  | Yes    | Failed to exchange authorization code for tokens        |
+| `OAUTH_TOKEN_REFRESH_FAILED`       | 401  | Yes    | Failed to refresh access token                          |
+| `OAUTH_CONNECTION_NOT_FOUND`       | 404  | No     | MCP OAuth connection not found                          |
+| `OAUTH_CONNECTION_REVOKED`         | 403  | No     | Connection has been revoked by user                     |
+| `OAUTH_ENCRYPTION_KEY_MISSING`     | 500  | No     | Token encryption key not configured                     |
+| `OAUTH_ENCRYPTION_KEY_INVALID`     | 500  | No     | Encryption key format is invalid (must be 64 hex chars) |
+| `OAUTH_INVALID_REDIRECT_URI`       | 400  | No     | Redirect URI format validation failed                   |
+| `OAUTH_DECRYPTION_FAILED`          | 500  | No     | Failed to decrypt refresh token                         |
+| `OAUTH_USER_INFO_FAILED`           | 500  | Yes    | Failed to get user info from access token               |
+
 **Common Causes:**
+
 - `OAUTH_CLIENT_REGISTRATION_FAILED`: OAuth client not configured or missing env var
 - `OAUTH_STATE_INVALID`: State token not found in database or already consumed
 - `OAUTH_STATE_EXPIRED`: State created more than 10 minutes ago
@@ -138,55 +183,98 @@ interface ErrorEnvelope {
 - `OAUTH_CONNECTION_NOT_FOUND`: Connection_id doesn't exist or was deleted
 - `OAUTH_ENCRYPTION_KEY_MISSING`: MCP_TOKEN_ENCRYPTION_KEY not set in environment
 - `OAUTH_DECRYPTION_FAILED`: Invalid encrypted token format or wrong encryption key
+
 ## Validation Errors
-| Code | HTTP | Retry? | Description |
-|------|------|--------|-------------|
-| `VALIDATION_MISSING_FIELD` | 400 | No | Required field is missing |
-| `VALIDATION_INVALID_TYPE` | 400 | No | Field has invalid type |
-| `VALIDATION_INVALID_FORMAT` | 400 | No | Field format is invalid (e.g., date) |
-| `VALIDATION_OUT_OF_RANGE` | 400 | No | Field value out of allowed range |
+
+| Code                        | HTTP | Retry? | Description                          |
+| --------------------------- | ---- | ------ | ------------------------------------ |
+| `VALIDATION_MISSING_FIELD`  | 400  | No     | Required field is missing            |
+| `VALIDATION_INVALID_TYPE`   | 400  | No     | Field has invalid type               |
+| `VALIDATION_INVALID_FORMAT` | 400  | No     | Field format is invalid (e.g., date) |
+| `VALIDATION_OUT_OF_RANGE`   | 400  | No     | Field value out of allowed range     |
+
 **Common Causes:**
+
 - `VALIDATION_MISSING_FIELD`: Missing required `type` or `properties`
 - `VALIDATION_INVALID_FORMAT`: Invalid date format or JSON structure
-## Graph Errors
-| Code | HTTP | Retry? | Description |
-|------|------|--------|-------------|
-| `GRAPH_ORPHAN_NODE` | 500 | No | Attempted to create orphan node (violates integrity) |
-| `GRAPH_CYCLE_DETECTED` | 500 | No | Graph cycle detected (should not occur) |
-| `GRAPH_EDGE_INVALID` | 400 | No | Invalid edge type or source/target |
+
+## Idempotency Errors
+
+| Code                        | HTTP | Retry? | Description                                                                                                     |
+| --------------------------- | ---- | ------ | --------------------------------------------------------------------------------------------------------------- |
+| `ERR_IDEMPOTENCY_MISMATCH`  | 400  | No     | `idempotency_key` reused with a different canonicalized predicate (`entity_split`, `correct`).                  |
+| `ERR_IDEMPOTENCY_COLLISION` | 409  | No     | `idempotency_key` reused on `/store` with different content (different content hash) than the original request. |
+
+`ERR_IDEMPOTENCY_MISMATCH` and `ERR_IDEMPOTENCY_COLLISION` describe the same
+semantic class — a previously-seen idempotency key reused with different
+content — and exist for historical reasons on different endpoints. New clients
+SHOULD treat both as the same condition: the prior request's result is _not_
+replayable, and the caller MUST either supply a fresh key or send a payload
+whose canonical content hash matches the prior call. See
+`docs/architecture/idempotence_pattern.md`.
+
 **Common Causes:**
+
+- Caller reuses a key across semantically different requests
+- Caller mutates the payload between retries without regenerating the key
+- Two unrelated callers collide on a non-unique key
+
+## Graph Errors
+
+| Code                   | HTTP | Retry? | Description                                          |
+| ---------------------- | ---- | ------ | ---------------------------------------------------- |
+| `GRAPH_ORPHAN_NODE`    | 500  | No     | Attempted to create orphan node (violates integrity) |
+| `GRAPH_CYCLE_DETECTED` | 500  | No     | Graph cycle detected (should not occur)              |
+| `GRAPH_EDGE_INVALID`   | 400  | No     | Invalid edge type or source/target                   |
+
+**Common Causes:**
+
 - `GRAPH_ORPHAN_NODE`: Entity or event created without record link
 - `GRAPH_EDGE_INVALID`: Invalid edge type (not in allowed set)
+
 ## Generic Errors
-| Code | HTTP | Retry? | Description |
-|------|------|--------|-------------|
-| `INTERNAL_ERROR` | 500 | Yes | Unexpected server error |
-| `SERVICE_UNAVAILABLE` | 503 | Yes | Service temporarily unavailable |
-| `TIMEOUT` | 504 | Yes | Request timed out |
-| `NOT_IMPLEMENTED` | 501 | No | Feature not yet implemented |
+
+| Code                  | HTTP | Retry? | Description                     |
+| --------------------- | ---- | ------ | ------------------------------- |
+| `INTERNAL_ERROR`      | 500  | Yes    | Unexpected server error         |
+| `SERVICE_UNAVAILABLE` | 503  | Yes    | Service temporarily unavailable |
+| `TIMEOUT`             | 504  | Yes    | Request timed out               |
+| `NOT_IMPLEMENTED`     | 501  | No     | Feature not yet implemented     |
+
 **Common Causes:**
+
 - `INTERNAL_ERROR`: Unexpected exception (check logs with trace_id)
 - `SERVICE_UNAVAILABLE`: Database or external service down
+
 ## Retry Guidelines
+
 ### Retry Eligible (Yes)
+
 - Network errors (`DB_CONNECTION_FAILED`, `TIMEOUT`)
 - Transient errors (`SERVICE_UNAVAILABLE`, `SEARCH_INDEX_UNAVAILABLE`)
 - Rate limits (`PLAID_RATE_LIMIT_EXCEEDED`, `PROVIDER_RATE_LIMIT_EXCEEDED`)
-**Retry Strategy:**
+  **Retry Strategy:**
 - Exponential backoff: `delay = 2^attempt * 1000ms`
 - Max retries: 3-5 attempts
 - Jitter: Add random 0-1000ms to prevent thundering herd
+
 ### Not Retry Eligible (No)
+
 - Client errors (4xx): Fix request before retrying
 - Validation errors: Correct input format
 - Authentication errors: Fix token/credentials
 - Constraint violations: Handle duplicate/conflict
+
 ## Error Code Format
+
 Error codes follow this pattern:
+
 ```
 <CATEGORY>_<SPECIFIC_ERROR>
 ```
+
 **Categories:**
+
 - `INGESTION_*`: File upload and processing
 - `AUTH_*`: Authentication and authorization
 - `DB_*`: Database operations
@@ -198,24 +286,34 @@ Error codes follow this pattern:
 - `OAUTH_*`: MCP OAuth authentication
 - `VALIDATION_*`: Input validation
 - `GRAPH_*`: Graph operations
+
 ## Agent Instructions
+
 ### When to Load This Document
+
 Load when:
+
 - Implementing error handling
 - Debugging API errors
 - Adding new error codes
 - Understanding error responses
+
 ### Required Co-Loaded Documents
+
 - `docs/subsystems/errors.md` — Error handling patterns
 - `docs/architecture/architecture.md` — Error propagation
 - `docs/api/rest_api.md` — API error responses
+
 ### Constraints Agents Must Enforce
+
 1. **Use canonical error codes** — Don't invent new codes without updating this doc
 2. **Include trace_id** — For distributed tracing
 3. **Never include PII** — In error details
 4. **Follow retry guidelines** — Respect retry eligibility
 5. **Update this doc** — When adding new error codes
+
 ### Forbidden Patterns
+
 - Creating ad-hoc error codes without documentation
 - Including PII in error details
 - Retrying non-retryable errors

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -107,11 +107,11 @@ components:
         related_entities:
           type: array
           items:
-            $ref: '#/components/schemas/RecentConversationRelatedEntity'
+            $ref: "#/components/schemas/RecentConversationRelatedEntity"
         hook_summary:
           anyOf:
             - type: "null"
-            - $ref: '#/components/schemas/ConversationTurnHookSummary'
+            - $ref: "#/components/schemas/ConversationTurnHookSummary"
     RecentConversationItem:
       type: object
       properties:
@@ -134,7 +134,7 @@ components:
         messages:
           type: array
           items:
-            $ref: '#/components/schemas/RecentConversationMessage'
+            $ref: "#/components/schemas/RecentConversationMessage"
     StoreResolutionIssue:
       type: object
       description: |
@@ -174,7 +174,7 @@ components:
                     Short, actionable instruction for the caller (e.g. "Declare
                     `conversation_id` on entity_type \"conversation\"…"). PII-free.
                 required_identity_fields:
-                  $ref: '#/components/schemas/RequiredIdentityFields'
+                  $ref: "#/components/schemas/RequiredIdentityFields"
           description: |
             Optional structured upgrade guidance. Populated when the server can
             detect a common caller mistake (e.g. wrapping fields inside
@@ -243,7 +243,7 @@ components:
             issues:
               type: array
               items:
-                $ref: '#/components/schemas/StoreResolutionIssue'
+                $ref: "#/components/schemas/StoreResolutionIssue"
     SplitPredicate:
       type: object
       description: |
@@ -293,7 +293,7 @@ components:
         source_entity_id:
           type: string
         predicate:
-          $ref: '#/components/schemas/SplitPredicate'
+          $ref: "#/components/schemas/SplitPredicate"
         new_entity:
           type: object
           required:
@@ -922,7 +922,7 @@ components:
             the ingestion pipeline.
           additionalProperties: true
           allOf:
-            - $ref: '#/components/schemas/AgentAttribution'
+            - $ref: "#/components/schemas/AgentAttribution"
     Observation:
       type: object
       properties:
@@ -989,7 +989,7 @@ components:
             free-form provenance keys supplied at write time.
           additionalProperties: true
           allOf:
-            - $ref: '#/components/schemas/AgentAttribution'
+            - $ref: "#/components/schemas/AgentAttribution"
     RelationshipSnapshot:
       type: object
       properties:
@@ -1031,7 +1031,7 @@ components:
             row. `null` when no contributing observation carried
             attribution keys.
           allOf:
-            - $ref: '#/components/schemas/AgentAttribution'
+            - $ref: "#/components/schemas/AgentAttribution"
         user_id:
           type: string
         source_entity_name:
@@ -1092,7 +1092,7 @@ components:
             the `AgentAttribution` keys stamped by the AAuth middleware.
           additionalProperties: true
           allOf:
-            - $ref: '#/components/schemas/AgentAttribution'
+            - $ref: "#/components/schemas/AgentAttribution"
     EntitySchema:
       type: object
       properties:
@@ -1129,7 +1129,7 @@ components:
             the `AgentAttribution` keys stamped by the AAuth middleware.
           additionalProperties: true
           allOf:
-            - $ref: '#/components/schemas/AgentAttribution'
+            - $ref: "#/components/schemas/AgentAttribution"
     InterpretationConfig:
       type: object
       additionalProperties: true
@@ -1171,7 +1171,7 @@ components:
             file source in combined file+entities requests, or `structured`
             for the generated JSON source.
         interpretation_config:
-          $ref: '#/components/schemas/InterpretationConfig'
+          $ref: "#/components/schemas/InterpretationConfig"
     CreateInterpretationRequest:
       type: object
       additionalProperties: false
@@ -1185,11 +1185,11 @@ components:
             type: object
             additionalProperties: true
         interpretation_config:
-          $ref: '#/components/schemas/InterpretationConfig'
+          $ref: "#/components/schemas/InterpretationConfig"
         relationships:
           type: array
           items:
-            $ref: '#/components/schemas/StoreRelationshipInput'
+            $ref: "#/components/schemas/StoreRelationshipInput"
         idempotency_key:
           type: string
         user_id:
@@ -1291,7 +1291,37 @@ components:
           properties:
             relationship_type:
               type: string
-              enum: [PART_OF, CORRECTS, REFERS_TO, SETTLES, DUPLICATE_OF, DEPENDS_ON, SUPERSEDES, EMBEDS, works_at, owns, manages, part_of, related_to, depends_on, references, transacted_with, member_of, reports_to, located_at, created_by, funded_by, acquired_by, subsidiary_of, partner_of, competitor_of, supplies_to, contracted_with, invested_in]
+              enum:
+                [
+                  PART_OF,
+                  CORRECTS,
+                  REFERS_TO,
+                  SETTLES,
+                  DUPLICATE_OF,
+                  DEPENDS_ON,
+                  SUPERSEDES,
+                  EMBEDS,
+                  works_at,
+                  owns,
+                  manages,
+                  part_of,
+                  related_to,
+                  depends_on,
+                  references,
+                  transacted_with,
+                  member_of,
+                  reports_to,
+                  located_at,
+                  created_by,
+                  funded_by,
+                  acquired_by,
+                  subsidiary_of,
+                  partner_of,
+                  competitor_of,
+                  supplies_to,
+                  contracted_with,
+                  invested_in,
+                ]
             source_index:
               type: integer
               minimum: 0
@@ -1309,7 +1339,37 @@ components:
           properties:
             relationship_type:
               type: string
-              enum: [PART_OF, CORRECTS, REFERS_TO, SETTLES, DUPLICATE_OF, DEPENDS_ON, SUPERSEDES, EMBEDS, works_at, owns, manages, part_of, related_to, depends_on, references, transacted_with, member_of, reports_to, located_at, created_by, funded_by, acquired_by, subsidiary_of, partner_of, competitor_of, supplies_to, contracted_with, invested_in]
+              enum:
+                [
+                  PART_OF,
+                  CORRECTS,
+                  REFERS_TO,
+                  SETTLES,
+                  DUPLICATE_OF,
+                  DEPENDS_ON,
+                  SUPERSEDES,
+                  EMBEDS,
+                  works_at,
+                  owns,
+                  manages,
+                  part_of,
+                  related_to,
+                  depends_on,
+                  references,
+                  transacted_with,
+                  member_of,
+                  reports_to,
+                  located_at,
+                  created_by,
+                  funded_by,
+                  acquired_by,
+                  subsidiary_of,
+                  partner_of,
+                  competitor_of,
+                  supplies_to,
+                  contracted_with,
+                  invested_in,
+                ]
             source_index:
               type: integer
               minimum: 0
@@ -1326,7 +1386,37 @@ components:
           properties:
             relationship_type:
               type: string
-              enum: [PART_OF, CORRECTS, REFERS_TO, SETTLES, DUPLICATE_OF, DEPENDS_ON, SUPERSEDES, EMBEDS, works_at, owns, manages, part_of, related_to, depends_on, references, transacted_with, member_of, reports_to, located_at, created_by, funded_by, acquired_by, subsidiary_of, partner_of, competitor_of, supplies_to, contracted_with, invested_in]
+              enum:
+                [
+                  PART_OF,
+                  CORRECTS,
+                  REFERS_TO,
+                  SETTLES,
+                  DUPLICATE_OF,
+                  DEPENDS_ON,
+                  SUPERSEDES,
+                  EMBEDS,
+                  works_at,
+                  owns,
+                  manages,
+                  part_of,
+                  related_to,
+                  depends_on,
+                  references,
+                  transacted_with,
+                  member_of,
+                  reports_to,
+                  located_at,
+                  created_by,
+                  funded_by,
+                  acquired_by,
+                  subsidiary_of,
+                  partner_of,
+                  competitor_of,
+                  supplies_to,
+                  contracted_with,
+                  invested_in,
+                ]
             source_entity_id:
               type: string
               description: Existing source entity ID.
@@ -1343,7 +1433,37 @@ components:
           properties:
             relationship_type:
               type: string
-              enum: [PART_OF, CORRECTS, REFERS_TO, SETTLES, DUPLICATE_OF, DEPENDS_ON, SUPERSEDES, EMBEDS, works_at, owns, manages, part_of, related_to, depends_on, references, transacted_with, member_of, reports_to, located_at, created_by, funded_by, acquired_by, subsidiary_of, partner_of, competitor_of, supplies_to, contracted_with, invested_in]
+              enum:
+                [
+                  PART_OF,
+                  CORRECTS,
+                  REFERS_TO,
+                  SETTLES,
+                  DUPLICATE_OF,
+                  DEPENDS_ON,
+                  SUPERSEDES,
+                  EMBEDS,
+                  works_at,
+                  owns,
+                  manages,
+                  part_of,
+                  related_to,
+                  depends_on,
+                  references,
+                  transacted_with,
+                  member_of,
+                  reports_to,
+                  located_at,
+                  created_by,
+                  funded_by,
+                  acquired_by,
+                  subsidiary_of,
+                  partner_of,
+                  competitor_of,
+                  supplies_to,
+                  contracted_with,
+                  invested_in,
+                ]
             source_entity_id:
               type: string
               description: Existing source entity ID.
@@ -1420,9 +1540,9 @@ components:
             and `source_entity_id` or `target_entity_id` for existing entities.
             Index and id endpoints may be mixed in one relationship.
           items:
-            $ref: '#/components/schemas/StoreRelationshipInput'
+            $ref: "#/components/schemas/StoreRelationshipInput"
         interpretation:
-          $ref: '#/components/schemas/StoreInterpretationInput'
+          $ref: "#/components/schemas/StoreInterpretationInput"
         source_priority:
           type: integer
         observation_source:
@@ -1435,7 +1555,7 @@ components:
             unspecified. Applies to every observation created by this
             request.
         external_actor:
-          $ref: '#/components/schemas/ExternalActorInput'
+          $ref: "#/components/schemas/ExternalActorInput"
           description: |
             Optional upstream author (e.g. GitHub user for issue submission).
             Stamped into observation provenance; must align with
@@ -1484,9 +1604,9 @@ components:
       type: object
       properties:
         structured:
-          $ref: '#/components/schemas/StoreStructuredResponse'
+          $ref: "#/components/schemas/StoreStructuredResponse"
         unstructured:
-          $ref: '#/components/schemas/StoreUnstructuredResponse'
+          $ref: "#/components/schemas/StoreUnstructuredResponse"
     StoreStructuredRequest:
       type: object
       additionalProperties: false
@@ -1516,9 +1636,9 @@ components:
             Index and id endpoints may be mixed in one relationship.
             Enables one-call chat persistence: store [conversation, conversation_message] with relationships [{ relationship_type: "PART_OF", source_index: 1, target_index: 0 }]. (`agent_message` remains accepted as a legacy alias for pre-v0.6 clients.)
           items:
-            $ref: '#/components/schemas/StoreRelationshipInput'
+            $ref: "#/components/schemas/StoreRelationshipInput"
         interpretation:
-          $ref: '#/components/schemas/StoreInterpretationInput'
+          $ref: "#/components/schemas/StoreInterpretationInput"
         source_priority:
           type: integer
         observation_source:
@@ -1621,7 +1741,7 @@ components:
                   values). See
                   `.cursor/plans/conversation_entity_collision_fix_aef8ba0d.plan.md`.
                 items:
-                  $ref: '#/components/schemas/ResolverWarning'
+                  $ref: "#/components/schemas/ResolverWarning"
         warnings:
           type: array
           description: |
@@ -1631,13 +1751,51 @@ components:
             walking every entity trace.
           items:
             allOf:
-              - $ref: '#/components/schemas/ResolverWarning'
+              - $ref: "#/components/schemas/ResolverWarning"
               - type: object
                 properties:
                   observation_index:
                     type: integer
                   entity_id:
                     type: string
+        store_warnings:
+          type: array
+          description: |
+            Schema-driven non-fatal warnings emitted when a stored observation
+            omits all fields listed by a schema's `store_warnings` rule. Used
+            by schemas to surface identity-quality issues (e.g. a
+            `product_feedback` observation that supplies none of the declared
+            feedback-source identity fields) without rejecting the write.
+            Schema-agnostic: the rule lives on the entity's `SchemaDefinition`,
+            not in per-type code. Present only when at least one rule fired
+            during this request.
+          items:
+            type: object
+            required:
+              - code
+              - message
+              - observation_index
+              - entity_type
+              - entity_id
+            properties:
+              code:
+                type: string
+                description: |
+                  Schema-defined warning code (declared in the schema's
+                  `store_warnings[].code`). Stable identifier callers can
+                  switch on.
+              message:
+                type: string
+                description: Human-readable description from the schema rule.
+              observation_index:
+                type: integer
+                description: |
+                  Index into the request's `entities[]` array identifying which
+                  observation triggered the warning.
+              entity_type:
+                type: string
+              entity_id:
+                type: string
         interpretation_id:
           type: string
           nullable: true
@@ -1759,7 +1917,37 @@ components:
       properties:
         relationship_type:
           type: string
-          enum: [PART_OF, CORRECTS, REFERS_TO, SETTLES, DUPLICATE_OF, DEPENDS_ON, SUPERSEDES, EMBEDS, works_at, owns, manages, part_of, related_to, depends_on, references, transacted_with, member_of, reports_to, located_at, created_by, funded_by, acquired_by, subsidiary_of, partner_of, competitor_of, supplies_to, contracted_with, invested_in]
+          enum:
+            [
+              PART_OF,
+              CORRECTS,
+              REFERS_TO,
+              SETTLES,
+              DUPLICATE_OF,
+              DEPENDS_ON,
+              SUPERSEDES,
+              EMBEDS,
+              works_at,
+              owns,
+              manages,
+              part_of,
+              related_to,
+              depends_on,
+              references,
+              transacted_with,
+              member_of,
+              reports_to,
+              located_at,
+              created_by,
+              funded_by,
+              acquired_by,
+              subsidiary_of,
+              partner_of,
+              competitor_of,
+              supplies_to,
+              contracted_with,
+              invested_in,
+            ]
         source_entity_id:
           type: string
         target_entity_id:
@@ -1772,7 +1960,7 @@ components:
       required: [snapshot, observations]
       properties:
         snapshot:
-          $ref: '#/components/schemas/RelationshipSnapshot'
+          $ref: "#/components/schemas/RelationshipSnapshot"
         observations:
           type: array
           items:
@@ -1828,22 +2016,22 @@ paths:
           required: false
           schema: { type: integer }
       responses:
-        '200':
+        "200":
           description: Signed URL
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/FileUrlResponse'
-        '400':
+                $ref: "#/components/schemas/FileUrlResponse"
+        "400":
           description: Invalid parameters
           content:
             application/json:
-              schema: { $ref: '#/components/schemas/Error' }
-        '401':
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
           description: Missing or invalid bearer token
           content:
             application/json:
-              schema: { $ref: '#/components/schemas/Error' }
+              schema: { $ref: "#/components/schemas/Error" }
 
   /health:
     get:
@@ -1851,7 +2039,7 @@ paths:
       operationId: healthCheck
       security: []
       responses:
-        '200':
+        "200":
           description: Server is healthy
           content:
             application/json:
@@ -1867,7 +2055,7 @@ paths:
       operationId: getOpenApiSpec
       security: []
       responses:
-        '200':
+        "200":
           description: OpenAPI specification in YAML
           content:
             application/yaml:
@@ -1879,7 +2067,7 @@ paths:
       summary: Get server info
       operationId: getServerInfo
       responses:
-        '200':
+        "200":
           description: Server info
           content:
             application/json:
@@ -1899,18 +2087,18 @@ paths:
         required: true
         content:
           application/json:
-            schema: { $ref: '#/components/schemas/OAuthInitiateRequest' }
+            schema: { $ref: "#/components/schemas/OAuthInitiateRequest" }
       responses:
-        '200':
+        "200":
           description: OAuth initiation result
           content:
             application/json:
-              schema: { $ref: '#/components/schemas/OAuthInitiateResponse' }
-        '400':
+              schema: { $ref: "#/components/schemas/OAuthInitiateResponse" }
+        "400":
           description: Invalid request
           content:
             application/json:
-              schema: { $ref: '#/components/schemas/ErrorEnvelope' }
+              schema: { $ref: "#/components/schemas/ErrorEnvelope" }
 
   /mcp/oauth/authorize:
     get:
@@ -1942,7 +2130,7 @@ paths:
           required: false
           schema: { type: string }
       responses:
-        '302':
+        "302":
           description: Redirect to authorization URL
 
   /mcp/oauth/token:
@@ -1961,7 +2149,7 @@ paths:
                 code:
                   type: string
       responses:
-        '200':
+        "200":
           description: OAuth token response
           content:
             application/json:
@@ -1974,7 +2162,7 @@ paths:
                     type: string
                   expires_in:
                     type: integer
-        '400':
+        "400":
           description: Token exchange error
           content:
             application/json:
@@ -1987,7 +2175,7 @@ paths:
       summary: Get current authenticated user
       operationId: getMe
       responses:
-        '200':
+        "200":
           description: Current user details
           content:
             application/json:
@@ -2008,11 +2196,11 @@ paths:
                         type: string
                       sqlite_db:
                         type: string
-        '401':
+        "401":
           description: Not authenticated
           content:
             application/json:
-              schema: { $ref: '#/components/schemas/Error' }
+              schema: { $ref: "#/components/schemas/Error" }
 
   /mcp/oauth/status:
     get:
@@ -2024,23 +2212,23 @@ paths:
           required: true
           schema: { type: string }
       responses:
-        '200':
+        "200":
           description: Connection status
           content:
             application/json:
-              schema: { $ref: '#/components/schemas/OAuthStatusResponse' }
-        '400':
+              schema: { $ref: "#/components/schemas/OAuthStatusResponse" }
+        "400":
           description: Invalid request
           content:
             application/json:
-              schema: { $ref: '#/components/schemas/ErrorEnvelope' }
+              schema: { $ref: "#/components/schemas/ErrorEnvelope" }
 
   /mcp/oauth/connections:
     get:
       summary: List OAuth connections
       operationId: mcpOAuthListConnections
       responses:
-        '200':
+        "200":
           description: Connection list
           content:
             application/json:
@@ -2052,11 +2240,11 @@ paths:
                     items:
                       type: object
                       additionalProperties: true
-        '401':
+        "401":
           description: Unauthorized
           content:
             application/json:
-              schema: { $ref: '#/components/schemas/Error' }
+              schema: { $ref: "#/components/schemas/Error" }
 
   /mcp/oauth/connections/{connection_id}:
     delete:
@@ -2068,7 +2256,7 @@ paths:
           required: true
           schema: { type: string }
       responses:
-        '200':
+        "200":
           description: Revoked
           content:
             application/json:
@@ -2083,7 +2271,7 @@ paths:
       summary: OAuth 2.0 Authorization Server Metadata (RFC 8414)
       operationId: oauthServerMetadata
       responses:
-        '200':
+        "200":
           description: Authorization server metadata
           content:
             application/json:
@@ -2095,7 +2283,7 @@ paths:
       summary: OAuth 2.0 Protected Resource Metadata
       operationId: oauthProtectedResource
       responses:
-        '200':
+        "200":
           description: Protected resource metadata
           content:
             application/json:
@@ -2114,7 +2302,7 @@ paths:
           name: state
           schema: { type: string }
       responses:
-        '302':
+        "302":
           description: Redirect after OAuth callback
 
   /mcp/oauth/key-auth:
@@ -2126,7 +2314,7 @@ paths:
           name: next
           schema: { type: string }
       responses:
-        '200':
+        "200":
           description: Key auth HTML page
           content:
             text/html:
@@ -2145,7 +2333,7 @@ paths:
                 key:
                   type: string
       responses:
-        '302':
+        "302":
           description: Redirect after key auth
 
   /mcp/oauth/local-login:
@@ -2153,7 +2341,7 @@ paths:
       summary: Local login for development (auto-creates dev user)
       operationId: mcpOAuthLocalLogin
       responses:
-        '302':
+        "302":
           description: Redirect after local login
 
   /mcp/oauth/register:
@@ -2173,7 +2361,7 @@ paths:
                   type: array
                   items: { type: string }
       responses:
-        '201':
+        "201":
           description: Client registered
           content:
             application/json:
@@ -2185,7 +2373,7 @@ paths:
       summary: Authorization details proxy
       operationId: mcpOAuthAuthorizationDetails
       responses:
-        '200':
+        "200":
           description: Authorization details
           content:
             application/json:
@@ -2207,7 +2395,7 @@ paths:
                 user_id:
                   type: string
       responses:
-        '200':
+        "200":
           description: Signed in
           content:
             application/json:
@@ -2243,19 +2431,19 @@ paths:
                 sort_by:
                   type: string
                   enum:
-                  - entity_id
-                  - canonical_name
-                  - observation_count
-                  - last_observation_at
-                  - submitted_at
+                    - entity_id
+                    - canonical_name
+                    - observation_count
+                    - last_observation_at
+                    - submitted_at
                   description: |
                     Non-default values cannot be combined with `search`.
                     `submitted_at` orders by `snapshot.created_at` (ISO string), e.g. GitHub issue opened time.
                 sort_order:
                   type: string
                   enum:
-                  - asc
-                  - desc
+                    - asc
+                    - desc
                   description: "`desc` cannot be combined with `search`."
                 published:
                   type: boolean
@@ -2298,7 +2486,7 @@ paths:
                     resolution" filter so operators can audit entities that
                     were matched by name/title rather than by a schema rule.
       responses:
-        '200':
+        "200":
           description: Entity list
           content:
             application/json:
@@ -2308,7 +2496,7 @@ paths:
                   entities:
                     type: array
                     items:
-                      $ref: '#/components/schemas/EntitySnapshot'
+                      $ref: "#/components/schemas/EntitySnapshot"
                   total:
                     type: integer
                   limit:
@@ -2341,16 +2529,16 @@ paths:
           description: Optional guest read-back token scoped to this entity.
           schema: { type: string }
       responses:
-        '200':
+        "200":
           description: Entity
           content:
             application/json:
-              schema: { $ref: '#/components/schemas/EntitySnapshot' }
-        '404':
+              schema: { $ref: "#/components/schemas/EntitySnapshot" }
+        "404":
           description: Entity not found
           content:
             application/json:
-              schema: { $ref: '#/components/schemas/ErrorEnvelope' }
+              schema: { $ref: "#/components/schemas/ErrorEnvelope" }
 
   /entities/{id}/observations:
     get:
@@ -2362,7 +2550,7 @@ paths:
           required: true
           schema: { type: string }
       responses:
-        '200':
+        "200":
           description: Observations
           content:
             application/json:
@@ -2372,7 +2560,7 @@ paths:
                   observations:
                     type: array
                     items:
-                      $ref: '#/components/schemas/Observation'
+                      $ref: "#/components/schemas/Observation"
 
   /entities/{id}/relationships:
     get:
@@ -2393,7 +2581,7 @@ paths:
             `source_entity_type`, `target_entity_type`, and their labels).
           schema: { type: boolean }
       responses:
-        '200':
+        "200":
           description: Relationships
           content:
             application/json:
@@ -2403,15 +2591,15 @@ paths:
                   outgoing:
                     type: array
                     items:
-                      $ref: '#/components/schemas/RelationshipSnapshot'
+                      $ref: "#/components/schemas/RelationshipSnapshot"
                   incoming:
                     type: array
                     items:
-                      $ref: '#/components/schemas/RelationshipSnapshot'
+                      $ref: "#/components/schemas/RelationshipSnapshot"
                   relationships:
                     type: array
                     items:
-                      $ref: '#/components/schemas/RelationshipSnapshot'
+                      $ref: "#/components/schemas/RelationshipSnapshot"
                   related_entities:
                     type: object
                     nullable: true
@@ -2469,7 +2657,7 @@ paths:
             minimum: 1
             maximum: 200
       responses:
-        '200':
+        "200":
           description: Ranked list of candidate duplicate pairs.
           content:
             application/json:
@@ -2529,7 +2717,7 @@ paths:
                 user_id:
                   type: string
       responses:
-        '200':
+        "200":
           description: Merge result
           content:
             application/json:
@@ -2577,28 +2765,28 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/SplitEntityRequest'
+              $ref: "#/components/schemas/SplitEntityRequest"
       responses:
-        '200':
+        "200":
           description: Split result (or idempotent replay).
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SplitEntityResponse'
-        '400':
+                $ref: "#/components/schemas/SplitEntityResponse"
+        "400":
           description: |
             Invalid predicate, idempotency mismatch, or the predicate matched
             zero / all observations.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorEnvelope'
-        '404':
+                $ref: "#/components/schemas/ErrorEnvelope"
+        "404":
           description: Source entity not found.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorEnvelope'
+                $ref: "#/components/schemas/ErrorEnvelope"
 
   /sources:
     get:
@@ -2630,7 +2818,7 @@ paths:
           required: false
           schema: { type: integer }
       responses:
-        '200':
+        "200":
           description: Sources
           content:
             application/json:
@@ -2640,7 +2828,7 @@ paths:
                   sources:
                     type: array
                     items:
-                      $ref: '#/components/schemas/Source'
+                      $ref: "#/components/schemas/Source"
 
   /sources/{id}:
     get:
@@ -2652,11 +2840,11 @@ paths:
           required: true
           schema: { type: string }
       responses:
-        '200':
+        "200":
           description: Source
           content:
             application/json:
-              schema: { $ref: '#/components/schemas/Source' }
+              schema: { $ref: "#/components/schemas/Source" }
 
   /sources/{id}/relationships:
     get:
@@ -2680,7 +2868,7 @@ paths:
           required: false
           schema: { type: string }
       responses:
-        '200':
+        "200":
           description: Relationships and optional related entity expansions
           content:
             application/json:
@@ -2689,7 +2877,7 @@ paths:
                 properties:
                   relationships:
                     type: array
-                    items: { $ref: '#/components/schemas/RelationshipSnapshot' }
+                    items: { $ref: "#/components/schemas/RelationshipSnapshot" }
                   related_entities:
                     type: object
                     additionalProperties: true
@@ -2720,7 +2908,7 @@ paths:
           required: false
           schema: { type: integer }
       responses:
-        '200':
+        "200":
           description: Observations
           content:
             application/json:
@@ -2730,7 +2918,7 @@ paths:
                   observations:
                     type: array
                     items:
-                      $ref: '#/components/schemas/Observation'
+                      $ref: "#/components/schemas/Observation"
 
   /observations/query:
     post:
@@ -2766,7 +2954,7 @@ paths:
                     ISO 8601 timestamp. Return only observations whose
                     observed_at is greater than or equal to this value.
       responses:
-        '200':
+        "200":
           description: Observations
           content:
             application/json:
@@ -2776,7 +2964,7 @@ paths:
                   observations:
                     type: array
                     items:
-                      $ref: '#/components/schemas/Observation'
+                      $ref: "#/components/schemas/Observation"
                   total:
                     type: integer
                   limit:
@@ -2817,7 +3005,7 @@ paths:
           required: false
           schema: { type: integer }
       responses:
-        '200':
+        "200":
           description: Recent record activity
           content:
             application/json:
@@ -3328,7 +3516,7 @@ paths:
           description: Filter by latest observation attribution key (same as GET /agents `agent_key`)
           schema: { type: string }
       responses:
-        '200':
+        "200":
           description: Recent conversations
           content:
             application/json:
@@ -3425,18 +3613,18 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: Conversation with nested messages
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/RecentConversationItem'
-        '404':
+                $ref: "#/components/schemas/RecentConversationItem"
+        "404":
           description: Conversation not found or not visible to the caller
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorEnvelope'
+                $ref: "#/components/schemas/ErrorEnvelope"
 
   /observations/create:
     post:
@@ -3450,7 +3638,7 @@ paths:
               type: object
               additionalProperties: true
       responses:
-        '200':
+        "200":
           description: Observation created
           content:
             application/json:
@@ -3463,7 +3651,7 @@ paths:
       summary: List relationships
       operationId: listRelationships
       responses:
-        '200':
+        "200":
           description: Relationships
           content:
             application/json:
@@ -3473,7 +3661,7 @@ paths:
                   relationships:
                     type: array
                     items:
-                      $ref: '#/components/schemas/RelationshipSnapshot'
+                      $ref: "#/components/schemas/RelationshipSnapshot"
 
   /relationships/{id}:
     get:
@@ -3485,11 +3673,11 @@ paths:
           required: true
           schema: { type: string }
       responses:
-        '200':
+        "200":
           description: Relationship
           content:
             application/json:
-              schema: { $ref: '#/components/schemas/RelationshipSnapshot' }
+              schema: { $ref: "#/components/schemas/RelationshipSnapshot" }
 
   /relationships/snapshot:
     post:
@@ -3499,13 +3687,13 @@ paths:
         required: true
         content:
           application/json:
-            schema: { $ref: '#/components/schemas/GetRelationshipSnapshotRequest' }
+            schema: { $ref: "#/components/schemas/GetRelationshipSnapshotRequest" }
       responses:
-        '200':
+        "200":
           description: Relationship snapshot and observations
           content:
             application/json:
-              schema: { $ref: '#/components/schemas/GetRelationshipSnapshotResponse' }
+              schema: { $ref: "#/components/schemas/GetRelationshipSnapshotResponse" }
 
   /timeline:
     get:
@@ -3545,7 +3733,7 @@ paths:
             enum: [event_timestamp, created_at]
             default: event_timestamp
       responses:
-        '200':
+        "200":
           description: Timeline events
           content:
             application/json:
@@ -3555,7 +3743,7 @@ paths:
                   events:
                     type: array
                     items:
-                      $ref: '#/components/schemas/TimelineEvent'
+                      $ref: "#/components/schemas/TimelineEvent"
 
   /timeline/{id}:
     get:
@@ -3571,7 +3759,7 @@ paths:
           required: false
           schema: { type: string }
       responses:
-        '200':
+        "200":
           description: Timeline event
           content:
             application/json:
@@ -3579,7 +3767,7 @@ paths:
                 type: object
                 properties:
                   event:
-                    $ref: '#/components/schemas/TimelineEvent'
+                    $ref: "#/components/schemas/TimelineEvent"
 
   /schemas:
     get:
@@ -3613,7 +3801,7 @@ paths:
             Defaults to false when `keyword` is present, true when it is not.
           schema: { type: boolean }
       responses:
-        '200':
+        "200":
           description: Schemas
           content:
             application/json:
@@ -3623,7 +3811,7 @@ paths:
                   schemas:
                     type: array
                     items:
-                      $ref: '#/components/schemas/EntitySchema'
+                      $ref: "#/components/schemas/EntitySchema"
 
   /schemas/{entity_type}:
     get:
@@ -3635,11 +3823,11 @@ paths:
           required: true
           schema: { type: string }
       responses:
-        '200':
+        "200":
           description: Schema
           content:
             application/json:
-              schema: { $ref: '#/components/schemas/EntitySchema' }
+              schema: { $ref: "#/components/schemas/EntitySchema" }
 
   /interpretations:
     get:
@@ -3663,7 +3851,7 @@ paths:
           required: false
           schema: { type: integer }
       responses:
-        '200':
+        "200":
           description: Interpretations
           content:
             application/json:
@@ -3673,7 +3861,7 @@ paths:
                   interpretations:
                     type: array
                     items:
-                      $ref: '#/components/schemas/Interpretation'
+                      $ref: "#/components/schemas/Interpretation"
 
   /interpretations/create:
     post:
@@ -3683,13 +3871,13 @@ paths:
         required: true
         content:
           application/json:
-            schema: { $ref: '#/components/schemas/CreateInterpretationRequest' }
+            schema: { $ref: "#/components/schemas/CreateInterpretationRequest" }
       responses:
-        '200':
+        "200":
           description: Interpretation result
           content:
             application/json:
-              schema: { $ref: '#/components/schemas/CreateInterpretationResponse' }
+              schema: { $ref: "#/components/schemas/CreateInterpretationResponse" }
 
   /stats:
     get:
@@ -3701,11 +3889,11 @@ paths:
           required: false
           schema: { type: string }
       responses:
-        '200':
+        "200":
           description: Stats
           content:
             application/json:
-              schema: { $ref: '#/components/schemas/Stats' }
+              schema: { $ref: "#/components/schemas/Stats" }
 
   /access_policies:
     get:
@@ -3716,7 +3904,7 @@ paths:
         that has a non-default (non-closed) policy, plus the default mode.
         Resolution precedence per type: env var > SchemaMetadata > config file > closed.
       responses:
-        '200':
+        "200":
           description: Map of entity types to their effective guest access policy mode
           content:
             application/json:
@@ -3745,18 +3933,18 @@ paths:
         required: true
         content:
           application/json:
-            schema: { $ref: '#/components/schemas/StoreRequest' }
+            schema: { $ref: "#/components/schemas/StoreRequest" }
       responses:
-        '200':
+        "200":
           description: Store result
           content:
             application/json:
               schema:
                 oneOf:
-                  - { $ref: '#/components/schemas/StoreStructuredResponse' }
-                  - { $ref: '#/components/schemas/StoreUnstructuredResponse' }
-                  - { $ref: '#/components/schemas/StoreResponse' }
-        '400':
+                  - { $ref: "#/components/schemas/StoreStructuredResponse" }
+                  - { $ref: "#/components/schemas/StoreUnstructuredResponse" }
+                  - { $ref: "#/components/schemas/StoreResponse" }
+        "400":
           description: |
             Request rejected. `ERR_STORE_RESOLUTION_FAILED` uses the richer
             `StoreResolutionErrorEnvelope` shape. `ERR_IDEMPOTENCY_MISMATCH` is
@@ -3767,16 +3955,16 @@ paths:
             application/json:
               schema:
                 oneOf:
-                  - { $ref: '#/components/schemas/StoreResolutionErrorEnvelope' }
-                  - { $ref: '#/components/schemas/ErrorEnvelope' }
-        '409':
+                  - { $ref: "#/components/schemas/StoreResolutionErrorEnvelope" }
+                  - { $ref: "#/components/schemas/ErrorEnvelope" }
+        "409":
           description: |
             Idempotency key collision (`ERR_IDEMPOTENCY_COLLISION`). The
             idempotency_key was already used for a store call with different
             content. Use a new idempotency_key to write the updated payload.
           content:
             application/json:
-              schema: { $ref: '#/components/schemas/ErrorEnvelope' }
+              schema: { $ref: "#/components/schemas/ErrorEnvelope" }
 
   /get_entity_snapshot:
     post:
@@ -3802,11 +3990,11 @@ paths:
                     deterministic markdown for KV-cache stability. `json` returns the raw
                     snapshot payload for programmatic callers.
       responses:
-        '200':
+        "200":
           description: Entity snapshot
           content:
             application/json:
-              schema: { $ref: '#/components/schemas/EntitySnapshot' }
+              schema: { $ref: "#/components/schemas/EntitySnapshot" }
 
   /list_observations:
     post:
@@ -3836,7 +4024,7 @@ paths:
                     ISO 8601 timestamp. Return only observations whose
                     observed_at is greater than or equal to this value.
       responses:
-        '200':
+        "200":
           description: Observations
           content:
             application/json:
@@ -3846,7 +4034,7 @@ paths:
                   observations:
                     type: array
                     items:
-                      $ref: '#/components/schemas/Observation'
+                      $ref: "#/components/schemas/Observation"
 
   /get_field_provenance:
     post:
@@ -3864,7 +4052,7 @@ paths:
                 field:
                   type: string
       responses:
-        '200':
+        "200":
           description: Provenance
           content:
             application/json:
@@ -3898,7 +4086,37 @@ paths:
                     `PART_OF`, `CORRECTS`, `REFERS_TO`, `SETTLES`,
                     `DUPLICATE_OF`, `DEPENDS_ON`, `SUPERSEDES`, `EMBEDS`. Domain
                     types (e.g. `works_at`, `owns`, `manages`) are also accepted.
-                  enum: [PART_OF, CORRECTS, REFERS_TO, SETTLES, DUPLICATE_OF, DEPENDS_ON, SUPERSEDES, EMBEDS, works_at, owns, manages, part_of, related_to, depends_on, references, transacted_with, member_of, reports_to, located_at, created_by, funded_by, acquired_by, subsidiary_of, partner_of, competitor_of, supplies_to, contracted_with, invested_in]
+                  enum:
+                    [
+                      PART_OF,
+                      CORRECTS,
+                      REFERS_TO,
+                      SETTLES,
+                      DUPLICATE_OF,
+                      DEPENDS_ON,
+                      SUPERSEDES,
+                      EMBEDS,
+                      works_at,
+                      owns,
+                      manages,
+                      part_of,
+                      related_to,
+                      depends_on,
+                      references,
+                      transacted_with,
+                      member_of,
+                      reports_to,
+                      located_at,
+                      created_by,
+                      funded_by,
+                      acquired_by,
+                      subsidiary_of,
+                      partner_of,
+                      competitor_of,
+                      supplies_to,
+                      contracted_with,
+                      invested_in,
+                    ]
                 source_entity_id:
                   type: string
                   description: Existing entity id at the source end of the edge.
@@ -3922,11 +4140,11 @@ paths:
                     Optional explicit user id; inferred from authentication
                     when omitted.
       responses:
-        '200':
+        "200":
           description: Relationship created
           content:
             application/json:
-              schema: { $ref: '#/components/schemas/RelationshipSnapshot' }
+              schema: { $ref: "#/components/schemas/RelationshipSnapshot" }
 
   /create_relationships:
     post:
@@ -3951,7 +4169,37 @@ paths:
                     properties:
                       relationship_type:
                         type: string
-                        enum: [PART_OF, CORRECTS, REFERS_TO, SETTLES, DUPLICATE_OF, DEPENDS_ON, SUPERSEDES, EMBEDS, works_at, owns, manages, part_of, related_to, depends_on, references, transacted_with, member_of, reports_to, located_at, created_by, funded_by, acquired_by, subsidiary_of, partner_of, competitor_of, supplies_to, contracted_with, invested_in]
+                        enum:
+                          [
+                            PART_OF,
+                            CORRECTS,
+                            REFERS_TO,
+                            SETTLES,
+                            DUPLICATE_OF,
+                            DEPENDS_ON,
+                            SUPERSEDES,
+                            EMBEDS,
+                            works_at,
+                            owns,
+                            manages,
+                            part_of,
+                            related_to,
+                            depends_on,
+                            references,
+                            transacted_with,
+                            member_of,
+                            reports_to,
+                            located_at,
+                            created_by,
+                            funded_by,
+                            acquired_by,
+                            subsidiary_of,
+                            partner_of,
+                            competitor_of,
+                            supplies_to,
+                            contracted_with,
+                            invested_in,
+                          ]
                       source_entity_id:
                         type: string
                       target_entity_id:
@@ -3966,7 +4214,7 @@ paths:
                 user_id:
                   type: string
       responses:
-        '200':
+        "200":
           description: Relationships created
           content:
             application/json:
@@ -3984,7 +4232,7 @@ paths:
                   relationships:
                     type: array
                     items:
-                      $ref: '#/components/schemas/RelationshipSnapshot'
+                      $ref: "#/components/schemas/RelationshipSnapshot"
                   errors:
                     type: array
                     items:
@@ -4003,7 +4251,7 @@ paths:
               type: object
               additionalProperties: true
       responses:
-        '200':
+        "200":
           description: Relationships
           content:
             application/json:
@@ -4013,7 +4261,7 @@ paths:
                   relationships:
                     type: array
                     items:
-                      $ref: '#/components/schemas/RelationshipSnapshot'
+                      $ref: "#/components/schemas/RelationshipSnapshot"
 
   /retrieve_entity_by_identifier:
     post:
@@ -4065,7 +4313,7 @@ paths:
                     Maximum observations to attach per entity when
                     include_observations is true. Ignored otherwise.
       responses:
-        '200':
+        "200":
           description: Entity search results
           content:
             application/json:
@@ -4076,7 +4324,7 @@ paths:
                     type: array
                     items:
                       allOf:
-                        - $ref: '#/components/schemas/Entity'
+                        - $ref: "#/components/schemas/Entity"
                         - type: object
                           properties:
                             observations:
@@ -4091,11 +4339,11 @@ paths:
                                 additionalProperties: true
                   total:
                     type: integer
-        '400':
+        "400":
           description: Invalid request
           content:
             application/json:
-              schema: { $ref: '#/components/schemas/ErrorEnvelope' }
+              schema: { $ref: "#/components/schemas/ErrorEnvelope" }
 
   /retrieve_related_entities:
     post:
@@ -4128,7 +4376,7 @@ paths:
                   type: boolean
                   default: true
       responses:
-        '200':
+        "200":
           description: Related entities
           content:
             application/json:
@@ -4169,7 +4417,7 @@ paths:
                   type: boolean
                   default: false
       responses:
-        '200':
+        "200":
           description: Graph neighborhood
           content:
             application/json:
@@ -4203,7 +4451,7 @@ paths:
                 user_id:
                   type: string
       responses:
-        '200':
+        "200":
           description: Per-entity outcomes
           content:
             application/json:
@@ -4245,7 +4493,7 @@ paths:
                 user_id:
                   type: string
       responses:
-        '200':
+        "200":
           description: Per-entity outcomes
           content:
             application/json:
@@ -4329,7 +4577,7 @@ paths:
                 message records the environment it was authored against. Missing both emits a server-side warning;
                 the message still persists.
       responses:
-        '200':
+        "200":
           description: Message stored; flags indicate GitHub / remote submission outcomes.
           content:
             application/json:
@@ -4441,7 +4689,7 @@ paths:
                 user_id:
                   type: string
       responses:
-        '200':
+        "200":
           description: Issue created
           content:
             application/json:
@@ -4486,7 +4734,7 @@ paths:
                   github_mirror_guidance:
                     type: string
                     nullable: true
-        '400':
+        "400":
           description: |
             Validation error. `error_code: ERR_REPORTER_ENVIRONMENT_REQUIRED`
             is returned when neither `reporter_git_sha` nor
@@ -4494,7 +4742,7 @@ paths:
             lists the alternatives the caller can supply.
           content:
             application/json:
-              schema: { $ref: '#/components/schemas/ErrorEnvelope' }
+              schema: { $ref: "#/components/schemas/ErrorEnvelope" }
 
   /issues/status:
     post:
@@ -4528,7 +4776,7 @@ paths:
                   type: string
               description: Provide `entity_id` and/or `issue_number` (at least one required).
       responses:
-        '200':
+        "200":
           description: Issue status payload
           content:
             application/json:
@@ -4569,7 +4817,7 @@ paths:
                 user_id:
                   type: string
       responses:
-        '200':
+        "200":
           description: Sync counts and errors
           content:
             application/json:
@@ -4622,7 +4870,7 @@ paths:
                 user_id:
                   type: string
       responses:
-        '200':
+        "200":
           description: Entity deleted
           content:
             application/json:
@@ -4654,7 +4902,7 @@ paths:
                 user_id:
                   type: string
       responses:
-        '200':
+        "200":
           description: Entity restored
           content:
             application/json:
@@ -4680,7 +4928,37 @@ paths:
               properties:
                 relationship_type:
                   type: string
-                  enum: [PART_OF, CORRECTS, REFERS_TO, SETTLES, DUPLICATE_OF, DEPENDS_ON, SUPERSEDES, EMBEDS, works_at, owns, manages, part_of, related_to, depends_on, references, transacted_with, member_of, reports_to, located_at, created_by, funded_by, acquired_by, subsidiary_of, partner_of, competitor_of, supplies_to, contracted_with, invested_in]
+                  enum:
+                    [
+                      PART_OF,
+                      CORRECTS,
+                      REFERS_TO,
+                      SETTLES,
+                      DUPLICATE_OF,
+                      DEPENDS_ON,
+                      SUPERSEDES,
+                      EMBEDS,
+                      works_at,
+                      owns,
+                      manages,
+                      part_of,
+                      related_to,
+                      depends_on,
+                      references,
+                      transacted_with,
+                      member_of,
+                      reports_to,
+                      located_at,
+                      created_by,
+                      funded_by,
+                      acquired_by,
+                      subsidiary_of,
+                      partner_of,
+                      competitor_of,
+                      supplies_to,
+                      contracted_with,
+                      invested_in,
+                    ]
                 source_entity_id:
                   type: string
                 target_entity_id:
@@ -4690,7 +4968,7 @@ paths:
                 user_id:
                   type: string
       responses:
-        '200':
+        "200":
           description: Relationship deleted
           content:
             application/json:
@@ -4716,7 +4994,37 @@ paths:
               properties:
                 relationship_type:
                   type: string
-                  enum: [PART_OF, CORRECTS, REFERS_TO, SETTLES, DUPLICATE_OF, DEPENDS_ON, SUPERSEDES, EMBEDS, works_at, owns, manages, part_of, related_to, depends_on, references, transacted_with, member_of, reports_to, located_at, created_by, funded_by, acquired_by, subsidiary_of, partner_of, competitor_of, supplies_to, contracted_with, invested_in]
+                  enum:
+                    [
+                      PART_OF,
+                      CORRECTS,
+                      REFERS_TO,
+                      SETTLES,
+                      DUPLICATE_OF,
+                      DEPENDS_ON,
+                      SUPERSEDES,
+                      EMBEDS,
+                      works_at,
+                      owns,
+                      manages,
+                      part_of,
+                      related_to,
+                      depends_on,
+                      references,
+                      transacted_with,
+                      member_of,
+                      reports_to,
+                      located_at,
+                      created_by,
+                      funded_by,
+                      acquired_by,
+                      subsidiary_of,
+                      partner_of,
+                      competitor_of,
+                      supplies_to,
+                      contracted_with,
+                      invested_in,
+                    ]
                 source_entity_id:
                   type: string
                 target_entity_id:
@@ -4726,7 +5034,7 @@ paths:
                 user_id:
                   type: string
       responses:
-        '200':
+        "200":
           description: Relationship restored
           content:
             application/json:
@@ -4757,7 +5065,7 @@ paths:
                   type: number
                   default: 0.8
       responses:
-        '200':
+        "200":
           description: Schema candidates
           content:
             application/json:
@@ -4790,7 +5098,7 @@ paths:
                   type: string
                   enum: [pending, approved, rejected]
       responses:
-        '200':
+        "200":
           description: Schema recommendations
           content:
             application/json:
@@ -4848,7 +5156,7 @@ paths:
                   type: boolean
                   default: false
       responses:
-        '200':
+        "200":
           description: Schema updated
           content:
             application/json:
@@ -4892,7 +5200,7 @@ paths:
                   type: boolean
                   default: false
       responses:
-        '200':
+        "200":
           description: Schema registered
           content:
             application/json:
@@ -4931,7 +5239,7 @@ paths:
                 user_id:
                   type: string
       responses:
-        '200':
+        "200":
           description: Correction created
           content:
             application/json:
@@ -4951,7 +5259,7 @@ paths:
             schema:
               type: object
       responses:
-        '200':
+        "200":
           description: User ID
           content:
             application/json:
@@ -5003,7 +5311,7 @@ paths:
             type: string
           required: false
       responses:
-        '200':
+        "200":
           description: Session attribution + policy
           content:
             application/json:
@@ -5026,7 +5334,7 @@ paths:
                   type: boolean
                   default: false
       responses:
-        '200':
+        "200":
           description: Health check results
           content:
             application/json:
@@ -5078,7 +5386,7 @@ paths:
                     `source_peer_id` equals this value (prevents notifying a peer
                     about changes that originated from that peer).
       responses:
-        '200':
+        "200":
           description: Subscription created
           content:
             application/json:
@@ -5110,7 +5418,7 @@ paths:
                 subscription_id:
                   type: string
       responses:
-        '200':
+        "200":
           description: Subscription deactivated
           content:
             application/json:
@@ -5130,7 +5438,7 @@ paths:
               type: object
               additionalProperties: false
       responses:
-        '200':
+        "200":
           description: Active subscriptions
           content:
             application/json:
@@ -5155,7 +5463,7 @@ paths:
                 subscription_id:
                   type: string
       responses:
-        '200':
+        "200":
           description: Subscription status
           content:
             application/json:
@@ -5174,7 +5482,7 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: text/event-stream
 
   /peers:
@@ -5182,7 +5490,7 @@ paths:
       summary: List configured Neotoma peers for the authenticated user
       operationId: listPeers
       responses:
-        '200':
+        "200":
           description: Peer rows (shared_secret omitted)
           content:
             application/json:
@@ -5242,7 +5550,7 @@ paths:
                   format: uuid
                   description: Optional. Authenticated user_id on the peer instance for outbound POST /sync/webhook target_user_id.
       responses:
-        '201':
+        "201":
           description: Peer created
           content:
             application/json:
@@ -5261,7 +5569,7 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: Peer snapshot with remote health and local API version
           content:
             application/json:
@@ -5314,7 +5622,7 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: Peer deactivated
           content:
             application/json:
@@ -5346,7 +5654,7 @@ paths:
                   maximum: 500
                   description: Max observations to consider this run (default 200)
       responses:
-        '200':
+        "200":
           description: Sync acknowledgement
           content:
             application/json:
@@ -5381,7 +5689,7 @@ paths:
                   type: string
                   description: Optional query access_token for guest read on the remote instance
       responses:
-        '200':
+        "200":
           description: Resolution result
           content:
             application/json:
@@ -5421,7 +5729,7 @@ paths:
                 guest_access_token:
                   type: string
       responses:
-        '200':
+        "200":
           description: Sync notification applied
           content:
             application/json:
@@ -5462,7 +5770,7 @@ paths:
                   minimum: 1
                   maximum: 500
       responses:
-        '200':
+        "200":
           description: Entity snapshots available to the peer
           content:
             application/json:

--- a/src/repositories/sqlite/__tests__/local_db_adapter.test.ts
+++ b/src/repositories/sqlite/__tests__/local_db_adapter.test.ts
@@ -1,7 +1,7 @@
 import path from "path";
 import { mkdtempSync, rmSync } from "fs";
 import { tmpdir } from "os";
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import { isRecoverableSqliteConnectionError, isSqliteLockError } from "../local_db_adapter.ts";
 
 let dbImportSeq = 0;
@@ -302,10 +302,6 @@ describe("local db adapter", () => {
   // -------------------------------------------------------------------------
 
   describe("SQLITE_BUSY retry with backoff", () => {
-    afterEach(() => {
-      vi.restoreAllMocks();
-    });
-
     it("succeeds under concurrent writes to the same SQLite file (retry path exercises)", async () => {
       const tempDir = makeTempDir("neotoma-concurrent");
       const db = await loadDb(tempDir);

--- a/src/repositories/sqlite/local_db_adapter.ts
+++ b/src/repositories/sqlite/local_db_adapter.ts
@@ -9,7 +9,14 @@ import { deriveKeys, deriveKeysFromMnemonic, hexToKey } from "../../crypto/key_d
 
 type QueryResult<T> = {
   data: T | null;
-  error: { message: string; code?: string } | null;
+  error: {
+    message: string;
+    code?: string;
+    /** Originating SQLite error code (e.g. SQLITE_BUSY) when retries were exhausted. */
+    sqlite_code?: string;
+    /** Originating SQLite errno when retries were exhausted. */
+    sqlite_errno?: number;
+  } | null;
   count?: number;
 };
 
@@ -686,6 +693,9 @@ class LocalQueryBuilder {
 
     const whereSql = whereClauses.length > 0 ? `WHERE ${whereClauses.join(" AND ")}` : "";
 
+    // Capture the last SQLite lock error so a retry-exhausted envelope can
+    // preserve its `code`/`errno` instead of returning a string-only message.
+    let lastLockError: { code?: string; errno?: number; message?: string } | null = null;
     for (let lockRetry = 0; lockRetry < SQLITE_LOCK_MAX_RETRIES; lockRetry += 1) {
       for (let attempt = 0; attempt < 2; attempt += 1) {
         const db = getSqliteDb();
@@ -935,8 +945,14 @@ class LocalQueryBuilder {
             continue;
           }
           if (isSqliteLockError(error)) {
-            // Break out of the connection-retry inner loop; the outer lock-retry
-            // loop will sleep and try again.
+            // Capture for the retry-exhausted envelope, then break out of the
+            // connection-retry inner loop; the outer lock-retry loop will sleep
+            // and try again.
+            lastLockError = {
+              code: error?.code,
+              errno: error?.errno,
+              message: error?.message || String(error),
+            };
             break;
           }
           const msg = error.message || String(error);
@@ -952,9 +968,20 @@ class LocalQueryBuilder {
       }
     } // end lock-retry loop
 
+    // Retry exhausted: surface a DB_CONNECTION_FAILED envelope so callers can
+    // distinguish lock-exhaustion from arbitrary adapter failures and so the
+    // originating SQLite `code`/`errno` is preserved for logging. Per
+    // `docs/reference/error_codes.md`, this is HTTP 503 / Retry? Yes.
     return {
       data: null,
-      error: { message: "SQLite database is locked: maximum retries exceeded" },
+      error: {
+        message: lastLockError?.message
+          ? `SQLite database is locked: maximum retries exceeded (${lastLockError.message})`
+          : "SQLite database is locked: maximum retries exceeded",
+        code: "DB_CONNECTION_FAILED",
+        ...(lastLockError?.code ? { sqlite_code: lastLockError.code } : {}),
+        ...(lastLockError?.errno !== undefined ? { sqlite_errno: lastLockError.errno } : {}),
+      },
     };
   }
 

--- a/src/shared/openapi_types.ts
+++ b/src/shared/openapi_types.ts
@@ -2693,6 +2693,14 @@ export interface components {
        *     fields before re-storing.
        */
       unknown_fields?: string[];
+      /**
+       * @description Actionable guidance when fields were dropped to `raw_fragments`.
+       *     Present only when `unknown_fields_count > 0`. Directs the caller
+       *     to use `update_schema_incremental` with `migrate_existing: true`
+       *     to promote the unknown fields into the schema and backfill existing
+       *     data.
+       */
+      hint?: string;
       relationships_created?: {
         [key: string]: unknown;
       }[];
@@ -3113,6 +3121,33 @@ export interface components {
         observation_index?: number;
         entity_id?: string;
       })[];
+      /**
+       * @description Schema-driven non-fatal warnings emitted when a stored observation
+       *     omits all fields listed by a schema's `store_warnings` rule. Used
+       *     by schemas to surface identity-quality issues (e.g. a
+       *     `product_feedback` observation that supplies none of the declared
+       *     feedback-source identity fields) without rejecting the write.
+       *     Schema-agnostic: the rule lives on the entity's `SchemaDefinition`,
+       *     not in per-type code. Present only when at least one rule fired
+       *     during this request.
+       */
+      store_warnings?: {
+        /**
+         * @description Schema-defined warning code (declared in the schema's
+         *     `store_warnings[].code`). Stable identifier callers can
+         *     switch on.
+         */
+        code: string;
+        /** @description Human-readable description from the schema rule. */
+        message: string;
+        /**
+         * @description Index into the request's `entities[]` array identifying which
+         *     observation triggered the warning.
+         */
+        observation_index: number;
+        entity_type: string;
+        entity_id: string;
+      }[];
       /** @description Interpretation row linked to observations when the request supplied an explicit interpretation block. */
       interpretation_id?: string | null;
       /**
@@ -3131,6 +3166,20 @@ export interface components {
        *     so future ingestion produces observations instead of fragments.
        */
       no_schema_entity_types?: string[];
+      /**
+       * @description Number of entity fields that were dropped because they are not
+       *     declared in the entity's active schema. These fields were stored in
+       *     `raw_fragments` and can be recovered.
+       */
+      unknown_fields_count?: number;
+      /**
+       * @description Actionable guidance when fields were dropped to `raw_fragments`.
+       *     Present only when `unknown_fields_count > 0`. Directs the caller
+       *     to use `update_schema_incremental` with `migrate_existing: true`
+       *     to promote the unknown fields into the schema and backfill existing
+       *     data.
+       */
+      hint?: string;
     };
     /**
      * @description Non-fatal warning emitted by entity resolution when a schema declares


### PR DESCRIPTION
## Summary

Batch follow-up addressing review findings that were posted on already-merged PRs but never landed before merge. Surfaced by audit on #234.

**PR #152 — `store_warnings` undeclared contract surface**
- `store_warnings` was being emitted at `src/actions.ts:6552` and `src/server.ts:5143` but absent from `openapi.yaml`. Declared on `StoreStructuredResponse`; types regenerated.

**PR #223 — SQLite retry regression test never ran + envelope had no `code`**
- `afterEach(vi.restoreAllMocks())` block threw `ReferenceError: vi is not defined` at runtime → the concurrent-write regression test for #173 never actually ran. Dropped the dead block (no mocks to restore).
- Retry-exhausted envelope now carries `code: "DB_CONNECTION_FAILED"` (per [docs/reference/error_codes.md](docs/reference/error_codes.md): HTTP 503, Retry? Yes) plus `sqlite_code` / `sqlite_errno` preserved for logging.

**PR #222 — `ERR_IDEMPOTENCY_*` codes absent from canonical catalog**
- Added Idempotency Errors section to `docs/reference/error_codes.md` documenting `ERR_IDEMPOTENCY_MISMATCH` and `ERR_IDEMPOTENCY_COLLISION`, with a note on their equivalence.

## Verification

- ✅ `npm run type-check`
- ✅ `npm run lint` (0 errors)
- ✅ `npm run format:check`
- ✅ `src/repositories/sqlite/__tests__/local_db_adapter.test.ts` (16/16, including previously-broken concurrent-write test)
- ✅ `tests/contract/openapi_schema.test.ts` (6/6)
- ⚠️  Full `npm test` not gating: 13 unrelated tests fail on `main` without these changes (inspector/ dir missing in worktree; hook-test process isolation). Documented in commit message.

## Test plan

- [ ] CI baseline lane green
- [ ] CI security_gates green
- [ ] No new entries in `docs/security/advisories/` (none implicated)

## Out of scope (deferred to follow-ups)

Per the audit, these remain unaddressed and warrant their own PRs:
- #224 `unknownFieldsCount` double-counting on dedup path; dead `db` param in `flushPendingFragments`
- #178 fail-open `shouldShowInternal` default; missing `security_review.md` entry
- #153 hook plugin still writes `session_id` not `session_uuid`
- #151 `message_count` stored-vs-aggregate two-source-of-truth collision
- #167 scope-bundling discipline
- #233/#232 `cli_agent_instructions.md` sync-rule violation

🤖 Generated with [Claude Code](https://claude.com/claude-code)