### PR TITLE
feat(bundles): introduce NEOTOMA_SCHEMA_MODE env var, parity-preserving (m1 PR C)

### DIFF
--- a/docs/developer/cli_reference.md
+++ b/docs/developer/cli_reference.md
@@ -271,6 +271,15 @@ These are read by the Neotoma HTTP server (not the CLI `preAction` hook) for out
 
 `GET /peers/{peer_id}` returns `remote_health` from probing `{peer_url}/health` and semver compat vs the local package version (same rules as `neotoma compat`). See `docs/subsystems/peer_sync.md`.
 
+### Schema mode (server process)
+
+Bundles m1 introduces a schema-mode selector read once at server boot. The value is currently observational — no runtime behavior is gated on it yet. Enforcement lands in m2 at `inferSchemaFromEntities` (`src/server.ts`) and `ensureSchemaForExtractedEntity` (`src/services/interpretation.ts`).
+
+| Environment variable | Values | Default | Purpose |
+|----------------------|--------|---------|---------|
+| `NEOTOMA_SCHEMA_MODE` | `evolving` / `guided` / `locked` (case-insensitive) | `evolving` | Selects schema evolution behavior. `evolving` allows free inference and extension; `guided` (m2) adds stronger user prompts; `locked` (m2) freezes the schema set and disables auto-inference. Invalid values fall back to `evolving` with a structured warning at startup. See `docs/foundation/bundles.md` for full semantics. |
+| `NEOTOMA_DEBUG_SCHEMA_MODE` | `1` | unset | Emit a debug log when the schema mode is resolved at boot. |
+
 ### MCP signed shim (`mcp.json` — not CLI `preAction`)
 
 Cursor reads these from the **`env`** block for **`run_neotoma_mcp_signed_stdio_dev_shim.sh`** (they are **not** parsed by `neotoma` CLI `preAction`; document them here for discoverability).

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -40,6 +40,7 @@ import {
   AccessPolicyError,
   type GuestIdentity,
 } from "./services/access_policy.js";
+import { getSchemaMode } from "./services/schema_mode.js";
 import { hashGuestAccessToken } from "./services/guest_access_token.js";
 import { IssueTransportError, IssueValidationError } from "./services/issues/errors.js";
 import {
@@ -9772,6 +9773,14 @@ export async function startHTTPServer() {
         await import("./services/subscriptions/install_subscription_bridge.js");
       subscriptionBridge.installSubscriptionBridge();
       logger.info("[Subscriptions] substrate event bridge installed");
+
+      // Bundles m1 (PR C): resolve schema mode once at boot so the parsed
+      // value is cached and any invalid-value warning surfaces during startup.
+      // No runtime behavior is gated on this yet; enforcement lands in m2.
+      // Plan: ent_089da2ecebc3bd804d63dcf2.
+      const schemaMode = getSchemaMode();
+      logger.info(`[SchemaMode] resolved schema mode: ${schemaMode}`);
+
       return { server, port: boundPort };
     } catch (err: unknown) {
       const code = (err as NodeJS.ErrnoException)?.code;

--- a/src/services/schema_mode.ts
+++ b/src/services/schema_mode.ts
@@ -1,0 +1,76 @@
+/**
+ * Schema mode configuration (Bundles m1).
+ *
+ * Reads the `NEOTOMA_SCHEMA_MODE` environment variable and exposes the parsed
+ * value via {@link getSchemaMode}. This is parity-preserving in m1: the value
+ * is read and cached at startup but no runtime behavior is gated on it yet.
+ *
+ * Enforcement points (m2) will live at:
+ *   - `src/server.ts` `inferSchemaFromEntities`
+ *   - `src/services/interpretation.ts` `ensureSchemaForExtractedEntity`
+ *
+ * Values:
+ *   - `evolving` (default): schemas may be inferred or extended freely.
+ *   - `guided`: schemas may evolve but with stronger user prompts (m2).
+ *   - `locked`: schema set is fixed; no auto-inference (m2).
+ *
+ * Invalid or unrecognized values fall back to `evolving` with a structured
+ * warning. Parsing never throws — startup must not break on misconfiguration.
+ *
+ * Comparison is case-insensitive: `LOCKED`, `Locked`, and `locked` all map to
+ * the canonical lowercase value.
+ *
+ * Tracking: Neotoma plan `ent_089da2ecebc3bd804d63dcf2` (Bundles m1 PR C).
+ */
+
+import { logger } from "../utils/logger.js";
+
+export type SchemaMode = "evolving" | "guided" | "locked";
+
+export const DEFAULT_SCHEMA_MODE: SchemaMode = "evolving";
+
+const VALID_MODES: ReadonlySet<SchemaMode> = new Set<SchemaMode>([
+  "evolving",
+  "guided",
+  "locked",
+]);
+
+let cached: SchemaMode | undefined;
+
+function parseSchemaMode(raw: string | undefined): SchemaMode {
+  if (raw === undefined) return DEFAULT_SCHEMA_MODE;
+  const trimmed = raw.trim();
+  if (trimmed === "") return DEFAULT_SCHEMA_MODE;
+  const normalized = trimmed.toLowerCase();
+  if (VALID_MODES.has(normalized as SchemaMode)) {
+    return normalized as SchemaMode;
+  }
+  logger.warn(
+    `[schema_mode] NEOTOMA_SCHEMA_MODE has invalid value ${JSON.stringify(
+      raw
+    )}; falling back to ${DEFAULT_SCHEMA_MODE}. Valid values: evolving, guided, locked.`
+  );
+  return DEFAULT_SCHEMA_MODE;
+}
+
+/**
+ * Returns the configured schema mode, reading `NEOTOMA_SCHEMA_MODE` once and
+ * caching the result for the lifetime of the process. Call {@link
+ * resetSchemaModeCacheForTesting} between tests that mutate the env var.
+ */
+export function getSchemaMode(): SchemaMode {
+  if (cached !== undefined) return cached;
+  cached = parseSchemaMode(process.env.NEOTOMA_SCHEMA_MODE);
+  if (process.env.NEOTOMA_DEBUG_SCHEMA_MODE === "1") {
+    logger.debug(`[schema_mode] resolved schema mode: ${cached}`);
+  }
+  return cached;
+}
+
+/**
+ * Test-only helper: clears the cached value so a subsequent {@link
+ * getSchemaMode} call re-reads `process.env`. Not part of the public API.
+ */
+export function resetSchemaModeCacheForTesting(): void {
+  cached = undefined;
+}

--- a/tests/unit/schema_mode.test.ts
+++ b/tests/unit/schema_mode.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Unit tests for `src/services/schema_mode.ts`.
+ *
+ * Covers parsing of the `NEOTOMA_SCHEMA_MODE` env var:
+ *
+ *   - Unset / empty -> default ("evolving")
+ *   - "guided" / "locked" -> respective canonical values
+ *   - Invalid value -> default with a structured warning
+ *   - Case-insensitive matching ("LOCKED", "Guided" -> "locked", "guided")
+ *
+ * Plan: ent_089da2ecebc3bd804d63dcf2 (Bundles m1 PR C).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  getSchemaMode,
+  resetSchemaModeCacheForTesting,
+} from "../../src/services/schema_mode.js";
+import { logger } from "../../src/utils/logger.js";
+
+describe("getSchemaMode", () => {
+  const originalValue = process.env.NEOTOMA_SCHEMA_MODE;
+
+  beforeEach(() => {
+    delete process.env.NEOTOMA_SCHEMA_MODE;
+    resetSchemaModeCacheForTesting();
+  });
+
+  afterEach(() => {
+    if (originalValue === undefined) {
+      delete process.env.NEOTOMA_SCHEMA_MODE;
+    } else {
+      process.env.NEOTOMA_SCHEMA_MODE = originalValue;
+    }
+    resetSchemaModeCacheForTesting();
+    vi.restoreAllMocks();
+  });
+
+  it("returns 'evolving' when env var is unset", () => {
+    expect(getSchemaMode()).toBe("evolving");
+  });
+
+  it("returns 'evolving' when env var is empty string", () => {
+    process.env.NEOTOMA_SCHEMA_MODE = "";
+    expect(getSchemaMode()).toBe("evolving");
+  });
+
+  it("returns 'evolving' when env var is whitespace only", () => {
+    process.env.NEOTOMA_SCHEMA_MODE = "   ";
+    expect(getSchemaMode()).toBe("evolving");
+  });
+
+  it("returns 'guided' when env var = 'guided'", () => {
+    process.env.NEOTOMA_SCHEMA_MODE = "guided";
+    expect(getSchemaMode()).toBe("guided");
+  });
+
+  it("returns 'locked' when env var = 'locked'", () => {
+    process.env.NEOTOMA_SCHEMA_MODE = "locked";
+    expect(getSchemaMode()).toBe("locked");
+  });
+
+  it("returns 'evolving' explicitly when env var = 'evolving'", () => {
+    process.env.NEOTOMA_SCHEMA_MODE = "evolving";
+    expect(getSchemaMode()).toBe("evolving");
+  });
+
+  it("falls back to 'evolving' and logs a warning when env var is invalid", () => {
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => undefined);
+    process.env.NEOTOMA_SCHEMA_MODE = "garbage";
+
+    expect(getSchemaMode()).toBe("evolving");
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const message = String(warnSpy.mock.calls[0][0]);
+    expect(message).toContain("NEOTOMA_SCHEMA_MODE");
+    expect(message).toContain("garbage");
+    expect(message).toContain("evolving");
+  });
+
+  it("does not throw on invalid values (startup must not break)", () => {
+    process.env.NEOTOMA_SCHEMA_MODE = "not-a-mode";
+    expect(() => getSchemaMode()).not.toThrow();
+  });
+
+  it("matches case-insensitively for 'LOCKED'", () => {
+    vi.spyOn(logger, "warn").mockImplementation(() => undefined);
+    process.env.NEOTOMA_SCHEMA_MODE = "LOCKED";
+    expect(getSchemaMode()).toBe("locked");
+  });
+
+  it("matches case-insensitively for mixed case 'Guided'", () => {
+    vi.spyOn(logger, "warn").mockImplementation(() => undefined);
+    process.env.NEOTOMA_SCHEMA_MODE = "Guided";
+    expect(getSchemaMode()).toBe("guided");
+  });
+
+  it("trims surrounding whitespace before matching", () => {
+    process.env.NEOTOMA_SCHEMA_MODE = "  locked  ";
+    expect(getSchemaMode()).toBe("locked");
+  });
+
+  it("caches the resolved value across calls", () => {
+    process.env.NEOTOMA_SCHEMA_MODE = "guided";
+    expect(getSchemaMode()).toBe("guided");
+
+    // Mutating the env after the first call should not change the cached value.
+    process.env.NEOTOMA_SCHEMA_MODE = "locked";
+    expect(getSchemaMode()).toBe("guided");
+
+    // Resetting the cache picks up the new value.
+    resetSchemaModeCacheForTesting();
+    expect(getSchemaMode()).toBe("locked");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `src/services/schema_mode.ts`: exports `SchemaMode` type (`evolving | guided | locked`), `getSchemaMode()` (cached, case-insensitive, warns on invalid value, defaults to `evolving`), and `resetSchemaModeCacheForTesting()`
- Calls `getSchemaMode()` at boot in `src/actions.ts` `tryListen` success block (after `installSubscriptionBridge()`) so the current mode is logged on startup
- Adds `NEOTOMA_SCHEMA_MODE` to `docs/developer/cli_reference.md` Runtime overrides table
- Adds `tests/unit/schema_mode.test.ts`: 12 tests covering default, empty string, valid values, invalid (falls back + logs warn), case insensitivity — all passing

## Test plan

- [ ] `npm test -- schema_mode` passes (12/12)
- [ ] `npm run type-check` clean
- [ ] `NEOTOMA_SCHEMA_MODE=locked npm run dev` logs `schema_mode: locked` at boot
- [ ] `NEOTOMA_SCHEMA_MODE=invalid npm run dev` logs warn and defaults to `evolving`

## Breaking changes

No breaking changes. Default is `evolving` which matches current behavior exactly. No enforcement of `guided` or `locked` postures yet — that gates in m2 at both auto-create points (`src/server.ts:4416`, `src/services/interpretation.ts:225`).

## Notes

- This is the only PR in m1 with a code change; all others are docs
- The env var was never previously implemented (`NEOTOMA_LOCKED_SCHEMAS` in the old superseded plan `ent_0aa6b785f6aa7391adb6f518` was never shipped)
- Part of Bundles Strategy m1 (`ent_089da2ecebc3bd804d63dcf2`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)