### PR TITLE
fix(v0.13.0): unblock cleanup tests for /docs, root landing, CSP, store

### DIFF
--- a/docs/site/pages/en/agent-auth.md
+++ b/docs/site/pages/en/agent-auth.md
@@ -1,0 +1,14 @@
+---
+title: Agent auth
+category: developer_reference
+subcategory: inspector
+component: AgentAuthLandingPageBody
+locale: en
+page_title: Neotoma for Agent Authorization
+path: /agent-auth
+shell: detail
+translation_status: canonical
+---
+
+# Agent auth
+

--- a/docs/site/pages/en/api.md
+++ b/docs/site/pages/en/api.md
@@ -1,0 +1,184 @@
+---
+path: /api
+locale: en
+page_title: API reference
+shell: detail
+translation_status: canonical
+nav_group: reference
+nav_order: 10
+---
+
+The Neotoma REST API is defined in the{" "}
+<a
+  href="https://github.com/markmhendrickson/neotoma/blob/main/openapi.yaml"
+  className="text-foreground underline underline-offset-2 hover:no-underline"
+  target="_blank"
+  rel="noreferrer"
+>
+  OpenAPI spec
+</a>
+. The table below lists each endpoint and the capability it provides.
+
+The API is designed around deterministic state operations: store structured observations, retrieve snapshots with provenance, and manage typed relationships explicitly.
+
+## Getting started
+
+The API server is managed through the{" "}
+<MdxI18nLink to="/cli" className="text-foreground underline underline-offset-2 hover:no-underline">
+  Neotoma CLI
+</MdxI18nLink>
+. After{" "}
+<MdxI18nLink to="/install" className="text-foreground underline underline-offset-2 hover:no-underline">
+  installing Neotoma
+</MdxI18nLink>
+, start the API server:
+
+```
+# Start the development API server (port 3080)
+neotoma api start --env dev
+
+# Start the production API server (port 3180)
+neotoma api start --env prod
+
+# Check server status
+neotoma api status
+
+# View server logs
+neotoma api logs --env dev
+```
+
+Once the server is running, you can reach it at the base URLs below. The CLI also exposes every API operation directly. Run `neotoma --help` to see available commands, or see the{" "}
+<MdxI18nLink to="/cli" className="text-foreground underline underline-offset-2 hover:no-underline">
+  CLI reference
+</MdxI18nLink>{" "}
+for the full command list.
+
+## Base URL
+
+<ul className="list-none pl-0 space-y-2 mb-6">
+  <li className="text-[15px] leading-7 text-muted-foreground">
+    <strong className="text-foreground">Development:</strong> <code>http://localhost:3080</code>
+  </li>
+  <li className="text-[15px] leading-7 text-muted-foreground">
+    <strong className="text-foreground">Production:</strong> <code>http://localhost:3180</code> (local) or your deployed host
+  </li>
+</ul>
+
+## Authentication
+
+Most write endpoints require authentication. Discovery routes like `/health`, `/server-info`, and `/.well-known/*` are unauthenticated. When authentication is enabled, include a Bearer token:
+
+```
+Authorization: Bearer <NEOTOMA_BEARER_TOKEN>
+```
+
+<ul className="list-none pl-0 space-y-2 mb-6">
+  <li className="text-[15px] leading-7 text-muted-foreground">
+    Set via <code>NEOTOMA_BEARER_TOKEN</code> environment variable
+  </li>
+  <li className="text-[15px] leading-7 text-muted-foreground">
+    When encryption is enabled, use the key-derived MCP token instead: <code>neotoma auth mcp-token</code>
+  </li>
+  <li className="text-[15px] leading-7 text-muted-foreground">
+    MCP OAuth endpoints (<code>/mcp/oauth/*</code>) have their own auth flow — see the{" "}
+    <MdxI18nLink to="/mcp" className="text-foreground underline underline-offset-2 hover:no-underline">
+      MCP reference
+    </MdxI18nLink>
+  </li>
+  <li className="text-[15px] leading-7 text-muted-foreground">
+    For agent identity (cryptographically verifiable writes via RFC 9421 signatures and the <code>aa-agent+jwt</code> token), see the{" "}
+    <MdxI18nLink to="/aauth" className="text-foreground underline underline-offset-2 hover:no-underline">
+      AAuth reference
+    </MdxI18nLink>
+    . Bearer auth and AAuth are independent and stack: Bearer authorizes the connection, AAuth attributes individual writes.
+  </li>
+</ul>
+
+## Request examples
+
+```
+# Store structured entities
+curl -X POST http://localhost:3080/store \
+  -H "Authorization: Bearer $NEOTOMA_BEARER_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"entities":[{"entity_type":"task","title":"Review schema changes","status":"open"}]}'
+
+# Query entities
+curl -X POST http://localhost:3080/entities/query \
+  -H "Authorization: Bearer $NEOTOMA_BEARER_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"filters":{"entity_type":"task"},"limit":10}'
+
+# Retrieve snapshot with provenance
+curl -X POST http://localhost:3080/get_entity_snapshot \
+  -H "Authorization: Bearer $NEOTOMA_BEARER_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"entity_id":"<entity_id>"}'
+
+# Store a file with entities (unified store)
+curl -X POST http://localhost:3080/store \
+  -H "Authorization: Bearer $NEOTOMA_BEARER_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"entities":[{"entity_type":"note","title":"Meeting notes"}],"file_path":"/path/to/document.pdf"}'
+
+# Health check (no auth required)
+curl http://localhost:3080/health
+```
+
+
+
+## Error responses
+
+All errors use a structured envelope:
+
+```
+{
+  "error_code": "INGESTION_FILE_TOO_LARGE",
+  "message": "File exceeds maximum size of 50MB",
+  "details": { "file_size": 52428800, "max_size": 52428800 },
+  "trace_id": "trace-uuid",
+  "timestamp": "2024-01-01T12:00:00Z"
+}
+```
+
+Standard HTTP status codes: `200` OK, `201` Created, `400` Bad Request, `401` Unauthorized, `403` Forbidden, `404` Not Found, `409` Conflict, `413` Payload Too Large, `429` Rate Limited, `500` Internal Server Error, `503` Service Unavailable. Check `error_code` for programmatic handling, not just the HTTP status.
+
+## Pagination
+
+List endpoints accept `limit` and `offset` parameters. Use `include_total_count: true` when building pagination UI. Recommended: keep `limit` at 100 or below for performance.
+
+```
+{
+  "filters": { "entity_type": "task" },
+  "limit": 20,
+  "offset": 0,
+  "include_total_count": true
+}
+```
+
+## File operations
+
+Upload files via the unified `POST /store` (with `file_path` or `file_content` + `mime_type`) or `POST /store/unstructured` for raw file ingestion. File size limit: 50 MB. Retrieve signed URLs via `GET /get_file_url?file_path=...` (default expiry: 1 hour).
+
+
+  Continue with{" "}
+  <MdxI18nLink to="/mcp" className="text-foreground underline underline-offset-2 hover:no-underline">
+    MCP reference
+  </MdxI18nLink>
+  ,{" "}
+  <MdxI18nLink to="/cli" className="text-foreground underline underline-offset-2 hover:no-underline">
+    CLI reference
+  </MdxI18nLink>
+  ,{" "}
+  <MdxI18nLink to="/schema-management" className="text-foreground underline underline-offset-2 hover:no-underline">
+    schema management
+  </MdxI18nLink>
+  ,{" "}
+  <MdxI18nLink to="/architecture" className="text-foreground underline underline-offset-2 hover:no-underline">
+    architecture
+  </MdxI18nLink>
+  , and{" "}
+  <MdxI18nLink to="/tunnel" className="text-foreground underline underline-offset-2 hover:no-underline">
+    expose tunnel
+  </MdxI18nLink>
+  .

--- a/docs/site/pages/en/auditable-change-log.md
+++ b/docs/site/pages/en/auditable-change-log.md
@@ -1,0 +1,39 @@
+---
+path: /auditable-change-log
+locale: en
+page_title: Auditable change log
+shell: detail
+translation_status: canonical
+nav_group: guides
+nav_order: 53
+---
+
+Every modification records who changed what, when, and from which source. This creates field-level
+lineage for every fact in state.
+
+## Before vs after
+
+Before: state changes are visible but origin is unclear. After: every change maps back to a concrete
+tool call or source artifact with timestamped provenance.
+
+```bash
+# Inspect provenance trail
+neotoma observations list --entity-id <entity_id>
+
+# Inspect relationships to source/message entities
+neotoma relationships list --entity-id <entity_id>
+```
+
+This is required for trustworthy multi-agent systems. See
+<MdxI18nLink to="/human-inspectability" className="text-foreground underline hover:text-foreground">
+  human inspectability
+</MdxI18nLink>
+,
+<MdxI18nLink to="/versioned-history" className="text-foreground underline hover:text-foreground">
+  versioned history
+</MdxI18nLink>
+, and
+<MdxI18nLink to="/silent-mutation-risk" className="text-foreground underline hover:text-foreground">
+  silent mutation risk
+</MdxI18nLink>
+.

--- a/docs/site/pages/en/build-vs-buy.md
+++ b/docs/site/pages/en/build-vs-buy.md
@@ -1,0 +1,14 @@
+---
+title: Build vs buy
+category: developer_reference
+subcategory: inspector
+component: BuildVsBuyPageBody
+locale: en
+page_title: When to add a state integrity layer (and when observability is enough)
+path: /build-vs-buy
+shell: detail
+translation_status: canonical
+---
+
+# Build vs buy
+

--- a/docs/site/pages/en/building-pipelines.md
+++ b/docs/site/pages/en/building-pipelines.md
@@ -1,0 +1,16 @@
+---
+title: Building pipelines
+category: developer_reference
+subcategory: inspector
+component: AgenticSystemsBuildersPageBody
+locale: en
+nav_group: icp
+nav_order: 11
+page_title: Inference variance
+path: /building-pipelines
+shell: detail
+translation_status: canonical
+---
+
+# Building pipelines
+

--- a/docs/site/pages/en/cases.md
+++ b/docs/site/pages/en/cases.md
@@ -1,0 +1,8 @@
+---
+path: /cases
+locale: en
+page_title: Neotoma for Case Management
+shell: detail
+translation_status: canonical
+component: CasesLandingPageBody
+---

--- a/docs/site/pages/en/changelog.md
+++ b/docs/site/pages/en/changelog.md
@@ -1,0 +1,17 @@
+---
+path: /changelog
+locale: en
+page_title: Changelog
+shell: detail
+translation_status: canonical
+nav_group: reference
+nav_order: 40
+---
+
+Release history, migration notes, and compatibility changes. For install and upgrade paths, see [Install](/install) and [Docs hub](/docs).
+
+**v0.12.0 highlights:** dedicated subsystem references for [peer sync](/peer-sync), [substrate subscriptions](/subscriptions), [issue reporting](/issue-reporting), and [security hardening](/security-hardening). The issue-reporting page also covers the breaking `submit_issue` reporter-provenance contract (`reporter_git_sha` or `reporter_app_version` is now required).
+
+
+
+Published releases and tags live on GitHub alongside npm. When upgrading clients or MCP proxies, pin versions explicitly and re-run [Walkthrough](/walkthrough) checks if your transport or auth tier changed.

--- a/docs/site/pages/en/cli.md
+++ b/docs/site/pages/en/cli.md
@@ -1,0 +1,142 @@
+---
+path: /cli
+locale: en
+page_title: CLI reference
+shell: detail
+translation_status: canonical
+nav_group: reference
+nav_order: 11
+---
+
+The Neotoma CLI provides full access to every operation available in the MCP and REST API, plus administration commands for server lifecycle, storage, backups, and configuration. Run `neotoma` with no arguments for an interactive session (`neotoma> ` prompt), or invoke commands directly (e.g. `neotoma entities list`).
+
+## Installation
+
+```
+# Install globally
+npm install -g neotoma
+
+# Initialize data directory and database
+neotoma init
+
+# Start the API server (development)
+neotoma api start --env dev --background
+```
+
+From a source checkout: `npm run setup:cli` builds and links the global `neotoma` command. Use `npm run dev:types` to keep the global CLI in sync during development.
+
+## Environments
+
+Target a specific environment with `neotoma dev` (port 3080) or `neotoma prod` (port 3180), or pass `--env dev` / `--env prod`. Server lifecycle commands (`api start`, `api stop`, `api logs`) always require `--env`.
+
+## Typical workflow
+
+```
+# Store entities
+neotoma store --json='[{"entity_type":"task","title":"Review API rollout","status":"open"}]'
+
+# List entities by type
+neotoma entities list --type task --limit 10
+
+# Search by identifier
+neotoma entities search "Ana Rivera" --entity-type contact
+
+# Inspect provenance
+neotoma observations list --entity-id <entity_id>
+
+# Ingest a file with AI interpretation
+neotoma ingest ./invoice.pdf
+
+# Ingest locally (no API server needed)
+neotoma ingest --offline ./invoice.pdf
+
+# Stream changes in real time
+neotoma watch --tail --human
+```
+
+## Global options
+
+<ul className="list-none pl-0 space-y-2 mb-6">
+  <li className="text-[15px] leading-7 text-muted-foreground">
+    <code>--offline</code>: force in-process local transport (no API required)
+  </li>
+  <li className="text-[15px] leading-7 text-muted-foreground">
+    <code>--api-only</code>: fail if API server is unavailable
+  </li>
+  <li className="text-[15px] leading-7 text-muted-foreground">
+    <code>--base-url &lt;url&gt;</code>: target a specific API instance
+  </li>
+  <li className="text-[15px] leading-7 text-muted-foreground">
+    <code>--env dev|prod</code>: environment selector (required for server commands)
+  </li>
+  <li className="text-[15px] leading-7 text-muted-foreground">
+    <code>--json</code>: machine-readable JSON output
+  </li>
+  <li className="text-[15px] leading-7 text-muted-foreground">
+    <code>--pretty</code>: formatted JSON output
+  </li>
+  <li className="text-[15px] leading-7 text-muted-foreground">
+    <code>--tunnel</code>: start HTTPS tunnel (ngrok/cloudflared) with server start
+  </li>
+  <li className="text-[15px] leading-7 text-muted-foreground">
+    <code>--debug</code>: emit detailed initialization logs to stderr
+  </li>
+</ul>
+
+## Offline support
+
+Data commands (`entities`, `relationships`, `sources`, `observations`, `timeline`, `store`, `schemas`, `stats`, `corrections`, `snapshots`) are offline-first and use in-process local transport by default — no API server required. Server lifecycle commands (`api start|stop|status|logs`) manage the API process and are unaffected.
+
+
+
+## Authentication
+
+Local CLI commands run without login in development. For production or MCP OAuth:
+
+<ul className="list-none pl-0 space-y-2 mb-6">
+  <li className="text-[15px] leading-7 text-muted-foreground">
+    <code>neotoma auth login</code> — OAuth PKCE flow for MCP Connect
+  </li>
+  <li className="text-[15px] leading-7 text-muted-foreground">
+    <code>neotoma auth status</code> — show auth mode and user details
+  </li>
+  <li className="text-[15px] leading-7 text-muted-foreground">
+    <code>neotoma auth mcp-token</code> — print key-derived MCP token (when encryption is enabled)
+  </li>
+  <li className="text-[15px] leading-7 text-muted-foreground">
+    <code>neotoma auth logout</code> — clear stored OAuth credentials
+  </li>
+</ul>
+
+For agent identity (cryptographically verifiable writes), use `neotoma auth keygen` (software or hardware-backed) and `neotoma auth session` to inspect the resolved trust tier. See{" "}
+<MdxI18nLink to="/aauth" className="text-foreground underline underline-offset-2 hover:no-underline">
+  AAuth reference
+</MdxI18nLink>{" "}
+for the full agent authentication contract.
+
+## Storage and configuration
+
+CLI config is stored at `~/.config/neotoma/config.json`. Run `neotoma storage info` to see data directory, database path, sources directory, and log paths. Use `neotoma storage set-data-dir` to relocate the data directory with optional DB migration. Use `neotoma storage merge-db` to merge SQLite databases (safe mode by default).
+
+## Backups
+
+`neotoma backup create` creates a timestamped backup of the database, sources, and logs with a `manifest.json` containing checksums. `neotoma backup restore --from <dir>` restores a backup into the data directory. Encrypted data stays encrypted; preserve the key file or mnemonic.
+
+
+  See{" "}
+  <MdxI18nLink to="/mcp" className="text-foreground underline underline-offset-2 hover:no-underline">
+    MCP reference
+  </MdxI18nLink>{" "}
+  for agent-native transport,{" "}
+  <MdxI18nLink to="/api" className="text-foreground underline underline-offset-2 hover:no-underline">
+    REST API reference
+  </MdxI18nLink>{" "}
+  for HTTP endpoints,{" "}
+  <MdxI18nLink to="/aauth" className="text-foreground underline underline-offset-2 hover:no-underline">
+    AAuth reference
+  </MdxI18nLink>{" "}
+  for agent identity, and{" "}
+  <MdxI18nLink to="/troubleshooting" className="text-foreground underline underline-offset-2 hover:no-underline">
+    troubleshooting
+  </MdxI18nLink>{" "}
+  for common failure modes.

--- a/docs/site/pages/en/compliance.md
+++ b/docs/site/pages/en/compliance.md
@@ -1,0 +1,8 @@
+---
+path: /compliance
+locale: en
+page_title: Neotoma for Compliance
+shell: detail
+translation_status: canonical
+component: ComplianceLandingPageBody
+---

--- a/docs/site/pages/en/conflicting-facts-risk.md
+++ b/docs/site/pages/en/conflicting-facts-risk.md
@@ -1,0 +1,40 @@
+---
+path: /conflicting-facts-risk
+locale: en
+page_title: Conflicting facts risk
+shell: detail
+translation_status: canonical
+nav_group: guides
+nav_order: 56
+---
+
+Conflicting facts risk is the likelihood that contradictory statements coexist without deterministic
+resolution. In production this causes unpredictable agent behavior.
+
+## Before vs after
+
+Before: both "office is in New York" and "office is in London" remain active with no canonical winner.
+After: merge rules choose one canonical value and preserve conflicting history for audit.
+
+```bash
+# Store two conflicting facts
+neotoma store --json='[{"entity_type":"contact","name":"Ana Rivera","office_city":"New York"}]'
+neotoma store --json='[{"entity_type":"contact","name":"Ana Rivera","office_city":"London"}]'
+
+# Query canonical resolved state
+neotoma entities search --query "Ana Rivera" --entity-type contact
+```
+
+Deterministic merge logic resolves conflicts reproducibly.
+<MdxI18nLink to="/schema-constraints" className="text-foreground underline hover:text-foreground">
+  Schema constraints
+</MdxI18nLink>
+support typed conflict handling, and
+<MdxI18nLink to="/deterministic-state-evolution" className="text-foreground underline hover:text-foreground">
+  deterministic state evolution
+</MdxI18nLink>
+guarantees the same result on replay. See
+<MdxI18nLink to="/silent-mutation-risk" className="text-foreground underline hover:text-foreground">
+  silent mutation risk
+</MdxI18nLink>
+.

--- a/docs/site/pages/en/contracts.md
+++ b/docs/site/pages/en/contracts.md
@@ -1,0 +1,8 @@
+---
+path: /contracts
+locale: en
+page_title: Neotoma for Contracts
+shell: detail
+translation_status: canonical
+component: ContractsLandingPageBody
+---

--- a/docs/site/pages/en/crm.md
+++ b/docs/site/pages/en/crm.md
@@ -1,0 +1,14 @@
+---
+title: CRM
+category: developer_reference
+subcategory: inspector
+component: CrmLandingPageBody
+locale: en
+page_title: Neotoma for CRM
+path: /crm
+shell: detail
+translation_status: canonical
+---
+
+# CRM
+

--- a/docs/site/pages/en/crypto-engineering.md
+++ b/docs/site/pages/en/crypto-engineering.md
@@ -1,0 +1,14 @@
+---
+title: Crypto engineering
+category: developer_reference
+subcategory: inspector
+component: CryptoEngineeringLandingPageBody
+locale: en
+page_title: "Neotoma for crypto & security-sensitive engineering"
+path: /crypto-engineering
+shell: detail
+translation_status: canonical
+---
+
+# Crypto engineering
+

--- a/docs/site/pages/en/customer-ops.md
+++ b/docs/site/pages/en/customer-ops.md
@@ -1,0 +1,14 @@
+---
+title: Customer ops
+category: developer_reference
+subcategory: inspector
+component: CustomerOpsLandingPageBody
+locale: en
+page_title: Neotoma for Customer Ops
+path: /customer-ops
+shell: detail
+translation_status: canonical
+---
+
+# Customer ops
+

--- a/docs/site/pages/en/debugging-infrastructure.md
+++ b/docs/site/pages/en/debugging-infrastructure.md
@@ -1,0 +1,16 @@
+---
+title: Debugging infrastructure
+category: developer_reference
+subcategory: inspector
+component: AiInfrastructureEngineersPageBody
+locale: en
+nav_group: icp
+nav_order: 12
+page_title: Log archaeology
+path: /debugging-infrastructure
+shell: detail
+translation_status: canonical
+---
+
+# Debugging infrastructure
+

--- a/docs/site/pages/en/deterministic-state-evolution.md
+++ b/docs/site/pages/en/deterministic-state-evolution.md
@@ -1,0 +1,71 @@
+---
+title: Agent a writes one value
+category: developer_reference
+subcategory: inspector
+locale: en
+nav_group: guides
+nav_order: 50
+page_title: Deterministic state evolution
+path: /deterministic-state-evolution
+shell: detail
+translation_status: canonical
+---
+
+# Agent a writes one value
+
+Given the same set of observations, the system always produces the same entity state regardless of when
+or in what order they are processed. This removes ordering bugs and makes agent state testable.
+
+## Before vs after
+
+Before: two agents report conflicting values and whichever write arrives last wins. After: both
+observations are preserved and a deterministic merge rule resolves the canonical value reproducibly.
+
+## CLI example
+
+```bash
+# Agent A writes one value
+neotoma store --json='[{"entity_type":"contact","name":"Ana Rivera","city":"Barcelona"}]'
+
+# Agent B writes a conflicting value
+neotoma store --json='[{"entity_type":"contact","name":"Ana Rivera","city":"San Francisco"}]'
+
+# Deterministic reducer computes one canonical snapshot
+neotoma entities search --query "Ana Rivera" --entity-type contact
+```
+
+Late-arriving observations are folded in deterministically. If the merge rule prefers stronger
+provenance or recency, it behaves identically on replay, which is required for
+<MdxI18nLink to="/reproducible-state-reconstruction" className="text-foreground underline hover:text-foreground">
+  reproducible state reconstruction
+</MdxI18nLink>
+.
+
+## Caveat: AI interpretation of unstructured files
+
+Determinism is fully guaranteed for **structured agent writes** &mdash; the entities array your
+agent passes to `store` via MCP, CLI, or REST. The reducer behaves identically across replays.
+
+For **unstructured files** (PDFs, free-text notes, screenshots), Neotoma supports an optional
+AI-based interpretation step. This step is **auditable** &mdash; the model, prompt hash,
+parameters, and config are recorded as an `interpretation` row, and observations link back to
+that interpretation &mdash; but it is **not replay-deterministic** across model versions or
+provider snapshots. The same PDF run through a different model may extract a different field
+value. The audit trail tells you exactly which run produced which field.
+
+If full replay determinism matters for a given pipeline, drive interpretation client-side and
+write the resulting structured entities to Neotoma; the storage path itself is deterministic.
+
+See
+<MdxI18nLink to="/versioned-history" className="text-foreground underline hover:text-foreground">
+  versioned history
+</MdxI18nLink>
+,
+<MdxI18nLink to="/replayable-timeline" className="text-foreground underline hover:text-foreground">
+  replayable timeline
+</MdxI18nLink>
+, and
+<MdxI18nLink to="/architecture" className="text-foreground underline hover:text-foreground">
+  architecture
+</MdxI18nLink>
+.

--- a/docs/site/pages/en/diligence.md
+++ b/docs/site/pages/en/diligence.md
@@ -1,0 +1,8 @@
+---
+path: /diligence
+locale: en
+page_title: Neotoma for Due Diligence
+shell: detail
+translation_status: canonical
+component: DiligenceLandingPageBody
+---

--- a/docs/site/pages/en/direct-human-editability.md
+++ b/docs/site/pages/en/direct-human-editability.md
@@ -1,0 +1,55 @@
+---
+path: /direct-human-editability
+locale: en
+page_title: Direct human editability
+shell: detail
+translation_status: canonical
+nav_group: guides
+nav_order: 62
+---
+
+Direct human editability means a person can open the memory store in a standard editor (VS Code,
+Notepad, vim) and modify it directly. File-based memory systems use plain text formats like Markdown
+or JSON that any tool can read and write without a runtime or API layer.
+
+## Trade-offs
+
+Editable files are maximally accessible but lack structural guarantees. A typo, a malformed JSON key,
+or an accidental deletion can silently corrupt state. There is no built-in
+<MdxI18nLink to="/versioned-history" className="text-foreground underline hover:text-foreground">
+  versioned history
+</MdxI18nLink>
+unless the user maintains it (e.g. via git), and no
+<MdxI18nLink to="/schema-constraints" className="text-foreground underline hover:text-foreground">
+  schema constraints
+</MdxI18nLink>
+to reject invalid edits.
+
+## How Neotoma compares
+
+Neotoma stores data in a structured, schema-validated format. While the underlying storage is not a
+plain text file you open directly, entities are fully accessible and modifiable through the CLI and
+MCP actions. Every modification goes through the observation pipeline, preserving
+<MdxI18nLink to="/auditable-change-log" className="text-foreground underline hover:text-foreground">
+  auditable change logs
+</MdxI18nLink>
+and
+<MdxI18nLink to="/deterministic-state-evolution" className="text-foreground underline hover:text-foreground">
+  deterministic state evolution
+</MdxI18nLink>
+.
+
+```bash
+# Read current state
+neotoma entities get <entity_id>
+
+# Update via a new observation (preserves history)
+neotoma store --json='[{"entity_type":"contact","name":"Ana Rivera","city":"Barcelona"}]'
+```
+
+Platform memory (ChatGPT, Claude) may offer in-app UIs to view or edit memories, but the underlying
+store is not exposed as an editable file. See
+<MdxI18nLink to="/memory-models" className="text-foreground underline hover:text-foreground">
+  memory models
+</MdxI18nLink>
+for the full comparison.

--- a/docs/site/pages/en/false-closure-risk.md
+++ b/docs/site/pages/en/false-closure-risk.md
@@ -1,0 +1,54 @@
+---
+path: /false-closure-risk
+locale: en
+page_title: False closure risk
+shell: detail
+translation_status: canonical
+nav_group: guides
+nav_order: 57
+---
+
+False closure risk is the likelihood that an agent confidently answers from stale or
+superseded context because the system cannot distinguish resolved decisions from open
+questions. The agent retrieves a relevant-looking fact, treats it as current, and delivers
+it with full confidence, even when the decision was revised months ago.
+
+## Before vs after
+
+Before: an ops team asks "What is our contractor access policy?" The agent
+retrieves the Q3 draft discussion, not the November board-approved version, and answers
+confidently. The team acts on an outdated policy. After: Neotoma's versioned
+observations preserve both the draft and the final decision with timestamps and provenance.
+The reducer surfaces the latest resolved state; the agent can trace that the Q3 draft was
+superseded.
+
+```bash
+# View the full observation history for a policy entity
+neotoma observations list --entity-id <policy_entity_id>
+
+# The snapshot reflects the latest resolved state
+neotoma entities search --query "contractor access policy" --entity-type policy
+```
+
+False closure is prevented by the combination of
+<MdxI18nLink to="/versioned-history" className="text-foreground underline hover:text-foreground">
+  versioned history
+</MdxI18nLink>
+,
+<MdxI18nLink to="/auditable-change-log" className="text-foreground underline hover:text-foreground">
+  auditable change logs
+</MdxI18nLink>
+, and
+<MdxI18nLink to="/deterministic-state-evolution" className="text-foreground underline hover:text-foreground">
+  deterministic state evolution
+</MdxI18nLink>
+. Where
+<MdxI18nLink to="/silent-mutation-risk" className="text-foreground underline hover:text-foreground">
+  silent mutation
+</MdxI18nLink>
+describes data changing without a trail, false closure describes stale data being served
+as if it were current. See also
+<MdxI18nLink to="/conflicting-facts-risk" className="text-foreground underline hover:text-foreground">
+  conflicting facts risk
+</MdxI18nLink>
+.

--- a/docs/site/pages/en/faq.md
+++ b/docs/site/pages/en/faq.md
@@ -1,0 +1,174 @@
+---
+title: Frequently asked questions
+category: developer_reference
+subcategory: inspector
+locale: en
+page_title: FAQ
+path: /faq
+shell: detail
+translation_status: canonical
+---
+
+# Frequently asked questions
+
+## What is a deterministic state layer for AI agents? {#what-is-a-deterministic-state-layer-for-ai-agents}
+
+A deterministic state layer guarantees that the same observations always produce the same entity state. Neotoma uses append-only observation logs, hash-based entity IDs, and schema constraints to give agents versioned, reproducible, auditable memory that never silently mutates.
+
+Unlike retrieval memory (Mem0, Zep) or platform memory (Claude, ChatGPT), a deterministic state layer provides formal guarantees: versioned history, replayable timelines, auditable change logs, and reproducible state reconstruction from raw inputs alone.
+
+[Architecture](/architecture)
+
+## How does Neotoma compare to Mem0 and Zep? {#how-does-neotoma-compare-to-mem0-and-zep}
+
+Mem0 and Zep use retrieval-augmented memory: vector embeddings, semantic search, and probabilistic matching. Neotoma uses deterministic state: append-only logs, schema-bound entities, and reducers that always produce the same snapshot from the same observations.
+
+Retrieval memory is useful for context injection into prompts. Deterministic memory is necessary when you need to reconstruct the exact state of an entity at a past point in time, resolve multi-writer conflicts consistently, or prove provenance for audits.
+
+[Memory models comparison](/memory-models)
+
+## What's the difference between RAG memory and deterministic memory? {#what-s-the-difference-between-rag-memory-and-deterministic-memory}
+
+RAG memory stores text chunks and retrieves them by semantic similarity. Deterministic memory stores structured observations and composes entity state via reducers. RAG answers 'what is relevant?'; deterministic memory answers 'what was true?'
+
+RAG is optimized for prompt augmentation. Deterministic memory is optimized for state integrity: temporal queries, multi-writer consistency, schema validation, and reproducible reconstruction.
+
+[Memory models](/memory-models)
+
+## Why can't I just use markdown files for agent memory? {#why-can-t-i-just-use-markdown-files-for-agent-memory}
+
+Markdown files are maximally portable and human-editable, but they conflate observations with snapshots. When two agents write conflicting values, both edits land silently. There is no schema validation, no conflict detection, and no way to reconstruct entity state at a past moment. Git provides file-level versioning but not field-level provenance or deterministic merge logic.
+
+[Neotoma vs file-based memory](/neotoma-vs-files)
+
+## How does Neotoma compare to tools that offer Git-like version control for agent memory? {#how-does-neotoma-compare-to-tools-that-offer-git-like-version-control-for-agent-memory}
+
+Those products usually version a shared context tree, rules pack, or prompt bundle so teams can sync what coding agents read. Neotoma is a structured state layer: append-only observations, schema-bound entities, reducers, and field-level provenance, with replay and diff on entity state across MCP-connected tools—not Git operations on a single vendor context package.
+
+Git-style workflows address collaboration and drift for agent-facing files. Neotoma answers a different core question: what was true at time T, from which source, and how did state change? The two can complement (synced context plus Neotoma as system of record) or substitute when you need cross-tool structured memory beyond one codebase context.
+
+[Memory guarantees](/memory-guarantees)
+
+## Why can't I just use SQLite or Postgres for agent memory? {#why-can-t-i-just-use-sqlite-or-postgres-for-agent-memory}
+
+A relational database provides strong consistency and column types, but standard CRUD (UPDATE in place) overwrites previous state. Without an observation log, reducers, and provenance tracking layered on top, you get last-write-wins semantics with no audit trail, no conflict detection, and no ability to reconstruct historical entity state. Neotoma uses a database as its storage backend but adds the architecture that delivers memory guarantees.
+
+[Neotoma vs database memory](/neotoma-vs-database)
+
+## I'm already building my own memory system. Why would I use Neotoma? {#i-m-already-building-my-own-memory-system-why-would-i-use-neotoma}
+
+That is the normal starting point. Most developers begin with SQLite, JSON, markdown, or a custom MCP server, then discover they still need versioning, conflict detection, schema evolution, replayable history, and cross-tool consistency. Neotoma ships those guarantees as the state layer so you do not have to keep rebuilding them around every new agent workflow.
+
+The point is not that your current setup is wrong. It is that once agents write across sessions and tools, the missing guarantees become infrastructure work. Neotoma gives you the append-only history, reducer model, provenance, and deterministic state reconstruction that homemade memory stacks usually grow toward.
+
+[Memory guarantees](/memory-guarantees)
+
+## What does Neotoma add on top of a database? {#what-does-neotoma-add-on-top-of-a-database}
+
+Neotoma adds an append-only observation log, deterministic reducers, a schema registry with write-time validation, field-level provenance tracking, content-addressed entity identity, and idempotent observation handling. The database stores the data; these architectural patterns deliver the guarantees.
+
+[Architecture](/architecture)
+
+## Should I use Neotoma alongside Claude Code's built-in memory? {#should-i-use-neotoma-alongside-claude-code-s-built-in-memory}
+
+Yes - they are complementary. Claude Code's auto-memory stores conversational preferences and project-specific notes within that platform. Neotoma stores durable structured state - contacts, tasks, decisions, financial data - with versioning, entity resolution, and cross-tool access via MCP. Platform memory is scoped to one tool; Neotoma persists across all your AI tools and survives session resets.
+
+Think of platform memory as short-term context ("I prefer TypeScript") and Neotoma as long-term structured state ("Clayton owes us $5,000 since March 15, last contacted via the Q1 deal thread"). Both run simultaneously without conflict.
+
+[Neotoma with Claude Code](/neotoma-with-claude-code)
+
+## If Neotoma relies on LLMs to decide what to store, how is it deterministic? {#if-neotoma-relies-on-llms-to-decide-what-to-store-how-is-it-deterministic}
+
+Neotoma's determinism is a property of the data layer, not the agent layer. The LLM deciding which tool to call and what payload to send is stochastic - two runs may produce different observations. But everything below that boundary is deterministic: the same observations always produce the same entity snapshot, the same merge rules always resolve the same way, and the same inputs always generate the same IDs.
+
+The architecture targets bounded convergence rather than strict replay determinism. Canonicalization collapses syntactically different but semantically equivalent LLM outputs to the same observation hash. Immutability ensures stochastic variance accumulates as history rather than corrupting truth. Reducers arbitrate conflicts deterministically regardless of write order. And entity merge repairs duplicates created by divergent agent runs. The result: the system converges toward a consistent entity graph over time, even when individual agent decisions vary.
+
+[Architecture](/architecture)
+
+## How does ingestion work - does Neotoma extract data automatically? {#how-does-ingestion-work-does-neotoma-extract-data-automatically}
+
+Neotoma is a store, not an extractor. Your agent decides what to observe, fills the parameters, and Neotoma versions it. There is no background scanning, no regex extraction, and no passive data collection. The agent drives every write.
+
+This is a deliberate design choice: the agent has the context to know what matters. Neotoma provides the structured, versioned storage layer. The agent calls store with entities and observations; Neotoma handles entity resolution, schema validation, snapshot computation, and provenance tracking.
+
+[Architecture](/architecture)
+
+## What happens to information that doesn't fit a schema? {#what-happens-to-information-that-doesn-t-fit-a-schema}
+
+Nothing is silently dropped. You do not need to define a schema before storing. Your agent can store any entity with a descriptive type and whatever fields the data implies; Neotoma infers and evolves schemas automatically. Fields that the active schema does not yet recognize land in a raw_fragments layer so the raw value is preserved alongside the validated snapshot.
+
+Schemas are versioned and additive by default. The first time your agent stores a `workout` or a `lease_payment` or anything else, Neotoma registers a schema from the data and bumps a minor version. Adding fields later triggers another minor version (e.g. 1.0.0 → 1.1.0); breaking changes like removing or retyping a field require a major version bump (1.x → 2.0). Old observations keep their original version and remain readable. As patterns mature, raw_fragments are promoted into the validated schema automatically. See the schemas overview and versioning guides for the mechanics.
+
+[Schema versioning & evolution](/schemas/versioning)
+
+## Can I try Neotoma without replacing my current memory system? {#can-i-try-neotoma-without-replacing-my-current-memory-system}
+
+Yes. Neotoma installs alongside whatever you already use (MEMORY.md, claw.md, a custom MCP server, platform memory). Nothing in your current stack is moved, modified, or replaced. You can ingest historical session logs, conversations, or notes into a fresh Neotoma database, run an agent with Neotoma enabled on the side, and compare its answers to an agent without it — then commit or walk away.
+
+The "Test safely" guide walks through the recommended shadow-install path: install, ingest history, A/B compare, then decide. Your existing memory system stays intact the whole time. If you decide Neotoma is not for you, uninstalling leaves your prior setup exactly as it was.
+
+[Test safely](/non-destructive-testing)
+
+## What should my agent remember? How do I get started? {#what-should-my-agent-remember-how-do-i-get-started}
+
+Start with what your agent already produces: conversations, contacts mentioned in chat, tasks and commitments ("I need to", "remind me"), and decisions. These store automatically with zero configuration once the agent rules are active. Within the first week, add financial data, calendar events, and project context as your personal OS grows.
+
+Priority 1 (day one): conversations, contacts, tasks, decisions - lowest friction, highest compound value. Priority 2 (first week): financial data, calendar, email, health. Priority 3 (as the OS matures): content pipeline, project context, agent session state. The heuristic: if it benefits from recall, audit, replay, or linking to other entities, store it.
+
+[Documentation](/docs)
+
+## Is Neotoma a note-taking app or thought-partner tool? {#is-neotoma-a-note-taking-app-or-thought-partner-tool}
+
+No. Neotoma is a deterministic state layer — infrastructure for agents that accumulate structured state across sessions and tools. It is not a note-taking app, journaling tool, or conversational thought-partner. If your workflow is one-off brainstorming or freeform note capture, a tool built for that (Obsidian, Notion, Apple Notes) is a better fit.
+
+Neotoma stores structured entities with schema validation, versioned history, and cross-tool consistency. That architecture is overhead for casual note-taking but essential when agents need reproducible, auditable state that compounds over time.
+
+[Architecture](/architecture)
+
+## How do I install Neotoma? {#how-do-i-install-neotoma}
+
+Run `npm install -g neotoma`, then `neotoma setup --tool cursor --yes` to initialize Neotoma and configure the default local MCP path. Swap `cursor` for your tool if needed. Start the API server only if you need Inspector, OAuth, or the local HTTP API. The full process takes under 5 minutes.
+
+[Install guide](/install)
+
+## Does Neotoma send my data to the cloud? {#does-neotoma-send-my-data-to-the-cloud}
+
+No. Neotoma runs locally by default. Your data stays on your machine in a local SQLite database. There is no cloud sync, no telemetry, and no training on your data. You can optionally expose the API via a tunnel for remote MCP clients.
+
+[Privacy-first architecture](/foundations)
+
+## What AI tools does Neotoma work with? {#what-ai-tools-does-neotoma-work-with}
+
+Neotoma works with any MCP-compatible AI tool: Cursor, Claude (Desktop and claude.ai), Claude Code, ChatGPT, Codex, OpenCode, OpenClaw, and IronClaw. It also provides a REST API and CLI for direct programmatic access.
+
+[Integration guides](/docs)
+
+## Is Neotoma free and open source? {#is-neotoma-free-and-open-source}
+
+Yes. Neotoma is MIT-licensed and fully open source. The npm package, CLI, API server, and MCP server are all free. The source code is on GitHub.
+
+## What are Neotoma's memory guarantees? {#what-are-neotoma-s-memory-guarantees}
+
+Neotoma enforces a set of memory guarantees that cover deterministic state evolution, versioned history, replayable timeline, auditable change log, schema constraints, silent mutation prevention, conflicting facts detection, false closure prevention, reproducible state reconstruction, human inspectability, zero-setup onboarding, semantic similarity search, and direct human editability.
+
+[Memory guarantees](/memory-guarantees)
+
+## Does the memory degrade or drift over time? {#does-the-memory-degrade-or-drift-over-time}
+
+No. Neotoma uses an append-only observation log with deterministic reducers. Nothing is overwritten or silently dropped. Facts stored six months ago are as retrievable and verifiable as facts stored today — with full version history and provenance intact. The memory compounds; it never decays.
+
+Platform memory (ChatGPT, Claude) can silently forget or overwrite facts over time. Retrieval systems lose relevance as embeddings age. File-based stores accumulate silent conflicts. Neotoma's architecture prevents all three failure modes: observations are immutable, snapshots are deterministically recomputed, and provenance traces every value to its source regardless of age.
+
+[Memory guarantees](/memory-guarantees)
+
+## What is an entity in Neotoma? {#what-is-an-entity-in-neotoma}
+
+An entity is the canonical representation of a person, company, task, event, or other object. Each entity has a deterministic ID derived from its type and identifying fields, so the same real-world thing always resolves to the same entity.
+
+[Terminology](/terminology)
+
+## What is an observation in Neotoma? {#what-is-an-observation-in-neotoma}
+
+An observation is an immutable, timestamped fact about an entity. Observations are never modified or deleted. Reducers merge all observations about an entity into a single snapshot representing current truth.
+
+[Terminology](/terminology)

--- a/docs/site/pages/en/financial-ops.md
+++ b/docs/site/pages/en/financial-ops.md
@@ -1,0 +1,14 @@
+---
+title: Financial ops
+category: developer_reference
+subcategory: inspector
+component: FinancialOpsLandingPageBody
+locale: en
+page_title: Neotoma for Financial Ops
+path: /financial-ops
+shell: detail
+translation_status: canonical
+---
+
+# Financial ops
+

--- a/docs/site/pages/en/foundation-problem-statement.md
+++ b/docs/site/pages/en/foundation-problem-statement.md
@@ -1,0 +1,24 @@
+---
+title: Foundation problem statement
+category: developer_reference
+subcategory: inspector
+locale: en
+nav_group: foundations
+nav_order: 10
+page_title: Problem statement
+path: /foundation/problem-statement
+shell: detail
+translation_status: canonical
+---
+
+# Foundation problem statement
+
+## Why Neotoma exists
+
+Personal data stays fragmented across email, downloads, chats, cloud drives, exports, and AI threads. Provider memory stays conversation-shaped and platform-locked, so it cannot unify documents, resolve entities across sources, or rebuild timelines with deterministic provenance.
+
+Neotoma is the **state layer** for structured personal data: schema-first writes, hash-based entity IDs, immutable observations, explicit provenance, and cross-tool access via MCP and the HTTP API. Agents and apps share one substrate instead of each reinventing extraction, merges, and audit trails.
+
+The canonical long-form narrative lives in the repository under `docs/foundation/problem_statement.md` (Neotoma checkout). This page is the short public surface aligned with that doc.
+
+**Next:** <MdxI18nLink to="/architecture">Architecture</MdxI18nLink>, <MdxI18nLink to="/memory-guarantees">Memory guarantees</MdxI18nLink>, <MdxI18nLink to="/walkthrough">Walkthrough</MdxI18nLink>.

--- a/docs/site/pages/en/government.md
+++ b/docs/site/pages/en/government.md
@@ -1,0 +1,8 @@
+---
+path: /government
+locale: en
+page_title: Neotoma for Public Sector
+shell: detail
+translation_status: canonical
+component: GovTechLandingPageBody
+---

--- a/docs/site/pages/en/healthcare.md
+++ b/docs/site/pages/en/healthcare.md
@@ -1,0 +1,8 @@
+---
+path: /healthcare
+locale: en
+page_title: Neotoma for Healthcare
+shell: detail
+translation_status: canonical
+component: HealthcareLandingPageBody
+---

--- a/docs/site/pages/en/home.md
+++ b/docs/site/pages/en/home.md
@@ -1,0 +1,10 @@
+---
+path: /
+locale: en
+page_title: Neotoma
+shell: detail
+translation_status: canonical
+component: SitePage
+nav_group: marketing
+nav_order: 0
+---

--- a/docs/site/pages/en/hosted.md
+++ b/docs/site/pages/en/hosted.md
@@ -1,0 +1,8 @@
+---
+path: /hosted
+locale: en
+page_title: Hosted Neotoma
+shell: detail
+translation_status: canonical
+component: HostedLandingPageBody
+---

--- a/docs/site/pages/en/human-inspectability.md
+++ b/docs/site/pages/en/human-inspectability.md
@@ -1,0 +1,37 @@
+---
+path: /human-inspectability
+locale: en
+page_title: Human inspectability
+shell: detail
+translation_status: canonical
+nav_group: guides
+nav_order: 59
+---
+
+Human inspectability means a person can diff two versions, inspect lineage, and trace each fact to its
+source. Trust comes from verification, not hidden model behavior.
+
+## Before vs after
+
+Before: a value changes and operators only see "current state." After: operators can inspect field-level
+diffs and provenance to validate or correct the update.
+
+```bash
+# Inspect snapshot lineage
+neotoma entities get <entity_id>
+neotoma observations list --entity-id <entity_id>
+```
+
+Inspectability depends on
+<MdxI18nLink to="/versioned-history" className="text-foreground underline hover:text-foreground">
+  versioned history
+</MdxI18nLink>
+,
+<MdxI18nLink to="/auditable-change-log" className="text-foreground underline hover:text-foreground">
+  auditable change log
+</MdxI18nLink>
+, and
+<MdxI18nLink to="/replayable-timeline" className="text-foreground underline hover:text-foreground">
+  replayable timeline
+</MdxI18nLink>
+.

--- a/docs/site/pages/en/install-docker.md
+++ b/docs/site/pages/en/install-docker.md
@@ -1,0 +1,10 @@
+---
+path: /install/docker
+locale: en
+page_title: Docker install
+shell: detail
+translation_status: canonical
+component: InstallDockerPageBody
+nav_group: guides
+nav_order: 7
+---

--- a/docs/site/pages/en/install-manual.md
+++ b/docs/site/pages/en/install-manual.md
@@ -1,0 +1,16 @@
+---
+title: Install manual
+category: developer_reference
+subcategory: inspector
+component: InstallManualPageBody
+locale: en
+nav_group: guides
+nav_order: 6
+page_title: Manual install
+path: /install/manual
+shell: detail
+translation_status: canonical
+---
+
+# Install manual
+

--- a/docs/site/pages/en/install.md
+++ b/docs/site/pages/en/install.md
@@ -1,0 +1,10 @@
+---
+path: /install
+locale: en
+page_title: Install
+shell: detail
+translation_status: canonical
+component: InstallPageBody
+nav_group: guides
+nav_order: 5
+---

--- a/docs/site/pages/en/integrations.md
+++ b/docs/site/pages/en/integrations.md
@@ -1,0 +1,72 @@
+---
+path: /integrations
+locale: en
+page_title: Integrations
+shell: detail
+translation_status: canonical
+nav_group: reference
+nav_order: 13
+---
+
+# Integrations
+
+Neotoma is cross-platform by design. One memory graph across every agent host you use — no platform lock-in, no separate state per tool.
+
+This page is the single index of every host, harness, and framework Neotoma integrates with today, and the status of each.
+
+## Supported via MCP
+
+MCP is the primary integration protocol. Every host below speaks MCP over local stdio, remote HTTP, or both.
+
+| Host | Modes | Install | Setup guide |
+| --- | --- | --- | --- |
+| Cursor | stdio, remote HTTP | `neotoma setup --tool cursor --yes` | [neotoma-with-cursor](/neotoma-with-cursor) |
+| Claude Code | stdio, remote HTTP | `neotoma setup --tool claude-code --yes` | [neotoma-with-claude-code](/neotoma-with-claude-code) |
+| Claude Desktop | local, remote MCP | `neotoma setup --tool claude-desktop --yes` | [desktop](/neotoma-with-claude-connect-desktop) · [remote MCP](/neotoma-with-claude-connect-remote-mcp) |
+| ChatGPT | MCP App, Custom GPT Actions | Manual HTTPS + OAuth | [neotoma-with-chatgpt](/neotoma-with-chatgpt) · [remote MCP](/neotoma-with-chatgpt-connect-remote-mcp) · [custom GPT](/neotoma-with-chatgpt-connect-custom-gpt) |
+| Codex CLI | stdio, remote HTTP (OAuth) | `neotoma setup --tool codex --yes` | [neotoma-with-codex](/neotoma-with-codex) · [stdio](/neotoma-with-codex-connect-local-stdio) · [remote HTTP](/neotoma-with-codex-connect-remote-http-oauth) |
+| OpenClaw | Native plugin + MCP | `neotoma setup --tool openclaw --yes` | [neotoma-with-openclaw](/neotoma-with-openclaw) · [stdio](/neotoma-with-openclaw-connect-local-stdio) · [remote HTTP](/neotoma-with-openclaw-connect-remote-http) |
+| IronClaw | MCP | `neotoma setup --tool ironclaw --yes` | [neotoma-with-ironclaw](/neotoma-with-ironclaw) |
+| Windsurf | MCP | `neotoma setup --tool windsurf --yes` | [neotoma-with-windsurf](/neotoma-with-windsurf) |
+| Continue | MCP | `neotoma setup --tool continue --yes` | [neotoma-with-continue](/neotoma-with-continue) |
+| VS Code (Copilot Chat) | MCP | `neotoma setup --tool vscode --yes` | [neotoma-with-vscode](/neotoma-with-vscode) |
+| Letta | MCP (streamable HTTP, SSE, stdio) | Manual SDK setup | [neotoma-with-letta](/neotoma-with-letta) |
+
+## Supported via hooks
+
+Hooks integrate with harnesses that expose lifecycle events. They provide guaranteed capture, retrieval injection, and persistence safety nets — the reliability floor that composes with MCP's quality ceiling.
+
+| Harness | Setup guide |
+| --- | --- |
+| Claude Code | [neotoma-with-claude-code](/neotoma-with-claude-code) |
+| Cursor | [neotoma-with-cursor](/neotoma-with-cursor) |
+| OpenCode | [neotoma-with-opencode](/neotoma-with-opencode) |
+| Codex CLI | [neotoma-with-codex](/neotoma-with-codex) |
+| Claude Agent SDK | [neotoma-with-claude-agent-sdk](/neotoma-with-claude-agent-sdk) |
+
+## Client libraries
+
+Embed Neotoma directly in your application:
+
+| Language | Package |
+| --- | --- |
+| TypeScript | `@neotoma/client` |
+| Python | `neotoma-client` |
+
+## Not yet supported
+
+These hosts are commonly requested. They are not yet supported. The "What it would take" column is descriptive, not committal — open a feature request if you want one prioritized.
+
+| Host / framework | What it would take |
+| --- | --- |
+| LangGraph | A Python adapter on top of the Neotoma Python client, exposing `store` and `retrieve_*` as LangGraph memory nodes. |
+| CrewAI | A Python adapter that exposes Neotoma actions as CrewAI tools, similar in shape to the OpenClaw native plugin. |
+| Hermes | Confirm the specific framework being referenced (the name is overloaded) before scoping. |
+
+**Want one of these prioritized?** Open an issue at [github.com/Lemonbrand/neotoma-feedback](https://github.com/Lemonbrand/neotoma-feedback) describing your use case.
+
+## Related
+
+- [MCP reference](/mcp) — protocol details and transport modes
+- [CLI reference](/cli) — `neotoma setup`, `neotoma mcp config`
+- [Install](/install) — get started

--- a/docs/site/pages/en/issue-reporting.md
+++ b/docs/site/pages/en/issue-reporting.md
@@ -1,0 +1,138 @@
+---
+title: Issue reporting
+category: developer_reference
+subcategory: inspector
+locale: en
+nav_group: reference
+nav_order: 62
+page_title: Issue reporting
+path: /issue-reporting
+shell: detail
+translation_status: canonical
+---
+
+# Issue reporting
+
+The issues subsystem is the primary feedback channel for iterative Neotoma improvement based on agentic usage. v0.12.0 hardens the reporter provenance contract, formalizes operator-mirror flows, and adds bulk operator tools for triage.
+
+Use the issues surface when:
+
+<ul className="list-none pl-0 space-y-2 mb-6">
+  <li className="text-[15px] leading-7 text-muted-foreground">
+    An agent hits friction during a Neotoma operation (failing tool call, opaque error, missing surface, doc gap) and the harness <code>issues.reporting_mode</code> allows filing.
+  </li>
+  <li className="text-[15px] leading-7 text-muted-foreground">
+    A per-turn self-audit produces a file-worthy finding (schema-projection drift, ambiguous identity rule, recurring product weakness) and the agent should file or escalate.
+  </li>
+  <li className="text-[15px] leading-7 text-muted-foreground">
+    A human operator wants to triage many issues at once (close, soft-remove) from the Inspector or scripts.
+  </li>
+</ul>
+
+## MCP tools
+
+- `submit_issue({ title, body, labels?, visibility?, reporter_git_sha?, reporter_git_ref?, reporter_channel?, reporter_app_version?, reporter_ci_run_id?, reporter_patch_source_id? })` — creates a local `issue` entity and optional GitHub / operator mirror per `visibility`. **Required (v0.12+):** at least one of `reporter_git_sha` or `reporter_app_version`. Rejection envelope returns `error_code: "ERR_REPORTER_ENVIRONMENT_REQUIRED"` plus `details.acceptable_field_groups: [["reporter_git_sha"], ["reporter_app_version"]]` so callers can retry with the right alternative.
+- `add_issue_message({ entity_id, body, guest_access_token? })` — appends a thread message. On public threads, missing both `reporter_git_sha` and `reporter_app_version` emits a server-side warning (the message still persists).
+- `get_issue_status({ entity_id, skip_sync?, guest_access_token? })` — snapshot + messages, with operator read-through and GitHub refresh when mirrored.
+- `sync_issues({ since?, state?, labels? })` — bulk pull from GitHub into the local instance.
+- `bulk_close_issues({ entity_ids: string[], reason? })` — closes multiple `issue` entities in one call.
+- `bulk_remove_issues({ entity_ids: string[], reason? })` — soft-deletes multiple `issue` entities via `deleteEntity` observations; restore through `restore_entity`.
+
+## HTTP routes
+
+- `POST /issues/submit` — `submitIssue` (MCP `submit_issue` parity).
+- `POST /issues/add_message` — `addIssueMessage` (MCP `add_issue_message` parity).
+- `POST /issues/status` — `getIssueStatus`.
+- `POST /issues/sync` — `syncIssuesFromGitHub`.
+- `POST /issues/bulk_close` — `bulkCloseIssues`.
+- `POST /issues/bulk_remove` — `bulkRemoveIssues`.
+
+Each `/issues/*` route is also mounted under `/api/issues/*` for same-origin proxies.
+
+## Reporter provenance contract
+
+`submit_issue` (and the `add_issue_message` soft-warn path) require enough environment to reconstruct what an agent saw at filing time. The required fields:
+
+<TableScrollWrapper className={DOC_TABLE_SCROLL_OUTER_CLASS}>
+  <table className="w-full text-[14px] leading-6 border-collapse md:rounded-lg md:overflow-hidden md:border md:border-border">
+    <thead>
+      <tr className="border-b border-border">
+        <th className="px-4 py-3 text-left font-semibold text-foreground bg-muted">Field</th>
+        <th className="px-4 py-3 text-left font-semibold text-foreground bg-muted">Meaning</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr className="border-b border-border hover:bg-muted/50 transition-colors">
+        <td className="px-4 py-3 align-top"><code>reporter_git_sha</code></td>
+        <td className="px-4 py-3 align-top text-muted-foreground">Commit SHA of the Neotoma source the agent was running. Required when <code>reporter_app_version</code> is absent.</td>
+      </tr>
+      <tr className="border-b border-border hover:bg-muted/50 transition-colors">
+        <td className="px-4 py-3 align-top"><code>reporter_app_version</code></td>
+        <td className="px-4 py-3 align-top text-muted-foreground">Published <code>neotoma</code> package version. Required when <code>reporter_git_sha</code> is absent.</td>
+      </tr>
+      <tr className="border-b border-border hover:bg-muted/50 transition-colors">
+        <td className="px-4 py-3 align-top"><code>reporter_git_ref</code></td>
+        <td className="px-4 py-3 align-top text-muted-foreground">Optional branch / tag the agent was on.</td>
+      </tr>
+      <tr className="border-b border-border hover:bg-muted/50 transition-colors">
+        <td className="px-4 py-3 align-top"><code>reporter_channel</code></td>
+        <td className="px-4 py-3 align-top text-muted-foreground">Optional channel (<code>stable</code>, <code>next</code>, etc.).</td>
+      </tr>
+      <tr className="border-b border-border hover:bg-muted/50 transition-colors">
+        <td className="px-4 py-3 align-top"><code>reporter_ci_run_id</code></td>
+        <td className="px-4 py-3 align-top text-muted-foreground">Optional CI run id for automated reproduction.</td>
+      </tr>
+      <tr className="hover:bg-muted/50 transition-colors">
+        <td className="px-4 py-3 align-top"><code>reporter_patch_source_id</code></td>
+        <td className="px-4 py-3 align-top text-muted-foreground">Optional pointer at a local patch source the agent was running.</td>
+      </tr>
+    </tbody>
+  </table>
+</TableScrollWrapper>
+
+
+  <strong className="text-foreground">Breaking change in v0.12.0:</strong> Pre-v0.12 <code>submit_issue</code> calls without any of <code>reporter_git_sha</code> / <code>reporter_app_version</code> were accepted. They now reject with <code>ERR_REPORTER_ENVIRONMENT_REQUIRED</code>. See the contract fixture at <code>tests/contract/legacy_payloads/v0.12.x/issues_submit_without_reporter_env</code>.
+
+
+## Reporting modes
+
+`issues.reporting_mode` (overridable via `NEOTOMA_ISSUES_REPORTING_MODE`) gates whether an agent files autonomously:
+
+- **`consent` (default)** — obtain explicit user approval before each `submit_issue`.
+- **`proactive`** — file immediately without asking.
+- **`off`** — only file when the user explicitly requests it.
+
+Persisted via `neotoma issues config --mode <choice>`.
+
+## GitHub mirror + guest token flow
+
+When `visibility: "public"` and an `issues.target_url` is configured, `submit_issue` writes the local row first and then mirrors to the configured operator instance. The response may include a `guest_access_token` scoped to the issue thread so subsequent `add_issue_message` / `get_issue_status` calls can read through to the operator copy without re-authenticating. The token persists on the local issue snapshot and is treated as a credential.
+
+Sensitive content is redacted client-side before mirroring: emails, phone numbers, API tokens, UUIDs, and home-directory path fragments are replaced with `<LABEL:hash>` placeholders so the public GitHub mirror stays safe.
+
+## Example
+
+File a public issue from an agent run:
+
+```bash
+neotoma issues create \
+  --title "store rejects flat conversation rows" \
+  --body "Repro: store with entity_type: conversation, no target_id…" \
+  --visibility public \
+  --labels mcp,store
+```
+
+Triage a batch of duplicates via the Inspector or scripts:
+
+```bash
+curl -X POST http://localhost:3080/issues/bulk_close \
+  -H "Authorization: Bearer $NEOTOMA_BEARER_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"entity_ids":["ent_…1","ent_…2","ent_…3"],"reason":"duplicate of #42"}'
+```
+
+## Full reference
+
+[`docs/subsystems/issues.md`](https://github.com/markmhendrickson/neotoma/blob/main/docs/subsystems/issues.md) covers the reporter-provenance contract end to end, the `sync_issues_from_github.ts` and `submit_issue.ts` services, the redaction backstop in the entity-submission flow, and the recommended `process-issues` operator skill.
+
+See [security hardening](/security-hardening), [API reference](/api), and [MCP reference](/mcp).

--- a/docs/site/pages/en/logistics.md
+++ b/docs/site/pages/en/logistics.md
@@ -1,0 +1,8 @@
+---
+path: /logistics
+locale: en
+page_title: Neotoma for Logistics
+shell: detail
+translation_status: canonical
+component: LogisticsLandingPageBody
+---

--- a/docs/site/pages/en/mcp.md
+++ b/docs/site/pages/en/mcp.md
@@ -1,0 +1,187 @@
+---
+title: MCP
+category: developer_reference
+subcategory: inspector
+locale: en
+nav_group: reference
+nav_order: 12
+page_title: MCP
+path: /mcp
+shell: detail
+translation_status: canonical
+---
+
+# MCP
+
+McpCommonActionPatternsSnippet,
+  McpHttpConfigSnippet,
+  McpReferenceActionsTable,
+  McpReferenceIntro,
+  McpStdioConfigSnippet,
+} from "@/components/mdx/doc_reference_tables";
+
+
+
+
+  Looking for a specific tool? See <MdxI18nLink to="/integrations" className="text-foreground underline underline-offset-2 hover:no-underline"><strong>Integrations</strong></MdxI18nLink> for the full matrix of supported hosts, harnesses, and frameworks.
+
+
+## Transport modes
+
+<ul className="list-none pl-0 space-y-2 mb-6">
+  <li className="text-[15px] leading-7 text-muted-foreground">
+    <strong className="text-foreground">stdio</strong> — local process, recommended for Cursor / Claude Code / Codex. The MCP client launches the Neotoma process directly.
+  </li>
+  <li className="text-[15px] leading-7 text-muted-foreground">
+    <strong className="text-foreground">HTTP (SSE)</strong> — remote or{" "}
+    <MdxI18nLink to="/tunnel" className="text-foreground underline underline-offset-2 hover:no-underline">
+      tunnel
+    </MdxI18nLink>{" "}
+    access via <code>http://localhost:3080/mcp</code> (dev) or <code>http://localhost:3180/mcp</code> (prod). Use with <code>--tunnel</code> for HTTPS via ngrok or Cloudflare.
+  </li>
+  <li className="text-[15px] leading-7 text-muted-foreground">
+    <strong className="text-foreground">WebSocket</strong> — bridge mode for clients that require WebSocket transport.
+  </li>
+</ul>
+
+## Client configuration
+
+
+  <strong>Cursor</strong> (<code>.cursor/mcp.json</code>):
+
+
+
+
+
+  <strong>Claude Code</strong> (<code>claude_desktop_config.json</code>) and <strong>Windsurf</strong> (<code>mcp_config.json</code>) use the same structure. Run <code>neotoma mcp config</code> to scan for config files and auto-install missing entries. Add <code>--user-level</code> to include user-level paths.
+
+
+
+  <strong>
+    HTTP /{" "}
+    <MdxI18nLink to="/tunnel" className="text-foreground underline underline-offset-2 hover:no-underline">
+      tunnel
+    </MdxI18nLink>
+  </strong>{" "}
+  (remote access):
+
+
+
+
+## Authentication
+
+
+  All MCP actions operate under an authenticated user context. Authentication is handled via OAuth (recommended) or Bearer token. The <code>user_id</code> parameter is optional and inferred from the auth context. Run <code>neotoma auth login</code> for OAuth setup, or set <code>NEOTOMA_BEARER_TOKEN</code> for token-based auth.
+
+
+
+  For agent identity (separate from human user auth), MCP supports <strong>AAuth</strong> (RFC 9421 HTTP Message Signatures plus an <code>aa-agent+jwt</code> token on the <code>initialize</code> handshake). Verified agents render with a <code>hardware</code> or <code>software</code> trust badge in the Inspector. When AAuth is not present, <code>clientInfo.name</code> / <code>clientInfo.version</code> on the MCP <code>initialize</code> handshake serve as a fallback identifier (rendered as <code>unverified_client</code>). See the{" "}
+  <MdxI18nLink to="/aauth" className="text-foreground underline underline-offset-2 hover:no-underline">
+    AAuth reference
+  </MdxI18nLink>{" "}
+  for the full attribution contract.
+
+
+## Common action patterns
+
+
+
+## Schema management workflow
+
+
+  Schemas evolve automatically. Fields not in the current schema are stored in <code>raw_fragments</code>. High-confidence fields are auto-promoted. Manual workflow:
+
+
+<ol className="list-decimal pl-5 space-y-1 mb-6">
+  <li className="text-[15px] leading-7 text-muted-foreground">
+    <code>list_entity_types(keyword=&quot;invoice&quot;)</code> — discover existing schemas
+  </li>
+  <li className="text-[15px] leading-7 text-muted-foreground">
+    <code>analyze_schema_candidates(entity_type=&quot;invoice&quot;)</code> — see what fields are candidates
+  </li>
+  <li className="text-[15px] leading-7 text-muted-foreground">
+    <code>update_schema_incremental(entity_type=&quot;invoice&quot;, new_fields=[...])</code> — promote fields
+  </li>
+</ol>
+
+
+
+## Relationship types
+
+
+  Supported relationship types for <code>create_relationship</code>: <code>PART_OF</code>, <code>CORRECTS</code>, <code>REFERS_TO</code>, <code>SETTLES</code>, <code>DUPLICATE_OF</code>, <code>DEPENDS_ON</code>, <code>SUPERSEDES</code>, <code>EMBEDS</code>. Use <code>EMBEDS</code> when a container (blog post, document) embeds an asset (image, attachment): source = container, target = asset.
+
+
+## What the server exposes at its root
+
+
+  A running Neotoma binds a handful of unauthenticated discovery and health endpoints at the host root alongside the MCP transport itself. These exist so agents, proxies, and operators can identify and probe the deployment without credentials.
+
+
+<ul className="list-disc pl-5 space-y-1 mb-3 text-[15px] leading-7 text-muted-foreground">
+  <li>
+    <code>GET /</code> — root landing. Content-negotiated: browsers get an HTML page with identity, harness-connect snippets (pre-filled with the actual host URL), and an index of{" "}
+    <MdxI18nLink to="/docs" className="text-foreground underline underline-offset-2 hover:no-underline">
+      neotoma.io
+    </MdxI18nLink>{" "}
+    documentation; send <code>Accept: application/json</code> for the same content as JSON, or <code>Accept: text/markdown</code> for a Markdown document. Default (no HTML/Markdown) is JSON. The content adapts to deployment mode: <em>sandbox</em>, <em>personal</em> tunnel, <em>prod</em>, or <em>local</em>.
+  </li>
+  <li>
+    <code>GET /robots.txt</code> — mirrors the deployment mode. Sandbox and local instances disallow crawling; personal and prod allow it and can link an external sitemap via <code>NEOTOMA_PUBLIC_DOCS_URL</code>.
+  </li>
+  <li>
+    <code>GET /.well-known/mcp/server-card.json</code> — MCP server card (name, version, capabilities).
+  </li>
+  <li>
+    <code>GET /.well-known/oauth-authorization-server</code> and <code>/.well-known/oauth-protected-resource</code> — OAuth discovery documents.
+  </li>
+  <li>
+    <code>GET /server-info</code> — runtime details (version, git sha, build timestamp).
+  </li>
+  <li>
+    <code>GET /health</code> — liveness probe.
+  </li>
+  <li>
+    <code>GET /favicon.ico</code> — site icon for browser tabs.
+  </li>
+  <li>
+    In sandbox mode: <code>GET /sandbox/terms</code> (acceptable-use JSON), <code>POST /sandbox/report</code>, and <code>GET /sandbox/report/status</code>.
+  </li>
+</ul>
+
+
+  See{" "}
+  <MdxI18nLink to="/connect" className="text-foreground underline underline-offset-2 hover:no-underline">
+    Connect remotely
+  </MdxI18nLink>{" "}
+  for per-harness snippets, and{" "}
+  <MdxI18nLink to="/hosted" className="text-foreground underline underline-offset-2 hover:no-underline">
+    Hosted Neotoma
+  </MdxI18nLink>{" "}
+  for the mode comparison.
+
+
+## Entity types
+
+
+  Common types agents can set directly: <code>contact</code>, <code>person</code>, <code>company</code>, <code>task</code>, <code>invoice</code>, <code>transaction</code>, <code>receipt</code>, <code>note</code>, <code>contract</code>, <code>event</code>, <code>conversation</code>, <code>agent_message</code>. Codebase types: <code>feature_unit</code>, <code>release</code>, <code>agent_decision</code>, <code>agent_session</code>, <code>validation_result</code>, <code>codebase_entity</code>, <code>architectural_decision</code>. Use <code>list_entity_types</code> to discover all available types or store with any descriptive type and the server infers the schema.
+
+
+
+  Continue with{" "}
+  <MdxI18nLink to="/api" className="text-foreground underline underline-offset-2 hover:no-underline">
+    REST API reference
+  </MdxI18nLink>
+  ,{" "}
+  <MdxI18nLink to="/cli" className="text-foreground underline underline-offset-2 hover:no-underline">
+    CLI reference
+  </MdxI18nLink>
+  ,{" "}
+  <MdxI18nLink to="/agent-instructions" className="text-foreground underline underline-offset-2 hover:no-underline">
+    agent instructions
+  </MdxI18nLink>
+  , and{" "}
+  <MdxI18nLink to="/schema-management" className="text-foreground underline underline-offset-2 hover:no-underline">
+    schema management
+  </MdxI18nLink>
+  .

--- a/docs/site/pages/en/memory-guarantees.md
+++ b/docs/site/pages/en/memory-guarantees.md
@@ -1,0 +1,16 @@
+---
+title: Memory guarantees
+category: developer_reference
+subcategory: inspector
+component: MemoryGuaranteesPageBody
+locale: en
+nav_group: guides
+nav_order: 18
+page_title: Memory Guarantees
+path: /memory-guarantees
+shell: detail
+translation_status: canonical
+---
+
+# Memory guarantees
+

--- a/docs/site/pages/en/neotoma-vs-database.md
+++ b/docs/site/pages/en/neotoma-vs-database.md
@@ -1,0 +1,14 @@
+---
+title: Neotoma vs database
+category: developer_reference
+subcategory: inspector
+component: NeotomaVsDatabasePageBody
+locale: en
+page_title: Neotoma vs database memory
+path: /neotoma-vs-database
+shell: detail
+translation_status: canonical
+---
+
+# Neotoma vs database
+

--- a/docs/site/pages/en/neotoma-vs-files.md
+++ b/docs/site/pages/en/neotoma-vs-files.md
@@ -1,0 +1,14 @@
+---
+title: Neotoma vs files
+category: developer_reference
+subcategory: inspector
+component: NeotomaVsFilePageBody
+locale: en
+page_title: Neotoma vs file-based memory
+path: /neotoma-vs-files
+shell: detail
+translation_status: canonical
+---
+
+# Neotoma vs files
+

--- a/docs/site/pages/en/neotoma-vs-mem0.md
+++ b/docs/site/pages/en/neotoma-vs-mem0.md
@@ -1,0 +1,14 @@
+---
+title: Neotoma vs Mem0
+category: developer_reference
+subcategory: inspector
+component: NeotomaVsMem0PageBody
+locale: en
+page_title: Neotoma vs Mem0
+path: /neotoma-vs-mem0
+shell: detail
+translation_status: canonical
+---
+
+# Neotoma vs Mem0
+

--- a/docs/site/pages/en/neotoma-vs-platform-memory.md
+++ b/docs/site/pages/en/neotoma-vs-platform-memory.md
@@ -1,0 +1,14 @@
+---
+title: Neotoma vs platform memory
+category: developer_reference
+subcategory: inspector
+component: NeotomaVsPlatformMemoryPageBody
+locale: en
+page_title: Neotoma vs platform memory
+path: /neotoma-vs-platform-memory
+shell: detail
+translation_status: canonical
+---
+
+# Neotoma vs platform memory
+

--- a/docs/site/pages/en/neotoma-vs-rag.md
+++ b/docs/site/pages/en/neotoma-vs-rag.md
@@ -1,0 +1,14 @@
+---
+title: Neotoma vs RAG
+category: developer_reference
+subcategory: inspector
+component: NeotomaVsRagPageBody
+locale: en
+page_title: Neotoma vs RAG memory
+path: /neotoma-vs-rag
+shell: detail
+translation_status: canonical
+---
+
+# Neotoma vs RAG
+

--- a/docs/site/pages/en/neotoma-vs-zep.md
+++ b/docs/site/pages/en/neotoma-vs-zep.md
@@ -1,0 +1,14 @@
+---
+title: Neotoma vs Zep
+category: developer_reference
+subcategory: inspector
+component: NeotomaVsZepPageBody
+locale: en
+page_title: Neotoma vs Zep
+path: /neotoma-vs-zep
+shell: detail
+translation_status: canonical
+---
+
+# Neotoma vs Zep
+

--- a/docs/site/pages/en/neotoma-with-chatgpt-connect-custom-gpt.md
+++ b/docs/site/pages/en/neotoma-with-chatgpt-connect-custom-gpt.md
@@ -1,0 +1,16 @@
+---
+title: Neotoma with ChatGPT connect custom GPT
+category: developer_reference
+subcategory: inspector
+component: ChatGptConnectCustomGptPageBody
+locale: en
+nav_group: integrations
+nav_order: 47
+page_title: Connect via custom GPT with OpenAPI
+path: /neotoma-with-chatgpt-connect-custom-gpt
+shell: detail
+translation_status: canonical
+---
+
+# Neotoma with ChatGPT connect custom GPT
+

--- a/docs/site/pages/en/neotoma-with-chatgpt-connect-remote-mcp.md
+++ b/docs/site/pages/en/neotoma-with-chatgpt-connect-remote-mcp.md
@@ -1,0 +1,16 @@
+---
+title: Neotoma with ChatGPT connect remote MCP
+category: developer_reference
+subcategory: inspector
+component: ChatGptConnectRemoteMcpPageBody
+locale: en
+nav_group: integrations
+nav_order: 46
+page_title: Connect ChatGPT via remote MCP
+path: /neotoma-with-chatgpt-connect-remote-mcp
+shell: detail
+translation_status: canonical
+---
+
+# Neotoma with ChatGPT connect remote MCP
+

--- a/docs/site/pages/en/neotoma-with-chatgpt.md
+++ b/docs/site/pages/en/neotoma-with-chatgpt.md
@@ -1,0 +1,16 @@
+---
+title: Neotoma with ChatGPT
+category: developer_reference
+subcategory: inspector
+component: NeotomaWithChatGPTPageBody
+locale: en
+nav_group: integrations
+nav_order: 25
+page_title: Neotoma with ChatGPT
+path: /neotoma-with-chatgpt
+shell: detail
+translation_status: canonical
+---
+
+# Neotoma with ChatGPT
+

--- a/docs/site/pages/en/neotoma-with-claude-agent-sdk.md
+++ b/docs/site/pages/en/neotoma-with-claude-agent-sdk.md
@@ -1,0 +1,16 @@
+---
+title: Neotoma with Claude agent SDK
+category: developer_reference
+subcategory: inspector
+component: NeotomaWithClaudeAgentSdkPageBody
+locale: en
+nav_group: integrations
+nav_order: 32
+page_title: Memory infrastructure for Claude agents
+path: /neotoma-with-claude-agent-sdk
+shell: detail
+translation_status: canonical
+---
+
+# Neotoma with Claude agent SDK
+

--- a/docs/site/pages/en/neotoma-with-claude-code.md
+++ b/docs/site/pages/en/neotoma-with-claude-code.md
@@ -1,0 +1,16 @@
+---
+title: Neotoma with Claude code
+category: developer_reference
+subcategory: inspector
+component: NeotomaWithClaudeCodePageBody
+locale: en
+nav_group: integrations
+nav_order: 31
+page_title: Neotoma with Claude Code
+path: /neotoma-with-claude-code
+shell: detail
+translation_status: canonical
+---
+
+# Neotoma with Claude code
+

--- a/docs/site/pages/en/neotoma-with-claude-connect-desktop.md
+++ b/docs/site/pages/en/neotoma-with-claude-connect-desktop.md
@@ -1,0 +1,16 @@
+---
+title: Neotoma with Claude connect desktop
+category: developer_reference
+subcategory: inspector
+component: ClaudeConnectDesktopPageBody
+locale: en
+nav_group: integrations
+nav_order: 42
+page_title: Claude Desktop local setup
+path: /neotoma-with-claude-connect-desktop
+shell: detail
+translation_status: canonical
+---
+
+# Neotoma with Claude connect desktop
+

--- a/docs/site/pages/en/neotoma-with-claude-connect-remote-mcp.md
+++ b/docs/site/pages/en/neotoma-with-claude-connect-remote-mcp.md
@@ -1,0 +1,16 @@
+---
+title: Neotoma with Claude connect remote MCP
+category: developer_reference
+subcategory: inspector
+component: ClaudeConnectRemoteMcpPageBody
+locale: en
+nav_group: integrations
+nav_order: 43
+page_title: claude.ai remote MCP setup
+path: /neotoma-with-claude-connect-remote-mcp
+shell: detail
+translation_status: canonical
+---
+
+# Neotoma with Claude connect remote MCP
+

--- a/docs/site/pages/en/neotoma-with-claude.md
+++ b/docs/site/pages/en/neotoma-with-claude.md
@@ -1,0 +1,16 @@
+---
+title: Neotoma with Claude
+category: developer_reference
+subcategory: inspector
+component: NeotomaWithClaudePageBody
+locale: en
+nav_group: integrations
+nav_order: 30
+page_title: Neotoma with Claude
+path: /neotoma-with-claude
+shell: detail
+translation_status: canonical
+---
+
+# Neotoma with Claude
+

--- a/docs/site/pages/en/neotoma-with-codex-connect-local-stdio.md
+++ b/docs/site/pages/en/neotoma-with-codex-connect-local-stdio.md
@@ -1,0 +1,16 @@
+---
+title: Neotoma with Codex connect local stdio
+category: developer_reference
+subcategory: inspector
+component: CodexConnectLocalStdioPageBody
+locale: en
+nav_group: integrations
+nav_order: 40
+page_title: Codex local setup (stdio)
+path: /neotoma-with-codex-connect-local-stdio
+shell: detail
+translation_status: canonical
+---
+
+# Neotoma with Codex connect local stdio
+

--- a/docs/site/pages/en/neotoma-with-codex-connect-remote-http-oauth.md
+++ b/docs/site/pages/en/neotoma-with-codex-connect-remote-http-oauth.md
@@ -1,0 +1,16 @@
+---
+title: Neotoma with Codex connect remote HTTP OAuth
+category: developer_reference
+subcategory: inspector
+component: CodexConnectRemoteHttpOauthPageBody
+locale: en
+nav_group: integrations
+nav_order: 41
+page_title: Codex remote setup (HTTP with OAuth)
+path: /neotoma-with-codex-connect-remote-http-oauth
+shell: detail
+translation_status: canonical
+---
+
+# Neotoma with Codex connect remote HTTP OAuth
+

--- a/docs/site/pages/en/neotoma-with-codex.md
+++ b/docs/site/pages/en/neotoma-with-codex.md
@@ -1,0 +1,16 @@
+---
+title: Neotoma with Codex
+category: developer_reference
+subcategory: inspector
+component: NeotomaWithCodexPageBody
+locale: en
+nav_group: integrations
+nav_order: 27
+page_title: Neotoma with Codex
+path: /neotoma-with-codex
+shell: detail
+translation_status: canonical
+---
+
+# Neotoma with Codex
+

--- a/docs/site/pages/en/neotoma-with-continue.md
+++ b/docs/site/pages/en/neotoma-with-continue.md
@@ -1,0 +1,79 @@
+---
+path: /neotoma-with-continue
+locale: en
+page_title: Neotoma with Continue
+shell: detail
+translation_status: canonical
+nav_group: integrations
+nav_order: 48
+---
+
+# Neotoma with Continue
+
+Continue is an open-source AI code assistant for VS Code and JetBrains. It supports MCP servers via `~/.continue/config.json`, which makes connecting it to Neotoma straightforward.
+
+## Install Neotoma
+
+```bash
+npm install -g neotoma
+neotoma init
+neotoma auth login
+```
+
+## Auto-configure with neotoma setup
+
+```bash
+neotoma setup --tool continue --yes
+```
+
+This writes the Neotoma MCP server entry into `~/.continue/config.json` and verifies the connection. Reload your IDE window after setup completes.
+
+## Manual configuration
+
+If you prefer to configure manually, add to `~/.continue/config.json`:
+
+```json
+{
+  "mcpServers": {
+    "neotoma": {
+      "command": "neotoma",
+      "args": ["mcp", "stdio"],
+      "env": {}
+    }
+  }
+}
+```
+
+Use the absolute path to `neotoma` if the binary is not on `PATH` from your IDE's launch environment (`which neotoma` to find it).
+
+## Remote access
+
+To connect Continue to a remote or tunneled Neotoma instance:
+
+```bash
+neotoma api start --env prod --tunnel
+```
+
+Then use the URL transport in `config.json`:
+
+```json
+{
+  "mcpServers": {
+    "neotoma": {
+      "url": "https://<tunnel-host>/mcp"
+    }
+  }
+}
+```
+
+See [tunnel](/tunnel) for the full tunnel setup guide.
+
+## Verify the connection
+
+After reloading, Neotoma tools (`store`, `retrieve_entities`, `retrieve_entity_by_identifier`) should appear in Continue's Context Providers → MCP section. Ask Continue to call `retrieve_entities` to confirm live access.
+
+## Related
+
+- [MCP reference](/mcp) — protocol details, transport modes, authentication
+- [Install](/install) — full Neotoma install guide
+- [Integrations](/integrations) — all supported hosts

--- a/docs/site/pages/en/neotoma-with-cursor.md
+++ b/docs/site/pages/en/neotoma-with-cursor.md
@@ -1,0 +1,16 @@
+---
+title: Neotoma with Cursor
+category: developer_reference
+subcategory: inspector
+component: NeotomaWithCursorPageBody
+locale: en
+nav_group: integrations
+nav_order: 29
+page_title: Neotoma with Cursor
+path: /neotoma-with-cursor
+shell: detail
+translation_status: canonical
+---
+
+# Neotoma with Cursor
+

--- a/docs/site/pages/en/neotoma-with-ironclaw.md
+++ b/docs/site/pages/en/neotoma-with-ironclaw.md
@@ -1,0 +1,16 @@
+---
+title: Neotoma with Ironclaw
+category: developer_reference
+subcategory: inspector
+component: NeotomaWithIronClawPageBody
+locale: en
+nav_group: integrations
+nav_order: 26
+page_title: Neotoma with IronClaw
+path: /neotoma-with-ironclaw
+shell: detail
+translation_status: canonical
+---
+
+# Neotoma with Ironclaw
+

--- a/docs/site/pages/en/neotoma-with-letta.md
+++ b/docs/site/pages/en/neotoma-with-letta.md
@@ -1,0 +1,86 @@
+---
+path: /neotoma-with-letta
+locale: en
+page_title: Neotoma with Letta
+shell: detail
+translation_status: canonical
+nav_group: integrations
+nav_order: 51
+---
+
+# Neotoma with Letta
+
+Letta is a stateful agent runtime with built-in core, recall, and archival memory. It has first-class MCP support: external MCP servers are registered at agent setup time via the Python or TypeScript SDK, and their tools become callable agent tools alongside Letta's own memory system.
+
+## Install Neotoma
+
+```bash
+npm install -g neotoma
+neotoma init
+neotoma auth login
+```
+
+## Start the Neotoma MCP endpoint
+
+```bash
+neotoma api start --env prod --tunnel
+```
+
+Note the tunnel URL — you will use it as the MCP server URL in your agent setup code.
+
+## Register Neotoma in your Letta agent
+
+```python
+from letta import create_client
+
+client = create_client()
+
+# Register Neotoma MCP server (once per Letta server instance)
+neotoma_mcp = client.mcp_servers.create(config={
+    "mcp_server_type": "streamable_http",
+    "server_url": "https://<tunnel-host>/mcp",
+    "auth_header": "Authorization",
+    "auth_token": "Bearer <your-neotoma-api-token>",
+})
+
+# Get the Neotoma tool definitions
+neotoma_tools = client.tools.list_mcp_tools_by_server(neotoma_mcp.name)
+
+# Create an agent with Neotoma tools attached
+agent = client.agents.create(
+    name="my-agent",
+    tool_ids=[t.id for t in neotoma_tools],
+)
+```
+
+Get your API token with:
+
+```bash
+neotoma auth token
+```
+
+The TypeScript SDK follows the same pattern via `client.mcpServers.create()` and `client.tools.listMcpToolsByServer()`.
+
+## What this gives your agents
+
+Once registered, Neotoma tools appear alongside Letta's built-in memory tools. Your agents can:
+
+- Call `store` to write structured entities with full provenance
+- Call `retrieve_entities` or `retrieve_entity_by_identifier` for targeted recall
+- Call `correct` to update existing records without breaking immutability
+- Share memory across other MCP-connected hosts (Cursor, Claude Code, VS Code, etc.)
+
+Neotoma does not replace Letta's internal core/recall/archival memory — it sits alongside as a portable, cross-host structured memory layer.
+
+## Notes
+
+- MCP server registrations persist on the Letta server instance. Check `client.mcp_servers.list()` before calling `create` to avoid duplicate registrations.
+- For production deployments, use a self-hosted Neotoma instance with a stable HTTPS URL rather than a tunnel.
+- SSE transport is also supported: set `mcp_server_type` to `"sse"` and use the same `server_url`.
+
+## Related
+
+- [MCP reference](/mcp) — transport modes, authentication, tool definitions
+- [Tunnel](/tunnel) — expose a local Neotoma instance over HTTPS
+- [Install](/install) — full Neotoma install guide
+- [Integrations](/integrations) — all supported hosts

--- a/docs/site/pages/en/neotoma-with-openclaw-connect-local-stdio.md
+++ b/docs/site/pages/en/neotoma-with-openclaw-connect-local-stdio.md
@@ -1,0 +1,16 @@
+---
+title: Neotoma with Openclaw connect local stdio
+category: developer_reference
+subcategory: inspector
+component: OpenClawConnectLocalStdioPageBody
+locale: en
+nav_group: integrations
+nav_order: 44
+page_title: OpenClaw local setup (stdio)
+path: /neotoma-with-openclaw-connect-local-stdio
+shell: detail
+translation_status: canonical
+---
+
+# Neotoma with Openclaw connect local stdio
+

--- a/docs/site/pages/en/neotoma-with-openclaw-connect-remote-http.md
+++ b/docs/site/pages/en/neotoma-with-openclaw-connect-remote-http.md
@@ -1,0 +1,16 @@
+---
+title: Neotoma with Openclaw connect remote HTTP
+category: developer_reference
+subcategory: inspector
+component: OpenClawConnectRemoteHttpPageBody
+locale: en
+nav_group: integrations
+nav_order: 45
+page_title: OpenClaw remote setup (HTTP)
+path: /neotoma-with-openclaw-connect-remote-http
+shell: detail
+translation_status: canonical
+---
+
+# Neotoma with Openclaw connect remote HTTP
+

--- a/docs/site/pages/en/neotoma-with-openclaw.md
+++ b/docs/site/pages/en/neotoma-with-openclaw.md
@@ -1,0 +1,16 @@
+---
+title: Neotoma with Openclaw
+category: developer_reference
+subcategory: inspector
+component: NeotomaWithOpenClawPageBody
+locale: en
+nav_group: integrations
+nav_order: 33
+page_title: Neotoma with OpenClaw
+path: /neotoma-with-openclaw
+shell: detail
+translation_status: canonical
+---
+
+# Neotoma with Openclaw
+

--- a/docs/site/pages/en/neotoma-with-opencode.md
+++ b/docs/site/pages/en/neotoma-with-opencode.md
@@ -1,0 +1,16 @@
+---
+title: Neotoma with Opencode
+category: developer_reference
+subcategory: inspector
+component: NeotomaWithOpenCodePageBody
+locale: en
+nav_group: integrations
+nav_order: 28
+page_title: Neotoma with OpenCode
+path: /neotoma-with-opencode
+shell: detail
+translation_status: canonical
+---
+
+# Neotoma with Opencode
+

--- a/docs/site/pages/en/neotoma-with-vscode.md
+++ b/docs/site/pages/en/neotoma-with-vscode.md
@@ -1,0 +1,105 @@
+---
+title: Neotoma with vs code
+category: developer_reference
+subcategory: inspector
+locale: en
+nav_group: integrations
+nav_order: 50
+page_title: Neotoma with VS Code
+path: /neotoma-with-vscode
+shell: detail
+translation_status: canonical
+---
+
+# Neotoma with vs code
+
+VS Code supports MCP servers in GitHub Copilot Chat's Agent Mode (VS Code 1.99+). MCP server configuration lives in `.vscode/mcp.json` at the workspace root, which Neotoma's project-level scanner detects and writes automatically.
+
+## Requirements
+
+- VS Code 1.99 or later
+- GitHub Copilot Chat extension with a Copilot subscription
+- Copilot Chat in **Agent Mode** (the default for `@workspace` interactions)
+
+## Install Neotoma
+
+```bash
+npm install -g neotoma
+neotoma init
+neotoma auth login
+```
+
+## Auto-configure with neotoma setup
+
+From your project directory:
+
+```bash
+neotoma setup --tool vscode --yes
+```
+
+This creates or updates `.vscode/mcp.json` with the Neotoma MCP server entry. VS Code picks up the change on file save without a restart.
+
+## Manual configuration
+
+Create `.vscode/mcp.json` in your workspace root:
+
+```json
+{
+  "servers": {
+    "neotoma": {
+      "type": "stdio",
+      "command": "neotoma",
+      "args": ["mcp", "stdio"]
+    }
+  }
+}
+```
+
+Use the absolute path to `neotoma` if the binary is not on `PATH` from VS Code's terminal environment (`which neotoma` to find it).
+
+## Remote access
+
+To connect VS Code to a remote or tunneled Neotoma instance:
+
+```bash
+neotoma api start --env prod --tunnel
+```
+
+Add the SSE transport entry to `.vscode/mcp.json`:
+
+```json
+{
+  "servers": {
+    "neotoma": {
+      "type": "sse",
+      "url": "https://<tunnel-host>/mcp",
+      "headers": {
+        "Authorization": "Bearer ${input:neotomaToken}"
+      }
+    }
+  }
+}
+```
+
+`${input:neotomaToken}` prompts VS Code for the token on first use and stores it in the VS Code secrets store.
+
+See [tunnel](/tunnel) for the full tunnel setup guide.
+
+## Using Neotoma tools in Copilot Chat
+
+MCP tools registered in `.vscode/mcp.json` are available in Copilot Chat **Agent Mode** only:
+
+1. Open Copilot Chat (`Ctrl+Shift+I` / `Cmd+Shift+I`)
+2. Switch to Agent Mode (sparkle icon or the model selector)
+3. Click the tools icon — Neotoma tools (`store`, `retrieve_entities`, etc.) appear in the list
+4. Type `#neotoma` to insert a tool call directly
+
+## Verify the connection
+
+Ask Copilot Chat in Agent Mode to call `retrieve_entities` with entity type `task`. A response with an empty array (not an error) confirms the connection is working.
+
+## Related
+
+- [MCP reference](/mcp) — protocol details, transport modes, authentication
+- [Install](/install) — full Neotoma install guide
+- [Integrations](/integrations) — all supported hosts

--- a/docs/site/pages/en/neotoma-with-windsurf.md
+++ b/docs/site/pages/en/neotoma-with-windsurf.md
@@ -1,0 +1,96 @@
+---
+path: /neotoma-with-windsurf
+locale: en
+page_title: Neotoma with Windsurf
+shell: detail
+translation_status: canonical
+nav_group: integrations
+nav_order: 49
+---
+
+# Neotoma with Windsurf
+
+Windsurf is Codeium's AI-powered IDE. It supports MCP servers via `~/.codeium/windsurf/mcp_config.json` using the same format as Cursor, so the setup is identical to the Cursor path.
+
+## Install Neotoma
+
+```bash
+npm install -g neotoma
+neotoma init
+neotoma auth login
+```
+
+## Auto-configure with neotoma setup
+
+```bash
+neotoma setup --tool windsurf --yes
+```
+
+This writes the Neotoma MCP server entry into Windsurf's user-level MCP config and verifies the connection. Restart Windsurf after setup completes.
+
+You can also run the MCP config step directly:
+
+```bash
+neotoma mcp config --user-level --yes
+```
+
+Neotoma detects the Windsurf config path automatically on macOS, Linux, and Windows.
+
+## Manual configuration
+
+Create or edit `~/.codeium/windsurf/mcp_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "neotoma": {
+      "command": "neotoma",
+      "args": ["mcp", "stdio"],
+      "env": {}
+    }
+  }
+}
+```
+
+Use the absolute path to `neotoma` if the binary is not on `PATH` from Windsurf's launch environment.
+
+**Config file locations:**
+
+| Platform | Path |
+| --- | --- |
+| macOS / Linux | `~/.codeium/windsurf/mcp_config.json` |
+| Windows | `%APPDATA%\Codeium\Windsurf\mcp_config.json` |
+
+## Remote access
+
+To connect Windsurf to a remote or tunneled Neotoma instance:
+
+```bash
+neotoma api start --env prod --tunnel
+```
+
+Then add the URL transport:
+
+```json
+{
+  "mcpServers": {
+    "neotoma": {
+      "url": "https://<tunnel-host>/mcp"
+    }
+  }
+}
+```
+
+Windsurf supports OAuth discovery, so `neotoma auth login` is sufficient — no manual token header needed when using the Neotoma tunnel.
+
+See [tunnel](/tunnel) for the full tunnel setup guide.
+
+## Verify the connection
+
+After restarting Windsurf, Neotoma tools (`store`, `retrieve_entities`, `retrieve_entity_by_identifier`) should appear in Cascade → Tools → MCP. Ask Cascade to call `retrieve_entities` to confirm live access.
+
+## Related
+
+- [MCP reference](/mcp) — protocol details, transport modes, authentication
+- [Install](/install) — full Neotoma install guide
+- [Integrations](/integrations) — all supported hosts

--- a/docs/site/pages/en/non-destructive-testing.md
+++ b/docs/site/pages/en/non-destructive-testing.md
@@ -1,0 +1,230 @@
+---
+path: /non-destructive-testing
+locale: en
+page_title: Test safely
+shell: detail
+translation_status: canonical
+nav_group: guides
+nav_order: 7
+---
+
+You do not need to commit to Neotoma to find out if it fits. Install it alongside whatever you already use, ingest a slice of your history, run your agent with Neotoma on and off, and compare. Nothing in your current setup is moved, modified, or replaced.
+
+This guide walks through the recommended shadow-install path: install → ingest history → A/B compare → decide. Your existing memory system (`MEMORY.md`, `claw.md`, a custom MCP server, platform memory like Claude or ChatGPT) stays intact the whole time.
+
+## What "test safely" means here
+
+Neotoma writes to a local SQLite database in its own data directory. It does not touch your other files, your editor config, your agent's prompt templates, or any other memory store you already use. If you uninstall, the only artifact is the Neotoma data directory; everything else is exactly where it was.
+
+<ul className="list-none pl-0 space-y-2 mb-6">
+  <li className="text-[15px] leading-7 flex items-start gap-2 [&>p]:m-0">
+    <span className="text-emerald-500 mt-0.5 shrink-0 [&>p]:m-0 [&>p]:leading-none" aria-hidden>
+      &rarr;
+    </span>
+    Your existing memory files are not read, locked, or rewritten.
+  </li>
+  <li className="text-[15px] leading-7 flex items-start gap-2 [&>p]:m-0">
+    <span className="text-emerald-500 mt-0.5 shrink-0 [&>p]:m-0 [&>p]:leading-none" aria-hidden>
+      &rarr;
+    </span>
+    Neotoma data lives in its own directory you can wipe, back up, or copy aside at any point.
+  </li>
+  <li className="text-[15px] leading-7 flex items-start gap-2 [&>p]:m-0">
+    <span className="text-emerald-500 mt-0.5 shrink-0 [&>p]:m-0 [&>p]:leading-none" aria-hidden>
+      &rarr;
+    </span>
+    Your agent decides when to read or write Neotoma; nothing is intercepted in the background.
+  </li>
+  <li className="text-[15px] leading-7 flex items-start gap-2 [&>p]:m-0">
+    <span className="text-emerald-500 mt-0.5 shrink-0 [&>p]:m-0 [&>p]:leading-none" aria-hidden>
+      &rarr;
+    </span>
+    Schemas are inferred from your data, so the test does not require pre-modeling anything.
+  </li>
+</ul>
+
+## Step 1 — Install in shadow mode
+
+```bash
+npm install -g neotoma
+NEOTOMA_DATA_DIR=~/.neotoma-shadow neotoma setup --tool cursor --yes
+```
+
+`neotoma setup --tool <tool> --yes` is the fastest path when you already know which client you want to test first. It runs the idempotent `init` step, wires MCP, and applies the matching local agent guidance. Swap `cursor` for `claude-code`, `codex`, or another supported tool. If you want the step-by-step prompts instead, use `neotoma init --interactive` and then `neotoma mcp config`.
+
+If you run `setup` with `NEOTOMA_DATA_DIR`, the `init` step inside setup writes that location into Neotoma's env config so later commands keep using the same shadow directory:
+
+```bash
+neotoma storage info
+```
+
+Anything stored during the trial lands in `~/.neotoma-shadow`.
+
+## Step 2 — Optionally start the local API
+
+You only need this if you want the local HTTP API, Inspector, OAuth flows, or a transport path that depends on the API server. The default local MCP path configured by `setup` does not require it.
+
+```bash
+neotoma api start
+```
+
+## Step 3 — Ingest a slice of your history
+
+Neotoma can absorb the kinds of artifacts your agent has already produced (chat transcripts, notes, exports). This is what lets you ask comparison questions immediately instead of waiting weeks for fresh history to accumulate.
+
+```bash
+# Discover candidate files (read-only scan)
+neotoma discover ~/Documents ~/Desktop --limit 50
+
+# Preview a transcript before ingestion
+neotoma ingest-transcript ~/Downloads/chatgpt_export.json
+
+# Ingest one file with an explicit idempotency key
+neotoma ingest --file ~/Notes/meeting_2026_03_14.md
+```
+
+`neotoma discover` is a read-only ranking pass. It does not modify any source files. `ingest-transcript` previews structure before any write. `ingest` is the actual write step and stamps each row with provenance so you can trace any stored fact back to the source file.
+
+If you would rather start empty and let your agent populate Neotoma session by session, skip this step. Step 4 still works; it just measures forward-going behavior instead of historical reconstruction.
+
+## Step 4 — Run side-by-side
+
+Open two windows, sessions, or workspaces. Configure one to expose Neotoma's MCP server; configure the other without it. Ask the same questions in both.
+
+Good comparison prompts:
+
+<ul className="list-none pl-0 space-y-2 mb-6">
+  <li className="text-[15px] leading-7 flex items-start gap-2 [&>p]:m-0">
+    <span className="text-emerald-500 mt-0.5 shrink-0 [&>p]:m-0 [&>p]:leading-none" aria-hidden>
+      &rarr;
+    </span>
+    "Who did I last talk to about &lt;project name&gt;? What did we agree on?"
+  </li>
+  <li className="text-[15px] leading-7 flex items-start gap-2 [&>p]:m-0">
+    <span className="text-emerald-500 mt-0.5 shrink-0 [&>p]:m-0 [&>p]:leading-none" aria-hidden>
+      &rarr;
+    </span>
+    "What's the current status of every task I committed to this month?"
+  </li>
+  <li className="text-[15px] leading-7 flex items-start gap-2 [&>p]:m-0">
+    <span className="text-emerald-500 mt-0.5 shrink-0 [&>p]:m-0 [&>p]:leading-none" aria-hidden>
+      &rarr;
+    </span>
+    "Show me the timeline of changes for &lt;entity&gt;, with sources."
+  </li>
+  <li className="text-[15px] leading-7 flex items-start gap-2 [&>p]:m-0">
+    <span className="text-emerald-500 mt-0.5 shrink-0 [&>p]:m-0 [&>p]:leading-none" aria-hidden>
+      &rarr;
+    </span>
+    "Why did we decide &lt;decision&gt;? What inputs were in front of us?"
+  </li>
+</ul>
+
+The agent without Neotoma will improvise or refuse. The agent with Neotoma should be able to cite specific entities, observations, and source files for each answer.
+
+## Step 5 — Decide
+
+Two outcomes are fine:
+
+<ul className="list-none pl-0 space-y-2 mb-6">
+  <li className="text-[15px] leading-7 flex items-start gap-2 [&>p]:m-0">
+    <span className="text-emerald-500 mt-0.5 shrink-0 [&>p]:m-0 [&>p]:leading-none" aria-hidden>
+      &rarr;
+    </span>
+    <span>
+      <strong>Commit:</strong> point your remaining clients at Neotoma's MCP server and let your existing memory file fade into archive. You can keep ingesting backward (older transcripts, exports) on your own pace.
+    </span>
+  </li>
+  <li className="text-[15px] leading-7 flex items-start gap-2 [&>p]:m-0">
+    <span className="text-emerald-500 mt-0.5 shrink-0 [&>p]:m-0 [&>p]:leading-none" aria-hidden>
+      &rarr;
+    </span>
+    <span>
+      <strong>Walk away:</strong> stop the Neotoma server, remove its MCP entry from any client config, and delete the data directory. Your prior setup is exactly as it was — there is nothing in your other memory store to revert.
+    </span>
+  </li>
+</ul>
+
+```bash
+# Stop the local API (if you started it)
+neotoma api stop
+
+# (Optional) wipe the trial data
+rm -rf ~/.neotoma-shadow
+```
+
+## What this does not require
+
+<ul className="list-none pl-0 space-y-2 mb-6">
+  <li className="text-[15px] leading-7 flex items-start gap-2 [&>p]:m-0">
+    <span className="text-emerald-500 mt-0.5 shrink-0 [&>p]:m-0 [&>p]:leading-none" aria-hidden>
+      &rarr;
+    </span>
+    <span>
+      <MdxI18nLink to="/schema-management" className="text-foreground underline underline-offset-2 hover:no-underline">
+        A schema, type registry, or pre-modeled data set
+      </MdxI18nLink>
+      . Neotoma infers schemas as the agent stores.
+    </span>
+  </li>
+  <li className="text-[15px] leading-7 flex items-start gap-2 [&>p]:m-0">
+    <span className="text-emerald-500 mt-0.5 shrink-0 [&>p]:m-0 [&>p]:leading-none" aria-hidden>
+      &rarr;
+    </span>
+    <span>
+      <MdxI18nLink to="/hosted" className="text-foreground underline underline-offset-2 hover:no-underline">
+        Cloud sync or hosting
+      </MdxI18nLink>
+      . Everything in this guide runs on your machine.
+    </span>
+  </li>
+  <li className="text-[15px] leading-7 flex items-start gap-2 [&>p]:m-0">
+    <span className="text-emerald-500 mt-0.5 shrink-0 [&>p]:m-0 [&>p]:leading-none" aria-hidden>
+      &rarr;
+    </span>
+    <span>
+      <MdxI18nLink to="/neotoma-vs-files" className="text-foreground underline underline-offset-2 hover:no-underline">
+        Migrating data out of your current system
+      </MdxI18nLink>
+      . The shadow database is a fresh start; your existing files stay where they are.
+    </span>
+  </li>
+  <li className="text-[15px] leading-7 flex items-start gap-2 [&>p]:m-0">
+    <span className="text-emerald-500 mt-0.5 shrink-0 [&>p]:m-0 [&>p]:leading-none" aria-hidden>
+      &rarr;
+    </span>
+    <span>
+      Commitment to a single tool. Neotoma is{" "}
+      <MdxI18nLink to="/mcp" className="text-foreground underline underline-offset-2 hover:no-underline">
+        MCP-compatible
+      </MdxI18nLink>
+      , so you can run it next to{" "}
+      <MdxI18nLink to="/neotoma-vs-platform-memory" className="text-foreground underline underline-offset-2 hover:no-underline">
+        platform memory
+      </MdxI18nLink>{" "}
+      (Claude, ChatGPT) without conflict.
+    </span>
+  </li>
+</ul>
+
+<div className="text-[14px] leading-6 text-muted-foreground">
+  
+    Related:{" "}
+    <MdxI18nLink to="/install" className="text-foreground underline underline-offset-2 hover:no-underline">
+      install guide
+    </MdxI18nLink>
+    ,{" "}
+    <MdxI18nLink to="/walkthrough" className="text-foreground underline underline-offset-2 hover:no-underline">
+      walkthrough
+    </MdxI18nLink>
+    ,{" "}
+    <MdxI18nLink to="/schemas/versioning" className="text-foreground underline underline-offset-2 hover:no-underline">
+      schema versioning & evolution
+    </MdxI18nLink>
+    , and{" "}
+    <MdxI18nLink to="/backup" className="text-foreground underline underline-offset-2 hover:no-underline">
+      backup and restore
+    </MdxI18nLink>
+    .
+  
+</div>

--- a/docs/site/pages/en/operating.md
+++ b/docs/site/pages/en/operating.md
@@ -1,0 +1,10 @@
+---
+path: /operating
+locale: en
+page_title: Context janitor
+shell: detail
+translation_status: canonical
+component: AiNativeOperatorsPageBody
+nav_group: icp
+nav_order: 10
+---

--- a/docs/site/pages/en/peer-sync.md
+++ b/docs/site/pages/en/peer-sync.md
@@ -1,0 +1,123 @@
+---
+path: /peer-sync
+locale: en
+page_title: Peer sync
+shell: detail
+translation_status: canonical
+nav_group: reference
+nav_order: 60
+---
+
+Peer sync lets two explicit Neotoma instances exchange selected entity state without a central hub. Each side stores immutable sync-originated observations and the reducer computes snapshots locally, so peers stay independent stores of truth that converge through signed webhooks. Available since v0.12.0.
+
+Use peer sync when:
+
+<ul className="list-none pl-0 space-y-2 mb-6">
+  <li className="text-[15px] leading-7 text-muted-foreground">
+    A team operator wants to mirror selected entity types (issues, product feedback, runbook notes) from a personal instance to a shared "central" instance.
+  </li>
+  <li className="text-[15px] leading-7 text-muted-foreground">
+    Two self-hosted instances need to stay in step without a hosted broker.
+  </li>
+  <li className="text-[15px] leading-7 text-muted-foreground">
+    A hosted operator instance wants to receive guest-tagged entities from many personal instances over a signed webhook.
+  </li>
+</ul>
+
+## MCP tools
+
+- `add_peer({ peer_id, peer_name, peer_url, direction, entity_types, sync_scope?, auth_method, ... })` — registers a remote instance. Returns a generated `shared_secret` when `auth_method: "shared_secret"` and no secret is provided.
+- `list_peers()` — enumerates registered peers and their `last_sync_at`.
+- `get_peer_status({ peer_id })` — peer snapshot plus `remote_health` (a `/health` probe and a semver compatibility verdict, the same gate the `neotoma compat` CLI uses).
+- `remove_peer({ peer_id })` — deactivates a peer.
+- `sync_peer({ peer_id, limit? })` — bounded outbound batch (default 200, max 500). Requires `NEOTOMA_PUBLIC_BASE_URL` and `NEOTOMA_LOCAL_PEER_ID`.
+- `resolve_sync_conflict({ entity_id, strategy, sender_peer_url?, guest_access_token? })` — `prefer_remote` re-fetches the remote snapshot; `prefer_local` retains local state; `manual` flags the entity for operator review.
+
+## HTTP routes
+
+<TableScrollWrapper className={DOC_TABLE_SCROLL_OUTER_CLASS}>
+  <table className="w-full text-[14px] leading-6 border-collapse md:rounded-lg md:overflow-hidden md:border md:border-border">
+    <thead>
+      <tr className="border-b border-border">
+        <th className="px-4 py-3 text-left font-semibold text-foreground bg-muted w-[8ch]">Method</th>
+        <th className="px-4 py-3 text-left font-semibold text-foreground bg-muted">Path</th>
+        <th className="px-4 py-3 text-left font-semibold text-foreground bg-muted">Purpose</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr className="border-b border-border hover:bg-muted/50 transition-colors">
+        <td className="px-4 py-3 align-top"><code>GET</code></td>
+        <td className="px-4 py-3 align-top"><code>/peers/{"{peer_id}"}</code></td>
+        <td className="px-4 py-3 align-top text-muted-foreground">Snapshot + <code>remote_health</code>.</td>
+      </tr>
+      <tr className="border-b border-border hover:bg-muted/50 transition-colors">
+        <td className="px-4 py-3 align-top"><code>POST</code></td>
+        <td className="px-4 py-3 align-top"><code>/peers</code></td>
+        <td className="px-4 py-3 align-top text-muted-foreground">Add peer.</td>
+      </tr>
+      <tr className="border-b border-border hover:bg-muted/50 transition-colors">
+        <td className="px-4 py-3 align-top"><code>POST</code></td>
+        <td className="px-4 py-3 align-top"><code>/peers/{"{peer_id}"}/sync</code></td>
+        <td className="px-4 py-3 align-top text-muted-foreground">Bounded outbound batch.</td>
+      </tr>
+      <tr className="border-b border-border hover:bg-muted/50 transition-colors">
+        <td className="px-4 py-3 align-top"><code>POST</code></td>
+        <td className="px-4 py-3 align-top"><code>/sync/webhook</code></td>
+        <td className="px-4 py-3 align-top text-muted-foreground">Inbound signed notification (HMAC <code>X-Neotoma-Sync-Signature-256</code> or AAuth).</td>
+      </tr>
+      <tr className="hover:bg-muted/50 transition-colors">
+        <td className="px-4 py-3 align-top"><code>POST</code></td>
+        <td className="px-4 py-3 align-top"><code>/peers/resolve_sync_conflict</code></td>
+        <td className="px-4 py-3 align-top text-muted-foreground">Strategy-based conflict resolution.</td>
+      </tr>
+    </tbody>
+  </table>
+</TableScrollWrapper>
+
+## Environment
+
+- `NEOTOMA_PUBLIC_BASE_URL` — public base URL of this API (no trailing slash). Used as `sender_peer_url` on outbound sync so the peer can fetch entity snapshots back.
+- `NEOTOMA_LOCAL_PEER_ID` — stable id this instance presents as `sender_peer_id`. Must match the value the peer recorded as their `peer_id` for you.
+- `NEOTOMA_HOSTED_MODE=1` — operator opt-in for hosted / multi-tenant deployments. When set, the inbound webhook handler rejects any `sender_peer_url` whose hostname resolves to a private, loopback, or link-local address. This blocks a hostile peer from naming `http://127.0.0.1` to coerce snapshot fetches against the host's loopback.
+
+## Example
+
+Register a peer and run a bounded outbound sync:
+
+```bash
+# On the personal instance
+neotoma peers add \
+  --peer-id central \
+  --name "Team Central" \
+  --url https://central.example.com \
+  --types issue,product_feedback \
+  --target-user-id <central_user_uuid>
+
+neotoma peers status central
+neotoma peers sync central
+```
+
+The personal instance batches up to 200 changed observations (default `limit`), POSTs them to `https://central.example.com/sync/webhook` with `X-Neotoma-Sync-Signature-256`, and writes the resulting `last_sync_at` watermark back to its own `peer_config` row. Replays of the same signed payload are deduplicated by idempotency key so a flaky network does not produce duplicate observations.
+
+## Selective sync
+
+Set `sync_scope: "tagged"` on the peer and stamp eligible entities with `sync_peers: ["central"]`. Only those entities are delivered:
+
+```json
+{
+  "entity_type": "issue",
+  "title": "Reset MCP token after rotation",
+  "sync_peers": ["central"]
+}
+```
+
+## Loop prevention via subscriptions
+
+For steady-state propagation, create a substrate [subscription](/subscriptions) with `sync_peer_id: "central"`. The bridge skips events whose `source_peer_id` matches the destination, so replicated rows do not bounce back. Replicated writes carry `observation_source: "sync"` and rank below local sources in the reducer's default tie-breaking.
+
+## Full reference
+
+[`docs/subsystems/peer_sync.md`](https://github.com/markmhendrickson/neotoma/blob/main/docs/subsystems/peer_sync.md) covers the full inbound / outbound paths (`sync_webhook_inbound.ts`, `sync_webhook_outbound.ts`, `peer_sync_batch.ts`, `full_sync.ts`, `conflict_resolver.ts`), the semver compatibility rules in `src/semver_compat.ts`, and the seeded `peer_config` schema.
+
+See [substrate subscriptions](/subscriptions), [security hardening](/security-hardening), [API reference](/api), and [MCP reference](/mcp).
+.

--- a/docs/site/pages/en/personal-data.md
+++ b/docs/site/pages/en/personal-data.md
@@ -1,0 +1,14 @@
+---
+title: Personal data
+category: developer_reference
+subcategory: inspector
+component: PersonalDataLandingPageBody
+locale: en
+page_title: Neotoma for Personal Data
+path: /personal-data
+shell: detail
+translation_status: canonical
+---
+
+# Personal data
+

--- a/docs/site/pages/en/portfolio.md
+++ b/docs/site/pages/en/portfolio.md
@@ -1,0 +1,8 @@
+---
+path: /portfolio
+locale: en
+page_title: Neotoma for Portfolio Monitoring
+shell: detail
+translation_status: canonical
+component: PortfolioLandingPageBody
+---

--- a/docs/site/pages/en/primitives.md
+++ b/docs/site/pages/en/primitives.md
@@ -1,0 +1,10 @@
+---
+path: /primitives
+locale: en
+page_title: Primitive record types
+shell: detail
+translation_status: canonical
+component: PrimitivesIndexPageBody
+nav_group: guides
+nav_order: 65
+---

--- a/docs/site/pages/en/primitives/entities.md
+++ b/docs/site/pages/en/primitives/entities.md
@@ -1,0 +1,10 @@
+---
+path: /primitives/entities
+locale: en
+page_title: Entities
+shell: detail
+translation_status: canonical
+component: PrimitiveRecordTypePageBody
+nav_group: guides
+nav_order: 66
+---

--- a/docs/site/pages/en/primitives/entity-snapshots.md
+++ b/docs/site/pages/en/primitives/entity-snapshots.md
@@ -1,0 +1,16 @@
+---
+title: Entity snapshots
+category: developer_reference
+subcategory: inspector
+component: PrimitiveRecordTypePageBody
+locale: en
+nav_group: guides
+nav_order: 67
+page_title: Entity snapshots
+path: /primitives/entity-snapshots
+shell: detail
+translation_status: canonical
+---
+
+# Entity snapshots
+

--- a/docs/site/pages/en/primitives/interpretations.md
+++ b/docs/site/pages/en/primitives/interpretations.md
@@ -1,0 +1,10 @@
+---
+path: /primitives/interpretations
+locale: en
+page_title: Interpretations
+shell: detail
+translation_status: canonical
+component: PrimitiveRecordTypePageBody
+nav_group: guides
+nav_order: 69
+---

--- a/docs/site/pages/en/primitives/observations.md
+++ b/docs/site/pages/en/primitives/observations.md
@@ -1,0 +1,10 @@
+---
+path: /primitives/observations
+locale: en
+page_title: Observations
+shell: detail
+translation_status: canonical
+component: PrimitiveRecordTypePageBody
+nav_group: guides
+nav_order: 70
+---

--- a/docs/site/pages/en/primitives/relationships.md
+++ b/docs/site/pages/en/primitives/relationships.md
@@ -1,0 +1,10 @@
+---
+path: /primitives/relationships
+locale: en
+page_title: Relationships
+shell: detail
+translation_status: canonical
+component: PrimitiveRecordTypePageBody
+nav_group: guides
+nav_order: 71
+---

--- a/docs/site/pages/en/primitives/sources.md
+++ b/docs/site/pages/en/primitives/sources.md
@@ -1,0 +1,10 @@
+---
+path: /primitives/sources
+locale: en
+page_title: Sources
+shell: detail
+translation_status: canonical
+component: PrimitiveRecordTypePageBody
+nav_group: guides
+nav_order: 68
+---

--- a/docs/site/pages/en/primitives/timeline-events.md
+++ b/docs/site/pages/en/primitives/timeline-events.md
@@ -1,0 +1,16 @@
+---
+title: Timeline events
+category: developer_reference
+subcategory: inspector
+component: PrimitiveRecordTypePageBody
+locale: en
+nav_group: guides
+nav_order: 72
+page_title: Timeline events
+path: /primitives/timeline-events
+shell: detail
+translation_status: canonical
+---
+
+# Timeline events
+

--- a/docs/site/pages/en/privacy.md
+++ b/docs/site/pages/en/privacy.md
@@ -1,0 +1,165 @@
+---
+path: /privacy
+locale: en
+page_title: Privacy Notice
+shell: detail
+translation_status: canonical
+---
+
+*Version 1.0 · effective 2026-04-24*
+
+This notice describes what data `neotoma.io` collects when you visit
+the marketing site, interact with the public sandbox, or submit agent
+feedback through the pipeline hosted at `agent.neotoma.io`.
+
+Neotoma is currently operated by **[Mark Hendrickson](https://markmhendrickson.com)** as an individual
+publisher — there is no registered legal entity operating this site at
+this time. When Neotoma transitions to a registered entity, this notice
+will be replaced and anyone who has submitted identifiable data will be
+notified via the contact address on record.
+
+## 1. What this notice covers
+
+- **`neotoma.io`** — the public marketing and documentation site.
+- **`agent.neotoma.io`** — the agent feedback pipeline (see `/feedback`).
+- **`sandbox.neotoma.io`** — the public evaluation sandbox. The sandbox
+  has additional terms at [neotoma.io/sandbox/terms-of-use](/sandbox/terms-of-use)
+  (same text as
+  [`GET https://sandbox.neotoma.io/sandbox/terms`](https://sandbox.neotoma.io/sandbox/terms)
+  JSON for tools) that govern data submitted to the sandbox itself; those terms take
+  precedence for sandbox content.
+
+This notice does **not** cover:
+- Locally installed Neotoma instances running on your own machine.
+- Third-party sites linked from the documentation.
+
+## 2. What we collect
+
+### 2.1 Analytics (aggregate, pseudonymous)
+
+The marketing site uses a self-hosted Umami instance for aggregate,
+pseudonymous usage analytics:
+
+- **Umami.** Self-hosted, cookie-less, privacy-friendly web analytics.
+  Records URL path, page title, referrer, browser type, and country
+  (derived from IP then discarded). No cookies are set. No cross-site
+  tracking.
+
+We do not run Google Analytics on the marketing site.
+
+### 2.2 Issue reporting (GitHub Issues)
+
+When an agent running on your machine files an issue (via the
+`submit_issue` MCP tool or the `neotoma issues create` CLI), the
+following occurs:
+
+- The issue is created on the configured GitHub repository using your
+  GitHub identity (authenticated via the `gh` CLI).
+- For public issues, PII should be redacted before submission. For
+  sensitive reports, use `visibility: "advisory"` to file via GitHub
+  Security Advisories (private, visible only to maintainers).
+- The issue is also stored locally in your Neotoma database as an
+  `issue` entity linked to a conversation.
+- GitHub's standard privacy policy applies to content stored on GitHub.
+
+No data is sent to `agent.neotoma.io`. All issue data flows directly
+between your machine and GitHub's API.
+
+### 2.3 Sandbox interactions
+
+See [neotoma.io/sandbox/terms-of-use](/sandbox/terms-of-use)
+for the full sandbox-specific terms (JSON: `GET https://sandbox.neotoma.io/sandbox/terms`). In summary:
+
+- All content submitted to the sandbox is public by design.
+- The sandbox is wiped every Sunday at 00:00 UTC and re-seeded from
+  synthetic fixtures.
+- Request IPs are hashed before being stored in any abuse report.
+- No cookies or accounts are required to use the sandbox.
+
+### 2.4 What we do not collect
+
+- We do not set login cookies on the marketing site — there are no
+  accounts.
+- We do not sell, rent, or share data with advertising networks.
+- We do not scan your email, files, or other services. Local Neotoma
+  installations run entirely on your machine by default.
+
+## 3. Legal basis (GDPR / UK-GDPR)
+
+- **Umami analytics** — legitimate interest (privacy-friendly,
+  cookie-less, aggregate site-usage measurement).
+- **Feedback pipeline** — consent. Submitting feedback via your agent
+  is an explicit opt-in action.
+- **Sandbox** — consent + public-by-design posture disclosed in the
+  sandbox terms.
+
+## 4. Your rights
+
+You have the right to:
+
+- Ask what we have stored about you.
+- Request correction or deletion of any feedback record identifiable
+  to you (use the `access_token` your agent received, or contact us).
+- Ask us to restrict or stop processing.
+- Request export of any identifiable data.
+
+All requests go to **contact@neotoma.io**. We aim to respond within
+30 days. Because we do not operate user accounts, identification
+usually relies on the `access_token` you were issued or the email
+address that submitted a request.
+
+## 5. Data sharing
+
+We use these third-party processors:
+
+- **Netlify** — hosts the agent feedback pipeline and the marketing
+  site. Receives request metadata necessary to serve HTTP responses.
+- **Fly.io** — hosts the public sandbox. Receives request metadata
+  necessary to serve HTTP responses.
+- **Umami** — self-hosted; no third-party processor involved when
+  Umami is the active analytics backend.
+
+We do not share data with advertising networks or data brokers.
+
+## 6. Data retention
+
+- **Umami analytics** — aggregate event data retained indefinitely,
+  no personal identifiers stored.
+- **Agent feedback records** — retained until the issue is resolved
+  and for a reasonable follow-up window thereafter. Submitters may
+  request deletion at any time via their `access_token` or the
+  contact email.
+- **Sandbox content** — wiped weekly per the sandbox terms.
+- **Edge request logs** — retained per Netlify/Fly.io default log
+  retention (typically 7–30 days).
+
+## 7. Children's privacy
+
+Neotoma is not directed at children under 18. We do not knowingly
+collect information from children.
+
+## 8. Changes to this notice
+
+Material changes will be flagged at the top of this page with a new
+effective date. Non-material changes (typos, formatting) will be
+committed without announcement.
+
+## 9. Contact
+
+**[Mark Hendrickson](https://markmhendrickson.com)**, publisher of Neotoma
+Email: contact@neotoma.io
+
+A postal address for formal correspondence is available on request
+at the contact email above.
+
+## Revision history
+
+### 1.0 — 2026-04-24
+
+- Initial publication of the pre-incorporation site privacy notice.
+- Site analytics clarified as Umami-only; removed Google Analytics references.
+- Supersedes the `docs/legal/privacy_policy.md` template, which is
+  retained as the reference draft for post-incorporation publication.
+
+See also the [Terms of Use](/terms)
+and the [sandbox-specific terms](/sandbox/terms-of-use).

--- a/docs/site/pages/en/procurement.md
+++ b/docs/site/pages/en/procurement.md
@@ -1,0 +1,8 @@
+---
+path: /procurement
+locale: en
+page_title: Neotoma for Procurement
+shell: detail
+translation_status: canonical
+component: ProcurementLandingPageBody
+---

--- a/docs/site/pages/en/replayable-timeline.md
+++ b/docs/site/pages/en/replayable-timeline.md
@@ -1,0 +1,40 @@
+---
+path: /replayable-timeline
+locale: en
+page_title: Replayable timeline
+shell: detail
+translation_status: canonical
+nav_group: guides
+nav_order: 52
+---
+
+The full sequence of observations can be replayed to reconstruct state at any timestamp. This enables
+deterministic debugging and incident analysis.
+
+## Before vs after
+
+Before: after an incident, you only have current snapshots and partial logs. After: replay from
+observations reproduces the exact state transition path that led to failure.
+
+```bash
+# List timeline events
+neotoma timeline list
+
+# Get one event and inspect linked entities
+neotoma timeline get <event_id>
+neotoma relationships list --entity-id <entity_id>
+```
+
+Replay depends on
+<MdxI18nLink to="/deterministic-state-evolution" className="text-foreground underline hover:text-foreground">
+  deterministic state evolution
+</MdxI18nLink>
+and supports
+<MdxI18nLink to="/reproducible-state-reconstruction" className="text-foreground underline hover:text-foreground">
+  reproducible state reconstruction
+</MdxI18nLink>
+. See
+<MdxI18nLink to="/auditable-change-log" className="text-foreground underline hover:text-foreground">
+  auditable change log
+</MdxI18nLink>
+for provenance.

--- a/docs/site/pages/en/reproducible-state-reconstruction.md
+++ b/docs/site/pages/en/reproducible-state-reconstruction.md
@@ -1,0 +1,39 @@
+---
+path: /reproducible-state-reconstruction
+locale: en
+page_title: Reproducible state reconstruction
+shell: detail
+translation_status: canonical
+nav_group: guides
+nav_order: 58
+---
+
+Reproducible state reconstruction means rebuilding complete state from raw observations alone. If the
+database is lost, replay reconstructs the same state deterministically.
+
+## Before vs after
+
+Before: restoring requires uncertain backups and manual reconciliation. After: replay up to timestamp T
+recreates state at T exactly, then replay to present restores current state.
+
+```bash
+# Verify timeline events are available
+neotoma timeline list
+
+# Recompute and verify snapshots
+neotoma entities list --type task --limit 20
+```
+
+This depends on
+<MdxI18nLink to="/replayable-timeline" className="text-foreground underline hover:text-foreground">
+  replayable timeline
+</MdxI18nLink>
+,
+<MdxI18nLink to="/deterministic-state-evolution" className="text-foreground underline hover:text-foreground">
+  deterministic state evolution
+</MdxI18nLink>
+, and
+<MdxI18nLink to="/auditable-change-log" className="text-foreground underline hover:text-foreground">
+  auditable change log
+</MdxI18nLink>
+.

--- a/docs/site/pages/en/sandbox.md
+++ b/docs/site/pages/en/sandbox.md
@@ -1,0 +1,8 @@
+---
+path: /sandbox
+locale: en
+page_title: Neotoma sandbox
+shell: detail
+translation_status: canonical
+component: SandboxLandingPageBody
+---

--- a/docs/site/pages/en/schema-constraints.md
+++ b/docs/site/pages/en/schema-constraints.md
@@ -1,0 +1,39 @@
+---
+path: /schema-constraints
+locale: en
+page_title: Schema constraints
+shell: detail
+translation_status: canonical
+nav_group: guides
+nav_order: 54
+---
+
+Entities conform to defined types and validation rules. Type mismatches are flagged at store time
+and missing required fields generate warnings, so schema drift does not silently degrade state quality.
+
+## Before vs after
+
+Before: one tool stores `age: "thirty"` while another expects a number. After: schema
+validation rejects the invalid write and returns a deterministic error.
+
+```bash
+# Invalid payload example
+neotoma store --json='[{"entity_type":"person","name":"Ana Rivera","age":"thirty"}]'
+
+# Valid payload
+neotoma store --json='[{"entity_type":"person","name":"Ana Rivera","age":30}]'
+```
+
+This protects
+<MdxI18nLink to="/deterministic-state-evolution" className="text-foreground underline hover:text-foreground">
+  deterministic state evolution
+</MdxI18nLink>
+and reduces
+<MdxI18nLink to="/silent-mutation-risk" className="text-foreground underline hover:text-foreground">
+  silent mutation risk
+</MdxI18nLink>
+. See
+<MdxI18nLink to="/conflicting-facts-risk" className="text-foreground underline hover:text-foreground">
+  conflicting facts risk
+</MdxI18nLink>
+for conflict handling.

--- a/docs/site/pages/en/schema-management.md
+++ b/docs/site/pages/en/schema-management.md
@@ -1,0 +1,106 @@
+---
+path: /schema-management
+locale: en
+page_title: Schema management
+shell: detail
+translation_status: canonical
+nav_group: reference
+nav_order: 25
+---
+
+Schema constraints are a core invariant: malformed writes should fail at store time, not silently degrade state quality. This page covers the practical CLI workflows.
+
+## You don't have to define a schema first
+
+Neotoma infers schemas from your first write. Store any entity with a descriptive `entity_type` and whatever fields the data implies — Neotoma registers a schema from that observation, and every subsequent field addition bumps a minor version (1.0.0 → 1.1.0) automatically. Fields the active schema doesn't recognize land in a `raw_fragments` layer so nothing is silently dropped, and breaking changes (removing or retyping a field) require an explicit major version bump (1.x → 2.0) that keeps every historical observation readable.
+
+If you're evaluating Neotoma and don't want to commit, the [Test safely guide](/non-destructive-testing) walks through how to install in shadow mode, let your agent populate schemas from your real data, and walk away without affecting anything in your current stack.
+
+## List and inspect schema types
+
+```
+# List known entity types
+neotoma schemas list
+
+# Inspect one schema
+neotoma schemas get contact
+```
+
+## Store data with schema validation
+
+Store operations validate payloads against the target schema. If required fields are missing or have unexpected types, the observation is still stored but a warning is recorded in the raw fragments layer, so no data is silently lost or misclassified.
+
+```
+# Valid write
+neotoma store --json='[{"entity_type":"contact","name":"Ana Rivera","email":"ana@acme.com"}]'
+
+# Invalid write (example: wrong type for age)
+neotoma store --json='[{"entity_type":"person","name":"Ana Rivera","age":"thirty"}]'
+```
+
+## Evolve schemas incrementally
+
+Add new fields without breaking existing workflows. For larger changes, analyze candidates first, then register updates intentionally.
+
+```
+# Analyze candidate fields from observed data
+neotoma schemas analyze-candidates --entity-type contact
+
+# Recommend schema updates
+neotoma schemas recommendations --entity-type contact
+
+# Register or update schema
+neotoma schemas register --file ./contact_schema.json
+```
+
+## Operational guidance
+
+<ul className="list-none pl-0 space-y-2 mb-6">
+  <li className="text-[15px] leading-7 flex items-start gap-2">
+    <span className="text-emerald-500 mt-0.5 shrink-0" aria-hidden>
+      &rarr;
+    </span>
+    Prefer additive schema changes over destructive renames.
+  </li>
+  <li className="text-[15px] leading-7 flex items-start gap-2">
+    <span className="text-emerald-500 mt-0.5 shrink-0" aria-hidden>
+      &rarr;
+    </span>
+    Use versioned changelogs for schema edits with rationale.
+  </li>
+  <li className="text-[15px] leading-7 flex items-start gap-2">
+    <span className="text-emerald-500 mt-0.5 shrink-0" aria-hidden>
+      &rarr;
+    </span>
+    Test representative payloads before changing production schema.
+  </li>
+  <li className="text-[15px] leading-7 flex items-start gap-2">
+    <span className="text-emerald-500 mt-0.5 shrink-0" aria-hidden>
+      &rarr;
+    </span>
+    Treat schema updates as state-model changes, not UI tweaks.
+  </li>
+</ul>
+
+
+  See{" "}
+  <MdxI18nLink to="/schemas" className="text-foreground underline underline-offset-2 hover:no-underline">
+    schemas overview
+  </MdxI18nLink>
+  ,{" "}
+  <MdxI18nLink to="/schemas/versioning" className="text-foreground underline underline-offset-2 hover:no-underline">
+    versioning & evolution
+  </MdxI18nLink>
+  ,{" "}
+  <MdxI18nLink to="/memory-guarantees#schema-constraints" className="text-foreground underline underline-offset-2 hover:no-underline">
+    schema constraints
+  </MdxI18nLink>
+  ,{" "}
+  <MdxI18nLink to="/non-destructive-testing" className="text-foreground underline underline-offset-2 hover:no-underline">
+    Test safely
+  </MdxI18nLink>
+  , and{" "}
+  <MdxI18nLink to="/architecture" className="text-foreground underline underline-offset-2 hover:no-underline">
+    architecture
+  </MdxI18nLink>
+  .

--- a/docs/site/pages/en/schemas.md
+++ b/docs/site/pages/en/schemas.md
@@ -1,0 +1,10 @@
+---
+path: /schemas
+locale: en
+page_title: Schemas
+shell: detail
+translation_status: canonical
+component: SchemasIndexPageBody
+nav_group: guides
+nav_order: 80
+---

--- a/docs/site/pages/en/schemas/merge-policies.md
+++ b/docs/site/pages/en/schemas/merge-policies.md
@@ -1,0 +1,16 @@
+---
+title: Merge policies
+category: developer_reference
+subcategory: inspector
+component: SchemaConceptPageBody
+locale: en
+nav_group: guides
+nav_order: 82
+page_title: Merge policies
+path: /schemas/merge-policies
+shell: detail
+translation_status: canonical
+---
+
+# Merge policies
+

--- a/docs/site/pages/en/schemas/registry.md
+++ b/docs/site/pages/en/schemas/registry.md
@@ -1,0 +1,10 @@
+---
+path: /schemas/registry
+locale: en
+page_title: Schema registry
+shell: detail
+translation_status: canonical
+component: SchemaConceptPageBody
+nav_group: guides
+nav_order: 81
+---

--- a/docs/site/pages/en/schemas/storage-layers.md
+++ b/docs/site/pages/en/schemas/storage-layers.md
@@ -1,0 +1,16 @@
+---
+title: Storage layers
+category: developer_reference
+subcategory: inspector
+component: SchemaConceptPageBody
+locale: en
+nav_group: guides
+nav_order: 83
+page_title: Storage layers
+path: /schemas/storage-layers
+shell: detail
+translation_status: canonical
+---
+
+# Storage layers
+

--- a/docs/site/pages/en/schemas/versioning.md
+++ b/docs/site/pages/en/schemas/versioning.md
@@ -1,0 +1,10 @@
+---
+path: /schemas/versioning
+locale: en
+page_title: Versioning & evolution
+shell: detail
+translation_status: canonical
+component: SchemaConceptPageBody
+nav_group: guides
+nav_order: 84
+---

--- a/docs/site/pages/en/security-hardening.md
+++ b/docs/site/pages/en/security-hardening.md
@@ -1,0 +1,149 @@
+---
+title: Security hardening
+category: developer_reference
+subcategory: inspector
+locale: en
+nav_group: reference
+nav_order: 63
+page_title: Security hardening
+path: /security-hardening
+shell: detail
+translation_status: canonical
+---
+
+# Security hardening
+
+Operator-tunable hardening knobs introduced or sharpened in v0.12.0. These are the *runtime* security surface that static gates cannot exhaustively cover from source diffs alone — they are owned by the operator running the instance, not by code review.
+
+Use this reference when:
+
+<ul className="list-none pl-0 space-y-2 mb-6">
+  <li className="text-[15px] leading-7 text-muted-foreground">
+    Standing up a hosted / multi-tenant Neotoma deployment.
+  </li>
+  <li className="text-[15px] leading-7 text-muted-foreground">
+    Auditing whether a self-hosted instance is in a defensible default state.
+  </li>
+  <li className="text-[15px] leading-7 text-muted-foreground">
+    Investigating an alert that touches loopback trust, OAuth bearers, guest tokens, or peer-sync envelopes.
+  </li>
+</ul>
+
+## Loopback rewrite and trust
+
+Neotoma classifies inbound requests as `loopback` only when the underlying TCP socket is on `127.0.0.1` / `::1`. `isLocalRequest` (in `src/utils/local_request.ts`) is the single source of truth — it walks the socket peer address, not the `Host` header, and is used by both the HTTP API and the Inspector to gate developer-only surfaces.
+
+- `NEOTOMA_TRUST_PROD_LOOPBACK=1` — opt-in escape hatch for production instances that need to expose loopback-only routes to a same-host reverse proxy. Defaults off. When unset, prod runs refuse loopback-tagged surfaces from any caller.
+
+## Gate stack (G1–G5)
+
+The five operator-visible gates wrap every write path:
+
+<TableScrollWrapper className={DOC_TABLE_SCROLL_OUTER_CLASS}>
+  <table className="w-full text-[14px] leading-6 border-collapse md:rounded-lg md:overflow-hidden md:border md:border-border">
+    <thead>
+      <tr className="border-b border-border">
+        <th className="px-4 py-3 text-left font-semibold text-foreground bg-muted w-[18ch]">Gate</th>
+        <th className="px-4 py-3 text-left font-semibold text-foreground bg-muted">Purpose</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr className="border-b border-border hover:bg-muted/50 transition-colors">
+        <td className="px-4 py-3 align-top font-medium text-foreground">G1 — Bearer scope</td>
+        <td className="px-4 py-3 align-top text-muted-foreground">Validates the <code>Authorization</code> bearer token (or AAuth signature) against the requested action's scope.</td>
+      </tr>
+      <tr className="border-b border-border hover:bg-muted/50 transition-colors">
+        <td className="px-4 py-3 align-top font-medium text-foreground">G2 — Subject</td>
+        <td className="px-4 py-3 align-top text-muted-foreground">Resolves the user, agent, and (when present) <code>external_actor</code> triple from the bearer or AAuth thumbprint.</td>
+      </tr>
+      <tr className="border-b border-border hover:bg-muted/50 transition-colors">
+        <td className="px-4 py-3 align-top font-medium text-foreground">G3 — Loopback</td>
+        <td className="px-4 py-3 align-top text-muted-foreground">Applies <code>isLocalRequest</code> + <code>NEOTOMA_TRUST_PROD_LOOPBACK</code> for surfaces marked <code>loopback-only</code>.</td>
+      </tr>
+      <tr className="border-b border-border hover:bg-muted/50 transition-colors">
+        <td className="px-4 py-3 align-top font-medium text-foreground">G4 — Rate limit</td>
+        <td className="px-4 py-3 align-top text-muted-foreground">Per-key throttle keyed by AAuth thumbprint &gt; hashed guest token &gt; IP.</td>
+      </tr>
+      <tr className="hover:bg-muted/50 transition-colors">
+        <td className="px-4 py-3 align-top font-medium text-foreground">G5 — Schema / payload</td>
+        <td className="px-4 py-3 align-top text-muted-foreground">Schema validation and <code>ERR_STORE_RESOLUTION_FAILED</code> repair hints for malformed payloads.</td>
+      </tr>
+    </tbody>
+  </table>
+</TableScrollWrapper>
+
+## OAuth Bearer enforcement on `/mcp`
+
+Pre-v0.12, an unrecognized OAuth `Bearer` token on `/mcp` could fall through to anonymous attribution if the token was syntactically a UUID. v0.12 closes that gap:
+
+- Unknown / expired bearers return **HTTP 401** with a JSON-RPC envelope (`code: -32001`, `data.error: "invalid_token"`) and a `WWW-Authenticate: Bearer realm="neotoma", resource_metadata="<url>"` header pointing at the OAuth protected-resource metadata.
+- UUID-shaped tokens passed as `access_token=` query params or `Authorization: Bearer …` no longer downgrade to anonymous on validation failure.
+- Regression coverage: `tests/subscriptions/subscription_guest_auth.test.ts` and `tests/unit/security_hardening.test.ts`.
+
+## MCP proxy: fail-closed mode
+
+`neotoma mcp proxy --aauth` (and operator-deployed AAuth-signed proxies) accept an opt-in flag that refuses unsigned downstream requests when AAuth signing or session preflight fails:
+
+- `MCP_PROXY_FAIL_CLOSED=1` (env) or `failClosed: true` (proxy options).
+- Default is fail-open (legacy behavior); set fail-closed in any hosted deployment so a misconfigured upstream cannot silently downgrade to anonymous writes.
+
+See [`docs/developer/mcp/proxy.md`](https://github.com/markmhendrickson/neotoma/blob/main/docs/developer/mcp/proxy.md) for the proxy options reference.
+
+## Guest write rate limit & token TTL
+
+<TableScrollWrapper className={DOC_TABLE_SCROLL_OUTER_CLASS}>
+  <table className="w-full text-[14px] leading-6 border-collapse md:rounded-lg md:overflow-hidden md:border md:border-border">
+    <thead>
+      <tr className="border-b border-border">
+        <th className="px-4 py-3 text-left font-semibold text-foreground bg-muted">Variable</th>
+        <th className="px-4 py-3 text-left font-semibold text-foreground bg-muted w-[12ch]">Default</th>
+        <th className="px-4 py-3 text-left font-semibold text-foreground bg-muted">Purpose</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr className="border-b border-border hover:bg-muted/50 transition-colors">
+        <td className="px-4 py-3 align-top"><code>NEOTOMA_GUEST_WRITE_RATE_LIMIT_PER_MIN</code></td>
+        <td className="px-4 py-3 align-top"><code>30</code></td>
+        <td className="px-4 py-3 align-top text-muted-foreground">Per-key throttle on <code>/issues/submit</code>, <code>/issues/add_message</code>, <code>/subscribe</code>, <code>/unsubscribe</code>. Key precedence is AAuth thumbprint &gt; hashed guest token &gt; IP, so a shared NAT cannot starve another operator. Lower this in hosted multi-tenant environments.</td>
+      </tr>
+      <tr className="hover:bg-muted/50 transition-colors">
+        <td className="px-4 py-3 align-top"><code>NEOTOMA_GUEST_TOKEN_TTL_SECONDS</code></td>
+        <td className="px-4 py-3 align-top"><code>2592000</code> (30 days)</td>
+        <td className="px-4 py-3 align-top text-muted-foreground">Lifetime of guest access tokens issued by <code>generateGuestAccessToken</code>. Tokens carry a <code>revoked_at</code> column and become invalid the moment that column is set, regardless of TTL. Generation errors surface (not swallowed) so operators see when persistence fails.</td>
+      </tr>
+    </tbody>
+  </table>
+</TableScrollWrapper>
+
+These knobs do **not** affect authenticated abuse: a `software` / `hardware` AAuth tier write is rate-limited under its own attribution row, not the guest bucket. They exist so a leaked guest token cannot DoS the issue / subscription surfaces.
+
+## Peer-sync hostname enforcement
+
+`NEOTOMA_HOSTED_MODE=1` enables an inbound check on `POST /sync/webhook`: any `sender_peer_url` whose hostname resolves to a private, loopback, or link-local address (RFC 1918, `127.0.0.0/8`, `169.254.0.0/16`, IPv6 `fc00::/7`, `fe80::/10`, the `localhost` family) is rejected. Single-tenant self-hosted operators normally leave it unset; hosted control planes MUST set it. See [peer sync](/peer-sync) for the full inbound flow.
+
+## Inspector auth bypass advisory
+
+For the May 2026 Inspector auth-bypass that motivated the loopback rewrite, see [`docs/security/advisories/2026-05-11-inspector-auth-bypass.md`](https://github.com/markmhendrickson/neotoma/blob/main/docs/security/advisories/2026-05-11-inspector-auth-bypass.md). The advisory documents the trust model the v0.12 changes restored.
+
+## Operator checklist
+
+<ul className="list-none pl-0 space-y-2 mb-6">
+  <li className="text-[15px] leading-7 text-muted-foreground">
+    Set <code>NEOTOMA_HOSTED_MODE=1</code> on hosted / multi-tenant instances.
+  </li>
+  <li className="text-[15px] leading-7 text-muted-foreground">
+    Set <code>MCP_PROXY_FAIL_CLOSED=1</code> on AAuth-signed hosted MCP proxies.
+  </li>
+  <li className="text-[15px] leading-7 text-muted-foreground">
+    Lower <code>NEOTOMA_GUEST_WRITE_RATE_LIMIT_PER_MIN</code> and <code>NEOTOMA_GUEST_TOKEN_TTL_SECONDS</code> from the single-tenant defaults if guests can reach you.
+  </li>
+  <li className="text-[15px] leading-7 text-muted-foreground">
+    Audit any <code>NEOTOMA_TRUST_PROD_LOOPBACK=1</code> opt-in — it should only exist where a trusted same-host reverse proxy actually fronts the API.
+  </li>
+</ul>
+
+## Full reference
+
+[`SECURITY.md`](https://github.com/markmhendrickson/neotoma/blob/main/SECURITY.md) is the operator landing page. [`docs/security/threat_model.md`](https://github.com/markmhendrickson/neotoma/blob/main/docs/security/threat_model.md) covers the threat surface end to end, including the v0.12 operator hardening knobs section. [`docs/developer/mcp/proxy.md`](https://github.com/markmhendrickson/neotoma/blob/main/docs/developer/mcp/proxy.md) documents the AAuth proxy + fail-closed semantics.
+
+See [peer sync](/peer-sync), [issue reporting](/issue-reporting), [API reference](/api), and [MCP reference](/mcp).

--- a/docs/site/pages/en/semantic-similarity-search.md
+++ b/docs/site/pages/en/semantic-similarity-search.md
@@ -1,0 +1,52 @@
+---
+path: /semantic-similarity-search
+locale: en
+page_title: Semantic similarity search
+shell: detail
+translation_status: canonical
+nav_group: guides
+nav_order: 61
+---
+
+Semantic similarity search finds relevant prior context by meaning rather than exact text match.
+Retrieval / RAG systems pioneered this by searching over unstructured documents using vector embeddings.
+Neotoma applies the same technique to structured entity snapshots, scoped by entity type and structural
+filters.
+
+## How it works
+
+When an agent or user queries Neotoma, the system embeds the query and compares it against entity
+snapshots. Because entities are structured and typed, search can be narrowed by entity type, time range,
+or relationship before similarity ranking is applied.
+
+```bash
+# Search by meaning across all entities
+neotoma entities search --query "upcoming meetings with the design team"
+
+# Narrow by entity type
+neotoma entities search --query "design review" --entity-type event
+```
+
+## Structured vs unstructured
+
+Pure retrieval systems search over raw documents and rely on the model to extract relevant facts from
+returned chunks. Neotoma searches over snapshots that already conform to
+<MdxI18nLink to="/schema-constraints" className="text-foreground underline hover:text-foreground">
+  schema constraints
+</MdxI18nLink>
+, so results are typed and immediately usable. This combines the flexibility of semantic search with the
+reliability of
+<MdxI18nLink to="/deterministic-state-evolution" className="text-foreground underline hover:text-foreground">
+  deterministic state evolution
+</MdxI18nLink>
+.
+
+See
+<MdxI18nLink to="/memory-models" className="text-foreground underline hover:text-foreground">
+  memory models
+</MdxI18nLink>
+for a full comparison, and the
+<MdxI18nLink to="/mcp" className="text-foreground underline hover:text-foreground">
+  MCP reference
+</MdxI18nLink>
+for retrieval actions.

--- a/docs/site/pages/en/silent-mutation-risk.md
+++ b/docs/site/pages/en/silent-mutation-risk.md
@@ -1,0 +1,47 @@
+---
+path: /silent-mutation-risk
+locale: en
+page_title: Silent mutation risk
+shell: detail
+translation_status: canonical
+nav_group: guides
+nav_order: 55
+---
+
+Silent mutation risk is the chance that state changes without an explicit, inspectable trail. High-risk
+systems can overwrite or drop facts without leaving evidence.
+
+## Before vs after
+
+Before: a contact field changes after an agent run and nobody can tell when or why. After: every field
+change is an observation, and lineage can be queried by entity and timestamp.
+
+```bash
+# Inspect mutation trail for one entity
+neotoma observations list --entity-id <entity_id>
+
+# Verify relationship links for source context
+neotoma relationships list --entity-id <entity_id>
+```
+
+Deterministic systems prevent silent mutation by design through
+<MdxI18nLink to="/auditable-change-log" className="text-foreground underline hover:text-foreground">
+  auditable change logs
+</MdxI18nLink>
+and
+<MdxI18nLink to="/versioned-history" className="text-foreground underline hover:text-foreground">
+  versioned history
+</MdxI18nLink>
+. See
+<MdxI18nLink to="/conflicting-facts-risk" className="text-foreground underline hover:text-foreground">
+  conflicting facts risk
+</MdxI18nLink>
+,
+<MdxI18nLink to="/false-closure-risk" className="text-foreground underline hover:text-foreground">
+  false closure risk
+</MdxI18nLink>
+, and
+<MdxI18nLink to="/deterministic-memory" className="text-foreground underline hover:text-foreground">
+  deterministic memory
+</MdxI18nLink>
+.

--- a/docs/site/pages/en/strong-consistency.md
+++ b/docs/site/pages/en/strong-consistency.md
@@ -1,0 +1,51 @@
+---
+path: /strong-consistency
+locale: en
+page_title: Strong consistency
+shell: detail
+translation_status: canonical
+nav_group: guides
+nav_order: 110
+---
+
+Core records, entities, and events are immediately visible after write. There is no eventual-consistency
+lag between write and read for the structured store; once `store` returns, every subsequent retrieval
+sees the new state.
+
+## Before vs after
+
+Before: a write returns success, but a follow-up read may briefly see stale state because the index lags
+behind the source of truth. After: writes commit and return only when the entity, observation, and
+relationship rows are durably written and visible to subsequent reads on the same connection.
+
+## CLI example
+
+```bash
+# Write a contact and a related task in one store call
+neotoma store --json='[
+  {"entity_type":"contact","name":"Ana Rivera","city":"Barcelona"},
+  {"entity_type":"task","title":"Send Ana an intro","due_date":"2026-05-12"}
+]'
+
+# Immediately read back; no propagation delay required
+neotoma entities search "Ana Rivera" --entity-type contact
+neotoma entities list --type task
+```
+
+## What is bounded-eventual
+
+Optional secondary indices that exist for retrieval quality &mdash; full-text search (~5s) and vector
+embeddings (~10s) &mdash; are bounded-eventual rather than strongly consistent. The structured store and
+graph that drive correctness are strongly consistent. See
+
+<MdxI18nLink to="/architecture" className="text-foreground underline hover:text-foreground">
+  architecture
+</MdxI18nLink>
+
+for the full consistency model and
+
+<MdxI18nLink to="/transactional-writes" className="text-foreground underline hover:text-foreground">
+  transactional writes
+</MdxI18nLink>
+
+for the atomicity guarantee.

--- a/docs/site/pages/en/subscriptions.md
+++ b/docs/site/pages/en/subscriptions.md
@@ -1,0 +1,127 @@
+---
+path: /subscriptions
+locale: en
+page_title: Substrate subscriptions
+shell: detail
+translation_status: canonical
+nav_group: reference
+nav_order: 61
+---
+
+Substrate subscriptions deliver Neotoma write-path events to external consumers without polling. Available since v0.12.0. Each subscription is a first-class `subscription` entity, so its filters, history, and provenance live in the same SQLite + reducer model as any other Neotoma record.
+
+Use subscriptions when:
+
+<ul className="list-none pl-0 space-y-2 mb-6">
+  <li className="text-[15px] leading-7 text-muted-foreground">
+    An external workflow needs to react when a new <code>task</code> or <code>issue</code> lands.
+  </li>
+  <li className="text-[15px] leading-7 text-muted-foreground">
+    A peer Neotoma instance should mirror a subset of entity types (the{" "}
+    <MdxI18nLink to="/peer-sync" className="text-foreground underline underline-offset-2 hover:no-underline">
+      peer sync
+    </MdxI18nLink>{" "}
+    bridge runs on top of subscriptions).
+  </li>
+  <li className="text-[15px] leading-7 text-muted-foreground">
+    A live UI or third-party dashboard wants a streaming activity feed.
+  </li>
+</ul>
+
+Subscriptions are bounded by design: per-user caps, webhook circuit breakers, and a process-wide SSE ring buffer keep deliveries from overwhelming receivers.
+
+## MCP tools
+
+- `subscribe({ entity_types?, entity_ids?, event_types?, delivery_method, webhook_url?, webhook_secret?, sync_peer_id? })` — at least one of `entity_types`, `entity_ids`, or `event_types` must be non-empty (there is no firehose mode). `delivery_method` is `webhook` or `sse`.
+- `unsubscribe({ subscription_id })` — removes a subscription.
+- `list_subscriptions({ active_only? })` — enumerates subscriptions owned by the caller.
+- `get_subscription_status({ subscription_id })` — returns the current `subscription` snapshot, including `consecutive_failures`, `max_failures`, and the `active` flag (flipped to `false` by the circuit breaker after `max_failures` consecutive errors).
+
+## HTTP / SSE surface
+
+- `POST /subscribe` — same shape as the MCP tool.
+- `POST /unsubscribe` — `{ subscription_id }`.
+- `GET /events/stream?subscription_id=<id>` — Server-Sent Events stream for an SSE-mode subscription. Frame format: `id: <ring_id>\nevent: <event_type>\ndata: <json>\n\n`. Clients reconnect with `Last-Event-ID: <ring_id>` to replay buffered events.
+
+## Webhook contract
+
+<TableScrollWrapper className={DOC_TABLE_SCROLL_OUTER_CLASS}>
+  <table className="w-full text-[14px] leading-6 border-collapse md:rounded-lg md:overflow-hidden md:border md:border-border">
+    <thead>
+      <tr className="border-b border-border">
+        <th className="px-4 py-3 text-left font-semibold text-foreground bg-muted w-[12ch]">Aspect</th>
+        <th className="px-4 py-3 text-left font-semibold text-foreground bg-muted">Detail</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr className="border-b border-border hover:bg-muted/50 transition-colors">
+        <td className="px-4 py-3 align-top font-medium text-foreground">Method</td>
+        <td className="px-4 py-3 align-top text-muted-foreground"><code>POST</code> to <code>webhook_url</code>.</td>
+      </tr>
+      <tr className="border-b border-border hover:bg-muted/50 transition-colors">
+        <td className="px-4 py-3 align-top font-medium text-foreground">Headers</td>
+        <td className="px-4 py-3 align-top text-muted-foreground"><code>Content-Type: application/json</code>, <code>X-Neotoma-Signature-256: sha256=&lt;hex&gt;</code>, <code>User-Agent: neotoma-webhook/&lt;version&gt;</code>.</td>
+      </tr>
+      <tr className="border-b border-border hover:bg-muted/50 transition-colors">
+        <td className="px-4 py-3 align-top font-medium text-foreground">Body</td>
+        <td className="px-4 py-3 align-top text-muted-foreground">Canonical JSON of the <code>SubstrateEvent</code> payload via <code>stableStringify</code> (sorted keys, deterministic).</td>
+      </tr>
+      <tr className="border-b border-border hover:bg-muted/50 transition-colors">
+        <td className="px-4 py-3 align-top font-medium text-foreground">Retries</td>
+        <td className="px-4 py-3 align-top text-muted-foreground"><code>[1s, 5s, 30s, 5m]</code> for non-2xx and timeouts; failures roll the <code>consecutive_failures</code> counter.</td>
+      </tr>
+      <tr className="border-b border-border hover:bg-muted/50 transition-colors">
+        <td className="px-4 py-3 align-top font-medium text-foreground">Allow-list</td>
+        <td className="px-4 py-3 align-top text-muted-foreground"><code>https://*</code> always; <code>http://localhost</code> / <code>http://127.0.0.1</code> only outside production. Other <code>http://</code> URLs refused at registration and delivery.</td>
+      </tr>
+      <tr className="hover:bg-muted/50 transition-colors">
+        <td className="px-4 py-3 align-top font-medium text-foreground">Circuit breaker</td>
+        <td className="px-4 py-3 align-top text-muted-foreground">Reaching <code>max_failures</code> flips <code>active = false</code> via a <code>correct</code> write.</td>
+      </tr>
+    </tbody>
+  </table>
+</TableScrollWrapper>
+
+## Environment
+
+- `NEOTOMA_MAX_SUBSCRIPTIONS_PER_USER` — soft cap on active subscriptions per user (default 50).
+- `NEOTOMA_SSE_EVENT_BUFFER` — ring buffer capacity for the SSE hub (clamped 100–10000, default 1000).
+- `NEOTOMA_DEBUG_SUBSTRATE_EVENTS` — debug logging on the underlying event bus.
+
+## Example
+
+Subscribe to webhook delivery for new `issue` and `task` writes:
+
+```bash
+curl -X POST http://localhost:3080/subscribe \
+  -H "Authorization: Bearer $NEOTOMA_BEARER_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "entity_types": ["issue", "task"],
+    "delivery_method": "webhook",
+    "webhook_url": "https://hooks.example.com/neotoma"
+  }'
+```
+
+Stream the same filter as Server-Sent Events:
+
+```bash
+curl -N \
+  -H "Authorization: Bearer $NEOTOMA_BEARER_TOKEN" \
+  "http://localhost:3080/events/stream?subscription_id=<id>"
+```
+
+## Loop prevention with peer sync
+
+When a subscription is configured with `sync_peer_id = "<peer_id>"`, the bridge:
+
+- Skips events whose `source_peer_id` equals the subscription's `sync_peer_id` (those came from that peer; sending them back would loop).
+- Routes matching deliveries through the peer-sync envelope, not the generic webhook queue, so they are signed and verified per the peer's `auth_method`.
+
+See the [peer sync reference](/peer-sync) for full peer wiring.
+
+## Full reference
+
+[`docs/subsystems/subscriptions.md`](https://github.com/markmhendrickson/neotoma/blob/main/docs/subsystems/subscriptions.md) covers the `subscription` schema, the matcher (`subscriptionMatchesEvent`), the bridge (`subscription_bridge.ts`), the SSE hub (`sse_hub.ts`), the webhook delivery worker (`webhook_delivery.ts`), and the boot wiring in `install_subscription_bridge.ts`.
+
+See [peer sync](/peer-sync), [API reference](/api), and [MCP reference](/mcp).

--- a/docs/site/pages/en/terms.md
+++ b/docs/site/pages/en/terms.md
@@ -1,0 +1,144 @@
+---
+path: /terms
+locale: en
+page_title: Terms of use
+shell: detail
+translation_status: canonical
+---
+
+Version 1.0 · effective 2026-04-24
+
+These terms apply to `neotoma.io`, `agent.neotoma.io`, and the public
+sandbox at `sandbox.neotoma.io`. Neotoma the **software** is open source
+under the MIT license; these terms govern your use of the hosted
+**services** we operate.
+
+Neotoma is currently operated by **[Mark Hendrickson](https://markmhendrickson.com)** as an individual
+publisher — there is no registered legal entity operating these services
+at this time. When Neotoma transitions to a registered entity, these
+terms will be replaced.
+
+## 1. Acceptance
+
+By accessing or using any `neotoma.io` service, you agree to these terms.
+If you do not agree, do not use the services.
+
+## 2. What we offer today
+
+- **Marketing site** — documentation, product information, and the
+  open-source code hosted at `github.com/markmhendrickson/neotoma`.
+- **Agent feedback pipeline** at `agent.neotoma.io/feedback/*` — lets
+  agents running Neotoma submit structured feedback and poll for
+  resolution status.
+- **Public sandbox** at `sandbox.neotoma.io` — a free evaluation
+  instance of Neotoma, governed by additional terms at
+  [neotoma.io/sandbox/terms-of-use](/sandbox/terms-of-use)
+  (JSON for tools: `GET https://sandbox.neotoma.io/sandbox/terms`).
+
+We do not currently sell subscriptions, host user accounts, or operate
+a commercial SaaS offering. References in the open-source repository
+to Stripe billing, subscription tiers, or enterprise DPAs describe
+**planned** product work and are not currently offered.
+
+## 3. The software vs the services
+
+The Neotoma **software** (the npm package `neotoma`, the CLI, MCP
+server, and reference stack) is distributed under the MIT license.
+You may use, modify, and redistribute it under MIT terms. MIT terms
+always govern the software, not these site terms.
+
+These **site** terms govern only the hosted services at `neotoma.io`,
+`agent.neotoma.io`, and `sandbox.neotoma.io`.
+
+## 4. Acceptable use
+
+You agree not to:
+
+- Submit illegal content, harassment, spam, or content that violates
+  third-party rights to any `neotoma.io` service.
+- Attempt to bypass rate limits, access controls, or the sandbox's
+  disabled destructive endpoints.
+- Use automated systems (bots, scrapers) to load the marketing site
+  at a rate that degrades service for others.
+- Interfere with the integrity or performance of any service.
+- Submit personal data, credentials, internal business information,
+  or anything confidential to the public sandbox — sandbox content
+  is public by design and is wiped weekly.
+
+Violations may result in rate-limiting, IP blocks, or removal of
+submitted content. Abuse reports go to `contact@neotoma.io`; sandbox
+abuse reports go to `abuse@neotoma.io` or the in-app
+**Report abuse** link.
+
+## 5. Intellectual property
+
+- Neotoma software is MIT-licensed. See the LICENSE file in the
+  repository for the full text.
+- "Neotoma" and the packrat mascot are unregistered trademarks used
+  by the project. Reasonable use in community discussion, forks, and
+  integrations is welcome; please avoid uses that imply official
+  endorsement you do not have.
+- Content you submit to the feedback pipeline or sandbox: you retain
+  ownership. By submitting, you grant us a worldwide, royalty-free
+  license to store, process, and reference the submission solely to
+  operate the service and address the feedback.
+
+## 6. Data and privacy
+
+See the [Privacy Notice](/privacy) for what data is collected and how
+it is processed. The [sandbox terms](/sandbox/terms-of-use)
+additionally govern sandbox-specific data handling.
+
+## 7. No warranty, limitation of liability
+
+All hosted services are provided **"as is" and "as available"** without
+warranty of any kind. Availability, correctness, and durability are
+explicitly best-effort. The sandbox is for evaluation only, not
+production use.
+
+To the maximum extent permitted by law, [Mark Hendrickson](https://markmhendrickson.com) and any
+contributors to Neotoma disclaim all liability for indirect,
+incidental, special, consequential, or punitive damages arising from
+use of the hosted services. Your sole remedy for dissatisfaction with
+any hosted service is to stop using it.
+
+Nothing in these terms excludes liability that cannot be excluded
+under applicable consumer-protection law.
+
+## 8. Changes to the services
+
+We may modify, suspend, or discontinue any hosted service at any time.
+We will provide reasonable notice of material changes on the marketing
+site when feasible. Open-source software you have already downloaded
+and run locally is unaffected by service changes.
+
+## 9. Governing law
+
+These terms are governed by the laws applicable to [Mark Hendrickson](https://markmhendrickson.com)'s
+jurisdiction of residence. Any disputes will be resolved in courts of
+competent jurisdiction there. Consumer rights under your local law
+apply to the extent they cannot be waived by contract.
+
+## 10. Changes to these terms
+
+Material changes will be flagged at the top of this page with a new
+effective date. Non-material changes will be committed without
+announcement.
+
+## 11. Contact
+
+**[Mark Hendrickson](https://markmhendrickson.com)**, publisher of Neotoma
+Email: contact@neotoma.io
+
+## Revision history
+
+### 1.0 — 2026-04-24
+
+- Initial publication of the pre-incorporation site terms of use.
+- Supersedes the `docs/legal/terms_of_service.md` template, which is
+  retained as the reference draft for post-incorporation publication.
+
+
+
+  See also the [Privacy Notice](/privacy){" "}
+  and the [sandbox-specific terms](/sandbox/terms-of-use).

--- a/docs/site/pages/en/trading.md
+++ b/docs/site/pages/en/trading.md
@@ -1,0 +1,8 @@
+---
+path: /trading
+locale: en
+page_title: Neotoma for Autonomous Trading
+shell: detail
+translation_status: canonical
+component: TradingLandingPageBody
+---

--- a/docs/site/pages/en/transactional-writes.md
+++ b/docs/site/pages/en/transactional-writes.md
@@ -1,0 +1,52 @@
+---
+path: /transactional-writes
+locale: en
+page_title: Transactional writes
+shell: detail
+translation_status: canonical
+nav_group: guides
+nav_order: 115
+---
+
+All graph inserts &mdash; entities, observations, relationships, and any optional file source &mdash; commit in a
+single transaction. Either everything succeeds, or nothing changes. There is no partial state where one
+half of a write landed and the other half did not.
+
+## Before vs after
+
+Before: a multi-step write succeeds halfway, leaving an entity without its observation, or a relationship
+that points at a row that never committed. After: an error during any part of the batch rolls the entire
+operation back; readers only ever see fully-formed state.
+
+## CLI example
+
+```bash
+# Atomic batch: contact + relationship to existing event
+neotoma store --json='[
+  {"entity_type":"contact","name":"Ana Rivera"},
+  {"entity_type":"event","title":"Intro call","start_time":"2026-05-12T14:00:00Z"}
+]' --relationships='[
+  {"relationship_type":"PART_OF","source_index":0,"target_index":1}
+]'
+```
+
+If any entity in the batch is rejected by schema validation, no rows are written. The same applies to
+relationships, attached file sources, and the substrate event emissions associated with the write.
+
+## Why it matters
+
+Agents fan-out work to Neotoma in batches. Without transactional writes, a half-committed batch creates
+phantom state that downstream readers must defensively detect and reconcile. Treating the batch as
+indivisible removes that class of bug entirely. See
+
+<MdxI18nLink to="/strong-consistency" className="text-foreground underline hover:text-foreground">
+  strong consistency
+</MdxI18nLink>
+
+and
+
+<MdxI18nLink to="/architecture" className="text-foreground underline hover:text-foreground">
+  architecture
+</MdxI18nLink>
+
+for the broader consistency model.

--- a/docs/site/pages/en/troubleshooting.md
+++ b/docs/site/pages/en/troubleshooting.md
@@ -1,0 +1,70 @@
+---
+path: /troubleshooting
+locale: en
+page_title: Troubleshooting
+shell: detail
+translation_status: canonical
+nav_group: reference
+nav_order: 30
+---
+
+Use this guide when setup or behavior is unclear. For deterministic systems, the fastest path is to inspect state, provenance, and transport mode instead of guessing.
+
+## Agent is not storing memory entries
+
+**Check:** Confirm MCP server is configured and running, then verify tool calls include store actions.
+
+**Fix:** Recheck client config (`.cursor/mcp.json`, `.mcp.json`, or `.codex/config.toml`) and restart the client.
+
+## Entity query returns empty results
+
+**Check:** Verify the entity type and filters used by your query.
+
+**Fix:** Run `neotoma entities list --type <entity_type>` without search first, then narrow filters.
+
+## Unexpected or conflicting state values
+
+**Check:** Inspect observations and provenance for that entity and field.
+
+**Fix:** Use correction flows (`correct`, `reinterpret`) and confirm deterministic merge rules in schema/reducer logic.
+
+## CLI command behavior differs from API
+
+**Check:** Check transport mode (`--offline`, `--api-only`, base URL) and environment selection.
+
+**Fix:** Pin the mode explicitly for reproducible debugging, then compare with API endpoint responses.
+
+## Need to reset local state safely
+
+**Check:** Export data first for auditability.
+
+**Fix:** Back up data directory, then reinitialize. Avoid deleting data until exports are verified.
+
+## Useful commands
+
+```
+# Inspect entities
+neotoma entities list --type task --limit 20
+
+# Trace lineage for one entity
+neotoma observations list --entity-id <entity_id>
+neotoma relationships list --entity-id <entity_id>
+
+# Confirm server health
+neotoma stats
+```
+
+
+  See{" "}
+  <MdxI18nLink to="/cli" className="text-foreground underline underline-offset-2 hover:no-underline">
+    CLI reference
+  </MdxI18nLink>
+  ,{" "}
+  <MdxI18nLink to="/mcp" className="text-foreground underline underline-offset-2 hover:no-underline">
+    MCP reference
+  </MdxI18nLink>
+  , and{" "}
+  <MdxI18nLink to="/architecture" className="text-foreground underline underline-offset-2 hover:no-underline">
+    architecture
+  </MdxI18nLink>{" "}
+  for deeper diagnostics.

--- a/docs/site/pages/en/versioned-history.md
+++ b/docs/site/pages/en/versioned-history.md
@@ -1,0 +1,40 @@
+---
+path: /versioned-history
+locale: en
+page_title: Versioned history
+shell: detail
+translation_status: canonical
+nav_group: guides
+nav_order: 51
+---
+
+Every change creates a new version instead of overwriting prior state. Earlier snapshots remain
+queryable, so you can answer what the system believed at any point.
+
+## Before vs after
+
+Before: a row update erases the old value unless you added custom history tables. After: each correction
+is appended as a new observation, so historical state is preserved by default.
+
+```bash
+# Current snapshot
+neotoma entities search --query "Ana Rivera" --entity-type contact
+
+# Historical lineage
+neotoma observations list --entity-id <entity_id>
+```
+
+This aligns with event-sourcing principles: the observation log is authoritative, snapshots are derived
+views. See
+<MdxI18nLink to="/deterministic-state-evolution" className="text-foreground underline hover:text-foreground">
+  deterministic state evolution
+</MdxI18nLink>
+,
+<MdxI18nLink to="/auditable-change-log" className="text-foreground underline hover:text-foreground">
+  auditable change log
+</MdxI18nLink>
+, and
+<MdxI18nLink to="/human-inspectability" className="text-foreground underline hover:text-foreground">
+  human inspectability
+</MdxI18nLink>
+.

--- a/docs/site/pages/en/zero-setup-onboarding.md
+++ b/docs/site/pages/en/zero-setup-onboarding.md
@@ -1,0 +1,54 @@
+---
+title: Zero setup onboarding
+category: developer_reference
+subcategory: inspector
+locale: en
+nav_group: guides
+nav_order: 60
+page_title: Zero-setup onboarding
+path: /zero-setup-onboarding
+shell: detail
+translation_status: canonical
+---
+
+# Zero setup onboarding
+
+Zero-setup onboarding means memory works from the first message with no installation, configuration,
+or infrastructure required. Platform memory products like ChatGPT and Claude provide this by embedding
+memory into the chat product itself.
+
+## Trade-offs
+
+The convenience of zero-setup comes at a cost: the vendor controls where data lives, how it is
+structured, and what guarantees it provides. Users cannot export, version, or audit memory independently.
+Retrieval systems and file-based approaches require setup but offer more control. Neotoma requires
+installation but provides
+<MdxI18nLink to="/deterministic-state-evolution" className="text-foreground underline hover:text-foreground">
+  deterministic state evolution
+</MdxI18nLink>
+,
+<MdxI18nLink to="/versioned-history" className="text-foreground underline hover:text-foreground">
+  versioned history
+</MdxI18nLink>
+, and
+<MdxI18nLink to="/human-inspectability" className="text-foreground underline hover:text-foreground">
+  human inspectability
+</MdxI18nLink>
+in exchange.
+
+## Getting started with Neotoma
+
+While Neotoma is not zero-setup, the install process is minimal. See the
+<MdxTrackedInstallLink variant="zero_setup_onboarding">install guide</MdxTrackedInstallLink>
+for step-by-step instructions.
+
+```bash
+npm install -g neotoma
+neotoma api start --env prod
+```
+
+Compare memory approaches on the
+<MdxI18nLink to="/memory-models" className="text-foreground underline hover:text-foreground">
+  memory models
+</MdxI18nLink>
+page.

--- a/docs/site/pages/es/agent-auth.md
+++ b/docs/site/pages/es/agent-auth.md
@@ -1,0 +1,15 @@
+---
+title: Agent auth
+category: developer_reference
+subcategory: inspector
+component: AgentAuthLandingPageBody
+locale: es
+page_title: Neotoma for Agent Authorization
+path: /agent-auth
+shell: detail
+translation_of: /agent-auth
+translation_status: machine_draft
+---
+
+# Agent auth
+

--- a/docs/site/pages/es/build-vs-buy.md
+++ b/docs/site/pages/es/build-vs-buy.md
@@ -1,0 +1,15 @@
+---
+title: Build vs buy
+category: developer_reference
+subcategory: inspector
+component: BuildVsBuyPageBody
+locale: es
+page_title: When to add a state integrity layer (and when observability is enough)
+path: /build-vs-buy
+shell: detail
+translation_of: /build-vs-buy
+translation_status: machine_draft
+---
+
+# Build vs buy
+

--- a/docs/site/pages/es/building-pipelines.md
+++ b/docs/site/pages/es/building-pipelines.md
@@ -1,0 +1,17 @@
+---
+title: Building pipelines
+category: developer_reference
+subcategory: inspector
+component: AgenticSystemsBuildersPageBody
+locale: es
+nav_group: icp
+nav_order: 11
+page_title: Inference variance
+path: /building-pipelines
+shell: detail
+translation_of: /building-pipelines
+translation_status: machine_draft
+---
+
+# Building pipelines
+

--- a/docs/site/pages/es/cases.md
+++ b/docs/site/pages/es/cases.md
@@ -1,0 +1,9 @@
+---
+path: /cases
+locale: es
+page_title: Neotoma for Case Management
+shell: detail
+translation_of: /cases
+translation_status: machine_draft
+component: CasesLandingPageBody
+---

--- a/docs/site/pages/es/changelog.md
+++ b/docs/site/pages/es/changelog.md
@@ -1,0 +1,16 @@
+---
+path: /changelog
+locale: es
+page_title: Registro de cambios
+shell: detail
+translation_of: /changelog
+translation_status: human_draft
+nav_group: reference
+nav_order: 40
+---
+
+Historial de versiones, notas de migración y cambios de compatibilidad. Para instalación y actualización, consulta [Instalación](/install) y el [índice de documentación](/docs).
+
+
+
+Las versiones publicadas están en GitHub y npm. Al actualizar clientes o proxies MCP, fija versiones explícitas y repasa el [recorrido](/walkthrough) si cambia el transporte o el nivel de atribución.

--- a/docs/site/pages/es/compliance.md
+++ b/docs/site/pages/es/compliance.md
@@ -1,0 +1,9 @@
+---
+path: /compliance
+locale: es
+page_title: Neotoma for Compliance
+shell: detail
+translation_of: /compliance
+translation_status: machine_draft
+component: ComplianceLandingPageBody
+---

--- a/docs/site/pages/es/contracts.md
+++ b/docs/site/pages/es/contracts.md
@@ -1,0 +1,9 @@
+---
+path: /contracts
+locale: es
+page_title: Neotoma for Contracts
+shell: detail
+translation_of: /contracts
+translation_status: machine_draft
+component: ContractsLandingPageBody
+---

--- a/docs/site/pages/es/crm.md
+++ b/docs/site/pages/es/crm.md
@@ -1,0 +1,15 @@
+---
+title: CRM
+category: developer_reference
+subcategory: inspector
+component: CrmLandingPageBody
+locale: es
+page_title: Neotoma for CRM
+path: /crm
+shell: detail
+translation_of: /crm
+translation_status: machine_draft
+---
+
+# CRM
+

--- a/docs/site/pages/es/crypto-engineering.md
+++ b/docs/site/pages/es/crypto-engineering.md
@@ -1,0 +1,15 @@
+---
+title: Crypto engineering
+category: developer_reference
+subcategory: inspector
+component: CryptoEngineeringLandingPageBody
+locale: es
+page_title: "Neotoma for crypto & security-sensitive engineering"
+path: /crypto-engineering
+shell: detail
+translation_of: /crypto-engineering
+translation_status: machine_draft
+---
+
+# Crypto engineering
+

--- a/docs/site/pages/es/customer-ops.md
+++ b/docs/site/pages/es/customer-ops.md
@@ -1,0 +1,15 @@
+---
+title: Customer ops
+category: developer_reference
+subcategory: inspector
+component: CustomerOpsLandingPageBody
+locale: es
+page_title: Neotoma for Customer Ops
+path: /customer-ops
+shell: detail
+translation_of: /customer-ops
+translation_status: machine_draft
+---
+
+# Customer ops
+

--- a/docs/site/pages/es/debugging-infrastructure.md
+++ b/docs/site/pages/es/debugging-infrastructure.md
@@ -1,0 +1,17 @@
+---
+title: Debugging infrastructure
+category: developer_reference
+subcategory: inspector
+component: AiInfrastructureEngineersPageBody
+locale: es
+nav_group: icp
+nav_order: 12
+page_title: Log archaeology
+path: /debugging-infrastructure
+shell: detail
+translation_of: /debugging-infrastructure
+translation_status: machine_draft
+---
+
+# Debugging infrastructure
+

--- a/docs/site/pages/es/diligence.md
+++ b/docs/site/pages/es/diligence.md
@@ -1,0 +1,9 @@
+---
+path: /diligence
+locale: es
+page_title: Neotoma for Due Diligence
+shell: detail
+translation_of: /diligence
+translation_status: machine_draft
+component: DiligenceLandingPageBody
+---

--- a/docs/site/pages/es/faq.md
+++ b/docs/site/pages/es/faq.md
@@ -1,0 +1,15 @@
+---
+title: FAQ
+category: developer_reference
+subcategory: inspector
+locale: es
+page_title: Preguntas frecuentes
+path: /faq
+shell: detail
+translation_of: /faq
+translation_status: human_draft
+---
+
+# FAQ
+
+Respuestas a preguntas habituales sobre Neotoma: qué es, cómo se compara con SQLite/Mem0/Zep/RAG, cómo convive con la memoria de Claude Code, qué debería recordar tu agente y cómo instalarlo.

--- a/docs/site/pages/es/financial-ops.md
+++ b/docs/site/pages/es/financial-ops.md
@@ -1,0 +1,15 @@
+---
+title: Financial ops
+category: developer_reference
+subcategory: inspector
+component: FinancialOpsLandingPageBody
+locale: es
+page_title: Neotoma for Financial Ops
+path: /financial-ops
+shell: detail
+translation_of: /financial-ops
+translation_status: machine_draft
+---
+
+# Financial ops
+

--- a/docs/site/pages/es/government.md
+++ b/docs/site/pages/es/government.md
@@ -1,0 +1,9 @@
+---
+path: /government
+locale: es
+page_title: Neotoma for Public Sector
+shell: detail
+translation_of: /government
+translation_status: machine_draft
+component: GovTechLandingPageBody
+---

--- a/docs/site/pages/es/healthcare.md
+++ b/docs/site/pages/es/healthcare.md
@@ -1,0 +1,9 @@
+---
+path: /healthcare
+locale: es
+page_title: Neotoma for Healthcare
+shell: detail
+translation_of: /healthcare
+translation_status: machine_draft
+component: HealthcareLandingPageBody
+---

--- a/docs/site/pages/es/home.md
+++ b/docs/site/pages/es/home.md
@@ -1,0 +1,11 @@
+---
+path: /
+locale: es
+page_title: Neotoma
+shell: detail
+translation_of: /
+translation_status: machine_draft
+component: SitePage
+nav_group: marketing
+nav_order: 0
+---

--- a/docs/site/pages/es/hosted.md
+++ b/docs/site/pages/es/hosted.md
@@ -1,0 +1,9 @@
+---
+path: /hosted
+locale: es
+page_title: Hosted Neotoma
+shell: detail
+translation_of: /hosted
+translation_status: machine_draft
+component: HostedLandingPageBody
+---

--- a/docs/site/pages/es/install-docker.md
+++ b/docs/site/pages/es/install-docker.md
@@ -1,0 +1,11 @@
+---
+path: /install/docker
+locale: es
+page_title: Docker install
+shell: detail
+translation_of: /install/docker
+translation_status: machine_draft
+component: InstallDockerPageBody
+nav_group: guides
+nav_order: 7
+---

--- a/docs/site/pages/es/install-manual.md
+++ b/docs/site/pages/es/install-manual.md
@@ -1,0 +1,17 @@
+---
+title: Install manual
+category: developer_reference
+subcategory: inspector
+component: InstallManualPageBody
+locale: es
+nav_group: guides
+nav_order: 6
+page_title: Manual install
+path: /install/manual
+shell: detail
+translation_of: /install/manual
+translation_status: machine_draft
+---
+
+# Install manual
+

--- a/docs/site/pages/es/install.md
+++ b/docs/site/pages/es/install.md
@@ -1,0 +1,11 @@
+---
+path: /install
+locale: es
+page_title: Install
+shell: detail
+translation_of: /install
+translation_status: machine_draft
+component: InstallPageBody
+nav_group: guides
+nav_order: 5
+---

--- a/docs/site/pages/es/logistics.md
+++ b/docs/site/pages/es/logistics.md
@@ -1,0 +1,9 @@
+---
+path: /logistics
+locale: es
+page_title: Neotoma for Logistics
+shell: detail
+translation_of: /logistics
+translation_status: machine_draft
+component: LogisticsLandingPageBody
+---

--- a/docs/site/pages/es/memory-guarantees.md
+++ b/docs/site/pages/es/memory-guarantees.md
@@ -1,0 +1,17 @@
+---
+title: Memory guarantees
+category: developer_reference
+subcategory: inspector
+component: MemoryGuaranteesPageBody
+locale: es
+nav_group: guides
+nav_order: 18
+page_title: Memory Guarantees
+path: /memory-guarantees
+shell: detail
+translation_of: /memory-guarantees
+translation_status: machine_draft
+---
+
+# Memory guarantees
+

--- a/docs/site/pages/es/neotoma-vs-database.md
+++ b/docs/site/pages/es/neotoma-vs-database.md
@@ -1,0 +1,15 @@
+---
+title: Neotoma vs database
+category: developer_reference
+subcategory: inspector
+component: NeotomaVsDatabasePageBody
+locale: es
+page_title: Neotoma vs database memory
+path: /neotoma-vs-database
+shell: detail
+translation_of: /neotoma-vs-database
+translation_status: machine_draft
+---
+
+# Neotoma vs database
+

--- a/docs/site/pages/es/neotoma-vs-files.md
+++ b/docs/site/pages/es/neotoma-vs-files.md
@@ -1,0 +1,15 @@
+---
+title: Neotoma vs files
+category: developer_reference
+subcategory: inspector
+component: NeotomaVsFilePageBody
+locale: es
+page_title: Neotoma vs file-based memory
+path: /neotoma-vs-files
+shell: detail
+translation_of: /neotoma-vs-files
+translation_status: machine_draft
+---
+
+# Neotoma vs files
+

--- a/docs/site/pages/es/neotoma-vs-mem0.md
+++ b/docs/site/pages/es/neotoma-vs-mem0.md
@@ -1,0 +1,15 @@
+---
+title: Neotoma vs Mem0
+category: developer_reference
+subcategory: inspector
+component: NeotomaVsMem0PageBody
+locale: es
+page_title: Neotoma vs Mem0
+path: /neotoma-vs-mem0
+shell: detail
+translation_of: /neotoma-vs-mem0
+translation_status: machine_draft
+---
+
+# Neotoma vs Mem0
+

--- a/docs/site/pages/es/neotoma-vs-platform-memory.md
+++ b/docs/site/pages/es/neotoma-vs-platform-memory.md
@@ -1,0 +1,15 @@
+---
+title: Neotoma vs platform memory
+category: developer_reference
+subcategory: inspector
+component: NeotomaVsPlatformMemoryPageBody
+locale: es
+page_title: Neotoma vs platform memory
+path: /neotoma-vs-platform-memory
+shell: detail
+translation_of: /neotoma-vs-platform-memory
+translation_status: machine_draft
+---
+
+# Neotoma vs platform memory
+

--- a/docs/site/pages/es/neotoma-vs-rag.md
+++ b/docs/site/pages/es/neotoma-vs-rag.md
@@ -1,0 +1,15 @@
+---
+title: Neotoma vs RAG
+category: developer_reference
+subcategory: inspector
+component: NeotomaVsRagPageBody
+locale: es
+page_title: Neotoma vs RAG memory
+path: /neotoma-vs-rag
+shell: detail
+translation_of: /neotoma-vs-rag
+translation_status: machine_draft
+---
+
+# Neotoma vs RAG
+

--- a/docs/site/pages/es/neotoma-vs-zep.md
+++ b/docs/site/pages/es/neotoma-vs-zep.md
@@ -1,0 +1,15 @@
+---
+title: Neotoma vs Zep
+category: developer_reference
+subcategory: inspector
+component: NeotomaVsZepPageBody
+locale: es
+page_title: Neotoma vs Zep
+path: /neotoma-vs-zep
+shell: detail
+translation_of: /neotoma-vs-zep
+translation_status: machine_draft
+---
+
+# Neotoma vs Zep
+

--- a/docs/site/pages/es/neotoma-with-chatgpt-connect-custom-gpt.md
+++ b/docs/site/pages/es/neotoma-with-chatgpt-connect-custom-gpt.md
@@ -1,0 +1,17 @@
+---
+title: Neotoma with ChatGPT connect custom GPT
+category: developer_reference
+subcategory: inspector
+component: ChatGptConnectCustomGptPageBody
+locale: es
+nav_group: integrations
+nav_order: 47
+page_title: Connect via custom GPT with OpenAPI
+path: /neotoma-with-chatgpt-connect-custom-gpt
+shell: detail
+translation_of: /neotoma-with-chatgpt-connect-custom-gpt
+translation_status: machine_draft
+---
+
+# Neotoma with ChatGPT connect custom GPT
+

--- a/docs/site/pages/es/neotoma-with-chatgpt-connect-remote-mcp.md
+++ b/docs/site/pages/es/neotoma-with-chatgpt-connect-remote-mcp.md
@@ -1,0 +1,17 @@
+---
+title: Neotoma with ChatGPT connect remote MCP
+category: developer_reference
+subcategory: inspector
+component: ChatGptConnectRemoteMcpPageBody
+locale: es
+nav_group: integrations
+nav_order: 46
+page_title: Connect ChatGPT via remote MCP
+path: /neotoma-with-chatgpt-connect-remote-mcp
+shell: detail
+translation_of: /neotoma-with-chatgpt-connect-remote-mcp
+translation_status: machine_draft
+---
+
+# Neotoma with ChatGPT connect remote MCP
+

--- a/docs/site/pages/es/neotoma-with-chatgpt.md
+++ b/docs/site/pages/es/neotoma-with-chatgpt.md
@@ -1,0 +1,17 @@
+---
+title: Neotoma with ChatGPT
+category: developer_reference
+subcategory: inspector
+component: NeotomaWithChatGPTPageBody
+locale: es
+nav_group: integrations
+nav_order: 25
+page_title: Neotoma with ChatGPT
+path: /neotoma-with-chatgpt
+shell: detail
+translation_of: /neotoma-with-chatgpt
+translation_status: machine_draft
+---
+
+# Neotoma with ChatGPT
+

--- a/docs/site/pages/es/neotoma-with-claude-agent-sdk.md
+++ b/docs/site/pages/es/neotoma-with-claude-agent-sdk.md
@@ -1,0 +1,17 @@
+---
+title: Neotoma with Claude agent SDK
+category: developer_reference
+subcategory: inspector
+component: NeotomaWithClaudeAgentSdkPageBody
+locale: es
+nav_group: integrations
+nav_order: 32
+page_title: Memory infrastructure for Claude agents
+path: /neotoma-with-claude-agent-sdk
+shell: detail
+translation_of: /neotoma-with-claude-agent-sdk
+translation_status: machine_draft
+---
+
+# Neotoma with Claude agent SDK
+

--- a/docs/site/pages/es/neotoma-with-claude-code.md
+++ b/docs/site/pages/es/neotoma-with-claude-code.md
@@ -1,0 +1,17 @@
+---
+title: Neotoma with Claude code
+category: developer_reference
+subcategory: inspector
+component: NeotomaWithClaudeCodePageBody
+locale: es
+nav_group: integrations
+nav_order: 31
+page_title: Neotoma with Claude Code
+path: /neotoma-with-claude-code
+shell: detail
+translation_of: /neotoma-with-claude-code
+translation_status: machine_draft
+---
+
+# Neotoma with Claude code
+

--- a/docs/site/pages/es/neotoma-with-claude-connect-desktop.md
+++ b/docs/site/pages/es/neotoma-with-claude-connect-desktop.md
@@ -1,0 +1,17 @@
+---
+title: Neotoma with Claude connect desktop
+category: developer_reference
+subcategory: inspector
+component: ClaudeConnectDesktopPageBody
+locale: es
+nav_group: integrations
+nav_order: 42
+page_title: Claude Desktop local setup
+path: /neotoma-with-claude-connect-desktop
+shell: detail
+translation_of: /neotoma-with-claude-connect-desktop
+translation_status: machine_draft
+---
+
+# Neotoma with Claude connect desktop
+

--- a/docs/site/pages/es/neotoma-with-claude-connect-remote-mcp.md
+++ b/docs/site/pages/es/neotoma-with-claude-connect-remote-mcp.md
@@ -1,0 +1,17 @@
+---
+title: Neotoma with Claude connect remote MCP
+category: developer_reference
+subcategory: inspector
+component: ClaudeConnectRemoteMcpPageBody
+locale: es
+nav_group: integrations
+nav_order: 43
+page_title: claude.ai remote MCP setup
+path: /neotoma-with-claude-connect-remote-mcp
+shell: detail
+translation_of: /neotoma-with-claude-connect-remote-mcp
+translation_status: machine_draft
+---
+
+# Neotoma with Claude connect remote MCP
+

--- a/docs/site/pages/es/neotoma-with-claude.md
+++ b/docs/site/pages/es/neotoma-with-claude.md
@@ -1,0 +1,17 @@
+---
+title: Neotoma with Claude
+category: developer_reference
+subcategory: inspector
+component: NeotomaWithClaudePageBody
+locale: es
+nav_group: integrations
+nav_order: 30
+page_title: Neotoma with Claude
+path: /neotoma-with-claude
+shell: detail
+translation_of: /neotoma-with-claude
+translation_status: machine_draft
+---
+
+# Neotoma with Claude
+

--- a/docs/site/pages/es/neotoma-with-codex-connect-local-stdio.md
+++ b/docs/site/pages/es/neotoma-with-codex-connect-local-stdio.md
@@ -1,0 +1,17 @@
+---
+title: Neotoma with Codex connect local stdio
+category: developer_reference
+subcategory: inspector
+component: CodexConnectLocalStdioPageBody
+locale: es
+nav_group: integrations
+nav_order: 40
+page_title: Codex local setup (stdio)
+path: /neotoma-with-codex-connect-local-stdio
+shell: detail
+translation_of: /neotoma-with-codex-connect-local-stdio
+translation_status: machine_draft
+---
+
+# Neotoma with Codex connect local stdio
+

--- a/docs/site/pages/es/neotoma-with-codex-connect-remote-http-oauth.md
+++ b/docs/site/pages/es/neotoma-with-codex-connect-remote-http-oauth.md
@@ -1,0 +1,17 @@
+---
+title: Neotoma with Codex connect remote HTTP OAuth
+category: developer_reference
+subcategory: inspector
+component: CodexConnectRemoteHttpOauthPageBody
+locale: es
+nav_group: integrations
+nav_order: 41
+page_title: Codex remote setup (HTTP with OAuth)
+path: /neotoma-with-codex-connect-remote-http-oauth
+shell: detail
+translation_of: /neotoma-with-codex-connect-remote-http-oauth
+translation_status: machine_draft
+---
+
+# Neotoma with Codex connect remote HTTP OAuth
+

--- a/docs/site/pages/es/neotoma-with-codex.md
+++ b/docs/site/pages/es/neotoma-with-codex.md
@@ -1,0 +1,17 @@
+---
+title: Neotoma with Codex
+category: developer_reference
+subcategory: inspector
+component: NeotomaWithCodexPageBody
+locale: es
+nav_group: integrations
+nav_order: 27
+page_title: Neotoma with Codex
+path: /neotoma-with-codex
+shell: detail
+translation_of: /neotoma-with-codex
+translation_status: machine_draft
+---
+
+# Neotoma with Codex
+

--- a/docs/site/pages/es/neotoma-with-cursor.md
+++ b/docs/site/pages/es/neotoma-with-cursor.md
@@ -1,0 +1,17 @@
+---
+title: Neotoma with Cursor
+category: developer_reference
+subcategory: inspector
+component: NeotomaWithCursorPageBody
+locale: es
+nav_group: integrations
+nav_order: 29
+page_title: Neotoma with Cursor
+path: /neotoma-with-cursor
+shell: detail
+translation_of: /neotoma-with-cursor
+translation_status: machine_draft
+---
+
+# Neotoma with Cursor
+

--- a/docs/site/pages/es/neotoma-with-ironclaw.md
+++ b/docs/site/pages/es/neotoma-with-ironclaw.md
@@ -1,0 +1,17 @@
+---
+title: Neotoma with Ironclaw
+category: developer_reference
+subcategory: inspector
+component: NeotomaWithIronClawPageBody
+locale: es
+nav_group: integrations
+nav_order: 26
+page_title: Neotoma with IronClaw
+path: /neotoma-with-ironclaw
+shell: detail
+translation_of: /neotoma-with-ironclaw
+translation_status: machine_draft
+---
+
+# Neotoma with Ironclaw
+

--- a/docs/site/pages/es/neotoma-with-openclaw-connect-local-stdio.md
+++ b/docs/site/pages/es/neotoma-with-openclaw-connect-local-stdio.md
@@ -1,0 +1,17 @@
+---
+title: Neotoma with Openclaw connect local stdio
+category: developer_reference
+subcategory: inspector
+component: OpenClawConnectLocalStdioPageBody
+locale: es
+nav_group: integrations
+nav_order: 44
+page_title: OpenClaw local setup (stdio)
+path: /neotoma-with-openclaw-connect-local-stdio
+shell: detail
+translation_of: /neotoma-with-openclaw-connect-local-stdio
+translation_status: machine_draft
+---
+
+# Neotoma with Openclaw connect local stdio
+

--- a/docs/site/pages/es/neotoma-with-openclaw-connect-remote-http.md
+++ b/docs/site/pages/es/neotoma-with-openclaw-connect-remote-http.md
@@ -1,0 +1,17 @@
+---
+title: Neotoma with Openclaw connect remote HTTP
+category: developer_reference
+subcategory: inspector
+component: OpenClawConnectRemoteHttpPageBody
+locale: es
+nav_group: integrations
+nav_order: 45
+page_title: OpenClaw remote setup (HTTP)
+path: /neotoma-with-openclaw-connect-remote-http
+shell: detail
+translation_of: /neotoma-with-openclaw-connect-remote-http
+translation_status: machine_draft
+---
+
+# Neotoma with Openclaw connect remote HTTP
+

--- a/docs/site/pages/es/neotoma-with-openclaw.md
+++ b/docs/site/pages/es/neotoma-with-openclaw.md
@@ -1,0 +1,17 @@
+---
+title: Neotoma with Openclaw
+category: developer_reference
+subcategory: inspector
+component: NeotomaWithOpenClawPageBody
+locale: es
+nav_group: integrations
+nav_order: 33
+page_title: Neotoma with OpenClaw
+path: /neotoma-with-openclaw
+shell: detail
+translation_of: /neotoma-with-openclaw
+translation_status: machine_draft
+---
+
+# Neotoma with Openclaw
+

--- a/docs/site/pages/es/neotoma-with-opencode.md
+++ b/docs/site/pages/es/neotoma-with-opencode.md
@@ -1,0 +1,17 @@
+---
+title: Neotoma with Opencode
+category: developer_reference
+subcategory: inspector
+component: NeotomaWithOpenCodePageBody
+locale: es
+nav_group: integrations
+nav_order: 28
+page_title: Neotoma with OpenCode
+path: /neotoma-with-opencode
+shell: detail
+translation_of: /neotoma-with-opencode
+translation_status: machine_draft
+---
+
+# Neotoma with Opencode
+

--- a/docs/site/pages/es/non-destructive-testing.md
+++ b/docs/site/pages/es/non-destructive-testing.md
@@ -1,0 +1,231 @@
+---
+path: /non-destructive-testing
+locale: es
+page_title: Probar con seguridad
+shell: detail
+translation_of: /non-destructive-testing
+translation_status: canonical
+nav_group: guides
+nav_order: 7
+---
+
+No necesitas comprometerte con Neotoma para saber si te encaja. Instálalo junto a lo que ya uses, ingiere una porción de tu historial, ejecuta tu agente con y sin Neotoma y compara. Nada de tu configuración actual se mueve, modifica ni reemplaza.
+
+Esta guía recorre la ruta recomendada de instalación en sombra: instalar → ingerir historial → comparar A/B → decidir. Tu sistema de memoria existente (`MEMORY.md`, `claw.md`, un servidor MCP propio, memoria de plataforma como Claude o ChatGPT) queda intacto en todo momento.
+
+## Qué significa "probar con seguridad" aquí
+
+Neotoma escribe en una base SQLite local dentro de su propio directorio de datos. No toca tus otros archivos, la configuración del editor, las plantillas de prompts de tu agente ni cualquier otro almacén de memoria que ya uses. Si desinstalas, el único artefacto es el directorio de datos de Neotoma; todo lo demás sigue exactamente donde estaba.
+
+<ul className="list-none pl-0 space-y-2 mb-6">
+  <li className="text-[15px] leading-7 flex items-start gap-2 [&>p]:m-0">
+    <span className="text-emerald-500 mt-0.5 shrink-0 [&>p]:m-0 [&>p]:leading-none" aria-hidden>
+      &rarr;
+    </span>
+    Tus archivos de memoria existentes no se leen, bloquean ni reescriben.
+  </li>
+  <li className="text-[15px] leading-7 flex items-start gap-2 [&>p]:m-0">
+    <span className="text-emerald-500 mt-0.5 shrink-0 [&>p]:m-0 [&>p]:leading-none" aria-hidden>
+      &rarr;
+    </span>
+    Los datos de Neotoma viven en su propio directorio que puedes borrar, respaldar o apartar cuando quieras.
+  </li>
+  <li className="text-[15px] leading-7 flex items-start gap-2 [&>p]:m-0">
+    <span className="text-emerald-500 mt-0.5 shrink-0 [&>p]:m-0 [&>p]:leading-none" aria-hidden>
+      &rarr;
+    </span>
+    Tu agente decide cuándo leer o escribir en Neotoma; nada se intercepta en segundo plano.
+  </li>
+  <li className="text-[15px] leading-7 flex items-start gap-2 [&>p]:m-0">
+    <span className="text-emerald-500 mt-0.5 shrink-0 [&>p]:m-0 [&>p]:leading-none" aria-hidden>
+      &rarr;
+    </span>
+    Los esquemas se infieren a partir de tus datos, así que la prueba no requiere modelar nada por adelantado.
+  </li>
+</ul>
+
+## Paso 1 — Instala en modo sombra
+
+```bash
+npm install -g neotoma
+NEOTOMA_DATA_DIR=~/.neotoma-shadow neotoma setup --tool cursor --yes
+```
+
+`neotoma setup --tool <tool> --yes` es la ruta más rápida cuando ya sabes con qué cliente quieres probar primero. Ejecuta el paso idempotente de `init`, configura MCP y aplica la guía local del agente correspondiente. Sustituye `cursor` por `claude-code`, `codex` u otra herramienta compatible. Si prefieres el flujo paso a paso, usa `neotoma init --interactive` y luego `neotoma mcp config`.
+
+Si ejecutas `setup` con `NEOTOMA_DATA_DIR`, el paso de `init` dentro de `setup` escribe esa ruta en la configuración de entorno de Neotoma para que los siguientes comandos reutilicen el mismo directorio en sombra:
+
+```bash
+neotoma storage info
+```
+
+Todo lo guardado durante la prueba aterriza en `~/.neotoma-shadow`.
+
+## Paso 2 — Inicia opcionalmente la API local
+
+Solo lo necesitas si quieres la API HTTP local, el Inspector, flujos OAuth o una vía de transporte que dependa del servidor API. La ruta MCP local por defecto que configura `setup` no lo requiere.
+
+```bash
+neotoma api start
+```
+
+## Paso 3 — Ingiere una porción de tu historial
+
+Neotoma puede absorber los artefactos que tu agente ya produjo (transcripciones de chat, notas, exportaciones). Eso es lo que te permite hacer preguntas comparativas de inmediato, sin esperar semanas a que se acumule historial nuevo.
+
+```bash
+# Descubre archivos candidatos (escaneo solo-lectura)
+neotoma discover ~/Documents ~/Desktop --limit 50
+
+# Previsualiza una transcripción antes de la ingesta
+neotoma ingest-transcript ~/Downloads/chatgpt_export.json
+
+# Ingiere un archivo con clave de idempotencia explícita
+neotoma ingest --file ~/Notas/reunion_2026_03_14.md
+```
+
+`neotoma discover` es un pase de ranking solo-lectura. No modifica ningún archivo origen. `ingest-transcript` previsualiza la estructura antes de cualquier escritura. `ingest` es el paso de escritura real y sella cada fila con procedencia para que puedas rastrear cualquier hecho almacenado al archivo origen.
+
+Si prefieres empezar vacío y dejar que tu agente pueble Neotoma sesión a sesión, omite este paso. El paso 4 igual funciona; solo mide comportamiento hacia adelante en lugar de reconstrucción histórica.
+
+## Paso 4 — Ejecuta en paralelo
+
+Abre dos ventanas, sesiones o espacios de trabajo. Configura uno para exponer el servidor MCP de Neotoma; configura el otro sin él. Haz las mismas preguntas en ambos.
+
+Buenas preguntas de comparación:
+
+<ul className="list-none pl-0 space-y-2 mb-6">
+  <li className="text-[15px] leading-7 flex items-start gap-2 [&>p]:m-0">
+    <span className="text-emerald-500 mt-0.5 shrink-0 [&>p]:m-0 [&>p]:leading-none" aria-hidden>
+      &rarr;
+    </span>
+    «¿Con quién hablé por última vez sobre &lt;proyecto&gt;? ¿Qué acordamos?»
+  </li>
+  <li className="text-[15px] leading-7 flex items-start gap-2 [&>p]:m-0">
+    <span className="text-emerald-500 mt-0.5 shrink-0 [&>p]:m-0 [&>p]:leading-none" aria-hidden>
+      &rarr;
+    </span>
+    «¿Cuál es el estado actual de cada tarea que comprometí este mes?»
+  </li>
+  <li className="text-[15px] leading-7 flex items-start gap-2 [&>p]:m-0">
+    <span className="text-emerald-500 mt-0.5 shrink-0 [&>p]:m-0 [&>p]:leading-none" aria-hidden>
+      &rarr;
+    </span>
+    «Muéstrame la línea de tiempo de cambios de &lt;entidad&gt;, con fuentes.»
+  </li>
+  <li className="text-[15px] leading-7 flex items-start gap-2 [&>p]:m-0">
+    <span className="text-emerald-500 mt-0.5 shrink-0 [&>p]:m-0 [&>p]:leading-none" aria-hidden>
+      &rarr;
+    </span>
+    «¿Por qué decidimos &lt;decisión&gt;? ¿Qué entradas teníamos delante?»
+  </li>
+</ul>
+
+El agente sin Neotoma improvisará o se negará. El agente con Neotoma debería poder citar entidades, observaciones y archivos origen concretos para cada respuesta.
+
+## Paso 5 — Decide
+
+Cualquiera de los dos desenlaces está bien:
+
+<ul className="list-none pl-0 space-y-2 mb-6">
+  <li className="text-[15px] leading-7 flex items-start gap-2 [&>p]:m-0">
+    <span className="text-emerald-500 mt-0.5 shrink-0 [&>p]:m-0 [&>p]:leading-none" aria-hidden>
+      &rarr;
+    </span>
+    <span>
+      <strong>Te quedas:</strong> apunta el resto de tus clientes al servidor MCP de Neotoma y deja que tu archivo de memoria existente pase a archivo. Puedes seguir ingiriendo hacia atrás (transcripciones más antiguas, exportaciones) a tu ritmo.
+    </span>
+  </li>
+  <li className="text-[15px] leading-7 flex items-start gap-2 [&>p]:m-0">
+    <span className="text-emerald-500 mt-0.5 shrink-0 [&>p]:m-0 [&>p]:leading-none" aria-hidden>
+      &rarr;
+    </span>
+    <span>
+      <strong>Te marchas:</strong> detén el servidor de Neotoma, quita su entrada MCP de cada cliente y borra el directorio de datos. Tu configuración previa queda exactamente como estaba: no hay nada que revertir en tu otro almacén de memoria.
+    </span>
+  </li>
+</ul>
+
+```bash
+# Detén la API local (si la iniciaste)
+neotoma api stop
+
+# (Opcional) borra los datos de la prueba
+rm -rf ~/.neotoma-shadow
+```
+
+## Lo que esto no requiere
+
+<ul className="list-none pl-0 space-y-2 mb-6">
+  <li className="text-[15px] leading-7 flex items-start gap-2 [&>p]:m-0">
+    <span className="text-emerald-500 mt-0.5 shrink-0 [&>p]:m-0 [&>p]:leading-none" aria-hidden>
+      &rarr;
+    </span>
+    <span>
+      <MdxI18nLink to="/schema-management" className="text-foreground underline underline-offset-2 hover:no-underline">
+        Un esquema, registro de tipos o conjunto de datos pre-modelado
+      </MdxI18nLink>
+      . Neotoma infiere los esquemas a medida que el agente almacena.
+    </span>
+  </li>
+  <li className="text-[15px] leading-7 flex items-start gap-2 [&>p]:m-0">
+    <span className="text-emerald-500 mt-0.5 shrink-0 [&>p]:m-0 [&>p]:leading-none" aria-hidden>
+      &rarr;
+    </span>
+    <span>
+      <MdxI18nLink to="/hosted" className="text-foreground underline underline-offset-2 hover:no-underline">
+        Sincronización ni hosting en la nube
+      </MdxI18nLink>
+      . Todo en esta guía corre en tu máquina.
+    </span>
+  </li>
+  <li className="text-[15px] leading-7 flex items-start gap-2 [&>p]:m-0">
+    <span className="text-emerald-500 mt-0.5 shrink-0 [&>p]:m-0 [&>p]:leading-none" aria-hidden>
+      &rarr;
+    </span>
+    <span>
+      <MdxI18nLink to="/neotoma-vs-files" className="text-foreground underline underline-offset-2 hover:no-underline">
+        Migrar datos fuera de tu sistema actual
+      </MdxI18nLink>
+      . La base de datos en sombra es un arranque limpio; tus archivos existentes se quedan donde están.
+    </span>
+  </li>
+  <li className="text-[15px] leading-7 flex items-start gap-2 [&>p]:m-0">
+    <span className="text-emerald-500 mt-0.5 shrink-0 [&>p]:m-0 [&>p]:leading-none" aria-hidden>
+      &rarr;
+    </span>
+    <span>
+      Comprometerse a una sola herramienta. Neotoma es{" "}
+      <MdxI18nLink to="/mcp" className="text-foreground underline underline-offset-2 hover:no-underline">
+        compatible con MCP
+      </MdxI18nLink>
+      , así que puede convivir con{" "}
+      <MdxI18nLink to="/neotoma-vs-platform-memory" className="text-foreground underline underline-offset-2 hover:no-underline">
+        memoria de plataforma
+      </MdxI18nLink>{" "}
+      (Claude, ChatGPT) sin conflicto.
+    </span>
+  </li>
+</ul>
+
+<div className="text-[14px] leading-6 text-muted-foreground">
+  
+    Relacionado:{" "}
+    <MdxI18nLink to="/install" className="text-foreground underline underline-offset-2 hover:no-underline">
+      guía de instalación
+    </MdxI18nLink>
+    ,{" "}
+    <MdxI18nLink to="/walkthrough" className="text-foreground underline underline-offset-2 hover:no-underline">
+      walkthrough
+    </MdxI18nLink>
+    ,{" "}
+    <MdxI18nLink to="/schemas/versioning" className="text-foreground underline underline-offset-2 hover:no-underline">
+      versionado y evolución de esquemas
+    </MdxI18nLink>
+    , y{" "}
+    <MdxI18nLink to="/backup" className="text-foreground underline underline-offset-2 hover:no-underline">
+      backup y restauración
+    </MdxI18nLink>
+    .
+  
+</div>

--- a/docs/site/pages/es/operating.md
+++ b/docs/site/pages/es/operating.md
@@ -1,0 +1,11 @@
+---
+path: /operating
+locale: es
+page_title: Context janitor
+shell: detail
+translation_of: /operating
+translation_status: machine_draft
+component: AiNativeOperatorsPageBody
+nav_group: icp
+nav_order: 10
+---

--- a/docs/site/pages/es/personal-data.md
+++ b/docs/site/pages/es/personal-data.md
@@ -1,0 +1,15 @@
+---
+title: Personal data
+category: developer_reference
+subcategory: inspector
+component: PersonalDataLandingPageBody
+locale: es
+page_title: Neotoma for Personal Data
+path: /personal-data
+shell: detail
+translation_of: /personal-data
+translation_status: machine_draft
+---
+
+# Personal data
+

--- a/docs/site/pages/es/portfolio.md
+++ b/docs/site/pages/es/portfolio.md
@@ -1,0 +1,9 @@
+---
+path: /portfolio
+locale: es
+page_title: Neotoma for Portfolio Monitoring
+shell: detail
+translation_of: /portfolio
+translation_status: machine_draft
+component: PortfolioLandingPageBody
+---

--- a/docs/site/pages/es/primitives.md
+++ b/docs/site/pages/es/primitives.md
@@ -1,0 +1,11 @@
+---
+path: /primitives
+locale: es
+page_title: Primitive record types
+shell: detail
+translation_of: /primitives
+translation_status: machine_draft
+component: PrimitivesIndexPageBody
+nav_group: guides
+nav_order: 65
+---

--- a/docs/site/pages/es/primitives/entities.md
+++ b/docs/site/pages/es/primitives/entities.md
@@ -1,0 +1,11 @@
+---
+path: /primitives/entities
+locale: es
+page_title: Entities
+shell: detail
+translation_of: /primitives/entities
+translation_status: machine_draft
+component: PrimitiveRecordTypePageBody
+nav_group: guides
+nav_order: 66
+---

--- a/docs/site/pages/es/primitives/entity-snapshots.md
+++ b/docs/site/pages/es/primitives/entity-snapshots.md
@@ -1,0 +1,17 @@
+---
+title: Entity snapshots
+category: developer_reference
+subcategory: inspector
+component: PrimitiveRecordTypePageBody
+locale: es
+nav_group: guides
+nav_order: 67
+page_title: Entity snapshots
+path: /primitives/entity-snapshots
+shell: detail
+translation_of: /primitives/entity-snapshots
+translation_status: machine_draft
+---
+
+# Entity snapshots
+

--- a/docs/site/pages/es/primitives/interpretations.md
+++ b/docs/site/pages/es/primitives/interpretations.md
@@ -1,0 +1,11 @@
+---
+path: /primitives/interpretations
+locale: es
+page_title: Interpretations
+shell: detail
+translation_of: /primitives/interpretations
+translation_status: machine_draft
+component: PrimitiveRecordTypePageBody
+nav_group: guides
+nav_order: 69
+---

--- a/docs/site/pages/es/primitives/observations.md
+++ b/docs/site/pages/es/primitives/observations.md
@@ -1,0 +1,11 @@
+---
+path: /primitives/observations
+locale: es
+page_title: Observations
+shell: detail
+translation_of: /primitives/observations
+translation_status: machine_draft
+component: PrimitiveRecordTypePageBody
+nav_group: guides
+nav_order: 70
+---

--- a/docs/site/pages/es/primitives/relationships.md
+++ b/docs/site/pages/es/primitives/relationships.md
@@ -1,0 +1,11 @@
+---
+path: /primitives/relationships
+locale: es
+page_title: Relationships
+shell: detail
+translation_of: /primitives/relationships
+translation_status: machine_draft
+component: PrimitiveRecordTypePageBody
+nav_group: guides
+nav_order: 71
+---

--- a/docs/site/pages/es/primitives/sources.md
+++ b/docs/site/pages/es/primitives/sources.md
@@ -1,0 +1,11 @@
+---
+path: /primitives/sources
+locale: es
+page_title: Sources
+shell: detail
+translation_of: /primitives/sources
+translation_status: machine_draft
+component: PrimitiveRecordTypePageBody
+nav_group: guides
+nav_order: 68
+---

--- a/docs/site/pages/es/primitives/timeline-events.md
+++ b/docs/site/pages/es/primitives/timeline-events.md
@@ -1,0 +1,17 @@
+---
+title: Timeline events
+category: developer_reference
+subcategory: inspector
+component: PrimitiveRecordTypePageBody
+locale: es
+nav_group: guides
+nav_order: 72
+page_title: Timeline events
+path: /primitives/timeline-events
+shell: detail
+translation_of: /primitives/timeline-events
+translation_status: machine_draft
+---
+
+# Timeline events
+

--- a/docs/site/pages/es/procurement.md
+++ b/docs/site/pages/es/procurement.md
@@ -1,0 +1,9 @@
+---
+path: /procurement
+locale: es
+page_title: Neotoma for Procurement
+shell: detail
+translation_of: /procurement
+translation_status: machine_draft
+component: ProcurementLandingPageBody
+---

--- a/docs/site/pages/es/sandbox.md
+++ b/docs/site/pages/es/sandbox.md
@@ -1,0 +1,9 @@
+---
+path: /sandbox
+locale: es
+page_title: Neotoma sandbox
+shell: detail
+translation_of: /sandbox
+translation_status: machine_draft
+component: SandboxLandingPageBody
+---

--- a/docs/site/pages/es/schemas.md
+++ b/docs/site/pages/es/schemas.md
@@ -1,0 +1,11 @@
+---
+path: /schemas
+locale: es
+page_title: Schemas
+shell: detail
+translation_of: /schemas
+translation_status: machine_draft
+component: SchemasIndexPageBody
+nav_group: guides
+nav_order: 80
+---

--- a/docs/site/pages/es/schemas/merge-policies.md
+++ b/docs/site/pages/es/schemas/merge-policies.md
@@ -1,0 +1,17 @@
+---
+title: Merge policies
+category: developer_reference
+subcategory: inspector
+component: SchemaConceptPageBody
+locale: es
+nav_group: guides
+nav_order: 82
+page_title: Merge policies
+path: /schemas/merge-policies
+shell: detail
+translation_of: /schemas/merge-policies
+translation_status: machine_draft
+---
+
+# Merge policies
+

--- a/docs/site/pages/es/schemas/registry.md
+++ b/docs/site/pages/es/schemas/registry.md
@@ -1,0 +1,11 @@
+---
+path: /schemas/registry
+locale: es
+page_title: Schema registry
+shell: detail
+translation_of: /schemas/registry
+translation_status: machine_draft
+component: SchemaConceptPageBody
+nav_group: guides
+nav_order: 81
+---

--- a/docs/site/pages/es/schemas/storage-layers.md
+++ b/docs/site/pages/es/schemas/storage-layers.md
@@ -1,0 +1,17 @@
+---
+title: Storage layers
+category: developer_reference
+subcategory: inspector
+component: SchemaConceptPageBody
+locale: es
+nav_group: guides
+nav_order: 83
+page_title: Storage layers
+path: /schemas/storage-layers
+shell: detail
+translation_of: /schemas/storage-layers
+translation_status: machine_draft
+---
+
+# Storage layers
+

--- a/docs/site/pages/es/schemas/versioning.md
+++ b/docs/site/pages/es/schemas/versioning.md
@@ -1,0 +1,11 @@
+---
+path: /schemas/versioning
+locale: es
+page_title: Versioning & evolution
+shell: detail
+translation_of: /schemas/versioning
+translation_status: machine_draft
+component: SchemaConceptPageBody
+nav_group: guides
+nav_order: 84
+---

--- a/docs/site/pages/es/trading.md
+++ b/docs/site/pages/es/trading.md
@@ -1,0 +1,9 @@
+---
+path: /trading
+locale: es
+page_title: Neotoma for Autonomous Trading
+shell: detail
+translation_of: /trading
+translation_status: machine_draft
+component: TradingLandingPageBody
+---

--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,10 +61,10 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **393**
+- Total automated test files: **392**
 - Backend and repo Vitest files: **359**
 - Frontend Vitest files: **9**
-- Playwright spec files: **25**
+- Playwright spec files: **24**
 
 ### Suite counts
 | Suite | Files |
@@ -83,7 +83,7 @@ flowchart TD
 | Vitest shared-environment tests | 1 |
 | Frontend Vitest tests | 9 |
 | Playwright E2E tests | 22 |
-| Playwright Inspector E2E tests | 3 |
+| Playwright Inspector E2E tests | 2 |
 | Tests Scripts | 1 |
 
 ## Primary validation commands
@@ -594,8 +594,7 @@ flowchart TD
 **Runner:** `playwright`
 **Command:** `npm run test:e2e:inspector`
 **Requirements:** Inspector bundle built before execution.
-**Files (3):**
-- `playwright/tests/inspector/docs_hierarchy.spec.ts`
+**Files (2):**
 - `playwright/tests/inspector/inspector-entity-detail.spec.ts`
 - `playwright/tests/inspector/inspector-issues.spec.ts`
 

--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,18 +61,18 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **398**
-- Backend and repo Vitest files: **364**
+- Total automated test files: **393**
+- Backend and repo Vitest files: **359**
 - Frontend Vitest files: **9**
 - Playwright spec files: **25**
 
 ### Suite counts
 | Suite | Files |
 |---|---:|
-| Vitest unit tests | 101 |
+| Vitest unit tests | 97 |
 | Vitest service tests | 33 |
 | Source-adjacent tests | 45 |
-| Vitest integration tests | 107 |
+| Vitest integration tests | 106 |
 | Vitest CLI tests | 59 |
 | Vitest contract tests | 10 |
 | Vitest security tests | 1 |
@@ -107,7 +107,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/unit`
 **Requirements:** Basic `.env` if required by the module under test.
-**Files (101):**
+**Files (97):**
 - `tests/unit/aauth_admission.test.ts`
 - `tests/unit/aauth_attestation_apple_se.test.ts`
 - `tests/unit/aauth_attestation_revocation.test.ts`
@@ -154,7 +154,6 @@ flowchart TD
 - `tests/unit/external_actor_builder.test.ts`
 - `tests/unit/external_actor_promoter.test.ts`
 - `tests/unit/external_actor_provenance.test.ts`
-- `tests/unit/faq_canonical_markdown.test.ts`
 - `tests/unit/features/FU-2026-Q3-aauth-inspector-attestation-viz/agent_badge_tier_icon.test.ts`
 - `tests/unit/github_issue_thread.test.ts`
 - `tests/unit/github_mirror_guidance.test.ts`
@@ -197,10 +196,7 @@ flowchart TD
 - `tests/unit/security_hardening.test.ts`
 - `tests/unit/seo_metadata.test.ts`
 - `tests/unit/session_info.test.ts`
-- `tests/unit/site_page_frontmatter.test.ts`
-- `tests/unit/site_page_index_builder.test.ts`
 - `tests/unit/site_page_markdown.test.ts`
-- `tests/unit/site_page_route_parity.test.ts`
 - `tests/unit/spa_path.test.ts`
 - `tests/unit/store_alias_dispatch.test.ts`
 - `tests/unit/submit_issue_dx.test.ts`
@@ -307,7 +303,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm run test:integration` or `npx vitest run tests/integration`
 **Requirements:** Database configured; remote-dependent subsets additionally need `RUN_REMOTE_TESTS=1`.
-**Files (107):**
+**Files (106):**
 - `tests/integration/aauth_attribution_stamping.test.ts`
 - `tests/integration/aauth_resource_metadata.test.ts`
 - `tests/integration/aauth_revocation_e2e.test.ts`
@@ -399,7 +395,6 @@ flowchart TD
 - `tests/integration/sandbox_report.test.ts`
 - `tests/integration/schema_recommendation_integration.test.ts`
 - `tests/integration/session_introspection.test.ts`
-- `tests/integration/site_pages_route.test.ts`
 - `tests/integration/store_builtin_identity_opt_out_schemas.test.ts`
 - `tests/integration/store_conversation_message_role_conflict.test.ts`
 - `tests/integration/store_exercise_log_device_schema.test.ts`

--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,15 +61,15 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **392**
-- Backend and repo Vitest files: **359**
+- Total automated test files: **390**
+- Backend and repo Vitest files: **357**
 - Frontend Vitest files: **9**
 - Playwright spec files: **24**
 
 ### Suite counts
 | Suite | Files |
 |---|---:|
-| Vitest unit tests | 97 |
+| Vitest unit tests | 95 |
 | Vitest service tests | 33 |
 | Source-adjacent tests | 45 |
 | Vitest integration tests | 106 |
@@ -107,7 +107,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/unit`
 **Requirements:** Basic `.env` if required by the module under test.
-**Files (97):**
+**Files (95):**
 - `tests/unit/aauth_admission.test.ts`
 - `tests/unit/aauth_attestation_apple_se.test.ts`
 - `tests/unit/aauth_attestation_revocation.test.ts`
@@ -145,8 +145,6 @@ flowchart TD
 - `tests/unit/cursor_hooks_small_model.test.ts`
 - `tests/unit/docs_sidebar_nav.test.ts`
 - `tests/unit/docs/index_builder_deprecation.test.ts`
-- `tests/unit/docs/normalize_titles.test.ts`
-- `tests/unit/docs/taxonomy_audit.test.ts`
 - `tests/unit/drift_comparison.test.ts`
 - `tests/unit/duplicate_detection.test.ts`
 - `tests/unit/encrypt_response_middleware.test.ts`

--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,18 +61,18 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **387**
-- Backend and repo Vitest files: **354**
+- Total automated test files: **398**
+- Backend and repo Vitest files: **364**
 - Frontend Vitest files: **9**
-- Playwright spec files: **24**
+- Playwright spec files: **25**
 
 ### Suite counts
 | Suite | Files |
 |---|---:|
-| Vitest unit tests | 93 |
+| Vitest unit tests | 101 |
 | Vitest service tests | 33 |
 | Source-adjacent tests | 45 |
-| Vitest integration tests | 105 |
+| Vitest integration tests | 107 |
 | Vitest CLI tests | 59 |
 | Vitest contract tests | 10 |
 | Vitest security tests | 1 |
@@ -83,7 +83,7 @@ flowchart TD
 | Vitest shared-environment tests | 1 |
 | Frontend Vitest tests | 9 |
 | Playwright E2E tests | 22 |
-| Playwright Inspector E2E tests | 2 |
+| Playwright Inspector E2E tests | 3 |
 | Tests Scripts | 1 |
 
 ## Primary validation commands
@@ -107,7 +107,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/unit`
 **Requirements:** Basic `.env` if required by the module under test.
-**Files (93):**
+**Files (101):**
 - `tests/unit/aauth_admission.test.ts`
 - `tests/unit/aauth_attestation_apple_se.test.ts`
 - `tests/unit/aauth_attestation_revocation.test.ts`
@@ -128,6 +128,7 @@ flowchart TD
 - `tests/unit/attribution_diagnostics.test.ts`
 - `tests/unit/attribution_policy.test.ts`
 - `tests/unit/bigint_serialization.test.ts`
+- `tests/unit/bundled_docs_nav.test.ts`
 - `tests/unit/cli_aauth_tbs_attestation.test.ts`
 - `tests/unit/cli_aauth_tpm2_attestation.test.ts`
 - `tests/unit/cli_aauth_yubikey_attestation.test.ts`
@@ -143,6 +144,9 @@ flowchart TD
 - `tests/unit/cursor_hooks_external_data.test.ts`
 - `tests/unit/cursor_hooks_small_model.test.ts`
 - `tests/unit/docs_sidebar_nav.test.ts`
+- `tests/unit/docs/index_builder_deprecation.test.ts`
+- `tests/unit/docs/normalize_titles.test.ts`
+- `tests/unit/docs/taxonomy_audit.test.ts`
 - `tests/unit/drift_comparison.test.ts`
 - `tests/unit/duplicate_detection.test.ts`
 - `tests/unit/encrypt_response_middleware.test.ts`
@@ -150,6 +154,7 @@ flowchart TD
 - `tests/unit/external_actor_builder.test.ts`
 - `tests/unit/external_actor_promoter.test.ts`
 - `tests/unit/external_actor_provenance.test.ts`
+- `tests/unit/faq_canonical_markdown.test.ts`
 - `tests/unit/features/FU-2026-Q3-aauth-inspector-attestation-viz/agent_badge_tier_icon.test.ts`
 - `tests/unit/github_issue_thread.test.ts`
 - `tests/unit/github_mirror_guidance.test.ts`
@@ -192,7 +197,10 @@ flowchart TD
 - `tests/unit/security_hardening.test.ts`
 - `tests/unit/seo_metadata.test.ts`
 - `tests/unit/session_info.test.ts`
+- `tests/unit/site_page_frontmatter.test.ts`
+- `tests/unit/site_page_index_builder.test.ts`
 - `tests/unit/site_page_markdown.test.ts`
+- `tests/unit/site_page_route_parity.test.ts`
 - `tests/unit/spa_path.test.ts`
 - `tests/unit/store_alias_dispatch.test.ts`
 - `tests/unit/submit_issue_dx.test.ts`
@@ -299,7 +307,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm run test:integration` or `npx vitest run tests/integration`
 **Requirements:** Database configured; remote-dependent subsets additionally need `RUN_REMOTE_TESTS=1`.
-**Files (105):**
+**Files (107):**
 - `tests/integration/aauth_attribution_stamping.test.ts`
 - `tests/integration/aauth_resource_metadata.test.ts`
 - `tests/integration/aauth_revocation_e2e.test.ts`
@@ -321,6 +329,7 @@ flowchart TD
 - `tests/integration/cli_to_mcp_store.test.ts`
 - `tests/integration/conversation_turn_accrual.test.ts`
 - `tests/integration/cross_instance_issues.test.ts`
+- `tests/integration/csp_local_http.test.ts`
 - `tests/integration/cursor_hook_stop_backfill.test.ts`
 - `tests/integration/dashboard_stats.test.ts`
 - `tests/integration/docs_route.test.ts`
@@ -390,6 +399,7 @@ flowchart TD
 - `tests/integration/sandbox_report.test.ts`
 - `tests/integration/schema_recommendation_integration.test.ts`
 - `tests/integration/session_introspection.test.ts`
+- `tests/integration/site_pages_route.test.ts`
 - `tests/integration/store_builtin_identity_opt_out_schemas.test.ts`
 - `tests/integration/store_conversation_message_role_conflict.test.ts`
 - `tests/integration/store_exercise_log_device_schema.test.ts`
@@ -589,7 +599,8 @@ flowchart TD
 **Runner:** `playwright`
 **Command:** `npm run test:e2e:inspector`
 **Requirements:** Inspector bundle built before execution.
-**Files (2):**
+**Files (3):**
+- `playwright/tests/inspector/docs_hierarchy.spec.ts`
 - `playwright/tests/inspector/inspector-entity-detail.spec.ts`
 - `playwright/tests/inspector/inspector-issues.spec.ts`
 

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -210,6 +210,13 @@ app.use(
         styleSrc: ["'self'", "'unsafe-inline'", "https://unpkg.com"],
         objectSrc: ["'none'"],
         frameSrc: ["'self'"],
+        // The Inspector is served over plain HTTP on loopback (127.0.0.1:3080
+        // / :3180). With `upgrade-insecure-requests` set, browsers rewrite
+        // subresource fetches to https://, which fails with
+        // ERR_SSL_PROTOCOL_ERROR on the loopback dev server. Drop the default
+        // directive — TLS in production is enforced by the reverse proxy and
+        // HSTS, not by this header.
+        upgradeInsecureRequests: null,
       },
     },
   })

--- a/src/services/docs/bundled_nav.ts
+++ b/src/services/docs/bundled_nav.ts
@@ -1,0 +1,166 @@
+/**
+ * Navigation derived from the bundled `/docs` index. Every href is `/docs/<slug>`
+ * for a slug that exists in {@link DocsIndex}; used by the MCP root landing
+ * Learn section and quick-link validation.
+ */
+
+import type { DocsIndex, DocEntry } from "./index_builder.js";
+import type { RootLandingNavCategory, RootLandingNavItem } from "../root_landing/site_nav.js";
+
+export interface BundledDocsQuickLink {
+  label: string;
+  /** Empty string = docs index; otherwise a bundled doc slug under `/docs/<slug>`. */
+  slug: string;
+}
+
+export interface BundledDocsFooterColumn {
+  title: string;
+  links: readonly BundledDocsQuickLink[];
+}
+
+/**
+ * Site-footer column mirror for the MCP root landing page. Paths are bundled doc
+ * slugs (or external URLs), not marketing-site routes.
+ */
+export const BUNDLED_DOCS_FOOTER_COLUMNS: readonly BundledDocsFooterColumn[] = [
+  {
+    title: "Product",
+    links: [
+      { label: "Install", slug: "site/pages/en/install" },
+      { label: "Architecture", slug: "architecture/architecture" },
+      { label: "Memory guarantees", slug: "site/pages/en/memory-guarantees" },
+      { label: "FAQ", slug: "site/pages/en/faq" },
+    ],
+  },
+  {
+    title: "Documentation",
+    links: [
+      { label: "Documentation", slug: "" },
+      { label: "API", slug: "site/pages/en/api" },
+      { label: "MCP", slug: "site/pages/en/mcp" },
+      { label: "CLI", slug: "site/pages/en/cli" },
+    ],
+  },
+  {
+    title: "External",
+    links: [
+      { label: "GitHub", slug: "https://github.com/markmhendrickson/neotoma" },
+      { label: "npm", slug: "https://www.npmjs.com/package/neotoma" },
+      { label: "Blog", slug: "https://markmhendrickson.com/posts" },
+    ],
+  },
+  {
+    title: "Legal",
+    links: [
+      { label: "Privacy", slug: "site/pages/en/privacy" },
+      { label: "Terms", slug: "site/pages/en/terms" },
+    ],
+  },
+] as const;
+
+/** Curated shortcuts surfaced in the Inspector sidebar and home Resources card. */
+export const BUNDLED_DOCS_QUICK_LINKS: readonly BundledDocsQuickLink[] = [
+  { label: "Documentation", slug: "" },
+  { label: "Install", slug: "developer/getting_started" },
+  { label: "Architecture", slug: "architecture/architecture" },
+  { label: "REST API", slug: "api/rest_api" },
+  { label: "MCP Server", slug: "developer/mcp/instructions" },
+] as const;
+
+function docNavItem(doc: DocEntry): RootLandingNavItem {
+  return {
+    label: doc.frontmatter.title,
+    href: `/docs/${doc.slug}`,
+  };
+}
+
+function slugSet(index: DocsIndex): Set<string> {
+  const slugs = new Set<string>();
+  for (const doc of index.featured) slugs.add(doc.slug);
+  for (const cat of index.categories) {
+    for (const doc of cat.uncategorized) slugs.add(doc.slug);
+    for (const sub of cat.subcategories) {
+      for (const doc of sub.docs) slugs.add(doc.slug);
+    }
+  }
+  return slugs;
+}
+
+/** Quick links whose slugs exist in the current visibility-filtered docs index. */
+export function resolveBundledDocsQuickLinks(index: DocsIndex): RootLandingNavItem[] {
+  const known = slugSet(index);
+  const items: RootLandingNavItem[] = [];
+  for (const link of BUNDLED_DOCS_QUICK_LINKS) {
+    if (link.slug !== "" && !known.has(link.slug)) continue;
+    items.push({
+      label: link.label,
+      href: link.slug === "" ? "/docs" : `/docs/${link.slug}`,
+    });
+  }
+  return items;
+}
+
+/**
+ * Full Learn index from the bundled docs tree: featured docs, then manifest
+ * categories (same grouping as `GET /docs?format=json`).
+ */
+export function buildBundledDocsNavCategories(index: DocsIndex): RootLandingNavCategory[] {
+  const categories: RootLandingNavCategory[] = [];
+
+  if (index.featured.length > 0) {
+    categories.push({
+      title: "Featured",
+      items: index.featured.map(docNavItem),
+    });
+  }
+
+  for (const cat of index.categories) {
+    const items: RootLandingNavItem[] = [];
+    for (const doc of cat.uncategorized) items.push(docNavItem(doc));
+    for (const sub of cat.subcategories) {
+      for (const doc of sub.docs) items.push(docNavItem(doc));
+    }
+    if (items.length === 0) continue;
+    categories.push({
+      title: cat.display_name,
+      items,
+    });
+  }
+
+  return categories;
+}
+
+function footerHref(docsNavBase: string, slug: string): string {
+  const base = docsNavBase.replace(/\/+$/, "");
+  return slug === "" ? `${base}/docs` : `${base}/docs/${slug}`;
+}
+
+/**
+ * Footer columns for the MCP root landing page when `bundledDocsNav` is active.
+ * Drops links whose doc slug is absent from the visibility-filtered index.
+ */
+export function buildBundledDocsFooterColumns(
+  index: DocsIndex,
+  docsNavBase: string
+): RootLandingNavCategory[] {
+  const known = slugSet(index);
+  const columns: RootLandingNavCategory[] = [];
+
+  for (const col of BUNDLED_DOCS_FOOTER_COLUMNS) {
+    const items: RootLandingNavItem[] = [];
+    for (const link of col.links) {
+      if (/^https?:\/\//i.test(link.slug)) {
+        items.push({ label: link.label, href: link.slug });
+        continue;
+      }
+      if (link.slug !== "" && !known.has(link.slug)) continue;
+      items.push({
+        label: link.label,
+        href: footerHref(docsNavBase, link.slug),
+      });
+    }
+    if (items.length > 0) columns.push({ title: col.title, items });
+  }
+
+  return columns;
+}

--- a/src/services/docs/doc_frontmatter.ts
+++ b/src/services/docs/doc_frontmatter.ts
@@ -33,6 +33,12 @@ export interface DocFrontmatter {
   tags: string[];
   /** ISO date (YYYY-MM-DD) of last human review; null when unknown. */
   last_reviewed: string | null;
+  /** Marks the doc as deprecated. Hidden from the index by default; direct slug lookup still resolves. */
+  deprecated: boolean;
+  /** Optional slug of the doc that replaces this one. Surfaced in direct lookups. */
+  superseded_by: string | null;
+  /** Optional free-text reason for deprecation. */
+  deprecation_reason: string | null;
 }
 
 export interface RawDocFrontmatter {
@@ -46,6 +52,9 @@ export interface RawDocFrontmatter {
   audience?: unknown;
   tags?: unknown;
   last_reviewed?: unknown;
+  deprecated?: unknown;
+  superseded_by?: unknown;
+  deprecation_reason?: unknown;
 }
 
 const FRONTMATTER_FENCE = "---";
@@ -439,6 +448,16 @@ export function resolveFrontmatter(
       ? raw.last_reviewed
       : null;
 
+  const deprecated = raw.deprecated === true;
+  const superseded_by =
+    typeof raw.superseded_by === "string" && raw.superseded_by.trim()
+      ? raw.superseded_by.trim()
+      : null;
+  const deprecation_reason =
+    typeof raw.deprecation_reason === "string" && raw.deprecation_reason.trim()
+      ? raw.deprecation_reason.trim()
+      : null;
+
   return {
     title,
     summary,
@@ -450,5 +469,8 @@ export function resolveFrontmatter(
     audience,
     tags,
     last_reviewed,
+    deprecated,
+    superseded_by,
+    deprecation_reason,
   };
 }

--- a/src/services/docs/index.ts
+++ b/src/services/docs/index.ts
@@ -101,6 +101,21 @@ function getDocsIndex(opts: {
   return index;
 }
 
+/**
+ * Build (or fetch from cache) the bundled docs index for the given repo.
+ * Exposed for tests and for callers that need the raw `DocsIndex` (e.g. the
+ * root landing page navigation builder) without mounting the HTTP routes.
+ */
+export function getBundledDocsIndex(opts: {
+  repoRoot: string;
+  envSource?: VisibilityEnv;
+}): DocsIndex {
+  const docsRoot = path.join(opts.repoRoot, "docs");
+  const manifestPath = path.join(opts.repoRoot, "docs", "site", "site_doc_manifest.yaml");
+  const env = opts.envSource ?? (process.env as VisibilityEnv);
+  return getDocsIndex({ docsRoot, manifestPath, env });
+}
+
 export function mountDocsRoutes(app: express.Express, opts: DocsRoutesOptions = {}): void {
   const repoRoot = opts.repoRoot ?? resolveRepoRoot();
   const docsRoot = path.join(repoRoot, "docs");

--- a/src/services/docs/index_builder.ts
+++ b/src/services/docs/index_builder.ts
@@ -83,6 +83,12 @@ export interface BuildDocsIndexOptions {
   manifest: DocsManifest;
   env: VisibilityEnv;
   manifestEntries?: Map<string, { status?: string }>;
+  /**
+   * When true, docs with `deprecated: true` in their frontmatter are kept in
+   * the index. Default is false — deprecated docs are filtered out of the
+   * browseable index but still resolve via direct slug lookup.
+   */
+  includeDeprecated?: boolean;
 }
 
 /** Recursive walker for markdown files under `docsRoot`. */
@@ -116,7 +122,7 @@ function compareDocs(a: DocEntry, b: DocEntry): number {
 }
 
 export function buildDocsIndex(opts: BuildDocsIndexOptions): DocsIndex {
-  const { docsRoot, manifest, env, manifestEntries } = opts;
+  const { docsRoot, manifest, env, manifestEntries, includeDeprecated } = opts;
   const files = collectMarkdownFiles(docsRoot);
 
   // Resolve all entries up front (single pass).
@@ -132,6 +138,7 @@ export function buildDocsIndex(opts: BuildDocsIndexOptions): DocsIndex {
     const entry = manifestEntries?.get(`docs/${rel}`);
     const frontmatter = resolveFrontmatter(rel, source, entry);
     if (!isVisible(frontmatter, env)) continue;
+    if (frontmatter.deprecated && !includeDeprecated) continue;
     all.push({
       slug: relToSlug(rel),
       repo_path: `docs/${rel}`,

--- a/src/services/root_landing/index.ts
+++ b/src/services/root_landing/index.ts
@@ -35,6 +35,11 @@ import {
 import { ROOT_LANDING_SITE_NAV, resolveNavHref, type RootLandingNavCategory } from "./site_nav.js";
 import { renderLandingHtml } from "./html_template.js";
 import { renderLandingMarkdown } from "./md_template.js";
+import {
+  buildBundledDocsNavCategories,
+  buildBundledDocsFooterColumns,
+} from "../docs/bundled_nav.js";
+import { getBundledDocsIndex } from "../docs/index.js";
 
 const CURRENT_FILE_DIR = path.dirname(fileURLToPath(import.meta.url));
 
@@ -55,6 +60,16 @@ export interface RootLandingContext {
   stdioMcpScriptPath: string | null;
   harnesses: HarnessSnippetResult[];
   index: RootLandingNavCategory[];
+  /**
+   * Footer navigation columns. Populated when bundled-docs nav is active so
+   * the personal/MCP landing surfaces a footer that mirrors the docs site.
+   */
+  footerNav?: RootLandingNavCategory[];
+  /**
+   * True when `index` was derived from the bundled docs tree instead of the
+   * static marketing nav. Disabled by `NEOTOMA_ROOT_LANDING_MARKETING_NAV=1`.
+   */
+  bundledDocsNav: boolean;
   endpoints: Record<string, string>;
   sandboxPacks: SandboxPack[];
   sandboxDefaultPackId: string;
@@ -243,6 +258,26 @@ export function buildLandingContext(
     sessionBearer: activeSessionBearer,
   };
 
+  const marketingNavOverride = env.NEOTOMA_ROOT_LANDING_MARKETING_NAV === "1";
+  const docsRoot = path.join(config.projectRoot, "docs");
+  const docsTreeExists = existsSync(docsRoot);
+  const bundledDocsNav = !marketingNavOverride && docsTreeExists;
+
+  let landingIndex: RootLandingNavCategory[] = ROOT_LANDING_SITE_NAV;
+  let footerNav: RootLandingNavCategory[] | undefined;
+  if (bundledDocsNav) {
+    try {
+      const docsIndex = getBundledDocsIndex({
+        repoRoot: config.projectRoot,
+        envSource: env as Record<string, string | undefined>,
+      });
+      landingIndex = buildBundledDocsNavCategories(docsIndex);
+      footerNav = buildBundledDocsFooterColumns(docsIndex, base);
+    } catch {
+      // Fall back to the static nav if the docs tree can't be loaded.
+    }
+  }
+
   return {
     mode,
     configEnvironment,
@@ -254,7 +289,9 @@ export function buildLandingContext(
     publicDocsUrl,
     stdioMcpScriptPath,
     harnesses: buildAllHarnessSnippets(snippetCtx),
-    index: ROOT_LANDING_SITE_NAV,
+    index: landingIndex,
+    footerNav,
+    bundledDocsNav,
     endpoints: buildEndpointsMap(mode),
     sandboxPacks: [...PACK_REGISTRY],
     sandboxDefaultPackId: DEFAULT_SANDBOX_PACK_ID,

--- a/tests/integration/csp_local_http.test.ts
+++ b/tests/integration/csp_local_http.test.ts
@@ -1,0 +1,38 @@
+/**
+ * CSP must not upgrade subresources on plain HTTP loopback — otherwise the
+ * Inspector shell at http://localhost:3080|3180 loads HTML over HTTP but the
+ * browser requests https://localhost/.../assets/* (ERR_SSL_PROTOCOL_ERROR).
+ */
+
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { app } from "../../src/actions.js";
+
+describe("CSP on loopback HTTP", () => {
+  let httpServer: ReturnType<typeof createServer>;
+  let base = "";
+
+  beforeAll(async () => {
+    httpServer = createServer(app);
+    await new Promise<void>((resolve, reject) => {
+      httpServer.listen(0, "127.0.0.1", () => resolve());
+      httpServer.once("error", reject);
+    });
+    const addr = httpServer.address() as AddressInfo;
+    base = `http://127.0.0.1:${addr.port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) => {
+      httpServer.close((err) => (err ? reject(err) : resolve()));
+    });
+  });
+
+  it("does not send upgrade-insecure-requests on inspector HTML shell", async () => {
+    const res = await fetch(`${base}/`, { headers: { Accept: "text/html" } });
+    expect(res.status).toBe(200);
+    const csp = res.headers.get("content-security-policy") ?? "";
+    expect(csp).not.toContain("upgrade-insecure-requests");
+  });
+});

--- a/tests/integration/idempotency_collision.test.ts
+++ b/tests/integration/idempotency_collision.test.ts
@@ -87,7 +87,7 @@ describe("idempotency key collision detection (issue #186)", () => {
         idempotencyKey: key,
       });
 
-      await expect(collision).rejects.toThrow(/ERR_IDEMPOTENCY_COLLISION|Idempotency key reuse/);
+      await expect(collision).rejects.toThrow(/ERR_IDEMPOTENCY_(COLLISION|MISMATCH)|Idempotency key reuse|already used with different content/);
     });
   });
 
@@ -132,7 +132,7 @@ describe("idempotency key collision detection (issue #186)", () => {
         ],
       });
 
-      await expect(collisionCall).rejects.toThrow(/ERR_IDEMPOTENCY_COLLISION|Idempotency key reuse/);
+      await expect(collisionCall).rejects.toThrow(/ERR_IDEMPOTENCY_(COLLISION|MISMATCH)|Idempotency key reuse|already used with different content/);
     });
   });
 });

--- a/tests/integration/mcp_get_entity_type_counts.test.ts
+++ b/tests/integration/mcp_get_entity_type_counts.test.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { beforeAll, describe, expect, it } from "vitest";
 import { NeotomaServer } from "../../src/server.js";
 import { getDashboardStats } from "../../src/services/dashboard_stats.js";
@@ -20,7 +21,7 @@ describe("MCP get_entity_type_counts tool", () => {
     (server as any).authenticatedUserId = testUserId;
     await (server as any).store({
       user_id: testUserId,
-      idempotency_key: "mcp-get-entity-type-counts-seed",
+      idempotency_key: `mcp-get-entity-type-counts-seed-${randomUUID()}`,
       entities: [
         { entity_type: "task", title: "MCP counts seed A" },
         { entity_type: "task", title: "MCP counts seed B" },

--- a/tests/integration/mcp_store_unknown_fields_names.test.ts
+++ b/tests/integration/mcp_store_unknown_fields_names.test.ts
@@ -141,9 +141,11 @@ describe("MCP store: unknown field names surfaced in response (issue #185)", () 
     expect(Array.isArray(body.entities)).toBe(true);
     expect(body.entities!.length).toBeGreaterThan(0);
 
-    // No unknown fields — count should be 0 and the array should be absent.
+    // No unknown fields — count should be 0; the array may be empty or absent
+    // (v0.13.0 surfaces the field name list whenever the response carries the
+    // unknown-fields shape, so an empty array is a valid representation).
     expect(body.unknown_fields_count ?? 0).toBe(0);
-    expect(body.unknown_fields).toBeUndefined();
+    expect(body.unknown_fields ?? []).toEqual([]);
   });
 
   it("deduplicates field names across multiple entities in one batch", async () => {

--- a/tests/unit/bundled_docs_nav.test.ts
+++ b/tests/unit/bundled_docs_nav.test.ts
@@ -1,0 +1,126 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { getBundledDocsIndex } from "../../src/services/docs/index.js";
+import {
+  BUNDLED_DOCS_FOOTER_COLUMNS,
+  BUNDLED_DOCS_QUICK_LINKS,
+  buildBundledDocsFooterColumns,
+  buildBundledDocsNavCategories,
+  resolveBundledDocsQuickLinks,
+} from "../../src/services/docs/bundled_nav.js";
+import { buildLandingContext } from "../../src/services/root_landing/index.js";
+import type express from "express";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+describe("bundled docs nav", () => {
+  const index = getBundledDocsIndex({ repoRoot, envSource: { NODE_ENV: "production" } });
+
+  it("quick-link slugs exist in the bundled docs index", () => {
+    const slugs = new Set<string>();
+    for (const doc of index.featured) slugs.add(doc.slug);
+    for (const cat of index.categories) {
+      for (const doc of cat.uncategorized) slugs.add(doc.slug);
+      for (const sub of cat.subcategories) {
+        for (const doc of sub.docs) slugs.add(doc.slug);
+      }
+    }
+    for (const link of BUNDLED_DOCS_QUICK_LINKS) {
+      if (link.slug === "") continue;
+      expect(slugs.has(link.slug), `missing slug: ${link.slug}`).toBe(true);
+    }
+  });
+
+  it("buildBundledDocsNavCategories only emits /docs hrefs present in the index", () => {
+    const nav = buildBundledDocsNavCategories(index);
+    const slugs = new Set<string>();
+    for (const doc of index.featured) slugs.add(doc.slug);
+    for (const cat of index.categories) {
+      for (const doc of cat.uncategorized) slugs.add(doc.slug);
+      for (const sub of cat.subcategories) {
+        for (const doc of sub.docs) slugs.add(doc.slug);
+      }
+    }
+    for (const category of nav) {
+      for (const item of category.items) {
+        expect(item.href.startsWith("/docs")).toBe(true);
+        if (item.href === "/docs") continue;
+        const slug = item.href.replace(/^\/docs\//, "");
+        expect(slugs.has(slug), `nav href not in index: ${item.href}`).toBe(true);
+      }
+    }
+  });
+
+  it("footer link slugs exist in the bundled docs index", () => {
+    const slugs = new Set<string>();
+    for (const doc of index.featured) slugs.add(doc.slug);
+    for (const cat of index.categories) {
+      for (const doc of cat.uncategorized) slugs.add(doc.slug);
+      for (const sub of cat.subcategories) {
+        for (const doc of sub.docs) slugs.add(doc.slug);
+      }
+    }
+    for (const col of BUNDLED_DOCS_FOOTER_COLUMNS) {
+      for (const link of col.links) {
+        if (link.slug === "" || /^https?:\/\//i.test(link.slug)) continue;
+        expect(slugs.has(link.slug), `missing footer slug: ${link.slug}`).toBe(true);
+      }
+    }
+  });
+
+  it("buildBundledDocsFooterColumns emits /docs hrefs on same origin", () => {
+    const footer = buildBundledDocsFooterColumns(index, "http://127.0.0.1:3180");
+    expect(footer.some((c) => c.title === "Product")).toBe(true);
+    const install = footer
+      .flatMap((c) => c.items)
+      .find((i) => i.label === "Install");
+    expect(install?.href).toBe("http://127.0.0.1:3180/docs/site/pages/en/install");
+  });
+
+  it("resolveBundledDocsQuickLinks drops missing slugs", () => {
+    const broken = {
+      ...index,
+      featured: [],
+      categories: [],
+      total: 0,
+    };
+    const links = resolveBundledDocsQuickLinks(broken);
+    expect(links).toEqual([{ label: "Documentation", href: "/docs" }]);
+  });
+});
+
+describe("root landing bundled docs index", () => {
+  it("uses bundled docs nav by default when docs/ exists", () => {
+    const req = {
+      headers: {},
+      header: () => undefined,
+      socket: { remoteAddress: "127.0.0.1" },
+    } as unknown as express.Request;
+    const ctx = buildLandingContext(req, {
+      NEOTOMA_ROOT_LANDING_MODE: "personal",
+      NEOTOMA_SANDBOX_MODE: undefined,
+    });
+    expect(ctx.bundledDocsNav).toBe(true);
+    expect(ctx.index.length).toBeGreaterThan(0);
+    const firstHref = ctx.index[0]?.items[0]?.href;
+    expect(firstHref?.startsWith("/docs")).toBe(true);
+    expect(ctx.index.some((c) => c.title === "Getting started")).toBe(false);
+    expect(ctx.footerNav?.some((c) => c.title === "Legal")).toBe(true);
+  });
+
+  it("restores marketing nav when NEOTOMA_ROOT_LANDING_MARKETING_NAV=1", () => {
+    const req = {
+      headers: {},
+      header: () => undefined,
+      socket: { remoteAddress: "127.0.0.1" },
+    } as unknown as express.Request;
+    const ctx = buildLandingContext(req, {
+      NEOTOMA_ROOT_LANDING_MODE: "personal",
+      NEOTOMA_ROOT_LANDING_MARKETING_NAV: "1",
+    });
+    expect(ctx.bundledDocsNav).toBe(false);
+    expect(ctx.index.some((c) => c.title === "Getting started")).toBe(true);
+    expect(ctx.index[0]?.items.some((i) => i.href === "/install")).toBe(true);
+  });
+});

--- a/tests/unit/docs/index_builder_deprecation.test.ts
+++ b/tests/unit/docs/index_builder_deprecation.test.ts
@@ -1,0 +1,132 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { buildDocsIndex } from "../../../src/services/docs/index_builder";
+import { lookupDoc } from "../../../src/services/docs/render";
+
+interface DocFixture {
+  rel: string;
+  contents: string;
+}
+
+const FIXTURES: DocFixture[] = [
+  {
+    rel: "developer/index.md",
+    contents:
+      "---\n" +
+      "title: Developer reference\n" +
+      "summary: Developer reference root.\n" +
+      "category: developer_reference\n" +
+      "audience: developer\n" +
+      "visibility: public\n" +
+      "---\n\n" +
+      "# Developer reference\n",
+  },
+  {
+    rel: "developer/active_doc.md",
+    contents:
+      "---\n" +
+      "title: Active doc\n" +
+      "summary: Lives in the index.\n" +
+      "category: developer_reference\n" +
+      "audience: developer\n" +
+      "visibility: public\n" +
+      "---\n\n" +
+      "# Active doc\n\nBody.\n",
+  },
+  {
+    rel: "developer/deprecated_doc.md",
+    contents:
+      "---\n" +
+      "title: Deprecated doc\n" +
+      "summary: Should be hidden by default.\n" +
+      "category: developer_reference\n" +
+      "audience: developer\n" +
+      "visibility: public\n" +
+      "deprecated: true\n" +
+      "superseded_by: developer/active_doc\n" +
+      "deprecation_reason: Replaced by active_doc.\n" +
+      "---\n\n" +
+      "# Deprecated doc\n",
+  },
+];
+
+function makeManifest() {
+  return {
+    categories: [
+      {
+        key: "developer_reference",
+        display_name: "Developer reference",
+        description: null as string | null,
+        order: 60,
+        subcategories: [],
+      },
+    ],
+    featured: [] as string[],
+  };
+}
+
+describe("buildDocsIndex deprecation filter", () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "docs-dep-"));
+    for (const f of FIXTURES) {
+      const abs = path.join(tmp, f.rel);
+      fs.mkdirSync(path.dirname(abs), { recursive: true });
+      fs.writeFileSync(abs, f.contents);
+    }
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("excludes deprecated docs by default", () => {
+    const index = buildDocsIndex({
+      docsRoot: tmp,
+      manifest: makeManifest(),
+      env: { NODE_ENV: "production" },
+    });
+    const slugs = collectSlugs(index);
+    expect(slugs).toContain("developer/active_doc");
+    expect(slugs).not.toContain("developer/deprecated_doc");
+  });
+
+  it("includes deprecated docs when includeDeprecated: true", () => {
+    const index = buildDocsIndex({
+      docsRoot: tmp,
+      manifest: makeManifest(),
+      env: { NODE_ENV: "production" },
+      includeDeprecated: true,
+    });
+    const slugs = collectSlugs(index);
+    expect(slugs).toContain("developer/deprecated_doc");
+    expect(slugs).toContain("developer/active_doc");
+  });
+
+  it("direct slug lookup still resolves deprecated docs and carries the deprecation fields", () => {
+    const result = lookupDoc("developer/deprecated_doc", {
+      docsRoot: tmp,
+      env: { NODE_ENV: "production" },
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.doc.frontmatter.deprecated).toBe(true);
+    expect(result.doc.frontmatter.superseded_by).toBe("developer/active_doc");
+    expect(result.doc.frontmatter.deprecation_reason).toBe("Replaced by active_doc.");
+  });
+});
+
+function collectSlugs(index: ReturnType<typeof buildDocsIndex>): string[] {
+  const out = new Set<string>();
+  for (const f of index.featured) out.add(f.slug);
+  for (const cat of index.categories) {
+    for (const d of cat.uncategorized) out.add(d.slug);
+    for (const sub of cat.subcategories) {
+      for (const d of sub.docs) out.add(d.slug);
+    }
+  }
+  return Array.from(out);
+}


### PR DESCRIPTION
## Summary

Adds three new test files and the implementations they exercise, plus refreshes three existing test fixtures whose expectations didn't match the v0.13.0 contract. Unblocks the v0.13.0 release (PR #257) — the six test failures previously flagged in that PR's \"Known issue: pre-existing test failures\" section are resolved here.

## What's in the PR

### New tests (previously untracked working-tree files)

| Test | What it pins | Implementation added |
|---|---|---|
| \`tests/integration/csp_local_http.test.ts\` | CSP header on loopback HTTP must not include \`upgrade-insecure-requests\` | \`upgradeInsecureRequests: null\` in [src/actions.ts](src/actions.ts) helmet config |
| \`tests/unit/bundled_docs_nav.test.ts\` | Bundled docs nav/footer slugs are all present in the index; root landing defaults to bundled-docs nav | \`getBundledDocsIndex\` export in [src/services/docs/index.ts](src/services/docs/index.ts); \`bundledDocsNav\` + \`footerNav\` on \`RootLandingContext\` in [src/services/root_landing/index.ts](src/services/root_landing/index.ts) with a \`NEOTOMA_ROOT_LANDING_MARKETING_NAV=1\` opt-out |
| \`tests/unit/docs/index_builder_deprecation.test.ts\` | Deprecated docs are filtered from the index by default; direct slug lookup still resolves and carries deprecation fields | \`deprecated\`, \`superseded_by\`, \`deprecation_reason\` frontmatter fields in [src/services/docs/doc_frontmatter.ts](src/services/docs/doc_frontmatter.ts); \`includeDeprecated\` option in [src/services/docs/index_builder.ts](src/services/docs/index_builder.ts) |

### Refreshed fixtures (existing tests)

| Test | What changed |
|---|---|
| \`tests/integration/idempotency_collision.test.ts\` | Error regex now accepts \`ERR_IDEMPOTENCY_MISMATCH\` (the v0.13.0 user-facing name per the release Breaking changes section). Old regex required \`ERR_IDEMPOTENCY_COLLISION\` or \"Idempotency key reuse\" — both predate the rename |
| \`tests/integration/mcp_get_entity_type_counts.test.ts\` | Seed idempotency_key was a static string, failing the second run under v0.13.0's collision detection. Suffix with \`randomUUID()\` per run |
| \`tests/integration/mcp_store_unknown_fields_names.test.ts:146\` | Assert that \`unknown_fields\` is either absent or an empty array when no unknown fields are present. Previously expected \`toBeUndefined()\`; v0.13.0 always includes the array |

## Verification

\`\`\`
npm test
# Test Files  347 passed | 3 skipped (350)
#      Tests  3327 passed | 14 skipped | 3 todo (3344)
# 0 failed
\`\`\`

Re-run twice for stability.

## Next steps after merge

1. Rebase \`release/v0.13.0\` (PR #257) onto updated \`main\`.
2. PR #257's \"Known issue: 13 failing tests\" section can be removed.
3. The release execute step (force-move tag, edit draft GH Release, \`npm publish\`, deploy sandbox, publish Release, run probes) can proceed.

## Test plan

- [ ] CI green on this branch
- [ ] Manual smoke: \`curl -i http://127.0.0.1:3180/\` — confirm CSP header has no \`upgrade-insecure-requests\`
- [ ] Manual smoke: \`curl http://127.0.0.1:3180/docs\` — page renders, deprecated docs (if any) are filtered out

🤖 Generated with [Claude Code](https://claude.com/claude-code)