### PR TITLE
feat(schema): register preference entity schema

### DIFF
--- a/src/services/schema_definitions.ts
+++ b/src/services/schema_definitions.ts
@@ -3113,6 +3113,46 @@ export const ENTITY_SCHEMAS: Record<string, EntitySchema> = {
       },
     },
   },
+
+  preference: {
+    entity_type: "preference",
+    schema_version: "1.0",
+    metadata: {
+      label: "Preference",
+      description:
+        "User preference / setting persisted across sessions (e.g. issue_filing_consent).",
+      category: "agent_runtime",
+      aliases: ["setting"],
+    },
+    schema_definition: {
+      fields: {
+        schema_version: { type: "string", required: true },
+        // Stable identifier for the preference (e.g. "issue_filing_consent"). Acts as the key.
+        title: { type: "string", required: true, preserveCase: false },
+        // Current value of the preference (e.g. "always" | "ask" | "never"). Type is freeform
+        // string because preference shape varies; agents and UIs interpret per-title.
+        value: { type: "string", required: true, preserveCase: true },
+        // Optional scope qualifier — e.g. "global", "project:neotoma". Default behavior treats
+        // a preference as global when scope is omitted.
+        scope: { type: "string", required: false },
+        // Optional human-readable description of what the preference controls.
+        description: { type: "string", required: false, preserveCase: true },
+        created_date: { type: "date", required: false },
+        updated_date: { type: "date", required: false },
+      },
+      // A preference is uniquely identified by its title (plus optional scope when present).
+      // Two stores with the same title collapse to one entity; the latest write wins on value.
+      canonical_name_fields: ["title", { composite: ["scope", "title"] }],
+    },
+    reducer_config: {
+      merge_policies: {
+        value: { strategy: "last_write" },
+        scope: { strategy: "last_write" },
+        description: { strategy: "highest_priority" },
+        updated_date: { strategy: "last_write" },
+      },
+    },
+  },
 };
 
 /**


### PR DESCRIPTION
Fixes #339

## Summary
The v0.14.0 `[ISSUE REPORTING]` agent instructions direct agents to store a `preference` entity with `entity_type: "preference"`, `title: "issue_filing_consent"`, `value: <always|ask|never>` so future sessions can retrieve the preference without re-prompting. No `preference` schema was registered, so stores succeeded as schema-agnostic writes with `unknown_fields_count > 0` and field naming was unconstrained across agents.

Register a `preference` schema in `src/services/schema_definitions.ts` with declared `title`, `value`, `scope`, and `description` fields. Canonical name is composed from `title` (or `[scope, title]`), so two stores under the same title collapse to one entity. `value` uses `last_write` merge policy so the most recent agent decision wins.

## Why this matters
Without a registered schema, every agent storing this entity hits the unknown_fields repair loop, and there's no shape contract to prevent divergence (one agent might use `value`, another `mode`, another `choice`). The cross-session preference contract the instructions promise wasn't reliably delivered.

## Test plan
- [x] `npm run type-check` clean
- [ ] CI lanes pass
- [ ] Manual: store a `preference` entity via MCP, verify no `unknown_fields_count` warning
- [ ] Manual: retrieve via `retrieve_entities` with `entity_type: "preference"` filter

## Discovery context
Found during retroactive `/review` (Phase 5b — agent instruction coherence) of v0.13.0..HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)