### PR TITLE
fix(reviews,skills): address PR #153 hook bridge + harden /process_prs

### DIFF
--- a/.claude/skills/process_prs/SKILL.md
+++ b/.claude/skills/process_prs/SKILL.md
@@ -34,6 +34,7 @@ Exclude draft PRs from automated merge actions. Include them in the summary repo
 Before classifying for merge, check whether each PR needs (or needs another) automated Opus review. The `claude_pr_review.yml` workflow runs on `synchronize` events but deliberately skips `claude/*` branches to avoid runaway agent loops. This step compensates by explicitly posting `@claude review` on PRs that are worth a holistic look.
 
 **Skip review-requesting for:**
+
 - Draft PRs
 - Release PRs (dev→main with version bump)
 - PRs whose head branch starts with `claude/` — the workflow already runs on `opened` for these
@@ -51,6 +52,7 @@ gh pr diff <number> --name-only
 ```
 
 Post `@claude review` if **any** of the following are true:
+
 - Files changed > 5
 - Total lines changed (insertions + deletions) > 150
 - Diff touches both `src/` and `openapi.yaml` (contract surface change)
@@ -78,6 +80,64 @@ Post another `@claude review` if new commits since last review ≥ 3.
 
 **Never post `@claude review` more than once per batch run on the same PR.** If you already posted in this run, do not post again.
 
+### Step 1c: Audit Existing Review Findings (Merge Blocker)
+
+Reviews posted asynchronously by the Opus review job can land _after_ the author pushed the final commit. The agent that merges later must not assume "review happened, so review was addressed." This step blocks merge on unaddressed substantive findings.
+
+For each PR, fetch the most recent review comment from `github-actions[bot]`:
+
+```bash
+gh api repos/{owner}/{repo}/issues/<number>/comments \
+  --jq '[.[] | select(.user.login == "github-actions[bot]" and (.body | test("PR Review|Recommended|Blocker|Blocking|MUST|Findings"; "i")) and (.body | length > 300))] | last | {created_at, body}'
+```
+
+Detect and skip **placeholder reviews** that never completed:
+
+- Body contains only the line `I'll analyze this and get back to you.` (no substantive content)
+- `usage.output_tokens` was 0 (the action timed out or errored)
+
+If the most recent review is a placeholder, treat the PR as "review requested but not delivered" and re-post `@claude review` (subject to the once-per-batch cap in Step 1b).
+
+For substantive reviews, classify findings by scanning the body for:
+
+- **Blocking**: lines containing `Blocker`, `Blocking`, `MUST`, `must fix`, `Required:`, `request changes`, `Verdict: request changes`
+- **Substantive non-blocking**: numbered findings (`**1.**`, `### 1.`, `1. **`) that are not in a "Resolved" or "Verified" section
+- **Informational**: lines in an `## Approve`, `Verdict: approve`, `Resolved`, or `Non-blocking` section
+
+If the review has any **Blocking** items, the PR is **review-blocked** until either:
+
+1. A commit lands after the review timestamp whose **commit message** explicitly references the finding (by quoting the reviewer's text, the finding number, or a referenced filename and line number), or
+2. The author posts a comment containing the literal phrase `Waiver: <reason>` on a per-finding basis acknowledging the deferral, or
+3. A fresh `@claude review` is requested and the new review's verdict is `approve` / `approve in substance`.
+
+**Detecting "housekeeping commits" that do not count as addressing findings:**
+
+A commit is housekeeping (and **does not** clear a Blocking finding) if its message matches any of:
+
+- `^chore: regenerate test catalog`
+- `^chore: regenerate openapi types`
+- `^chore: apply prettier formatting`
+- `^chore: fix prettier formatting`
+- `^Merge branch 'main'` / `^Merge pull request`
+- `^chore: rebase onto main`
+
+Counting these as "post-review work" is the exact pattern that caused PRs #152, #222, #223, #224, #178, #233, #232, #151 to merge with unaddressed findings on 2026-05-18.
+
+Use this check to compute `pending_review_blockers` for each PR:
+
+```bash
+# Count substantive (non-housekeeping) commits after the latest substantive review
+last_review_iso=$(gh api repos/{owner}/{repo}/issues/<number>/comments \
+  --jq '[.[] | select(.user.login == "github-actions[bot]" and (.body | length > 300) and (.body | test("PR Review|Recommended|Blocker|MUST|Findings"; "i")))] | last | .created_at // empty')
+
+if [ -n "$last_review_iso" ]; then
+  gh api repos/{owner}/{repo}/pulls/<number>/commits \
+    --jq "[.[] | select(.commit.committer.date > \"$last_review_iso\") | select(.commit.message | test(\"^chore: (regenerate|apply|fix) prettier|^chore: regenerate test catalog|^chore: regenerate openapi types|^Merge branch|^Merge pull request|^chore: rebase\"; \"\") | not) | .sha[:8]]"
+fi
+```
+
+If the review had Blocking items and zero substantive (non-housekeeping) commits landed after it, **the PR is review-blocked**. Post a summary comment listing the unaddressed findings and request fixes; do not merge.
+
 ### Step 2: Classify Each PR
 
 For each open PR, determine:
@@ -100,6 +160,7 @@ For each open PR, determine:
    - `reviewDecision` is `APPROVED` or review is not required by branch protection
    - `mergeable` is `MERGEABLE`
    - Security gates pass (see Step 3)
+   - **No unaddressed review blockers from Step 1c.** A PR with Blocking findings from the most recent substantive `github-actions[bot]` review and no substantive (non-housekeeping) commits or `Waiver:` comments since is **review-blocked** and must not be merged.
 
 ### Step 3: Run Security Gates
 
@@ -108,16 +169,20 @@ For each open PR, determine:
 ```bash
 npm run security:lint
 ```
+
 Errors are blocking. Warnings are noted but do not block. If errors are found, report them on the PR and do not merge until resolved.
 
 ```bash
 npm run security:manifest:check
 npm run test:security:auth-matrix
 ```
+
 Both must pass. If `security:manifest:check` fails due to an out-of-date manifest (not a code error), run:
+
 ```bash
 npm run security:manifest:write
 ```
+
 and confirm the manifest change is staged in the PR branch before re-running the check.
 
 **For all other PRs — advisory:**
@@ -137,6 +202,7 @@ gh pr merge <number> --merge --delete-branch
 Use `--merge` (no-ff merge) to preserve PR history. Use `--squash` only if the PR branch has a single logical commit and the repo convention allows it. Do not rebase-merge.
 
 After merging, confirm the merge succeeded:
+
 ```bash
 gh pr view <number> --json state,mergedAt
 ```
@@ -147,6 +213,7 @@ For each PR that cannot be merged, take the appropriate action:
 
 - **CI failing**: Post a comment summarizing which checks failed. Do not merge.
 - **Security gate errors (G2/G3)**: Post a comment with the specific `security:lint` errors or manifest/auth-matrix failures. Do not merge.
+- **Review-blocked (Step 1c)**: Post a comment listing the unaddressed Blocking findings from the most recent review, quoting the relevant lines and naming the file paths. Request that the author either land substantive fix commits, post `Waiver: <reason>` comments per finding, or re-request `@claude review` after the fixes. Do not merge.
 - **Awaiting review**: Note in the summary report. Do not post a comment unless explicitly requested.
 - **Merge conflicts**: Post a comment asking the author to rebase.
 - **Draft**: Skip. Report in summary.
@@ -166,19 +233,19 @@ Produce a comprehensive summary covering:
 
 ## Security Gate Reference
 
-| Gate | Command | When to run | Blocks merge? |
-|------|---------|-------------|---------------|
-| G2 static lint | `npm run security:lint` | All PRs | Yes, on errors |
-| G3a manifest check | `npm run security:manifest:check` | All PRs | Yes, on failure |
-| G3b auth matrix | `npm run test:security:auth-matrix` | All PRs | Yes, on failure |
+| Gate               | Command                             | When to run | Blocks merge?   |
+| ------------------ | ----------------------------------- | ----------- | --------------- |
+| G2 static lint     | `npm run security:lint`             | All PRs     | Yes, on errors  |
+| G3a manifest check | `npm run security:manifest:check`   | All PRs     | Yes, on failure |
+| G3b auth matrix    | `npm run test:security:auth-matrix` | All PRs     | Yes, on failure |
 
 Gates **not** run here (release-only):
 
-| Gate | Reason |
-|------|--------|
+| Gate                        | Reason                                                |
+| --------------------------- | ----------------------------------------------------- |
 | G1 `security:classify-diff` | Requires `--base <last-tag>`; release-scoped semantic |
-| G4 `security:ai-review` | Requires tag, writes to release supplement path |
-| G5 deployed probes | Requires live deployed environment |
+| G4 `security:ai-review`     | Requires tag, writes to release supplement path       |
+| G5 deployed probes          | Requires live deployed environment                    |
 
 The `/release` Step 3.5 re-runs G2 and G3 against the exact release commit as a hard gate. The duplication is intentional: PRs merged to `dev` weeks before release may be followed by commits that break the gates.
 
@@ -190,11 +257,14 @@ The `/release` Step 3.5 re-runs G2 and G3 against the exact release commit as a 
 - Never amend a pushed commit.
 - Never merge if CI is failing or pending unless the user explicitly instructs.
 - Never merge if G2 or G3 produce errors on a security-adjacent PR.
+- **Never merge a PR that is review-blocked per Step 1c.** A substantive `github-actions[bot]` review with Blocking findings followed only by housekeeping commits is **not** a green light. The author must either (a) land non-housekeeping fix commits, (b) post `Waiver: <reason>` comments per deferred finding, or (c) trigger a re-review whose verdict is `approve`.
 - Always run G2 and G3 before merging a security-adjacent PR.
 - Always report security gate results in the summary, even when advisory.
+- Always run Step 1c (Audit Existing Review Findings) for every non-draft PR before classification in Step 2.
 - Never post `@claude review` on a `claude/*` branch PR — the workflow already runs on `opened` for those.
 - Never post `@claude review` more than once per batch run on the same PR.
 - Do not post `@claude review` on trivially small PRs (≤5 files, ≤150 lines, no contract surface changes, not security-adjacent).
+- Treat placeholder review bodies (`I'll analyze this and get back to you.` with 0 tokens) as "review not delivered," not "review approved." Re-trigger once per batch.
 
 ## Forbidden Patterns
 
@@ -205,3 +275,6 @@ The `/release` Step 3.5 re-runs G2 and G3 against the exact release commit as a 
 - Posting noisy comments on PRs that merely need a reviewer
 - Force-pushing or rebasing shared branches
 - Spamming `@claude review` on every push — only request when the diff genuinely warrants a holistic re-review (≥3 new commits since last request)
+- **Merging on the strength of a review timestamp alone.** A review was _posted_ does not mean its findings were _addressed_. Verify via Step 1c.
+- **Counting `chore: regenerate test catalog` / `prettier` / rebase-merge commits as "post-review fixes."** They are housekeeping and do not clear review blockers.
+- **Treating placeholder review comments (`I'll analyze this and get back to you.` with 0 output tokens) as completed reviews.** Re-trigger and wait for a substantive review.

--- a/.cursor/skills/process-prs/SKILL.md
+++ b/.cursor/skills/process-prs/SKILL.md
@@ -25,6 +25,7 @@ Exclude draft PRs from automated merge actions. Include them in the summary repo
 Before classifying for merge, check whether each PR needs (or needs another) automated Opus review. The `claude_pr_review.yml` workflow runs on `synchronize` events but deliberately skips `claude/*` branches to avoid runaway agent loops. This step compensates by explicitly posting `@claude review` on PRs that are worth a holistic look.
 
 **Skip review-requesting for:**
+
 - Draft PRs
 - Release PRs (dev→main with version bump)
 - PRs whose head branch starts with `claude/` — the workflow already runs on `opened` for these
@@ -42,6 +43,7 @@ gh pr diff <number> --name-only
 ```
 
 Post `@claude review` if **any** of the following are true:
+
 - Files changed > 5
 - Total lines changed (insertions + deletions) > 150
 - Diff touches both `src/` and `openapi.yaml` (contract surface change)
@@ -69,6 +71,64 @@ Post another `@claude review` if new commits since last review ≥ 3.
 
 **Never post `@claude review` more than once per batch run on the same PR.** If you already posted in this run, do not post again.
 
+### Step 1c: Audit Existing Review Findings (Merge Blocker)
+
+Reviews posted asynchronously by the Opus review job can land _after_ the author pushed the final commit. The agent that merges later must not assume "review happened, so review was addressed." This step blocks merge on unaddressed substantive findings.
+
+For each PR, fetch the most recent review comment from `github-actions[bot]`:
+
+```bash
+gh api repos/{owner}/{repo}/issues/<number>/comments \
+  --jq '[.[] | select(.user.login == "github-actions[bot]" and (.body | test("PR Review|Recommended|Blocker|Blocking|MUST|Findings"; "i")) and (.body | length > 300))] | last | {created_at, body}'
+```
+
+Detect and skip **placeholder reviews** that never completed:
+
+- Body contains only the line `I'll analyze this and get back to you.` (no substantive content)
+- `usage.output_tokens` was 0 (the action timed out or errored)
+
+If the most recent review is a placeholder, treat the PR as "review requested but not delivered" and re-post `@claude review` (subject to the once-per-batch cap in Step 1b).
+
+For substantive reviews, classify findings by scanning the body for:
+
+- **Blocking**: lines containing `Blocker`, `Blocking`, `MUST`, `must fix`, `Required:`, `request changes`, `Verdict: request changes`
+- **Substantive non-blocking**: numbered findings (`**1.**`, `### 1.`, `1. **`) that are not in a "Resolved" or "Verified" section
+- **Informational**: lines in an `## Approve`, `Verdict: approve`, `Resolved`, or `Non-blocking` section
+
+If the review has any **Blocking** items, the PR is **review-blocked** until either:
+
+1. A commit lands after the review timestamp whose **commit message** explicitly references the finding (by quoting the reviewer's text, the finding number, or a referenced filename and line number), or
+2. The author posts a comment containing the literal phrase `Waiver: <reason>` on a per-finding basis acknowledging the deferral, or
+3. A fresh `@claude review` is requested and the new review's verdict is `approve` / `approve in substance`.
+
+**Detecting "housekeeping commits" that do not count as addressing findings:**
+
+A commit is housekeeping (and **does not** clear a Blocking finding) if its message matches any of:
+
+- `^chore: regenerate test catalog`
+- `^chore: regenerate openapi types`
+- `^chore: apply prettier formatting`
+- `^chore: fix prettier formatting`
+- `^Merge branch 'main'` / `^Merge pull request`
+- `^chore: rebase onto main`
+
+Counting these as "post-review work" is the exact pattern that caused PRs #152, #222, #223, #224, #178, #233, #232, #151 to merge with unaddressed findings on 2026-05-18.
+
+Use this check to compute `pending_review_blockers` for each PR:
+
+```bash
+# Count substantive (non-housekeeping) commits after the latest substantive review
+last_review_iso=$(gh api repos/{owner}/{repo}/issues/<number>/comments \
+  --jq '[.[] | select(.user.login == "github-actions[bot]" and (.body | length > 300) and (.body | test("PR Review|Recommended|Blocker|MUST|Findings"; "i")))] | last | .created_at // empty')
+
+if [ -n "$last_review_iso" ]; then
+  gh api repos/{owner}/{repo}/pulls/<number>/commits \
+    --jq "[.[] | select(.commit.committer.date > \"$last_review_iso\") | select(.commit.message | test(\"^chore: (regenerate|apply|fix) prettier|^chore: regenerate test catalog|^chore: regenerate openapi types|^Merge branch|^Merge pull request|^chore: rebase\"; \"\") | not) | .sha[:8]]"
+fi
+```
+
+If the review had Blocking items and zero substantive (non-housekeeping) commits landed after it, **the PR is review-blocked**. Post a summary comment listing the unaddressed findings and request fixes; do not merge.
+
 ### Step 2: Classify Each PR
 
 For each open PR, determine:
@@ -91,6 +151,7 @@ For each open PR, determine:
    - `reviewDecision` is `APPROVED` or review is not required by branch protection
    - `mergeable` is `MERGEABLE`
    - Security gates pass (see Step 3)
+   - **No unaddressed review blockers from Step 1c.** A PR with Blocking findings from the most recent substantive `github-actions[bot]` review and no substantive (non-housekeeping) commits or `Waiver:` comments since is **review-blocked** and must not be merged.
 
 ### Step 3: Run Security Gates
 
@@ -99,16 +160,20 @@ For each open PR, determine:
 ```bash
 npm run security:lint
 ```
+
 Errors are blocking. Warnings are noted but do not block. If errors are found, report them on the PR and do not merge until resolved.
 
 ```bash
 npm run security:manifest:check
 npm run test:security:auth-matrix
 ```
+
 Both must pass. If `security:manifest:check` fails due to an out-of-date manifest (not a code error), run:
+
 ```bash
 npm run security:manifest:write
 ```
+
 and confirm the manifest change is staged in the PR branch before re-running the check.
 
 **For all other PRs — advisory:**
@@ -128,6 +193,7 @@ gh pr merge <number> --merge --delete-branch
 Use `--merge` (no-ff merge) to preserve PR history. Use `--squash` only if the PR branch has a single logical commit and the repo convention allows it. Do not rebase-merge.
 
 After merging, confirm the merge succeeded:
+
 ```bash
 gh pr view <number> --json state,mergedAt
 ```
@@ -138,6 +204,7 @@ For each PR that cannot be merged, take the appropriate action:
 
 - **CI failing**: Post a comment summarizing which checks failed. Do not merge.
 - **Security gate errors (G2/G3)**: Post a comment with the specific `security:lint` errors or manifest/auth-matrix failures. Do not merge.
+- **Review-blocked (Step 1c)**: Post a comment listing the unaddressed Blocking findings from the most recent review, quoting the relevant lines and naming the file paths. Request that the author either land substantive fix commits, post `Waiver: <reason>` comments per finding, or re-request `@claude review` after the fixes. Do not merge.
 - **Awaiting review**: Note in the summary report. Do not post a comment unless explicitly requested.
 - **Merge conflicts**: Post a comment asking the author to rebase.
 - **Draft**: Skip. Report in summary.
@@ -157,19 +224,19 @@ Produce a comprehensive summary covering:
 
 ## Security Gate Reference
 
-| Gate | Command | When to run | Blocks merge? |
-|------|---------|-------------|---------------|
-| G2 static lint | `npm run security:lint` | All PRs | Yes, on errors |
-| G3a manifest check | `npm run security:manifest:check` | All PRs | Yes, on failure |
-| G3b auth matrix | `npm run test:security:auth-matrix` | All PRs | Yes, on failure |
+| Gate               | Command                             | When to run | Blocks merge?   |
+| ------------------ | ----------------------------------- | ----------- | --------------- |
+| G2 static lint     | `npm run security:lint`             | All PRs     | Yes, on errors  |
+| G3a manifest check | `npm run security:manifest:check`   | All PRs     | Yes, on failure |
+| G3b auth matrix    | `npm run test:security:auth-matrix` | All PRs     | Yes, on failure |
 
 Gates **not** run here (release-only):
 
-| Gate | Reason |
-|------|--------|
+| Gate                        | Reason                                                |
+| --------------------------- | ----------------------------------------------------- |
 | G1 `security:classify-diff` | Requires `--base <last-tag>`; release-scoped semantic |
-| G4 `security:ai-review` | Requires tag, writes to release supplement path |
-| G5 deployed probes | Requires live deployed environment |
+| G4 `security:ai-review`     | Requires tag, writes to release supplement path       |
+| G5 deployed probes          | Requires live deployed environment                    |
 
 The `/release` Step 3.5 re-runs G2 and G3 against the exact release commit as a hard gate. The duplication is intentional: PRs merged to `dev` weeks before release may be followed by commits that break the gates.
 
@@ -181,11 +248,14 @@ The `/release` Step 3.5 re-runs G2 and G3 against the exact release commit as a 
 - Never amend a pushed commit.
 - Never merge if CI is failing or pending unless the user explicitly instructs.
 - Never merge if G2 or G3 produce errors on a security-adjacent PR.
+- **Never merge a PR that is review-blocked per Step 1c.** A substantive `github-actions[bot]` review with Blocking findings followed only by housekeeping commits is **not** a green light. The author must either (a) land non-housekeeping fix commits, (b) post `Waiver: <reason>` comments per deferred finding, or (c) trigger a re-review whose verdict is `approve`.
 - Always run G2 and G3 before merging a security-adjacent PR.
 - Always report security gate results in the summary, even when advisory.
+- Always run Step 1c (Audit Existing Review Findings) for every non-draft PR before classification in Step 2.
 - Never post `@claude review` on a `claude/*` branch PR — the workflow already runs on `opened` for those.
 - Never post `@claude review` more than once per batch run on the same PR.
 - Do not post `@claude review` on trivially small PRs (≤5 files, ≤150 lines, no contract surface changes, not security-adjacent).
+- Treat placeholder review bodies (`I'll analyze this and get back to you.` with 0 tokens) as "review not delivered," not "review approved." Re-trigger once per batch.
 
 ## Forbidden Patterns
 
@@ -196,3 +266,6 @@ The `/release` Step 3.5 re-runs G2 and G3 against the exact release commit as a 
 - Posting noisy comments on PRs that merely need a reviewer
 - Force-pushing or rebasing shared branches
 - Spamming `@claude review` on every push — only request when the diff genuinely warrants a holistic re-review (≥3 new commits since last request)
+- **Merging on the strength of a review timestamp alone.** A review was _posted_ does not mean its findings were _addressed_. Verify via Step 1c.
+- **Counting `chore: regenerate test catalog` / `prettier` / rebase-merge commits as "post-review fixes."** They are housekeeping and do not clear review blockers.
+- **Treating placeholder review comments (`I'll analyze this and get back to you.` with 0 output tokens) as completed reviews.** Re-trigger and wait for a substantive review.

--- a/.github/workflows/claude_pr_review.yml
+++ b/.github/workflows/claude_pr_review.yml
@@ -8,10 +8,11 @@ on:
       - synchronize
     # Only run when code or contract surfaces change — skip pure docs/config PRs.
     paths:
-      - 'src/**'
-      - 'openapi.yaml'
-      - 'package.json'
-      - 'tests/**'
+      - "src/**"
+      - "packages/**"
+      - "openapi.yaml"
+      - "package.json"
+      - "tests/**"
   issue_comment:
     types:
       - created
@@ -64,13 +65,15 @@ jobs:
 
           LINES=$((ADDITIONS + DELETIONS))
           TOUCHES_SRC=$(echo "$CHANGED_FILES" | grep -c "^src/" || true)
+          TOUCHES_PACKAGES=$(echo "$CHANGED_FILES" | grep -c "^packages/" || true)
           TOUCHES_OPENAPI=$(echo "$CHANGED_FILES" | grep -c "^openapi.yaml" || true)
           TOUCHES_AUTH=$(echo "$CHANGED_FILES" | grep -cE "(auth|token|session|credential|permission|middleware)" || true)
 
-          echo "files=$FILES lines=$LINES src=$TOUCHES_SRC openapi=$TOUCHES_OPENAPI auth=$TOUCHES_AUTH"
+          echo "files=$FILES lines=$LINES src=$TOUCHES_SRC packages=$TOUCHES_PACKAGES openapi=$TOUCHES_OPENAPI auth=$TOUCHES_AUTH"
 
           if [ "$FILES" -gt 5 ] || [ "$LINES" -gt 150 ] || \
              ( [ "$TOUCHES_SRC" -gt 0 ] && [ "$TOUCHES_OPENAPI" -gt 0 ] ) || \
+             [ "$TOUCHES_PACKAGES" -gt 0 ] || \
              [ "$TOUCHES_AUTH" -gt 0 ]; then
             echo "substantial=true" >> $GITHUB_OUTPUT
           else

--- a/packages/claude-code-plugin/hooks/session_start.py
+++ b/packages/claude-code-plugin/hooks/session_start.py
@@ -60,18 +60,32 @@ def main() -> int:
     if client is None:
         return 0
 
-    session_id = payload.get("session_id") or f"claude-code-{uuid.uuid4()}"
+    # Claude Code supplies a raw UUID in `session_id`. Persist it under both
+    # `session_id` (canonical identity for schema resolution) and
+    # `session_uuid` (the cross-reference bridge field declared on the
+    # conversation schema). The bridge lets a hook-created entity coalesce
+    # with the slug-keyed entity an MCP agent later creates for the same
+    # session. See `src/services/schema_definitions.ts` (conversation
+    # schema, v1.4 session_uuid bridge) and issue #145.
+    raw_session_id = payload.get("session_id")
+    session_id = raw_session_id or f"claude-code-{uuid.uuid4()}"
     conversation_title = payload.get("conversation_title") or "Claude Code session"
 
-    entities = [
-        {
-            "entity_type": "conversation",
-            "title": conversation_title,
-            "session_id": session_id,
-            "started_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
-            **harness_provenance({"hook_event": "SessionStart"}),
-        }
-    ]
+    conversation_entity = {
+        "entity_type": "conversation",
+        "title": conversation_title,
+        "session_id": session_id,
+        "started_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        **harness_provenance({"hook_event": "SessionStart"}),
+    }
+    # Only populate session_uuid when the host actually supplied a UUID
+    # (i.e. we did not synthesize a `claude-code-<uuid>` fallback). A
+    # synthesized session_id is not the harness-emitted UUID and would not
+    # match anything an MCP agent could cross-reference.
+    if raw_session_id:
+        conversation_entity["session_uuid"] = raw_session_id
+
+    entities = [conversation_entity]
 
     try:
         client.store(

--- a/packages/codex-hooks/hooks/session_start.py
+++ b/packages/codex-hooks/hooks/session_start.py
@@ -30,23 +30,31 @@ def main() -> int:
     if client is None:
         return 0
 
-    session_id = payload.get("session_id") or f"codex-{uuid.uuid4()}"
+    # Codex supplies a raw UUID in `session_id`. Persist it under both
+    # `session_id` (canonical identity) and `session_uuid` (cross-reference
+    # bridge field on the conversation schema, v1.4). The bridge lets this
+    # hook-created entity coalesce with a slug-keyed entity an MCP agent
+    # later creates for the same session. See issue #145.
+    raw_session_id = payload.get("session_id")
+    session_id = raw_session_id or f"codex-{uuid.uuid4()}"
     title = payload.get("title") or "Codex CLI session"
+
+    conversation_entity = {
+        "entity_type": "conversation",
+        "title": title,
+        "session_id": session_id,
+        "started_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        **harness_provenance({"hook_event": "session_start"}),
+    }
+    # Only populate session_uuid when the host actually supplied a UUID
+    # (not when we synthesized a `codex-<uuid>` fallback).
+    if raw_session_id:
+        conversation_entity["session_uuid"] = raw_session_id
 
     try:
         client.store(
             {
-                "entities": [
-                    {
-                        "entity_type": "conversation",
-                        "title": title,
-                        "session_id": session_id,
-                        "started_at": time.strftime(
-                            "%Y-%m-%dT%H:%M:%SZ", time.gmtime()
-                        ),
-                        **harness_provenance({"hook_event": "session_start"}),
-                    }
-                ],
+                "entities": [conversation_entity],
                 "idempotency_key": make_idempotency_key(
                     session_id, "session", "start"
                 ),


### PR DESCRIPTION
## Summary

Final batch in the review-audit cleanup (batches 1-3 = #252, #254, #255). Two changes:

### PR #153 — hook plugins populate `session_uuid` bridge field

`packages/claude-code-plugin/hooks/session_start.py` and the Codex equivalent previously wrote Claude Code's / Codex's raw session UUID only under `session_id`. The `conversation` schema declares `session_uuid` as the cross-reference bridge field (v1.4) so a hook-created entity can be correlated with the slug-keyed entity an MCP agent later creates for the same session. With only `session_id` populated, the cross-reference query never matched the hook entity.

Both hooks now also populate `session_uuid: <raw uuid>` when the host supplied a `session_id` (not a synthesized `claude-code-<uuid>` / `codex-<uuid>` fallback). The schema-side bridge test (`tests/unit/conversation_session_uuid_bridge.test.ts`) still passes; hook plugins have no Python test infrastructure.

### `/process_prs` skill — Step 1c "Audit Existing Review Findings"

The skill previously requested `@claude review` and merged PRs based on CI + security gates alone. It did not verify that posted reviews had been *addressed*. Today's audit found that PRs #152, #222, #223, #224, #178, #233, #232, #151 all merged with unaddressed Blocking findings, because the merge agent treated `chore: regenerate test catalog` and `prettier` commits as "post-review work."

Added a new Step 1c that:

- Fetches the most recent substantive review from `github-actions[bot]`
- Classifies findings as Blocking / Substantive non-blocking / Informational
- Detects **housekeeping commits** (catalog regen, prettier, rebase-merges, `Merge pull request`) and explicitly excludes them from "post-review fix" counting
- Detects **placeholder reviews** (`I'll analyze this and get back to you.` with 0 tokens) and re-triggers
- Adds a `Waiver: <reason>` escape hatch for explicit per-finding deferral
- Blocks merge when Blocking findings exist with no substantive (non-housekeeping) post-review commits, no `Waiver:` comments, and no fresh approving review

Updates Step 2 (merge-eligibility), Step 5 (blocked-PR handling), Constraints, and Forbidden Patterns. Synced both `.cursor/skills/process-prs/SKILL.md` (source) and `.claude/skills/process_prs/SKILL.md` (executed copy).

## Verification

- ✅ `npm run type-check`
- ✅ `npm run lint` (0 errors)
- ✅ `npm run format:check`
- ✅ `tests/unit/conversation_session_uuid_bridge.test.ts` (6/6)

## Test plan

- [ ] CI baseline lane green
- [ ] CI security_gates green
- [ ] Next `/process_prs` run uses Step 1c to block merge on PRs with unaddressed Blocking findings

## Out of scope

- **#167** scope-bundling discipline — process/governance, not a code fix; would require human policy decision on commit-message scope conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)