### PR TITLE
ci(pr-review): raise max_turns from 15 to 30

### DIFF
--- a/.github/workflows/claude_pr_review.yml
+++ b/.github/workflows/claude_pr_review.yml
@@ -87,7 +87,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           model: claude-opus-4-7
           timeout_minutes: 30
-          max_turns: 15
+          max_turns: 30
           trigger_phrase: "@claude review"
           direct_prompt: |
             Before reviewing, read docs/developer/pr_review_reading_list.md.

--- a/docs/releases/in_progress/v0.13.0/github_release_supplement.md
+++ b/docs/releases/in_progress/v0.13.0/github_release_supplement.md
@@ -58,6 +58,54 @@ v0.13.0 is a substantial feature release. The headline additions are **schema-le
 - **Untrusted `X-Forwarded-For` IPs are redacted in log lines.** `isLocalRequest` log output no longer leaks raw client IPs from spoofed headers (PII hardening).
 - **Neotoma entity IDs carved out of phone-number PII redaction.** Entity IDs of the form `ent_*` are no longer mistakenly matched as phone numbers (#130, #134).
 
+## MCP agent instructions changes
+
+`docs/developer/mcp/instructions.md` received significant additions in this release. The file is the behavioral contract the Neotoma MCP server sends to clients at runtime, so these changes take effect without any code changes on the agent side — as soon as the server is updated, connected agents receive the updated instructions.
+
+### New mandatory rules
+
+- **Image-only message compliance.** When the user message contains only an image or screenshot (no text), all five turn-lifecycle steps still MUST execute. Agents must store a `conversation_message` describing the image and extract any entities visible in it (tasks, events, contacts, transactions). (#93, #95)
+
+- **Short-pass compliance.** Doc-only edits, `neotoma cli config`, single-file lint tweaks, and other minimal turns are explicitly NOT exempt from steps 1–5. Rationalizing a store skip as "analysis-only", "in-session bookkeeping", or "just an evaluation" is FORBIDDEN. (#93)
+
+- **PII stripping checklist before issue filing.** A mandatory six-point checklist must be completed before every `submit_issue` or `add_issue_message` call: strip names/emails/phones, replace private identifiers with `ent_*` IDs or generic labels, redact credentials and verbatim sensitive data, and re-read the body before calling. (#139)
+
+- **Issue entity linking after filing.** Immediately after `submit_issue` returns, agents MUST call `create_relationships` with REFERS_TO edges to every Neotoma entity that motivated or is referenced by the issue. Likewise for `add_issue_message`. Previously these edges were optional. (#131, #135)
+
+- **Schema-level and per-entity agent instructions.** When `retrieve_entities` or `retrieve_entity_snapshot` returns a `schema_instructions` or `entity_instructions` field, agents MUST treat those strings as behavioral context and apply them to the current turn. FORBIDDEN: ignoring these fields when present. (#129, #146)
+
+- **Schema-first store for unfamiliar types.** Before the first `store` for an entity_type the agent has not used this session and that is not in the common-types short list, call `list_entity_types` with a keyword to discover whether a registered schema exists. FORBIDDEN: storing with an unfamiliar entity_type via intuited fields without a schema check. (#160, #174, #175, #176, #196, #208)
+
+- **Unknown-fields mandatory repair.** If any entity in a store response has `unknown_fields_count > 0`, agents must immediately re-store or `correct` those entities using declared field names before proceeding to the closing assistant store. (#185, #187)
+
+- **Automated sender extraction.** For every sender of an external-source record (email, notification, invoice), agents must create or match a `contact` entity for the sender address AND an `organization`/`company` entity for the underlying service, even for automated senders (no-reply, alerts, invoicing addresses). FORBIDDEN: extracting only the transactional payload without persisting the organization and sender contact. (#198)
+
+- **Session UUID bridge (Claude Code).** In Claude Code contexts, agents must call `get_session_identity` once per session and include `session_uuid` on the slug-keyed `conversation` entity. This coalesces the hook-created UUID entity with the agent-created slug entity so hook-written timeline events correlate with MCP conversation data. FORBIDDEN: omitting `session_uuid` when `get_session_identity` is available and returns a value. (#145, #153, #256)
+
+- **Proactive auto-file mandate.** When `issues.reporting_mode` is `proactive`, agents MUST call `submit_issue` for every qualifying finding in the same turn with no user confirmation prompt. FORBIDDEN: pausing to ask "should I file this?" when proactive mode is set. (#250)
+
+- **Retrieval-first for common query types.** When the user asks about tasks, schedule, contacts, notes, issues, events, finances, decisions, or commitments, agents MUST run a bounded Neotoma retrieval pass before answering or falling back to native integrations. (#97, #99)
+
+- **Named entity-type routing.** When the user asks about a named entity type ("newest plans", "my tasks", "open issues"), agents must call `retrieve_entities` with the matching `entity_type` directly. FORBIDDEN: searching conversation history as a substitute for a direct entity query. (#228)
+
+- **Artifact store triggers.** When a concrete artifact is approved or finalized in conversation (plan, schema_design, decision_record, feature_spec, etc.), agents must store it in the same turn without waiting for an explicit save instruction. FORBIDDEN: ending a turn where an artifact was finalized without storing it.
+
+- **`TodoWrite` is session-local.** The host tool `TodoWrite` does NOT satisfy the Neotoma store protocol. Persistent follow-up tasks must also be stored via `entity_type: "task"` in Neotoma. FORBIDDEN: using `TodoWrite` alone to record tasks that should persist beyond the current session.
+
+### Clarifications and fixes
+
+- **Fallback turn_key scoping.** Bare `chat:<turn>` turn_keys are now explicitly FORBIDDEN — they reuse across sessions and cause cross-session entity merges. The correct fallback is a session-epoch-scoped key (`chat-<session_epoch_ms>:<turn>`). (#127)
+
+- **Conversation entity maintenance.** When a conversation pivots materially in scope, agents must update `title` and `scope_summary` on the existing conversation entity. FORBIDDEN: minting a new conversation entity or new `conversation_id` to represent the new scope.
+
+- **Tool deregistration recovery.** When a tool call fails with "tool 'Neotoma:X' is not registered", agents must call `tool_search` to reload it and retry. This is a client-side cache eviction, not a server-side removal.
+
+- **`parse_file` is not file retention.** `parse_file` is a read-only inspection tool that writes nothing to Neotoma. Retention requires a subsequent `store` call with `file_path` or `file_content+mime_type`. FORBIDDEN: treating a successful `parse_file` call as sufficient persistence.
+
+- **Transport precedence.** When both `neotoma` (prod) and `neotoma-dev` MCP servers are connected, default to `neotoma` for all retrieval and store operations. Dev and prod are separate SQLite databases — data written to one is not visible in the other.
+
+- **Harness table added.** A new table of supported harnesses (Claude Code, Cursor, Codex, Continue, Windsurf, VS Code, Claude Desktop, Letta) with their configuration paths was added to the onboarding section. (`98d0907da`)
+
 ## Docs site & CI / tooling
 
 - **MCP integration guides added** for Continue, Windsurf, VS Code, and Letta. Each guide ships with a frontend subpage (`NeotomaWithContinuePage`, `NeotomaWithLettaPage`, `NeotomaWithVSCodePage`, `NeotomaWithWindsurfPage`) and a docs site MDX page.
@@ -89,7 +137,7 @@ v0.13.0 is a substantial feature release. The headline additions are **schema-le
 - **`src/services/schema_registry.ts`** — validates and persists `SchemaDefinition.agent_instructions`.
 - **`src/services/schema_recommendation.ts`** — `trusted_source_relaxation` config plus `TRUSTED_OBSERVATION_SOURCES = {llm_summary, import, sync}` allowlist.
 - **`src/server.ts`** — MCP instruction body refreshed (schema/fidelity, display rule, product-bug repair, issue reporting QA tightened); `entity_ids_to_link` plumbing on `submit_issue` and `add_issue_message`.
-- **MCP instruction file (`docs/developer/mcp/instructions.md`)** — major narrative refresh covering schema-instruction handling, retrieval-first behavior, image-only compliance, and global-conservative reducer policy (#97, #99, #93, #95). **PII stripping checklist** added to `[GUEST ENTITY SUBMISSION]` section: agents must strip names, emails, private identifiers, credentials, and sensitive field excerpts before every `submit_issue` or `add_issue_message` call (#139).
+- **MCP instruction file (`docs/developer/mcp/instructions.md`)** — see _MCP agent instructions changes_ section above for the full list of new mandatory rules and clarifications.
 - **`scripts/backfill_harness_transcripts.ts`** — loads `.env.production` for `NEOTOMA_BEARER_TOKEN`, surfaces child-process stderr on failure, accepts `--base-url` and explicit env injection.
 - **`scripts/audit_raw_fragments_schema_lag.ts`** — expanded from stub to full audit script for diagnosing raw_fragments rows misrouted by the schema-projection-lag bug (issue #142, fixed on main).
 - **`scripts/check_migration_run.ts`** (new) — operational helper for verifying a migration run completed and stored correctly.
@@ -146,7 +194,7 @@ v0.13.0 is a substantial feature release. The headline additions are **schema-le
 ## Security hardening
 
 `npm run security:classify-diff -- --base v0.12.1 --head HEAD` flagged `sensitive=true`. Concerns:
-- **openapi-security** — response field additions (`schema_instructions`, `entity_instructions`, `entity_ids_to_link`, `remote_submission_error`) on existing secured endpoints. No security blocks changed. No new unauthenticated endpoints.
+- **openapi-security** — response field additions (`schema_instructions`, `entity_instructions`, `entity_ids_to_link`, `remote_submission_error`) on existing secured endpoints. No security blocks changed. No new unauthenticated endpoints introduced.
 - **auth-middleware** — `src/actions.ts` modified for the timeline determinism fix only. `isLocalRequest`, `forwardedForValues`, `LOCAL_DEV_USER_ID`, and `assertExplicitlyTrusted` are unchanged from v0.12.1.
 
 Review artifact: [`docs/releases/in_progress/v0.13.0/security_review.md`](./security_review.md)
@@ -157,14 +205,104 @@ Review artifact: [`docs/releases/in_progress/v0.13.0/security_review.md`](./secu
 - G3 (`security:manifest:check` + `test:security:auth-matrix`): manifest in sync (106 routes, 97 protected, 7 runtime-only unauth with stated reasons); auth matrix 16/16 pass.
 - G4 (`security:ai-review`): review filled; sign-off verdict `with-caveats`. Caveat: `NEOTOMA_TRUSTED_PROXY_IPS` CGNAT residual risk documented in `docs/security/threat_model.md`; no new code in v0.13.0 touches this surface.
 
-Operational hardening landing in this release:
-- Untrusted XFF IPs redacted in `isLocalRequest` rejection logs (PII).
-- `NEOTOMA_TRUSTED_PROXY_IPS` discovery messages documented for CGNAT / Warp / Cloudflare Tunnel scenarios.
-- `cursor-hooks` plugin no longer ships a hardcoded dev-local token in the published artifact.
-- Cloud-fronted caller auth section added to the tunnel guide.
+**Operational hardening in this release:**
+
+- **`/docs` route — fail-closed visibility and XSS-safe rendering.** The new server-rendered `GET /docs` / `GET /docs/*` route is the only new unauthenticated public route in this release. It was hardened before exposure: unmapped `docs/*/` subtrees default to `visibility: "internal"` (fail-closed, not fail-open); `docs/private/` is never served regardless of configuration; rendered markdown escapes text boundaries; inline links with unsafe schemes (`javascript:`, `data:`, protocol-relative) are rewritten to `#`; `Cache-Control: public, max-age=60` with an in-process mtime-keyed cache. Registered in `protected_routes_manifest.json` with a stated `reason`. Addressed the fail-open default found in PR #178 review.
+
+- **`sync_issues --push` PII redaction at the GitHub API boundary.** The new push leg of `sync_issues` mirrors local public Neotoma issue entities to GitHub. Before calling `github.createIssue`, it runs `runRedactionGuard(mode: "scan")` on the issue title and body — the same redaction path used by `submitIssue` — so private identifiers, names, and sensitive content are stripped before any data leaves the local instance. Push failures are non-fatal and do not block the pull leg.
+
+- **Hardcoded credential removed from `cursor-hooks` published artifact.** The `@neotoma/cursor-hooks` npm package was shipping `Authorization: Bearer dev-local` in the client code included in the published artifact. Every consumer of the package was sending this hardcoded token to the Neotoma server on every hook call. The fix vendors the `neotoma-client` source directly into the plugin and omits the `Authorization` header entirely when no token is configured.
+
+- **Draft GitHub Release + RC branch flow.** Releases now stage as draft GitHub Releases and publish only after sandbox deployment is verified. This closes the window where a release could appear as "latest" on GitHub before the deployed surface matched the release body. A new RC branch + PR step opens `release/vX.Y.Z` → `main` for public review before the execute step runs.
+
+- **Untrusted XFF IPs redacted in `isLocalRequest` rejection logs** (PII hardening). `NEOTOMA_TRUSTED_PROXY_IPS` discovery messages documented for CGNAT / Warp / Cloudflare Tunnel scenarios.
+
+- **Cloud-fronted caller auth section** added to the tunnel guide with an advisory operational note covering Cloudflare Tunnel topology.
 
 No new security advisories opened for this release.
 
 ## Breaking changes
 
 - **`POST /create_relationship` — schema documentation corrected, `additionalProperties: false` now enforced at the OpenAPI level.** The request body schema previously declared `type: object, additionalProperties: true` with no fields. The handler has always required `relationship_type`, `source_entity_id`, and `target_entity_id` and rejected unknown fields via Zod validation. The OpenAPI spec is now aligned with that behavior. Migration: ensure callers send only the declared fields (`relationship_type`, `source_entity_id`, `target_entity_id`, optional `source_id`, `metadata`, `user_id`). Any caller already compliant with the Zod validation is unaffected.
+
+## Upgrading from v0.12.x — repair and migration guide
+
+Most upgrades are drop-in. The items below are opt-in repair and migration commands for deployments that were running during the affected window and may have accumulated data-quality issues from bugs fixed in this release. None are required if you are installing v0.13.0 fresh.
+
+### 1. Repair misrouted `raw_fragments` rows (schema-projection lag) — recommended for all existing deployments
+
+**Bug:** When `registerSchema` was called with `activate: true`, prior active schema rows for the same entity type were not deactivated. `loadGlobalSchema` uses `.single()`, so a second active row caused an error and new observations were silently routed to `raw_fragments` instead of the entity snapshot. Any entity type that was re-registered (e.g. during onboarding or version upgrades) was affected. (#142)
+
+**Impact:** Entity snapshots for affected types are incomplete — fields that should be first-class observations are in `raw_fragments` and invisible to retrieval and the reducer.
+
+**Fix (automatic on server start):** `queueSchemaLagRepair` runs on startup in v0.13.0 and queues a background audit. To verify the repair or run it on large databases, run manually:
+
+```
+neotoma db repair-schema-lag
+```
+
+Options: `--dry-run` audits without writing; `--types <types>` limits to specific entity types; `--rollback <run_id>` reverses a prior run. The repair is fully reversible.
+
+### 2. Migrate npm installs to production database — required for npm-installed deployments that pre-date this release
+
+**Bug:** Prior npm installs defaulted to the dev database (`neotoma.db`). v0.13.0 defaults to the production database (`neotoma.prod.db`). Existing deployments will appear empty after upgrading because the server now opens a different file. (#172)
+
+**Fix:**
+
+```
+neotoma db migrate-env-split
+```
+
+Run once immediately after upgrading. Self-hosted installs that set `NEOTOMA_DATA_DIR` explicitly are unaffected.
+
+### 3. Repair accidentally-plural entity types — if applicable
+
+**Bug:** The naming convention requires singular `entity_type` names. Deployments with plural types (e.g. `posts`, `transactions`) have fragmented entity graphs — queries for the singular canonical form will miss records stored under the plural variant. (#162)
+
+Check first with `neotoma schemas list`. If any types are plural, run:
+
+```
+neotoma schemas repair-plural-types
+```
+
+This coalesces plural types to the canonical singular form and declares the plural as an alias so existing references remain resolvable.
+
+### 4. Clean up duplicate conversation entities from session UUID bridge — Claude Code users
+
+**Bug:** Before the session UUID bridge fix, the Claude Code SessionStart hook and the MCP agent each created a separate `conversation` entity for the same session — one keyed by raw UUID, one by slug — that were never coalesced. (#145, #153, #256)
+
+v0.13.0 prevents new duplicates automatically. To clean up historical ones, use the `list_potential_duplicates` MCP tool (or Inspector → Entities) to identify duplicate `conversation` pairs and merge them with `merge_entities`. This is cosmetic but improves timeline coherence and reduces entity count.
+
+### 5. Encrypt existing data at rest — optional, self-hosted only
+
+v0.13.0 ships `db migrate-encryption` for deployments that want to encrypt existing SQLite data. This is opt-in; the database is not encrypted by default.
+
+```
+neotoma db migrate-encryption encrypt
+neotoma db migrate-encryption decrypt   # reverses it
+```
+
+Requires `NEOTOMA_KEY_FILE_PATH` or `NEOTOMA_MNEMONIC` (+ optional `NEOTOMA_MNEMONIC_PASSPHRASE`). Both directions are idempotent.
+
+### 6. Re-import harness transcripts to pick up previously missed conversations — optional
+
+**Bug:** The transcript parser missed several conversation shapes across Claude Code, Codex, and Cursor (hex-encoded blobs, malformed JSON turns, `state.vscdb` format). Sessions imported before this release may be incomplete. (#143)
+
+```
+neotoma onboarding import-transcripts
+```
+
+The importer is idempotent — already-imported conversations are matched by stable identity and updated rather than duplicated.
+
+---
+
+**Summary**
+
+| # | Command | Who should run it | Required? |
+|---|---------|-------------------|-----------|
+| 1 | `neotoma db repair-schema-lag` | All existing deployments | Recommended |
+| 2 | `neotoma db migrate-env-split` | npm installs pre-dating v0.13.0 | Required if affected |
+| 3 | `neotoma schemas repair-plural-types` | Anyone with plural entity type names | If applicable |
+| 4 | Merge duplicate `conversation` entities via Inspector | Claude Code users | Cosmetic/optional |
+| 5 | `neotoma db migrate-encryption encrypt` | Self-hosted, opt-in encryption | Optional |
+| 6 | `neotoma onboarding import-transcripts` | Any harness transcript user | Optional |

--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,18 +61,18 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **386**
-- Backend and repo Vitest files: **353**
+- Total automated test files: **398**
+- Backend and repo Vitest files: **364**
 - Frontend Vitest files: **9**
-- Playwright spec files: **24**
+- Playwright spec files: **25**
 
 ### Suite counts
 | Suite | Files |
 |---|---:|
-| Vitest unit tests | 93 |
+| Vitest unit tests | 101 |
 | Vitest service tests | 33 |
 | Source-adjacent tests | 45 |
-| Vitest integration tests | 104 |
+| Vitest integration tests | 107 |
 | Vitest CLI tests | 59 |
 | Vitest contract tests | 10 |
 | Vitest security tests | 1 |
@@ -83,7 +83,7 @@ flowchart TD
 | Vitest shared-environment tests | 1 |
 | Frontend Vitest tests | 9 |
 | Playwright E2E tests | 22 |
-| Playwright Inspector E2E tests | 2 |
+| Playwright Inspector E2E tests | 3 |
 | Tests Scripts | 1 |
 
 ## Primary validation commands
@@ -107,7 +107,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/unit`
 **Requirements:** Basic `.env` if required by the module under test.
-**Files (93):**
+**Files (101):**
 - `tests/unit/aauth_admission.test.ts`
 - `tests/unit/aauth_attestation_apple_se.test.ts`
 - `tests/unit/aauth_attestation_revocation.test.ts`
@@ -128,6 +128,7 @@ flowchart TD
 - `tests/unit/attribution_diagnostics.test.ts`
 - `tests/unit/attribution_policy.test.ts`
 - `tests/unit/bigint_serialization.test.ts`
+- `tests/unit/bundled_docs_nav.test.ts`
 - `tests/unit/cli_aauth_tbs_attestation.test.ts`
 - `tests/unit/cli_aauth_tpm2_attestation.test.ts`
 - `tests/unit/cli_aauth_yubikey_attestation.test.ts`
@@ -143,6 +144,9 @@ flowchart TD
 - `tests/unit/cursor_hooks_external_data.test.ts`
 - `tests/unit/cursor_hooks_small_model.test.ts`
 - `tests/unit/docs_sidebar_nav.test.ts`
+- `tests/unit/docs/index_builder_deprecation.test.ts`
+- `tests/unit/docs/normalize_titles.test.ts`
+- `tests/unit/docs/taxonomy_audit.test.ts`
 - `tests/unit/drift_comparison.test.ts`
 - `tests/unit/duplicate_detection.test.ts`
 - `tests/unit/encrypt_response_middleware.test.ts`
@@ -150,6 +154,7 @@ flowchart TD
 - `tests/unit/external_actor_builder.test.ts`
 - `tests/unit/external_actor_promoter.test.ts`
 - `tests/unit/external_actor_provenance.test.ts`
+- `tests/unit/faq_canonical_markdown.test.ts`
 - `tests/unit/features/FU-2026-Q3-aauth-inspector-attestation-viz/agent_badge_tier_icon.test.ts`
 - `tests/unit/github_issue_thread.test.ts`
 - `tests/unit/github_mirror_guidance.test.ts`
@@ -192,7 +197,10 @@ flowchart TD
 - `tests/unit/security_hardening.test.ts`
 - `tests/unit/seo_metadata.test.ts`
 - `tests/unit/session_info.test.ts`
+- `tests/unit/site_page_frontmatter.test.ts`
+- `tests/unit/site_page_index_builder.test.ts`
 - `tests/unit/site_page_markdown.test.ts`
+- `tests/unit/site_page_route_parity.test.ts`
 - `tests/unit/spa_path.test.ts`
 - `tests/unit/store_alias_dispatch.test.ts`
 - `tests/unit/submit_issue_dx.test.ts`
@@ -299,7 +307,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm run test:integration` or `npx vitest run tests/integration`
 **Requirements:** Database configured; remote-dependent subsets additionally need `RUN_REMOTE_TESTS=1`.
-**Files (104):**
+**Files (107):**
 - `tests/integration/aauth_attribution_stamping.test.ts`
 - `tests/integration/aauth_resource_metadata.test.ts`
 - `tests/integration/aauth_revocation_e2e.test.ts`
@@ -321,6 +329,7 @@ flowchart TD
 - `tests/integration/cli_to_mcp_store.test.ts`
 - `tests/integration/conversation_turn_accrual.test.ts`
 - `tests/integration/cross_instance_issues.test.ts`
+- `tests/integration/csp_local_http.test.ts`
 - `tests/integration/cursor_hook_stop_backfill.test.ts`
 - `tests/integration/dashboard_stats.test.ts`
 - `tests/integration/docs_route.test.ts`
@@ -378,6 +387,7 @@ flowchart TD
 - `tests/integration/payload_compiler.test.ts`
 - `tests/integration/payload/payload_submission.test.ts`
 - `tests/integration/peer_sync.test.ts`
+- `tests/integration/plan_body_raw_fragment_backfill.test.ts`
 - `tests/integration/process_issues_skill.test.ts`
 - `tests/integration/public_key_registry.test.ts`
 - `tests/integration/record_activity_attribution.test.ts`
@@ -389,6 +399,7 @@ flowchart TD
 - `tests/integration/sandbox_report.test.ts`
 - `tests/integration/schema_recommendation_integration.test.ts`
 - `tests/integration/session_introspection.test.ts`
+- `tests/integration/site_pages_route.test.ts`
 - `tests/integration/store_builtin_identity_opt_out_schemas.test.ts`
 - `tests/integration/store_conversation_message_role_conflict.test.ts`
 - `tests/integration/store_exercise_log_device_schema.test.ts`
@@ -588,7 +599,8 @@ flowchart TD
 **Runner:** `playwright`
 **Command:** `npm run test:e2e:inspector`
 **Requirements:** Inspector bundle built before execution.
-**Files (2):**
+**Files (3):**
+- `playwright/tests/inspector/docs_hierarchy.spec.ts`
 - `playwright/tests/inspector/inspector-entity-detail.spec.ts`
 - `playwright/tests/inspector/inspector-issues.spec.ts`
 

--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,18 +61,18 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **398**
-- Backend and repo Vitest files: **364**
+- Total automated test files: **388**
+- Backend and repo Vitest files: **355**
 - Frontend Vitest files: **9**
-- Playwright spec files: **25**
+- Playwright spec files: **24**
 
 ### Suite counts
 | Suite | Files |
 |---|---:|
-| Vitest unit tests | 101 |
+| Vitest unit tests | 94 |
 | Vitest service tests | 33 |
 | Source-adjacent tests | 45 |
-| Vitest integration tests | 107 |
+| Vitest integration tests | 105 |
 | Vitest CLI tests | 59 |
 | Vitest contract tests | 10 |
 | Vitest security tests | 1 |
@@ -83,7 +83,7 @@ flowchart TD
 | Vitest shared-environment tests | 1 |
 | Frontend Vitest tests | 9 |
 | Playwright E2E tests | 22 |
-| Playwright Inspector E2E tests | 3 |
+| Playwright Inspector E2E tests | 2 |
 | Tests Scripts | 1 |
 
 ## Primary validation commands
@@ -107,7 +107,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/unit`
 **Requirements:** Basic `.env` if required by the module under test.
-**Files (101):**
+**Files (94):**
 - `tests/unit/aauth_admission.test.ts`
 - `tests/unit/aauth_attestation_apple_se.test.ts`
 - `tests/unit/aauth_attestation_revocation.test.ts`
@@ -128,7 +128,6 @@ flowchart TD
 - `tests/unit/attribution_diagnostics.test.ts`
 - `tests/unit/attribution_policy.test.ts`
 - `tests/unit/bigint_serialization.test.ts`
-- `tests/unit/bundled_docs_nav.test.ts`
 - `tests/unit/cli_aauth_tbs_attestation.test.ts`
 - `tests/unit/cli_aauth_tpm2_attestation.test.ts`
 - `tests/unit/cli_aauth_yubikey_attestation.test.ts`
@@ -144,9 +143,6 @@ flowchart TD
 - `tests/unit/cursor_hooks_external_data.test.ts`
 - `tests/unit/cursor_hooks_small_model.test.ts`
 - `tests/unit/docs_sidebar_nav.test.ts`
-- `tests/unit/docs/index_builder_deprecation.test.ts`
-- `tests/unit/docs/normalize_titles.test.ts`
-- `tests/unit/docs/taxonomy_audit.test.ts`
 - `tests/unit/drift_comparison.test.ts`
 - `tests/unit/duplicate_detection.test.ts`
 - `tests/unit/encrypt_response_middleware.test.ts`
@@ -154,7 +150,6 @@ flowchart TD
 - `tests/unit/external_actor_builder.test.ts`
 - `tests/unit/external_actor_promoter.test.ts`
 - `tests/unit/external_actor_provenance.test.ts`
-- `tests/unit/faq_canonical_markdown.test.ts`
 - `tests/unit/features/FU-2026-Q3-aauth-inspector-attestation-viz/agent_badge_tier_icon.test.ts`
 - `tests/unit/github_issue_thread.test.ts`
 - `tests/unit/github_mirror_guidance.test.ts`
@@ -197,8 +192,6 @@ flowchart TD
 - `tests/unit/security_hardening.test.ts`
 - `tests/unit/seo_metadata.test.ts`
 - `tests/unit/session_info.test.ts`
-- `tests/unit/site_page_frontmatter.test.ts`
-- `tests/unit/site_page_index_builder.test.ts`
 - `tests/unit/site_page_markdown.test.ts`
 - `tests/unit/site_page_route_parity.test.ts`
 - `tests/unit/spa_path.test.ts`
@@ -307,7 +300,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm run test:integration` or `npx vitest run tests/integration`
 **Requirements:** Database configured; remote-dependent subsets additionally need `RUN_REMOTE_TESTS=1`.
-**Files (107):**
+**Files (105):**
 - `tests/integration/aauth_attribution_stamping.test.ts`
 - `tests/integration/aauth_resource_metadata.test.ts`
 - `tests/integration/aauth_revocation_e2e.test.ts`
@@ -329,7 +322,6 @@ flowchart TD
 - `tests/integration/cli_to_mcp_store.test.ts`
 - `tests/integration/conversation_turn_accrual.test.ts`
 - `tests/integration/cross_instance_issues.test.ts`
-- `tests/integration/csp_local_http.test.ts`
 - `tests/integration/cursor_hook_stop_backfill.test.ts`
 - `tests/integration/dashboard_stats.test.ts`
 - `tests/integration/docs_route.test.ts`
@@ -399,7 +391,6 @@ flowchart TD
 - `tests/integration/sandbox_report.test.ts`
 - `tests/integration/schema_recommendation_integration.test.ts`
 - `tests/integration/session_introspection.test.ts`
-- `tests/integration/site_pages_route.test.ts`
 - `tests/integration/store_builtin_identity_opt_out_schemas.test.ts`
 - `tests/integration/store_conversation_message_role_conflict.test.ts`
 - `tests/integration/store_exercise_log_device_schema.test.ts`
@@ -599,8 +590,7 @@ flowchart TD
 **Runner:** `playwright`
 **Command:** `npm run test:e2e:inspector`
 **Requirements:** Inspector bundle built before execution.
-**Files (3):**
-- `playwright/tests/inspector/docs_hierarchy.spec.ts`
+**Files (2):**
 - `playwright/tests/inspector/inspector-entity-detail.spec.ts`
 - `playwright/tests/inspector/inspector-issues.spec.ts`
 

--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,15 +61,15 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **388**
-- Backend and repo Vitest files: **355**
+- Total automated test files: **387**
+- Backend and repo Vitest files: **354**
 - Frontend Vitest files: **9**
 - Playwright spec files: **24**
 
 ### Suite counts
 | Suite | Files |
 |---|---:|
-| Vitest unit tests | 94 |
+| Vitest unit tests | 93 |
 | Vitest service tests | 33 |
 | Source-adjacent tests | 45 |
 | Vitest integration tests | 105 |
@@ -107,7 +107,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/unit`
 **Requirements:** Basic `.env` if required by the module under test.
-**Files (94):**
+**Files (93):**
 - `tests/unit/aauth_admission.test.ts`
 - `tests/unit/aauth_attestation_apple_se.test.ts`
 - `tests/unit/aauth_attestation_revocation.test.ts`
@@ -193,7 +193,6 @@ flowchart TD
 - `tests/unit/seo_metadata.test.ts`
 - `tests/unit/session_info.test.ts`
 - `tests/unit/site_page_markdown.test.ts`
-- `tests/unit/site_page_route_parity.test.ts`
 - `tests/unit/spa_path.test.ts`
 - `tests/unit/store_alias_dispatch.test.ts`
 - `tests/unit/submit_issue_dx.test.ts`

--- a/src/server.ts
+++ b/src/server.ts
@@ -3544,6 +3544,11 @@ export class NeotomaServer {
         user_id: parsed.user_specific ? userId : undefined,
         activate: parsed.activate,
         migrate_existing: parsed.migrate_existing,
+        // For global schemas user_id above is undefined, but migrate_existing must
+        // still scope to the authenticated caller so raw_fragments stored by this
+        // user are promoted.  Pass the resolved userId whenever we are doing a
+        // migration, regardless of user_specific.
+        migrate_user_id: parsed.migrate_existing ? userId : undefined,
       });
 
       return this.buildTextResponse({

--- a/src/services/plans/seed_schema.test.ts
+++ b/src/services/plans/seed_schema.test.ts
@@ -80,6 +80,7 @@ describe("seedPlanSchema", () => {
     expect(registry.updateSchemaIncremental).toHaveBeenCalledTimes(1);
     const update = registry.updateSchemaIncremental.mock.calls[0]?.[0] as {
       fields_to_add: Array<{ field_name: string }>;
+      migrate_existing?: boolean;
     };
     const fieldNames = update.fields_to_add.map((f) => f.field_name);
     expect(fieldNames).toContain("plan_kind");
@@ -87,6 +88,26 @@ describe("seedPlanSchema", () => {
     expect(fieldNames).toContain("public_overview");
     expect(fieldNames).toContain("worktree_path");
     expect(fieldNames).not.toContain("title"); // already present
+    // Must backfill raw_fragments so historical body values surface in snapshots.
+    expect(update.migrate_existing).toBe(true);
+  });
+
+  it("passes migrate_existing: true when body is among the missing fields", async () => {
+    // Simulates a DB that had plan schema registered before `body` was added.
+    const registry = makeRegistry({
+      exists: true,
+      existingFields: ["title", "slug", "harness", "harness_plan_id"],
+    });
+    await seedPlanSchema({
+      registry: registry as unknown as Parameters<typeof seedPlanSchema>[0]["registry"],
+    });
+    expect(registry.updateSchemaIncremental).toHaveBeenCalledTimes(1);
+    const update = registry.updateSchemaIncremental.mock.calls[0]?.[0] as {
+      fields_to_add: Array<{ field_name: string }>;
+      migrate_existing?: boolean;
+    };
+    expect(update.fields_to_add.map((f) => f.field_name)).toContain("body");
+    expect(update.migrate_existing).toBe(true);
   });
 
   it("skips updates when every field is already present", async () => {

--- a/src/services/plans/seed_schema.ts
+++ b/src/services/plans/seed_schema.ts
@@ -293,6 +293,12 @@ export async function seedPlanSchema(options?: {
     })),
     user_specific: false,
     activate: true,
+    // Promote any values for the newly-added fields that were previously
+    // routed to raw_fragments (because the field was absent from the active
+    // schema at store time). This is a one-time backfill per field per
+    // instance and is safe to run on every boot — the migration logic is
+    // idempotent for rows that were already promoted.
+    migrate_existing: true,
   });
 }
 

--- a/src/services/schema_registry.ts
+++ b/src/services/schema_registry.ts
@@ -857,6 +857,13 @@ export class SchemaRegistryService {
     user_specific?: boolean;
     user_id?: string;
     migrate_existing?: boolean; // Only for backfilling historical data
+    /**
+     * When migrate_existing is true, use this user_id as the scope for the
+     * raw_fragments query instead of options.user_id. Needed for global schemas
+     * (user_specific: false) where options.user_id is undefined but raw_fragments
+     * were stored by a specific authenticated user.
+     */
+    migrate_user_id?: string;
     activate?: boolean; // Default: true - activate immediately so new data uses updated schema
     force?: boolean;
   }): Promise<SchemaRegistryEntry> {
@@ -1063,7 +1070,9 @@ export class SchemaRegistryService {
         await this.migrateRawFragmentsToObservations({
           entity_type: options.entity_type,
           field_names: fieldNamesToMigrate,
-          user_id: options.user_id,
+          // migrate_user_id takes precedence: for global schemas the caller passes
+          // the authenticated user's id here while options.user_id is undefined.
+          user_id: options.migrate_user_id ?? options.user_id,
         });
       }
     }

--- a/tests/integration/plan_body_raw_fragment_backfill.test.ts
+++ b/tests/integration/plan_body_raw_fragment_backfill.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Regression test for issue #259:
+ * plan.body (and other fields added after initial schema registration) that
+ * were stored while the field was absent from the active schema land in
+ * raw_fragments and MUST be promoted to observations by calling
+ * updateSchemaIncremental with migrate_existing: true.
+ *
+ * This test exercises the full path:
+ *   1. Narrow plan schema registered (title only, no body).
+ *   2. Plan stored with body — body routes to raw_fragments, absent from snapshot.
+ *   3. updateSchemaIncremental adds body with migrate_existing: true.
+ *   4. Snapshot now reflects the body value.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { NeotomaServer } from "../../src/server.js";
+import { db } from "../../src/db.js";
+
+const TEST_USER_ID = "00000000-0000-0000-0000-000000000259";
+const ENTITY_TYPE = "issue_259_regression_plan";
+
+async function seedNarrowSchema(): Promise<void> {
+  await db.from("schema_registry").delete().eq("entity_type", ENTITY_TYPE);
+  const { error } = await db.from("schema_registry").insert({
+    entity_type: ENTITY_TYPE,
+    schema_version: "1.0",
+    schema_definition: {
+      fields: {
+        title: { type: "string", required: true },
+      },
+      canonical_name_fields: ["title"],
+    },
+    reducer_config: {
+      merge_policies: {
+        title: { strategy: "last_write", tie_breaker: "observed_at" },
+      },
+    },
+    active: true,
+    scope: "global",
+    user_id: null,
+  });
+  if (error) throw new Error(`Failed to seed narrow schema: ${error.message}`);
+}
+
+async function cleanup(entityIds: string[]): Promise<void> {
+  if (entityIds.length > 0) {
+    const { data: observations } = await db
+      .from("observations")
+      .select("source_id")
+      .in("entity_id", entityIds);
+    const sourceIds = Array.from(
+      new Set(
+        (observations ?? [])
+          .map((r) => r.source_id)
+          .filter((v): v is string => typeof v === "string"),
+      ),
+    );
+    await db.from("entity_snapshots").delete().in("entity_id", entityIds);
+    await db.from("raw_fragments").delete().in("entity_id", entityIds);
+    await db.from("observations").delete().in("entity_id", entityIds);
+    await db.from("entities").delete().in("id", entityIds);
+    if (sourceIds.length > 0) {
+      await db.from("sources").delete().in("id", sourceIds);
+    }
+  }
+  await db.from("schema_registry").delete().eq("entity_type", ENTITY_TYPE);
+}
+
+function parseResponse(result: { content: Array<{ type: string; text: string }> }) {
+  const text = result.content.find((c) => c.type === "text")?.text ?? "{}";
+  return JSON.parse(text);
+}
+
+describe("plan body raw_fragment backfill (issue #259)", () => {
+  const createdEntityIds: string[] = [];
+  let server: NeotomaServer & {
+    authenticatedUserId?: string | null;
+    store: (args: unknown) => Promise<{ content: Array<{ type: string; text: string }> }>;
+    updateSchemaIncremental: (
+      args: unknown,
+    ) => Promise<{ content: Array<{ type: string; text: string }> }>;
+    retrieveEntitySnapshot: (
+      args: unknown,
+    ) => Promise<{ content: Array<{ type: string; text: string }> }>;
+  };
+
+  beforeAll(async () => {
+    server = new NeotomaServer() as typeof server;
+    server.authenticatedUserId = TEST_USER_ID;
+    await seedNarrowSchema();
+  });
+
+  afterAll(async () => {
+    await cleanup(createdEntityIds);
+  });
+
+  it("body stored without schema routes to raw_fragments and is absent from snapshot", async () => {
+    const title = `Backfill regression plan ${Date.now()}`;
+    const bodyText = "## Goal\n\nThis body was stored before `body` was in the schema.";
+
+    const storeResult = await server.store({
+      idempotency_key: `issue-259-backfill-${Date.now()}`,
+      entities: [
+        {
+          entity_type: ENTITY_TYPE,
+          title,
+          body: bodyText,
+        },
+      ],
+    });
+    const stored = parseResponse(storeResult);
+    expect(stored.entities).toHaveLength(1);
+    const entityId = stored.entities[0].entity_id;
+    createdEntityIds.push(entityId);
+
+    // body is unknown in the narrow schema — unknown_fields_count and unknown_fields
+    // are returned at the top level of the store response (not per-entity).
+    expect(stored.unknown_fields_count).toBeGreaterThan(0);
+    if (Array.isArray(stored.unknown_fields)) {
+      expect(stored.unknown_fields).toContain("body");
+    }
+
+    // Snapshot must NOT contain body yet
+    const snapResult = await server.retrieveEntitySnapshot({ entity_id: entityId, format: "json" });
+    const snap = parseResponse(snapResult);
+    expect(snap.snapshot?.body).toBeUndefined();
+
+    // body must be sitting in raw_fragments
+    const { data: frags } = await db
+      .from("raw_fragments")
+      .select("fragment_key, fragment_value")
+      .eq("entity_id", entityId)
+      .eq("fragment_key", "body");
+    expect(frags).not.toBeNull();
+    expect(frags!.length).toBeGreaterThan(0);
+    expect(frags![0].fragment_value).toBe(bodyText);
+  });
+
+  it("updateSchemaIncremental with migrate_existing: true promotes body from raw_fragments to snapshot", async () => {
+    // This entity must have been created in the previous test.
+    expect(createdEntityIds.length).toBeGreaterThan(0);
+    const entityId = createdEntityIds[0];
+
+    // Extend the narrow schema to include `body`, migrating existing raw_fragments.
+    // Pass user_id so the migration query matches raw_fragments stored by this user.
+    const updateResult = await server.updateSchemaIncremental({
+      entity_type: ENTITY_TYPE,
+      fields_to_add: [{ field_name: "body", field_type: "string", reducer_strategy: "last_write" }],
+      activate: true,
+      migrate_existing: true,
+      user_id: TEST_USER_ID,
+    });
+    const updated = parseResponse(updateResult);
+    expect(updated.success).toBe(true);
+    expect(updated.fields_added).toContain("body");
+
+    // raw_fragments row for body is retained as provenance; the migration
+    // creates a new observation. Verify the observation count increased and
+    // that an observation contains the body field.
+    const { data: obsAfter } = await db
+      .from("observations")
+      .select("fields")
+      .eq("entity_id", entityId);
+    const bodyInObs = (obsAfter ?? []).some((o: { fields?: unknown }) => {
+      const f = typeof o.fields === "string" ? JSON.parse(o.fields) : o.fields;
+      return typeof f === "object" && f !== null && "body" in (f as Record<string, unknown>);
+    });
+    expect(bodyInObs).toBe(true);
+
+    // Snapshot must now reflect the body value
+    const snapResult = await server.retrieveEntitySnapshot({ entity_id: entityId, format: "json" });
+    const snap = parseResponse(snapResult);
+    expect(snap.snapshot?.body).toBe(
+      "## Goal\n\nThis body was stored before `body` was in the schema.",
+    );
+  });
+
+  it("idempotent: running migrate_existing again does not duplicate or corrupt the body value", async () => {
+    expect(createdEntityIds.length).toBeGreaterThan(0);
+    const entityId = createdEntityIds[0];
+
+    // Run the same updateSchemaIncremental again — body already in schema, no new fields to add.
+    // The call should succeed (no-op or minor version bump) and the snapshot must be unchanged.
+    // We add a dummy field to force an update call so migrate_existing fires again.
+    await server.updateSchemaIncremental({
+      entity_type: ENTITY_TYPE,
+      fields_to_add: [
+        { field_name: "notes", field_type: "string", reducer_strategy: "last_write" },
+      ],
+      activate: true,
+      migrate_existing: true,
+      user_id: TEST_USER_ID,
+    });
+
+    const snapResult = await server.retrieveEntitySnapshot({ entity_id: entityId, format: "json" });
+    const snap = parseResponse(snapResult);
+    // body must still have exactly the original value — no duplication
+    expect(snap.snapshot?.body).toBe(
+      "## Goal\n\nThis body was stored before `body` was in the schema.",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Bumps `max_turns` from 15 to 30 in the Claude PR Review workflow
- Root cause: reviewer hits turn exhaustion mid-read on PRs touching `src/services/schema_registry*` or `src/services/entity*`, which require 10 always-read docs + 3 conditional docs before synthesis — leaving no budget to post the review

## Test plan

- [ ] Merge this PR
- [ ] Verify the next schema/entity PR gets a complete review comment posted

🤖 Generated with [Claude Code](https://claude.com/claude-code)