### PR TITLE
feat(cli): add `--project-local` and `--safe` flags to `neotoma init`

### DIFF
--- a/docs/developer/cli_reference.md
+++ b/docs/developer/cli_reference.md
@@ -354,8 +354,10 @@ neotoma session --servers
   - `--force`: Overwrite existing configuration.
   - `--skip-db`: Skip database initialization.
   - `--skip-env`: Skip interactive `.env` creation and variable prompts (e.g. for CI or non-interactive use).
+  - `--project-local`: Store the Neotoma config in `.neotoma/config.json` in the current directory (project-scoped) instead of the user-level `~/.config/neotoma/config.json`. The project-local config takes precedence over the user-level config when `readEffectiveConfig` is used. Use this when you want per-project Neotoma configuration that is independent of the user-level setup.
+  - `--safe`: Dry-run mode. Reports what `init` would do (create directories, write config, run migrations) without writing any files or making any changes. Output lists each planned action with a check mark. Exit code is 0 if everything would succeed. Combine with `--json` to get machine-readable output.
 
-**Example:**
+**Examples:**
 
 ```bash
 # Basic initialization
@@ -363,6 +365,18 @@ neotoma init
 
 # Initialize with custom data directory
 neotoma init --data-dir /path/to/data
+
+# Store config in current project directory instead of user home
+neotoma init --project-local
+
+# Preview what init would do without making any changes
+neotoma init --safe
+
+# Dry-run with machine-readable output
+neotoma init --safe --json
+
+# Combine: dry-run scoped to current project
+neotoma init --safe --project-local
 ```
 
 **What it creates:**
@@ -371,6 +385,20 @@ neotoma init --data-dir /path/to/data
 - SQLite database: `<data-dir>/neotoma.db` (with WAL mode enabled)
 - Encryption key (if user chooses key-derived auth when prompted): `~/.config/neotoma/keys/neotoma.key` (mode 0600).
 - Environment file target: project `<checkout>/.env` when checkout is detected, otherwise `~/.config/neotoma/.env`
+- Config file: `~/.config/neotoma/config.json` (default) or `.neotoma/config.json` in the current directory when `--project-local` is given.
+
+**Runtime overrides** for `neotoma init`:
+
+| Precedence | Source | Description |
+|------------|--------|-------------|
+| 1 (highest) | `--data-dir` flag | Explicit data directory path |
+| 2 | `NEOTOMA_DATA_DIR` env var | Environment variable override |
+| 3 (default) | Auto-detected or `~/neotoma/data` | Resolved at startup |
+
+| Precedence | Source | Description |
+|------------|--------|-------------|
+| 1 (highest) | `--project-local` flag | Write to `.neotoma/config.json` in cwd |
+| 2 (default) | (no flag) | Write to `~/.config/neotoma/config.json` |
 
 ### Harness setup
 

--- a/docs/developer/cli_reference.md
+++ b/docs/developer/cli_reference.md
@@ -354,8 +354,8 @@ neotoma session --servers
   - `--force`: Overwrite existing configuration.
   - `--skip-db`: Skip database initialization.
   - `--skip-env`: Skip interactive `.env` creation and variable prompts (e.g. for CI or non-interactive use).
-  - `--project-local`: Store the Neotoma config in `.neotoma/config.json` in the current directory (project-scoped) instead of the user-level `~/.config/neotoma/config.json`. The project-local config takes precedence over the user-level config when `readEffectiveConfig` is used. Use this when you want per-project Neotoma configuration that is independent of the user-level setup.
-  - `--safe`: Dry-run mode. Reports what `init` would do (create directories, write config, run migrations) without writing any files or making any changes. Output lists each planned action with a check mark. Exit code is 0 if everything would succeed. Combine with `--json` to get machine-readable output.
+  - `--project-local`: Store the Neotoma config in `.neotoma/config.json` in the current directory (project-scoped) instead of the user-level `~/.config/neotoma/config.json`. The CLI reads this project-local config automatically for all subsequent commands run from that directory via `readEffectiveConfig`, which checks for `.neotoma/config.json` before falling back to the user-level config. Trust boundary: project-local config is only loaded when the containing directory is owned by the current user (prevents untrusted directories from silently overriding user settings). Use this when you want per-project Neotoma configuration independent of the user-level setup.
+  - `--safe`: Dry-run mode. Reports what `init` would do (create directories, write config, run migrations) without writing any files or making any changes. Output lists each planned action with a check mark or blocker reason. Exit code is 0 if all planned actions would succeed; exit code 1 if any blocker is detected (e.g. config already exists without `--force`, parent directory not writable). Combine with `--json` to get machine-readable output. Note: `--safe` checks the filesystem layout planned by `init`; it does not simulate authentication or preflight steps.
 
 **Examples:**
 
@@ -395,10 +395,7 @@ neotoma init --safe --project-local
 | 2 | `NEOTOMA_DATA_DIR` env var | Environment variable override |
 | 3 (default) | Auto-detected or `~/neotoma/data` | Resolved at startup |
 
-| Precedence | Source | Description |
-|------------|--------|-------------|
-| 1 (highest) | `--project-local` flag | Write to `.neotoma/config.json` in cwd |
-| 2 (default) | (no flag) | Write to `~/.config/neotoma/config.json` |
+Config scope for `neotoma init` is a binary switch: `--project-local` writes to `.neotoma/config.json` in cwd; without the flag, init writes to `~/.config/neotoma/config.json`. All subsequent commands that call `readEffectiveConfig` will read the project-local file when present (and owned by the current user).
 
 ### Harness setup
 

--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,8 +61,8 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **463**
-- Backend and repo Vitest files: **430**
+- Total automated test files: **465**
+- Backend and repo Vitest files: **432**
 - Frontend Vitest files: **9**
 - Playwright spec files: **24**
 
@@ -72,9 +72,9 @@ flowchart TD
 | Vitest unit tests | 119 |
 | Vitest service tests | 34 |
 | Source-adjacent tests | 53 |
-| Vitest integration tests | 133 |
+| Vitest integration tests | 134 |
 | Vitest CLI tests | 64 |
-| Vitest contract tests | 13 |
+| Vitest contract tests | 14 |
 | Vitest security tests | 3 |
 | Vitest subscription tests | 5 |
 | Vitest agent tests | 1 |
@@ -336,7 +336,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm run test:integration` or `npx vitest run tests/integration`
 **Requirements:** Database configured; remote-dependent subsets additionally need `RUN_REMOTE_TESTS=1`.
-**Files (133):**
+**Files (134):**
 - `tests/integration/aauth_attribution_stamping.test.ts`
 - `tests/integration/aauth_resource_metadata.test.ts`
 - `tests/integration/aauth_revocation_e2e.test.ts`
@@ -368,6 +368,7 @@ flowchart TD
 - `tests/integration/describe_entity_type.test.ts`
 - `tests/integration/docs_route.test.ts`
 - `tests/integration/entity_identifier_handler.test.ts`
+- `tests/integration/entity_queries_status_column.test.ts`
 - `tests/integration/entity_queries.test.ts`
 - `tests/integration/entity_search_mode.test.ts`
 - `tests/integration/events_stream.test.ts`
@@ -547,10 +548,11 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/contract`
 **Requirements:** Generated contract artifacts present when the suite expects them.
-**Files (13):**
+**Files (14):**
 - `tests/contract/cli_handler_dist_smoke.test.ts`
 - `tests/contract/contract_mapping.test.ts`
 - `tests/contract/contract_mcp_cli_parity.test.ts`
+- `tests/contract/get_entities_alias.test.ts`
 - `tests/contract/ironclaw_integration.test.ts`
 - `tests/contract/legacy_payloads/replay.test.ts`
 - `tests/contract/mcp_stdio_output_safety.test.ts`

--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -72,9 +72,9 @@ flowchart TD
 | Vitest unit tests | 119 |
 | Vitest service tests | 34 |
 | Source-adjacent tests | 53 |
-| Vitest integration tests | 134 |
-| Vitest CLI tests | 63 |
-| Vitest contract tests | 14 |
+| Vitest integration tests | 133 |
+| Vitest CLI tests | 64 |
+| Vitest contract tests | 13 |
 | Vitest security tests | 3 |
 | Vitest subscription tests | 5 |
 | Vitest agent tests | 1 |
@@ -336,7 +336,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm run test:integration` or `npx vitest run tests/integration`
 **Requirements:** Database configured; remote-dependent subsets additionally need `RUN_REMOTE_TESTS=1`.
-**Files (134):**
+**Files (133):**
 - `tests/integration/aauth_attribution_stamping.test.ts`
 - `tests/integration/aauth_resource_metadata.test.ts`
 - `tests/integration/aauth_revocation_e2e.test.ts`
@@ -368,7 +368,6 @@ flowchart TD
 - `tests/integration/describe_entity_type.test.ts`
 - `tests/integration/docs_route.test.ts`
 - `tests/integration/entity_identifier_handler.test.ts`
-- `tests/integration/entity_queries_status_column.test.ts`
 - `tests/integration/entity_queries.test.ts`
 - `tests/integration/entity_search_mode.test.ts`
 - `tests/integration/events_stream.test.ts`
@@ -477,7 +476,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/cli`
 **Requirements:** Basic `.env`; some tests provision temp config homes automatically.
-**Files (63):**
+**Files (64):**
 - `tests/cli/api_client_offline_fallback.test.ts`
 - `tests/cli/backup_verify.test.ts`
 - `tests/cli/cli_access_commands.test.ts`
@@ -498,6 +497,7 @@ flowchart TD
 - `tests/cli/cli_ingest_remote_upload.test.ts`
 - `tests/cli/cli_init_commands.test.ts`
 - `tests/cli/cli_init_env_targeting.test.ts`
+- `tests/cli/cli_init_flags.test.ts`
 - `tests/cli/cli_init_interactive.test.ts`
 - `tests/cli/cli_issues_commands.test.ts`
 - `tests/cli/cli_mcp_commands.test.ts`
@@ -547,11 +547,10 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/contract`
 **Requirements:** Generated contract artifacts present when the suite expects them.
-**Files (14):**
+**Files (13):**
 - `tests/contract/cli_handler_dist_smoke.test.ts`
 - `tests/contract/contract_mapping.test.ts`
 - `tests/contract/contract_mcp_cli_parity.test.ts`
-- `tests/contract/get_entities_alias.test.ts`
 - `tests/contract/ironclaw_integration.test.ts`
 - `tests/contract/legacy_payloads/replay.test.ts`
 - `tests/contract/mcp_stdio_output_safety.test.ts`

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -39,6 +39,55 @@ export const CONFIG_DIR = path.join(os.homedir(), ".config", "neotoma");
 export const CONFIG_PATH = path.join(CONFIG_DIR, "config.json");
 export const USER_ENV_PATH = path.join(CONFIG_DIR, ".env");
 
+/** Subdirectory name used for project-local Neotoma config when `--project-local` is given to `neotoma init`. */
+export const PROJECT_LOCAL_CONFIG_DIR_NAME = ".neotoma";
+/** Config file name inside a project-local config directory. */
+export const PROJECT_LOCAL_CONFIG_FILE_NAME = "config.json";
+
+/**
+ * Returns the project-local config path for the given directory (default: cwd).
+ * Project-local config lives at `<dir>/.neotoma/config.json` and takes
+ * precedence over the user-level `~/.config/neotoma/config.json` when present.
+ */
+export function projectLocalConfigPath(cwd?: string): string {
+  return path.join(
+    cwd ?? process.cwd(),
+    PROJECT_LOCAL_CONFIG_DIR_NAME,
+    PROJECT_LOCAL_CONFIG_FILE_NAME
+  );
+}
+
+/**
+ * Read the merged effective config: project-local (if present) takes precedence
+ * over user-level config. Call this instead of `readConfig()` when callers want
+ * the full precedence chain.
+ */
+export async function readEffectiveConfig(
+  cwd?: string
+): Promise<Config & { _source?: "project-local" | "user" }> {
+  const localPath = projectLocalConfigPath(cwd);
+  try {
+    const raw = await fs.readFile(localPath, "utf-8");
+    const local = JSON.parse(raw) as Config;
+    return { ...local, _source: "project-local" };
+  } catch {
+    // No project-local config; fall through to user-level.
+  }
+  const userConfig = await readConfig();
+  return { ...userConfig, _source: "user" };
+}
+
+/**
+ * Write config to the project-local path (`.neotoma/config.json` in `cwd`).
+ * Creates the `.neotoma/` directory if needed.
+ */
+export async function writeProjectLocalConfig(next: Config, cwd?: string): Promise<string> {
+  const localPath = projectLocalConfigPath(cwd);
+  await fs.mkdir(path.dirname(localPath), { recursive: true });
+  await fs.writeFile(localPath, JSON.stringify(next, null, 2));
+  return localPath;
+}
+
 const cliEnv = process.env.NEOTOMA_ENV || "development";
 /** True when NEOTOMA_ENV is "production". Used for API logs dir, PID path, and CLI log default. */
 export const isProd = cliEnv === "production";

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -58,20 +58,38 @@ export function projectLocalConfigPath(cwd?: string): string {
 }
 
 /**
- * Read the merged effective config: project-local (if present) takes precedence
- * over user-level config. Call this instead of `readConfig()` when callers want
- * the full precedence chain.
+ * Read the merged effective config: project-local (if present and trusted) takes
+ * precedence over user-level config. Call this instead of `readConfig()` when
+ * callers want the full precedence chain.
+ *
+ * Security: project-local config is only loaded when the directory containing
+ * `.neotoma/` is owned by the current user (similar to git's `safe.directory`
+ * model). This prevents a malicious `.neotoma/config.json` in an untrusted
+ * working directory from silently overriding user-level settings such as
+ * `base_url` or `access_token`.
  */
 export async function readEffectiveConfig(
   cwd?: string
 ): Promise<Config & { _source?: "project-local" | "user" }> {
   const localPath = projectLocalConfigPath(cwd);
+  const localDir = path.dirname(path.dirname(localPath)); // parent of .neotoma/
   try {
-    const raw = await fs.readFile(localPath, "utf-8");
-    const local = JSON.parse(raw) as Config;
-    return { ...local, _source: "project-local" };
+    // Trust-boundary check: only load project-local config when the containing
+    // directory is owned by the current process uid (mirrors git safe.directory).
+    const dirStat = await fs.stat(localDir);
+    const uid = process.getuid?.();
+    if (uid !== undefined && dirStat.uid !== uid) {
+      // Directory owned by a different user — refuse to load project-local config.
+      // Fall through to user-level config silently (same as if the file didn't exist).
+    } else {
+      const raw = await fs.readFile(localPath, "utf-8");
+      const local = JSON.parse(raw) as Config;
+      // Strip _source so it is not written back through writeConfig paths.
+      const { _source: _, ...rest } = local as Config & { _source?: unknown };
+      return { ...rest, _source: "project-local" };
+    }
   } catch {
-    // No project-local config; fall through to user-level.
+    // No project-local config or unreadable; fall through to user-level.
   }
   const userConfig = await readConfig();
   return { ...userConfig, _source: "user" };
@@ -84,7 +102,9 @@ export async function readEffectiveConfig(
 export async function writeProjectLocalConfig(next: Config, cwd?: string): Promise<string> {
   const localPath = projectLocalConfigPath(cwd);
   await fs.mkdir(path.dirname(localPath), { recursive: true });
-  await fs.writeFile(localPath, JSON.stringify(next, null, 2));
+  // Write with mode 0600 (owner read/write only) to protect credentials that
+  // may be stored in the config (e.g. access_token, connection_id).
+  await fs.writeFile(localPath, JSON.stringify(next, null, 2), { mode: 0o600 });
   return localPath;
 }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -9,6 +9,7 @@ import path from "node:path";
 import process from "node:process";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import {
+  constants as fsConstants,
   createWriteStream,
   readdirSync,
   readFileSync,
@@ -39,6 +40,7 @@ import {
   isTokenExpired,
   isProd,
   readConfig,
+  readEffectiveConfig,
   rememberKnownApiPort,
   resolveBaseUrl as resolveBaseUrlInner,
   waitForApiReady,
@@ -682,7 +684,7 @@ async function resolveRepoRootWithPrecedence(params?: {
   repoRoot: string | null;
   source: RepoRootSource;
 }> {
-  const config = params?.config ?? (await readConfig());
+  const config = params?.config ?? (await readEffectiveConfig());
   const cwd = params?.cwd ?? process.cwd();
 
   const explicitRepoRoot = params?.explicitRepoRoot?.trim();
@@ -4702,17 +4704,45 @@ const initCommand = program
           const cwd = process.cwd();
           const homeDir = process.env.HOME || process.env.USERPROFILE || ".";
           const dataDirDefault = path.join(homeDir, "neotoma", "data");
-          const resolvedDataDir = opts.dataDir?.trim() || dataDirDefault;
+          const resolvedDataDir =
+            opts.dataDir?.trim() || process.env.NEOTOMA_DATA_DIR?.trim() || dataDirDefault;
           const configTarget = opts.projectLocal ? projectLocalConfigPath(cwd) : CONFIG_PATH;
-          const envTarget = path.join(CONFIG_DIR, ".env");
-          const dbPaths = [
-            path.join(resolvedDataDir, "neotoma.db"),
-            path.join(resolvedDataDir, "neotoma.prod.db"),
-          ];
+          // Env file lands next to the config dir for user-level init, or in the
+          // detected checkout root when a checkout is present. --safe reports the
+          // user-level path; the real init may differ when a checkout is detected.
+          const envTarget = USER_ENV_PATH;
+
+          // Compute blocker reasons for each planned action.
+          const configExists = await fs
+            .stat(configTarget)
+            .then(() => true)
+            .catch(() => false);
+          // Walk up to the nearest existing ancestor of resolvedDataDir to check writability.
+          // The data dir itself may not exist yet; we check whether we can create it.
+          const nearestWritableAncestor = async (dir: string): Promise<boolean> => {
+            let current = dir;
+            for (;;) {
+              try {
+                await fs.access(current, fsConstants.W_OK);
+                return true;
+              } catch {
+                const parent = path.dirname(current);
+                if (parent === current) return false; // reached filesystem root
+                current = parent;
+              }
+            }
+          };
+          const dataDirParentWritable = await nearestWritableAncestor(
+            path.dirname(resolvedDataDir)
+          );
+
           const plannedActions: Array<{ label: string; path?: string; blockerReason?: string }> = [
             {
               label: "Create data directory",
               path: resolvedDataDir,
+              blockerReason: !dataDirParentWritable
+                ? `data directory cannot be created: no writable ancestor found for ${resolvedDataDir}`
+                : undefined,
             },
             {
               label: "Create sources directory",
@@ -4722,18 +4752,27 @@ const initCommand = program
               label: "Create logs directory",
               path: path.join(resolvedDataDir, "logs"),
             },
-            ...dbPaths.map((p) => ({ label: `Initialize database`, path: p })),
+            ...(!opts.skipDb
+              ? [path.join(resolvedDataDir, isProd ? "neotoma.prod.db" : "neotoma.db")].map(
+                  (p) => ({ label: `Initialize database`, path: p })
+                )
+              : []),
             {
               label: `Write config`,
               path: configTarget,
+              blockerReason:
+                configExists && !opts.force
+                  ? `already exists (pass --force to overwrite)`
+                  : undefined,
             },
             ...(!opts.skipEnv ? [{ label: "Write environment file", path: envTarget }] : []),
           ];
+          const hasBlocker = plannedActions.some((a) => a.blockerReason);
           const outputMode = resolveOutputMode();
           if (outputMode === "json") {
             writeOutput(
               {
-                ok: true,
+                ok: !hasBlocker,
                 dry_run: true,
                 planned_actions: plannedActions.map((a) => ({
                   label: a.label,
@@ -4764,10 +4803,21 @@ const initCommand = program
                 : "";
               process.stdout.write(`  ${icon} ${action.label}${pathPart}${blockerPart}\n`);
             }
-            process.stdout.write(
-              "\n" + dim("All checks passed. Run without --safe to apply.") + "\n"
-            );
+            if (hasBlocker) {
+              process.stdout.write(
+                "\n" +
+                  warn(
+                    "One or more planned actions have blockers. Resolve them before running without --safe."
+                  ) +
+                  "\n"
+              );
+            } else {
+              process.stdout.write(
+                "\n" + dim("All checks passed. Run without --safe to apply.") + "\n"
+              );
+            }
           }
+          if (hasBlocker) process.exitCode = 1;
           return;
         }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -44,6 +44,8 @@ import {
   waitForApiReady,
   waitForHealth,
   writeConfig,
+  writeProjectLocalConfig,
+  projectLocalConfigPath,
   type ApiInstance,
   type Config,
 } from "./config.js";
@@ -4638,6 +4640,14 @@ const initCommand = program
     "Limit transcript import to a specific harness: claude-code, codex, or cursor"
   )
   .option("--transcript-limit <n>", "Maximum number of transcript files to import per harness")
+  .option(
+    "--project-local",
+    "Store init config in .neotoma/config.json in the current directory (project-scoped) instead of ~/.config/neotoma/config.json (user-scoped)"
+  )
+  .option(
+    "--safe",
+    "Dry-run mode: report what init would do (create directories, write config, run migrations) without making any changes. Exit 0 if everything would succeed."
+  )
   .action(
     async (opts: {
       dataDir?: string;
@@ -4662,6 +4672,8 @@ const initCommand = program
       importTranscripts?: boolean;
       transcriptHarness?: string;
       transcriptLimit?: string;
+      projectLocal?: boolean;
+      safe?: boolean;
     }) => {
       try {
         const outputMode = resolveOutputMode();
@@ -4685,6 +4697,80 @@ const initCommand = program
             // Fall through to normal init on any detection error.
           }
         }
+        // --safe: dry-run mode — report planned actions without making any changes.
+        if (opts.safe) {
+          const cwd = process.cwd();
+          const homeDir = process.env.HOME || process.env.USERPROFILE || ".";
+          const dataDirDefault = path.join(homeDir, "neotoma", "data");
+          const resolvedDataDir = opts.dataDir?.trim() || dataDirDefault;
+          const configTarget = opts.projectLocal ? projectLocalConfigPath(cwd) : CONFIG_PATH;
+          const envTarget = path.join(CONFIG_DIR, ".env");
+          const dbPaths = [
+            path.join(resolvedDataDir, "neotoma.db"),
+            path.join(resolvedDataDir, "neotoma.prod.db"),
+          ];
+          const plannedActions: Array<{ label: string; path?: string; blockerReason?: string }> = [
+            {
+              label: "Create data directory",
+              path: resolvedDataDir,
+            },
+            {
+              label: "Create sources directory",
+              path: path.join(resolvedDataDir, "sources"),
+            },
+            {
+              label: "Create logs directory",
+              path: path.join(resolvedDataDir, "logs"),
+            },
+            ...dbPaths.map((p) => ({ label: `Initialize database`, path: p })),
+            {
+              label: `Write config`,
+              path: configTarget,
+            },
+            ...(!opts.skipEnv ? [{ label: "Write environment file", path: envTarget }] : []),
+          ];
+          const outputMode = resolveOutputMode();
+          if (outputMode === "json") {
+            writeOutput(
+              {
+                ok: true,
+                dry_run: true,
+                planned_actions: plannedActions.map((a) => ({
+                  label: a.label,
+                  ...(a.path ? { path: a.path } : {}),
+                  would_succeed: !a.blockerReason,
+                  ...(a.blockerReason ? { blocker: a.blockerReason } : {}),
+                })),
+              },
+              outputMode
+            );
+          } else {
+            process.stdout.write(
+              bold("neotoma init --safe") + " (dry-run — no files will be written)\n\n"
+            );
+            process.stdout.write(
+              dim("Config scope: ") +
+                (opts.projectLocal
+                  ? pathStyle(configTarget) + " (project-local)"
+                  : pathStyle(configTarget) + " (user-level)") +
+                "\n\n"
+            );
+            for (const action of plannedActions) {
+              const ok = !action.blockerReason;
+              const icon = ok ? success("✓") : warn("✗");
+              const pathPart = action.path ? " " + pathStyle(action.path) : "";
+              const blockerPart = action.blockerReason
+                ? "\n    " + dim("blocker: " + action.blockerReason)
+                : "";
+              process.stdout.write(`  ${icon} ${action.label}${pathPart}${blockerPart}\n`);
+            }
+            process.stdout.write(
+              "\n" + dim("All checks passed. Run without --safe to apply.") + "\n"
+            );
+          }
+          return;
+        }
+
         const interactiveRequested = Boolean(opts.interactive || opts.advanced);
         let useAdvancedPrompts = interactiveRequested;
         const applyDefaultsWithoutPrompts = Boolean(opts.yes || !interactiveRequested);
@@ -6405,7 +6491,19 @@ NEOTOMA_MCP_TOKEN_ENCRYPTION_KEY=${mcpTokenEncryptionKey}
             ...(configRepoRoot ? { project_root: configRepoRoot, repo_root: configRepoRoot } : {}),
             ...(initAuthSummary.mode !== "skip" ? { init_auth_mode: initAuthSummary.mode } : {}),
           };
-          await writeConfig(nextConfig);
+          if (opts.projectLocal) {
+            // Write project-local config to .neotoma/config.json in cwd; this takes
+            // precedence over user-level config when running Neotoma from this directory.
+            const localConfigPath = await writeProjectLocalConfig(nextConfig, process.cwd());
+            if (outputMode === "pretty") {
+              process.stdout.write(
+                bullet(success("Project-local config written: ") + pathStyle(localConfigPath)) +
+                  "\n"
+              );
+            }
+          } else {
+            await writeConfig(nextConfig);
+          }
         }
 
         // If repo root was discovered late (after env setup phase), still ensure

--- a/tests/cli/cli_init_flags.test.ts
+++ b/tests/cli/cli_init_flags.test.ts
@@ -323,4 +323,151 @@ describe("neotoma init --project-local: config module", () => {
       await fs.rm(homeDir, { recursive: true, force: true });
     }
   });
+
+  it("writeProjectLocalConfig writes the file with mode 0600", async () => {
+    const { writeProjectLocalConfig } = await import("../../src/cli/config.ts");
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "neotoma-wplc-mode-"));
+    try {
+      const writtenPath = await writeProjectLocalConfig(
+        { init_auth_mode: "dev_local" as const },
+        cwd
+      );
+      const stat = await fs.stat(writtenPath);
+      // mode & 0o777 gives the permission bits; 0o600 = owner r/w only
+      expect(stat.mode & 0o777).toBe(0o600);
+    } finally {
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("neotoma init --safe: blocker detection", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it("reports a blocker when config target already exists (without --force)", async () => {
+    await withTempHome(async (homeDir) => {
+      const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "neotoma-safe-blocker-"));
+      const previousCwd = process.cwd();
+      process.chdir(cwd);
+      try {
+        mockReadlineForInit();
+        // Pre-create the config file so init would encounter an existing config
+        const configDir = path.join(homeDir, ".config", "neotoma");
+        await fs.mkdir(configDir, { recursive: true });
+        await fs.writeFile(path.join(configDir, "config.json"), JSON.stringify({}));
+
+        const { runCli } = await loadCli();
+        const out = captureStdout();
+        const previousExitCode = process.exitCode;
+        try {
+          await runCli([
+            "node",
+            "cli",
+            "init",
+            "--safe",
+            "--skip-db",
+            "--skip-env",
+            "--auth-mode",
+            "dev_local",
+          ]);
+        } finally {
+          out.restore();
+        }
+        const text = out.lines();
+        // Should report a blocker for the existing config
+        expect(text).toMatch(/already exists|blocker/i);
+        // exit code should be non-zero when there's a blocker
+        expect(process.exitCode).toBe(1);
+        process.exitCode = previousExitCode;
+      } finally {
+        process.chdir(previousCwd);
+        await fs.rm(cwd, { recursive: true, force: true });
+      }
+    });
+  }, 15000);
+
+  it("does not report a blocker when --force is given and config already exists", async () => {
+    await withTempHome(async (homeDir) => {
+      const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "neotoma-safe-force-"));
+      const previousCwd = process.cwd();
+      process.chdir(cwd);
+      try {
+        mockReadlineForInit();
+        // Pre-create the config file
+        const configDir = path.join(homeDir, ".config", "neotoma");
+        await fs.mkdir(configDir, { recursive: true });
+        await fs.writeFile(path.join(configDir, "config.json"), JSON.stringify({}));
+
+        const { runCli } = await loadCli();
+        const out = captureStdout();
+        const previousExitCode = process.exitCode;
+        try {
+          await runCli([
+            "node",
+            "cli",
+            "init",
+            "--safe",
+            "--force",
+            "--skip-db",
+            "--skip-env",
+            "--auth-mode",
+            "dev_local",
+          ]);
+        } finally {
+          out.restore();
+        }
+        const text = out.lines();
+        // With --force the config-exists blocker should not appear
+        expect(text).not.toMatch(/already exists.*blocker/i);
+        // No blocker → "All checks passed"
+        expect(text).toMatch(/all checks passed/i);
+        process.exitCode = previousExitCode;
+      } finally {
+        process.chdir(previousCwd);
+        await fs.rm(cwd, { recursive: true, force: true });
+      }
+    });
+  }, 15000);
+
+  it("omits database entries from planned actions when --skip-db is given", async () => {
+    await withTempHome(async (_homeDir) => {
+      const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "neotoma-safe-skipdb-"));
+      const previousCwd = process.cwd();
+      process.chdir(cwd);
+      try {
+        mockReadlineForInit();
+        const { runCli } = await loadCli();
+        const chunks: string[] = [];
+        const spy = vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+          if (typeof chunk === "string") chunks.push(chunk);
+          return true;
+        });
+        try {
+          await runCli([
+            "node",
+            "cli",
+            "--json",
+            "init",
+            "--safe",
+            "--skip-db",
+            "--skip-env",
+            "--auth-mode",
+            "dev_local",
+          ]);
+        } finally {
+          spy.mockRestore();
+        }
+        const parsed = JSON.parse(chunks.join("")) as { planned_actions: Array<{ label: string }> };
+        const labels = parsed.planned_actions.map((a) => a.label);
+        // When --skip-db is set, no "Initialize database" entries should appear
+        expect(labels.every((l) => !l.toLowerCase().includes("database"))).toBe(true);
+      } finally {
+        process.chdir(previousCwd);
+        await fs.rm(cwd, { recursive: true, force: true });
+      }
+    });
+  }, 15000);
 });

--- a/tests/cli/cli_init_flags.test.ts
+++ b/tests/cli/cli_init_flags.test.ts
@@ -1,0 +1,326 @@
+/**
+ * Tests for `neotoma init --safe` (dry-run) and `neotoma init --project-local`
+ * (project-scoped config) flags.
+ */
+
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+type CliModule = {
+  runCli: (argv: string[]) => Promise<void>;
+};
+
+async function loadCli(): Promise<CliModule> {
+  vi.resetModules();
+  return (await import("../../src/cli/index.ts")) as CliModule;
+}
+
+async function withTempHome<T>(callback: (homeDir: string) => Promise<T>): Promise<T> {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "neotoma-init-flags-home-"));
+  const previousHome = process.env.HOME;
+  const previousUserProfile = process.env.USERPROFILE;
+  const previousRepoRoot = process.env.NEOTOMA_REPO_ROOT;
+  const previousDataDir = process.env.NEOTOMA_DATA_DIR;
+  process.env.HOME = tempDir;
+  process.env.USERPROFILE = tempDir;
+  delete process.env.NEOTOMA_REPO_ROOT;
+  delete process.env.NEOTOMA_DATA_DIR;
+  try {
+    return await callback(tempDir);
+  } finally {
+    if (previousHome === undefined) delete process.env.HOME;
+    else process.env.HOME = previousHome;
+    if (previousUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = previousUserProfile;
+    if (previousRepoRoot === undefined) delete process.env.NEOTOMA_REPO_ROOT;
+    else process.env.NEOTOMA_REPO_ROOT = previousRepoRoot;
+    if (previousDataDir === undefined) delete process.env.NEOTOMA_DATA_DIR;
+    else process.env.NEOTOMA_DATA_DIR = previousDataDir;
+  }
+}
+
+function captureStdout(): { lines: () => string; restore: () => void } {
+  const chunks: string[] = [];
+  const spy = vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+    if (typeof chunk === "string") chunks.push(chunk);
+    return true;
+  });
+  return {
+    lines: () => chunks.join(""),
+    restore: () => spy.mockRestore(),
+  };
+}
+
+function mockReadlineForInit(): void {
+  vi.doMock("node:readline", () => ({
+    createInterface: () => ({
+      on: () => {},
+      question: (_q: string, cb: (v: string) => void) => cb(""),
+      close: () => {},
+    }),
+  }));
+}
+
+describe("neotoma init --safe (dry-run)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it("exits without creating any files", async () => {
+    await withTempHome(async (homeDir) => {
+      const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "neotoma-init-safe-cwd-"));
+      const previousCwd = process.cwd();
+      process.chdir(cwd);
+      try {
+        mockReadlineForInit();
+        const { runCli } = await loadCli();
+        const out = captureStdout();
+        try {
+          await runCli([
+            "node",
+            "cli",
+            "init",
+            "--safe",
+            "--skip-db",
+            "--skip-env",
+            "--auth-mode",
+            "dev_local",
+          ]);
+        } finally {
+          out.restore();
+        }
+
+        // No files should have been created in the home dir config dir
+        const configPath = path.join(homeDir, ".config", "neotoma", "config.json");
+        await expect(fs.access(configPath)).rejects.toThrow();
+
+        // The dry-run output should mention dry-run / no-files
+        const text = out.lines();
+        expect(text).toContain("dry-run");
+      } finally {
+        process.chdir(previousCwd);
+        await fs.rm(cwd, { recursive: true, force: true });
+      }
+    });
+  }, 15000);
+
+  it("reports planned actions in pretty mode", async () => {
+    await withTempHome(async (_homeDir) => {
+      const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "neotoma-init-safe-pretty-"));
+      const previousCwd = process.cwd();
+      process.chdir(cwd);
+      try {
+        mockReadlineForInit();
+        const { runCli } = await loadCli();
+        const out = captureStdout();
+        try {
+          await runCli([
+            "node",
+            "cli",
+            "init",
+            "--safe",
+            "--skip-db",
+            "--skip-env",
+            "--auth-mode",
+            "dev_local",
+          ]);
+        } finally {
+          out.restore();
+        }
+        const text = out.lines();
+        // Should include check marks for planned actions
+        expect(text).toContain("✓");
+        // Should list directory creation
+        expect(text).toMatch(/Create data directory|data directory/i);
+      } finally {
+        process.chdir(previousCwd);
+        await fs.rm(cwd, { recursive: true, force: true });
+      }
+    });
+  }, 15000);
+
+  it("reports project-local config path when combined with --project-local", async () => {
+    await withTempHome(async (_homeDir) => {
+      const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "neotoma-init-safe-local-"));
+      const previousCwd = process.cwd();
+      process.chdir(cwd);
+      try {
+        mockReadlineForInit();
+        const { runCli } = await loadCli();
+        const out = captureStdout();
+        try {
+          await runCli([
+            "node",
+            "cli",
+            "init",
+            "--safe",
+            "--project-local",
+            "--skip-db",
+            "--skip-env",
+            "--auth-mode",
+            "dev_local",
+          ]);
+        } finally {
+          out.restore();
+        }
+        const text = out.lines();
+        // Should mention the project-local config path
+        expect(text).toContain(".neotoma");
+        expect(text).toContain("project-local");
+      } finally {
+        process.chdir(previousCwd);
+        await fs.rm(cwd, { recursive: true, force: true });
+      }
+    });
+  }, 15000);
+
+  it("outputs JSON with dry_run=true and planned_actions array when --json is set", async () => {
+    await withTempHome(async (_homeDir) => {
+      const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "neotoma-init-safe-json-"));
+      const previousCwd = process.cwd();
+      process.chdir(cwd);
+      try {
+        mockReadlineForInit();
+        const { runCli } = await loadCli();
+        const chunks: string[] = [];
+        const spy = vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+          if (typeof chunk === "string") chunks.push(chunk);
+          return true;
+        });
+        try {
+          await runCli([
+            "node",
+            "cli",
+            "--json",
+            "init",
+            "--safe",
+            "--skip-db",
+            "--skip-env",
+            "--auth-mode",
+            "dev_local",
+          ]);
+        } finally {
+          spy.mockRestore();
+        }
+        const text = chunks.join("");
+        const parsed = JSON.parse(text) as Record<string, unknown>;
+        expect(parsed.ok).toBe(true);
+        expect(parsed.dry_run).toBe(true);
+        expect(Array.isArray(parsed.planned_actions)).toBe(true);
+      } finally {
+        process.chdir(previousCwd);
+        await fs.rm(cwd, { recursive: true, force: true });
+      }
+    });
+  }, 15000);
+});
+
+describe("neotoma init --project-local: config module", () => {
+  /**
+   * These tests exercise the config module functions directly to avoid
+   * running the full init flow (which requires SQLite and server setup).
+   */
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it("projectLocalConfigPath returns .neotoma/config.json relative to cwd", async () => {
+    const { projectLocalConfigPath } = await import("../../src/cli/config.ts");
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "neotoma-plcp-"));
+    try {
+      const result = projectLocalConfigPath(cwd);
+      expect(result).toBe(path.join(cwd, ".neotoma", "config.json"));
+    } finally {
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("writeProjectLocalConfig creates .neotoma/config.json with the supplied config", async () => {
+    const { writeProjectLocalConfig } = await import("../../src/cli/config.ts");
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "neotoma-wplc-"));
+    try {
+      const testConfig = { init_auth_mode: "dev_local" as const, project_root: "/some/path" };
+      const writtenPath = await writeProjectLocalConfig(testConfig, cwd);
+      expect(writtenPath).toBe(path.join(cwd, ".neotoma", "config.json"));
+
+      const raw = await fs.readFile(writtenPath, "utf-8");
+      const parsed = JSON.parse(raw) as Record<string, unknown>;
+      expect(parsed.init_auth_mode).toBe("dev_local");
+      expect(parsed.project_root).toBe("/some/path");
+    } finally {
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("writeProjectLocalConfig creates the .neotoma directory if it does not exist", async () => {
+    const { writeProjectLocalConfig } = await import("../../src/cli/config.ts");
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "neotoma-wplc-mkdir-"));
+    try {
+      const neotomaDir = path.join(cwd, ".neotoma");
+      // Directory should not exist yet
+      await expect(fs.access(neotomaDir)).rejects.toThrow();
+
+      await writeProjectLocalConfig({ init_auth_mode: "dev_local" as const }, cwd);
+
+      // Directory should now exist
+      await expect(fs.access(neotomaDir)).resolves.toBeUndefined();
+    } finally {
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("readEffectiveConfig prefers project-local config over user-level config", async () => {
+    const { readEffectiveConfig, writeProjectLocalConfig, writeConfig } = await import(
+      "../../src/cli/config.ts"
+    );
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "neotoma-rec-"));
+    const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), "neotoma-rec-home-"));
+    const previousHome = process.env.HOME;
+    process.env.HOME = homeDir;
+    try {
+      // Write user-level config
+      await writeConfig({ init_auth_mode: "oauth" as const, project_root: "/user/path" });
+      // Write project-local config with different values
+      await writeProjectLocalConfig(
+        { init_auth_mode: "dev_local" as const, project_root: "/local/path" },
+        cwd
+      );
+
+      const effective = await readEffectiveConfig(cwd);
+      expect(effective._source).toBe("project-local");
+      expect(effective.init_auth_mode).toBe("dev_local");
+      expect(effective.project_root).toBe("/local/path");
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      await fs.rm(cwd, { recursive: true, force: true });
+      await fs.rm(homeDir, { recursive: true, force: true });
+    }
+  });
+
+  it("readEffectiveConfig falls back to user-level config when no project-local config exists", async () => {
+    const { readEffectiveConfig, writeConfig } = await import("../../src/cli/config.ts");
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "neotoma-rec-fallback-"));
+    const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), "neotoma-rec-fallback-home-"));
+    const previousHome = process.env.HOME;
+    process.env.HOME = homeDir;
+    try {
+      // Write only user-level config; no project-local
+      await writeConfig({ init_auth_mode: "oauth" as const, project_root: "/user/path" });
+
+      const effective = await readEffectiveConfig(cwd);
+      expect(effective._source).toBe("user");
+      expect(effective.init_auth_mode).toBe("oauth");
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      await fs.rm(cwd, { recursive: true, force: true });
+      await fs.rm(homeDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Fixes #169

- `--project-local`: scopes init config to `.neotoma/config.json` in current directory, taking precedence over user-level config
- `--safe`: dry-run mode that reports planned changes without executing them