### PR TITLE
fix(plans): resolve #325, #262, #326 — reliable plan body field usage

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -6278,6 +6278,9 @@ export async function storeStructuredForApi(params: {
     entity_snapshot_after: Record<string, unknown> | null;
   }> = [];
 
+  let unknownFieldsCount = 0;
+  const unknownFieldNamesSet = new Set<string>();
+
   for (const r of resolved) {
     let observation_id: string | null = null;
     let snapshotAfter: Record<string, unknown> | null = null;
@@ -6378,6 +6381,42 @@ export async function storeStructuredForApi(params: {
         logger.warn(
           `Auto-link reference fields failed for ${r.entity_type}/${r.entity_id}: ${
             linkErr instanceof Error ? linkErr.message : String(linkErr)
+          }`
+        );
+      }
+
+      // Track unknown fields (fields not declared in the active schema) so the
+      // API response mirrors the MCP store_structured response shape.
+      try {
+        const { schemaRegistry } = await import("./services/schema_registry.js");
+        const schemaEntry = await schemaRegistry.loadActiveSchema(r.entity_type, userId);
+        if (schemaEntry?.schema_definition?.fields) {
+          const { validateFieldsWithConverters } = await import(
+            "./services/field_validation.js"
+          );
+          const { storeUnknownFields } = await import("./services/raw_fragments.js");
+          const validation = validateFieldsWithConverters(
+            r.fields,
+            schemaEntry.schema_definition.fields
+          );
+          if (Object.keys(validation.unknownFields).length > 0) {
+            const schemaVer = schemaEntry.schema_version || "1.0";
+            const ufResult = await storeUnknownFields({
+              sourceId: observationSourceId,
+              userId,
+              entityId: r.entity_id,
+              entityType: r.entity_type,
+              schemaVersion: schemaVer,
+              unknownFields: validation.unknownFields,
+            });
+            unknownFieldsCount += ufResult.count;
+            for (const f of ufResult.fields) unknownFieldNamesSet.add(f);
+          }
+        }
+      } catch (ufErr) {
+        logger.warn(
+          `Unknown-fields tracking failed for ${r.entity_type}/${r.entity_id}: ${
+            ufErr instanceof Error ? ufErr.message : String(ufErr)
           }`
         );
       }
@@ -6537,9 +6576,11 @@ export async function storeStructuredForApi(params: {
     await completeInterpretationRun({
       interpretationId,
       observationsCreated: createdEntities.filter((e) => e.observation_id).length,
-      unknownFieldsCount: 0,
+      unknownFieldsCount,
     });
   }
+
+  const unknownFieldNames = Array.from(unknownFieldNamesSet).sort();
 
   return {
     success: true,
@@ -6555,6 +6596,13 @@ export async function storeStructuredForApi(params: {
     observations_created: commit ? createdEntities.length : 0,
     entities: createdEntities,
     relationships_created: relationshipsCreated,
+    unknown_fields_count: unknownFieldsCount,
+    unknown_fields: unknownFieldNames,
+    ...(unknownFieldsCount > 0
+      ? {
+          hint: "Unknown fields were stored in raw_fragments. Call update_schema_incremental to promote them to schema fields, then set migrate_existing: true to backfill existing data.",
+        }
+      : {}),
     ...(aggregatedWarnings.length > 0 ? { warnings: aggregatedWarnings } : {}),
     ...(schemaStoreWarnings.length > 0 ? { store_warnings: schemaStoreWarnings } : {}),
   };

--- a/src/services/canonical_markdown.ts
+++ b/src/services/canonical_markdown.ts
@@ -643,7 +643,11 @@ export function renderProfileEntity(
   parts.push(fmLines.join("\n"));
 
   if (hasContent) {
-    parts.push(contentValue as string);
+    // Strip a spurious leading `## body` / `# body` heading that some harnesses
+    // emit when they serialise the plan body as markdown (e.g. "## body\n\n## Problem\n…").
+    // The heading is redundant: the mirror already knows which field is the body.
+    const strippedContent = (contentValue as string).replace(/^##?\s+body\s*\n+/i, "");
+    parts.push(strippedContent);
   } else {
     // No body — fall back: render all snapshot fields (except those already in frontmatter) as ## sections
     const bodyFields = Object.keys(snapshot).filter(

--- a/src/services/plans/seed_schema.ts
+++ b/src/services/plans/seed_schema.ts
@@ -83,7 +83,10 @@ const PLAN_FIELDS: FieldSpec = [
   {
     name: "body",
     type: "string",
-    description: "Full markdown body of the plan; preserves harness-authored content verbatim",
+    description:
+      "Primary long-form content field. Store the full plan markdown, spec, or prose here. " +
+      "Do not split content across `overview` or `goals` — those are for short summaries and " +
+      "structured sub-items only. This field is rendered as the document body in the markdown mirror.",
   },
   {
     name: "public_overview",

--- a/tests/integration/api_store_unknown_fields.test.ts
+++ b/tests/integration/api_store_unknown_fields.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Regression tests for issue #326: storeStructuredForApi (HTTP API store path)
+ * did not track or return unknown field names, unlike the MCP store path which
+ * correctly returns unknown_fields_count, unknown_fields, and hint.
+ *
+ * Verifies that:
+ * 1. When all fields are schema-known, unknown_fields_count is 0 and
+ *    unknown_fields is an empty array.
+ * 2. When unknown fields are submitted against a registered schema, they are
+ *    counted and returned in unknown_fields, and a hint is included.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import { db } from "../../src/db.js";
+import { storeStructuredForApi } from "../../src/actions.js";
+
+const TEST_USER_ID = "00000000-0000-4000-8000-000000000326";
+const ENTITY_TYPE = `api_store_uf_test_${Date.now()}`;
+
+async function cleanup() {
+  const { data: observations } = await db
+    .from("observations")
+    .select("entity_id, source_id")
+    .eq("user_id", TEST_USER_ID);
+  const entityIds = Array.from(
+    new Set((observations ?? []).map((obs: { entity_id: string }) => obs.entity_id).filter(Boolean))
+  );
+  const sourceIds = Array.from(
+    new Set((observations ?? []).map((obs: { source_id: string }) => obs.source_id).filter(Boolean))
+  );
+
+  await db.from("timeline_events").delete().eq("user_id", TEST_USER_ID);
+  if (entityIds.length > 0) await db.from("entity_snapshots").delete().in("entity_id", entityIds);
+  await db.from("observations").delete().eq("user_id", TEST_USER_ID);
+  if (sourceIds.length > 0) {
+    await db.from("raw_fragments").delete().in("source_id", sourceIds);
+    await db.from("sources").delete().in("id", sourceIds);
+  }
+  if (entityIds.length > 0) await db.from("entities").delete().in("id", entityIds);
+  await db.from("schema_registry").delete().eq("entity_type", ENTITY_TYPE);
+}
+
+describe("storeStructuredForApi — unknown fields tracking (issue #326)", () => {
+  beforeAll(async () => {
+    // Register a schema with only known declared fields so we can submit
+    // an entity with an extra undeclared field and test that it is tracked.
+    await db.from("schema_registry").insert({
+      entity_type: ENTITY_TYPE,
+      schema_version: "1.0",
+      schema_definition: {
+        fields: {
+          schema_version: { type: "string", required: true },
+          title: { type: "string" },
+          overview: { type: "string" },
+        },
+        canonical_name_fields: ["title"],
+      },
+      reducer_config: { merge_policies: { title: { strategy: "last_write" } } },
+      active: true,
+      scope: "global",
+      user_id: null,
+    });
+  });
+
+  afterAll(cleanup);
+
+  it("returns unknown_fields_count: 0 and unknown_fields: [] when all fields match the schema", async () => {
+    const result = await storeStructuredForApi({
+      userId: TEST_USER_ID,
+      idempotencyKey: `uf-known-${randomUUID()}`,
+      commit: true,
+      entities: [
+        {
+          entity_type: ENTITY_TYPE,
+          title: "Known fields only",
+          overview: "Short summary.",
+        },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+    expect(typeof result.unknown_fields_count).toBe("number");
+    expect(result.unknown_fields_count).toBe(0);
+    expect(Array.isArray(result.unknown_fields)).toBe(true);
+    expect(result.unknown_fields).toHaveLength(0);
+    expect(result.hint).toBeUndefined();
+  });
+
+  it("returns non-zero unknown_fields_count and a sorted unknown_fields list when undeclared fields are submitted", async () => {
+    const result = await storeStructuredForApi({
+      userId: TEST_USER_ID,
+      idempotencyKey: `uf-unknown-${randomUUID()}`,
+      commit: true,
+      entities: [
+        {
+          entity_type: ENTITY_TYPE,
+          title: "Entity with unknown fields",
+          overview: "Short summary.",
+          // These two fields are NOT declared in the schema above:
+          zebra_field: "z-value",
+          alpha_field: "a-value",
+        },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.unknown_fields_count).toBeGreaterThan(0);
+    expect(Array.isArray(result.unknown_fields)).toBe(true);
+    // Should contain the undeclared fields, sorted alphabetically
+    expect(result.unknown_fields).toContain("alpha_field");
+    expect(result.unknown_fields).toContain("zebra_field");
+    // Must be sorted
+    const sorted = [...result.unknown_fields].sort();
+    expect(result.unknown_fields).toEqual(sorted);
+  });
+
+  it("includes a hint when unknown fields are present", async () => {
+    const result = await storeStructuredForApi({
+      userId: TEST_USER_ID,
+      idempotencyKey: `uf-hint-${randomUUID()}`,
+      commit: true,
+      entities: [
+        {
+          entity_type: ENTITY_TYPE,
+          title: "Entity triggering hint",
+          unregistered_field: "value",
+        },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.unknown_fields_count).toBeGreaterThan(0);
+    expect(typeof result.hint).toBe("string");
+    expect(result.hint).toMatch(/update_schema_incremental/i);
+    expect(result.hint).toMatch(/raw_fragments/i);
+  });
+
+  it("returns unknown_fields_count: 0 when no schema is registered for the entity type (no tracking without schema)", async () => {
+    // For entity types with no schema, there is nothing to validate against,
+    // so unknown_fields_count stays 0.
+    const result = await storeStructuredForApi({
+      userId: TEST_USER_ID,
+      idempotencyKey: `uf-noschema-${randomUUID()}`,
+      commit: true,
+      entities: [
+        {
+          entity_type: "generic",
+          title: "No schema entity",
+          some_field: "value",
+        },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+    expect(typeof result.unknown_fields_count).toBe("number");
+    expect(Array.isArray(result.unknown_fields)).toBe(true);
+  });
+});

--- a/tests/unit/canonical_markdown_body_heading.test.ts
+++ b/tests/unit/canonical_markdown_body_heading.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Regression tests for issue #262: mirror profile renderer emits spurious
+ * `## body` section heading when the harness stores plan body content that
+ * literally begins with "## body\n\n".
+ */
+import { describe, expect, it } from "vitest";
+import { renderProfileEntity } from "../../src/services/canonical_markdown.js";
+
+const BASE_META = {
+  entity_id: "ent_abc123",
+  entity_type: "plan",
+  schema_version: "1.0",
+};
+
+describe("renderProfileEntity — body heading stripping (issue #262)", () => {
+  it("strips leading '## body' heading from body content", () => {
+    const snapshot = {
+      title: "My Plan",
+      body: "## body\n\n## Problem\n\nThe widget is broken.\n",
+    };
+    const result = renderProfileEntity(snapshot, BASE_META, {
+      render_mode: "frontmatter_content",
+      content_field: "body",
+    });
+    expect(result).not.toContain("## body");
+    expect(result).toContain("## Problem");
+    expect(result).toContain("The widget is broken.");
+  });
+
+  it("strips leading '# body' heading (single hash) from body content", () => {
+    const snapshot = {
+      title: "My Plan",
+      body: "# body\n\n## Solution\n\nReplace the widget.\n",
+    };
+    const result = renderProfileEntity(snapshot, BASE_META, {
+      render_mode: "frontmatter_content",
+      content_field: "body",
+    });
+    expect(result).not.toMatch(/^# body/m);
+    expect(result).toContain("## Solution");
+  });
+
+  it("strips case-insensitively (## Body)", () => {
+    const snapshot = {
+      body: "## Body\n\n## Goals\n\nShip it.\n",
+    };
+    const result = renderProfileEntity(snapshot, BASE_META, {
+      render_mode: "frontmatter_content",
+      content_field: "body",
+    });
+    expect(result).not.toContain("## Body");
+    expect(result).toContain("## Goals");
+  });
+
+  it("does not strip an embedded '## body' that is not at the start", () => {
+    const snapshot = {
+      body: "## Overview\n\n## body\n\nSome content.\n",
+    };
+    const result = renderProfileEntity(snapshot, BASE_META, {
+      render_mode: "frontmatter_content",
+      content_field: "body",
+    });
+    // First heading is ## Overview, not ## body — the embedded one stays
+    expect(result).toContain("## Overview");
+    expect(result).toContain("## body");
+  });
+
+  it("preserves body content that does not start with '## body'", () => {
+    const snapshot = {
+      body: "## Problem\n\nSomething is wrong.\n",
+    };
+    const result = renderProfileEntity(snapshot, BASE_META, {
+      render_mode: "frontmatter_content",
+      content_field: "body",
+    });
+    expect(result).toContain("## Problem");
+    expect(result).not.toMatch(/## body/i);
+  });
+
+  it("handles content_only render_mode without stripping (stripping only needed in frontmatter_content)", () => {
+    // content_only mode has a separate code path; stripping is not applied there
+    // (the heading would still be rendered, but that mode is used for raw export
+    // not the mirror renderer that triggered issue #262).
+    const snapshot = {
+      body: "## body\n\nRaw content.\n",
+    };
+    const result = renderProfileEntity(snapshot, BASE_META, {
+      render_mode: "content_only",
+      content_field: "body",
+    });
+    // content_only returns the raw value — no stripping in that path
+    expect(result).toContain("## body");
+    expect(result).toContain("Raw content.");
+  });
+});

--- a/tests/unit/plan_schema_body_field.test.ts
+++ b/tests/unit/plan_schema_body_field.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Regression test for issue #325: plan `body` field description was
+ * insufficient, causing agents to store content in `overview`/`goals`
+ * instead of `body`.
+ *
+ * Verifies that the body field description in PLAN_FIELD_SPECS explicitly:
+ * - calls `body` the primary long-form content field
+ * - warns against splitting content into `overview` or `goals`
+ * - mentions that the field is rendered as the document body in the mirror
+ */
+import { describe, expect, it } from "vitest";
+import { PLAN_FIELD_SPECS } from "../../src/services/plans/seed_schema.js";
+
+describe("plan seed schema — body field description (issue #325)", () => {
+  it("declares body as the primary long-form content field", () => {
+    const bodySpec = PLAN_FIELD_SPECS.find((f) => f.name === "body");
+    expect(bodySpec).toBeDefined();
+    expect(bodySpec!.description).toMatch(/primary/i);
+    expect(bodySpec!.description).toMatch(/long.form content/i);
+  });
+
+  it("warns against splitting content into overview or goals", () => {
+    const bodySpec = PLAN_FIELD_SPECS.find((f) => f.name === "body")!;
+    expect(bodySpec.description).toMatch(/overview/);
+    expect(bodySpec.description).toMatch(/goals/);
+    expect(bodySpec.description).toMatch(/do not split/i);
+  });
+
+  it("mentions the markdown mirror rendering", () => {
+    const bodySpec = PLAN_FIELD_SPECS.find((f) => f.name === "body")!;
+    expect(bodySpec.description).toMatch(/mirror/i);
+  });
+});


### PR DESCRIPTION
## Summary

- **#325** — Updated body field description in seed_schema.ts to make clear it is the primary long-form content field, and that agents must not split content into overview or goals
- **#262** — renderProfileEntity now strips a leading "## body" / "# body" heading from content before writing to the mirror output; harnesses like Claude Code store the plan body with a literal "## body\n\n" prefix that produced a spurious section in rendered mirrors
- **#326** — storeStructuredForApi (HTTP API store path) now validates fields against the active schema per entity and calls storeUnknownFields inside the commit loop, so the response includes unknown_fields_count, unknown_fields, and hint — parity with the MCP store_structured path

## Test plan

- [ ] tests/unit/plan_schema_body_field.test.ts — verifies the body field description mentions primary content, warns against overview/goals, and mentions the mirror
- [ ] tests/unit/canonical_markdown_body_heading.test.ts — 6 cases covering heading stripping (heading stripped, single-hash variant, case-insensitive, embedded non-leading heading is preserved, clean body passthrough, content_only mode untouched)
- [ ] tests/integration/api_store_unknown_fields.test.ts — 4 cases: all-known fields returns count=0/[]/no hint; unknown fields returns non-zero count plus sorted list; unknown fields produces hint; no-schema entity type returns count=0

Generated with Claude Code