### PR TITLE
fix(reviews): address overlooked findings from PRs #233, #232, #151

### DIFF
--- a/docs/developer/cli_agent_instructions.md
+++ b/docs/developer/cli_agent_instructions.md
@@ -16,10 +16,10 @@ When a Neotoma CLI session starts (dev or prod), applied rule files (e.g. `.curs
 
 ## Canonical behavioral instructions (read these for semantics)
 
-| Situation | Action |
-|-----------|--------|
-| MCP tools visible in the session | Follow MCP `instructions` / tool surface only for Neotoma behavior. |
-| MCP not available | Run `neotoma instructions print` (same body as the MCP fenced block), or open `docs/developer/mcp/instructions.md` in the Neotoma package / checkout. |
+| Situation                        | Action                                                                                                                                                |
+| -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| MCP tools visible in the session | Follow MCP `instructions` / tool surface only for Neotoma behavior.                                                                                   |
+| MCP not available                | Run `neotoma instructions print` (same body as the MCP fenced block), or open `docs/developer/mcp/instructions.md` in the Neotoma package / checkout. |
 
 Index and dual-host notes: `docs/developer/agent_instructions.md`.
 
@@ -90,14 +90,12 @@ When MCP is not available and prompt context may depend on prior memory:
 # Identifier lookup
 neotoma entities search "Acme Corp"
 
-# Type-based lookup
-neotoma entities list --type task
-neotoma entities list --type event
-
-# Named entity-type queries ("newest plans", "my tasks", "recent notes")
-# Use --type with the matching entity_type; do NOT search conversation history first.
+# Type-scoped queries — also covers named entity-type asks ("newest plans",
+# "my tasks", "recent notes", "open issues"). See MCP instructions
+# "Named entity-type routing" for the full behavioral rule.
 neotoma entities list --type plan
 neotoma entities list --type task
+neotoma entities list --type event
 
 # History/provenance lookup
 neotoma observations list --entity-id <entity_id>
@@ -108,7 +106,7 @@ neotoma relationships list --entity-id <entity_id>
 
 Use narrow queries first, then expand only if needed.
 
-**Named entity-type routing:** when the user asks about a named entity type ("newest plans", "my tasks", "open issues", "recent notes"), query `neotoma entities list --type <entity_type>` directly. FORBIDDEN: searching conversation history or agent_message rows as a substitute for a type-scoped entity list. Do not fall back to conversation search until the type-scoped query has been attempted and returned no relevant results. For recency queries, the most recently updated entities appear first in default output.
+**Named entity-type routing:** see `docs/developer/mcp/instructions.md` (search "Named entity-type routing"). The CLI form is `neotoma entities list --type <entity_type>`. Run `neotoma instructions print` to see the canonical behavioral rule.
 
 ## Install verification
 

--- a/src/cli/transcript_parser.ts
+++ b/src/cli/transcript_parser.ts
@@ -825,7 +825,7 @@ export function conversationsToEntities(
       conversation_id: conv.id,
       title: conv.title,
       source_platform: conv.source,
-      message_count: conv.messages.length,
+      reported_message_count: conv.messages.length,
       started_at: conv.createdAt,
       ended_at: conv.updatedAt,
     });

--- a/src/services/schema_definitions.ts
+++ b/src/services/schema_definitions.ts
@@ -913,9 +913,17 @@ export const ENTITY_SCHEMAS: Record<string, EntitySchema> = {
         ended_at: { type: "date", required: false },
         // v1.4: session date (day-level, for filtering/display).
         date: { type: "date", required: false },
-        // v1.4: participant count and message count for aggregate views.
+        // v1.4: participant count and reported message count for aggregate
+        // views. `reported_message_count` is the count as claimed by the
+        // ingesting source (e.g. transcript importer); it can disagree with
+        // the SQL aggregate over `conversation_message` rows when not every
+        // message was ingested as a separate row. Consumers that need the
+        // authoritative live count should query `conversation_message`
+        // directly (see `src/services/recent_conversations.ts`); the
+        // `message_count` field on `RecentConversationItem` is the SQL
+        // aggregate, not this stored field.
         participant_count: { type: "number", required: false },
-        message_count: { type: "number", required: false },
+        reported_message_count: { type: "number", required: false },
         // v1.4: names or identifiers of participants.
         participants: { type: "array", required: false },
         // v1.4: topics covered in the conversation.
@@ -988,7 +996,7 @@ export const ENTITY_SCHEMAS: Record<string, EntitySchema> = {
         ended_at: { strategy: "last_write" },
         date: { strategy: "last_write" },
         participant_count: { strategy: "last_write" },
-        message_count: { strategy: "last_write" },
+        reported_message_count: { strategy: "last_write" },
         participants: { strategy: "merge_array" },
         topics: { strategy: "merge_array" },
         decisions: { strategy: "merge_array" },

--- a/tests/unit/conversation_schema_bootstrap.test.ts
+++ b/tests/unit/conversation_schema_bootstrap.test.ts
@@ -12,10 +12,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { ENTITY_SCHEMAS } from "../../src/services/schema_definitions.js";
-import {
-  ObservationReducer,
-  type Observation,
-} from "../../src/reducers/observation_reducer.js";
+import { ObservationReducer, type Observation } from "../../src/reducers/observation_reducer.js";
 
 // ---------------------------------------------------------------------------
 // Mocks — keep unit tests database-free
@@ -36,13 +33,13 @@ vi.mock("../../src/services/schema_registry.js", () => ({
 }));
 
 vi.mock("../../src/services/field_validation.js", () => ({
-  validateFieldWithConverters: vi.fn().mockImplementation(
-    (_field: string, value: unknown, _fieldDef: unknown) => ({
+  validateFieldWithConverters: vi
+    .fn()
+    .mockImplementation((_field: string, value: unknown, _fieldDef: unknown) => ({
       isValid: true,
       value,
       shouldRouteToRawFragments: false,
-    }),
-  ),
+    })),
 }));
 
 // ---------------------------------------------------------------------------
@@ -52,7 +49,7 @@ vi.mock("../../src/services/field_validation.js", () => ({
 import { schemaRegistry } from "../../src/services/schema_registry.js";
 
 function makeObs(
-  overrides: Partial<Observation> & { fields: Record<string, unknown> },
+  overrides: Partial<Observation> & { fields: Record<string, unknown> }
 ): Observation {
   return {
     id: "obs_default",
@@ -87,8 +84,8 @@ describe("conversation schema definition — bootstrap registration (#138)", () 
     expect(cnf).toBeDefined();
     // Uses ordered-rule form: each field is an independent { composite: [...] } rule
     // so either field alone resolves deterministically without requiring both.
-    const hasConversationId = cnf?.some(
-      (r) => typeof r === "string" ? r === "conversation_id" : r.composite?.includes("conversation_id")
+    const hasConversationId = cnf?.some((r) =>
+      typeof r === "string" ? r === "conversation_id" : r.composite?.includes("conversation_id")
     );
     expect(hasConversationId).toBe(true);
   });
@@ -98,8 +95,8 @@ describe("conversation schema definition — bootstrap registration (#138)", () 
     expect(cnf).toBeDefined();
     // Uses ordered-rule form: each field is an independent { composite: [...] } rule
     // so either field alone resolves deterministically without requiring both.
-    const hasSessionId = cnf?.some(
-      (r) => typeof r === "string" ? r === "session_id" : r.composite?.includes("session_id")
+    const hasSessionId = cnf?.some((r) =>
+      typeof r === "string" ? r === "session_id" : r.composite?.includes("session_id")
     );
     expect(hasSessionId).toBe(true);
   });
@@ -132,7 +129,7 @@ describe("conversation schema definition — bootstrap registration (#138)", () 
       "date",
       "participants",
       "participant_count",
-      "message_count",
+      "reported_message_count",
       "model",
       "tool",
       "source_url",
@@ -141,7 +138,9 @@ describe("conversation schema definition — bootstrap registration (#138)", () 
       "open_tasks",
     ];
     for (const f of expected) {
-      expect(fields, `expected field '${f}' to be declared in conversation schema`).toHaveProperty(f);
+      expect(fields, `expected field '${f}' to be declared in conversation schema`).toHaveProperty(
+        f
+      );
     }
   });
 
@@ -183,36 +182,28 @@ describe("conversation snapshot projection (#138 — fields at top level)", () =
   });
 
   it("projects title to the snapshot top level", async () => {
-    const obs: Observation[] = [
-      makeObs({ fields: { title: "Refactor auth module" } }),
-    ];
+    const obs: Observation[] = [makeObs({ fields: { title: "Refactor auth module" } })];
     const snapshot = await reducer.computeSnapshot("ent_conv_test", obs);
     expect(snapshot).not.toBeNull();
     expect(snapshot!.snapshot.title).toBe("Refactor auth module");
   });
 
   it("projects session_id to the snapshot top level", async () => {
-    const obs: Observation[] = [
-      makeObs({ fields: { session_id: "sess_abc123" } }),
-    ];
+    const obs: Observation[] = [makeObs({ fields: { session_id: "sess_abc123" } })];
     const snapshot = await reducer.computeSnapshot("ent_conv_test", obs);
     expect(snapshot).not.toBeNull();
     expect(snapshot!.snapshot.session_id).toBe("sess_abc123");
   });
 
   it("projects summary to the snapshot top level", async () => {
-    const obs: Observation[] = [
-      makeObs({ fields: { summary: "Discussed migration strategy." } }),
-    ];
+    const obs: Observation[] = [makeObs({ fields: { summary: "Discussed migration strategy." } })];
     const snapshot = await reducer.computeSnapshot("ent_conv_test", obs);
     expect(snapshot).not.toBeNull();
     expect(snapshot!.snapshot.summary).toBe("Discussed migration strategy.");
   });
 
   it("projects model to the snapshot top level", async () => {
-    const obs: Observation[] = [
-      makeObs({ fields: { model: "claude-sonnet-4-5" } }),
-    ];
+    const obs: Observation[] = [makeObs({ fields: { model: "claude-sonnet-4-5" } })];
     const snapshot = await reducer.computeSnapshot("ent_conv_test", obs);
     expect(snapshot).not.toBeNull();
     expect(snapshot!.snapshot.model).toBe("claude-sonnet-4-5");


### PR DESCRIPTION
## Summary

Batch-2 follow-up to the review audit (#252 is batch-1).

**PRs #233 / #232 — `cli_agent_instructions.md` sync-rule violation**
The "Named entity-type routing" paragraph mirrored the MCP fenced-block rule almost verbatim, which `agent_instructions_sync_rules.mdc` explicitly forbids. Replaced with a one-line pointer to the canonical MCP doc + `neotoma instructions print`. Also folded a duplicated `--type plan` / `--type task` example block into the existing type-scoped queries block.

**PR #151 — `message_count` two-source-of-truth collision**
The `conversation` schema declared a stored `message_count` field with `last_write` semantics. `src/services/recent_conversations.ts` separately derives `message_count` via `COUNT(*)` over `conversation_message` rows. The two could diverge silently if only a subset of messages was ingested as separate rows.

Per the review's recommendation, renamed the stored variant to `reported_message_count`:
- Schema field + merge_policy in `src/services/schema_definitions.ts`
- Writer in `src/cli/transcript_parser.ts`
- Bootstrap test assertion

`RecentConversationItem.message_count` (the SQL aggregate) remains as the only `message_count` in the contract — the live, authoritative value. The stored `reported_message_count` is now an explicit ingest-time claim and never shadows the aggregate.

## Verification

- ✅ `npm run type-check`
- ✅ `npm run lint` (0 errors)
- ✅ `npm run format:check`
- ✅ `tests/unit/conversation_schema_bootstrap.test.ts` (15/15)
- ⚠️  Full `npm test` not gating: same 13 pre-existing failures present on `main` (inspector/ dir missing in worktree; hook-test process isolation). Documented in commit message and in #252.

## Test plan

- [ ] CI baseline lane green
- [ ] CI security_gates green
- [ ] No new entries in `docs/security/advisories/`

## Out of scope (still deferred)

- #224 `unknownFieldsCount` double-counting; dead `db` param in `flushPendingFragments`
- #178 fail-open `shouldShowInternal` default; missing `security_review.md` entry
- #153 hook plugin still writes `session_id` not `session_uuid`
- #167 scope-bundling discipline

🤖 Generated with [Claude Code](https://claude.com/claude-code)