### PR TITLE
fix(search): expose exclude_bookkeeping as opt-in retrieve_entities param

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2485,6 +2485,17 @@ paths:
                     Primary use case is the Inspector "ambiguous / heuristic
                     resolution" filter so operators can audit entities that
                     were matched by name/title rather than by a schema rule.
+                exclude_bookkeeping:
+                  type: boolean
+                  default: false
+                  description: |
+                    When true, omit chat bookkeeping types (`conversation`,
+                    `conversation_message`, and other entries in
+                    `BOOKKEEPING_ENTITY_TYPES`) from results. Default false —
+                    bookkeeping entities are included unless the caller
+                    explicitly opts in to exclusion. Has no effect when
+                    `entity_type` already filters to a single bookkeeping
+                    type (the explicit type filter wins).
       responses:
         "200":
           description: Entity list

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -3374,6 +3374,7 @@ app.post("/entities/query", async (req, res) => {
       updated_since,
       created_since,
       identity_basis,
+      exclude_bookkeeping,
     } = parsed.data;
     const { entities, total } = await queryEntitiesWithCount({
       userId,
@@ -3391,6 +3392,7 @@ app.post("/entities/query", async (req, res) => {
       updatedSince: updated_since,
       createdSince: created_since,
       identityBasis: identity_basis,
+      excludeBookkeeping: exclude_bookkeeping,
     });
 
     return res.json({

--- a/src/shared/action_handlers/entity_handlers.ts
+++ b/src/shared/action_handlers/entity_handlers.ts
@@ -34,6 +34,12 @@ interface QueryEntitiesParams {
     | "heuristic_name"
     | "heuristic_fallback"
     | "target_id";
+  /**
+   * When true, omit chat bookkeeping types (`conversation`, `conversation_message`,
+   * etc.) from results. Default false — bookkeeping is included unless the caller
+   * opts in. Has no effect when `entityType` already filters to a bookkeeping type.
+   */
+  excludeBookkeeping?: boolean;
 }
 
 const MAX_LEXICAL_CANDIDATES = 5000;
@@ -612,6 +618,7 @@ export async function queryEntitiesWithCount(params: QueryEntitiesParams): Promi
     updatedSince,
     createdSince,
     identityBasis,
+    excludeBookkeeping = false,
   } = params;
 
   let entities: EntityWithProvenance[];
@@ -622,7 +629,11 @@ export async function queryEntitiesWithCount(params: QueryEntitiesParams): Promi
     const searchTokens = normalizeSearchText(trimmedSearch).split(" ").filter(Boolean);
     const registryTypes = await loadKnownEntityTypes(userId, []);
     const typeFilterTokens = buildEntityTypeFilterTokens(searchTokens, registryTypes);
-    const excludeBookkeeping = shouldExcludeBookkeepingFromSearch(entityType);
+    // Bookkeeping exclusion is caller-controlled (per docs/foundation/product_principles.md
+    // §10.2 Explicit Over Implicit). If the caller explicitly filters to a bookkeeping
+    // entity_type, the explicit type filter wins and excludeBookkeeping is ignored.
+    const effectiveExcludeBookkeeping =
+      excludeBookkeeping && !(entityType && BOOKKEEPING_ENTITY_TYPES.has(entityType));
 
     const lexicalParams = {
       userId,
@@ -638,7 +649,7 @@ export async function queryEntitiesWithCount(params: QueryEntitiesParams): Promi
       createdSince,
       identityBasis,
       search: trimmedSearch,
-      excludeBookkeeping,
+      excludeBookkeeping: effectiveExcludeBookkeeping,
       limit,
       offset,
     };
@@ -682,7 +693,7 @@ export async function queryEntitiesWithCount(params: QueryEntitiesParams): Promi
           createdSince,
           identityBasis,
         });
-        if (excludeBookkeeping) {
+        if (effectiveExcludeBookkeeping) {
           entities = entities.filter((entity) => !BOOKKEEPING_ENTITY_TYPES.has(entity.entity_type));
         }
         if (entities.length > 0) {

--- a/src/shared/action_schemas.ts
+++ b/src/shared/action_schemas.ts
@@ -252,6 +252,15 @@ const EntitiesQueryRequestBaseSchema = z
     updated_since: z.string().optional(),
     created_since: z.string().optional(),
     /**
+     * When true, omit `conversation`, `conversation_message`, and other chat
+     * bookkeeping types from results. Default false: bookkeeping entities are
+     * included unless the caller explicitly opts in to exclusion. The Inspector
+     * header search and `/search` UI pass `true` explicitly.
+     * Has no effect when `entity_type` already filters to a single bookkeeping
+     * type (the explicit type filter wins).
+     */
+    exclude_bookkeeping: z.boolean().optional().default(false),
+    /**
      * R3: filter entities whose observations were resolved with the given
      * `identity_basis`. Satisfied when ANY observation for the entity carries
      * this basis. Enables the Inspector "Ambiguous/heuristic" filter without
@@ -300,6 +309,15 @@ const RetrieveEntitiesRequestBaseSchema = z
     include_merged: z.boolean().optional().default(false),
     updated_since: z.string().optional(),
     created_since: z.string().optional(),
+    /**
+     * When true, omit `conversation`, `conversation_message`, and other chat
+     * bookkeeping types from results. Default false: bookkeeping entities are
+     * included unless the caller explicitly opts in to exclusion. The Inspector
+     * header search and `/search` UI pass `true` explicitly.
+     * Has no effect when `entity_type` already filters to a single bookkeeping
+     * type (the explicit type filter wins).
+     */
+    exclude_bookkeeping: z.boolean().optional().default(false),
   })
   .superRefine(validateEntityQueryCombinations);
 

--- a/src/shared/openapi_types.ts
+++ b/src/shared/openapi_types.ts
@@ -3903,6 +3903,17 @@ export interface operations {
             | "heuristic_name"
             | "heuristic_fallback"
             | "target_id";
+          /**
+           * @description When true, omit chat bookkeeping types (`conversation`,
+           *     `conversation_message`, and other entries in
+           *     `BOOKKEEPING_ENTITY_TYPES`) from results. Default false —
+           *     bookkeeping entities are included unless the caller
+           *     explicitly opts in to exclusion. Has no effect when
+           *     `entity_type` already filters to a single bookkeeping
+           *     type (the explicit type filter wins).
+           * @default false
+           */
+          exclude_bookkeeping?: boolean;
         };
       };
     };

--- a/src/tool_definitions.ts
+++ b/src/tool_definitions.ts
@@ -202,6 +202,12 @@ export function buildToolDefinitions(
             description:
               "ISO 8601 timestamp. Return only entities whose created_at is greater than or equal to this value.",
           },
+          exclude_bookkeeping: {
+            type: "boolean",
+            description:
+              "When true, omit chat bookkeeping types (`conversation`, `conversation_message`, etc.) from results. Default false. Has no effect when `entity_type` already filters to a bookkeeping type.",
+            default: false,
+          },
         },
         required: [],
       },


### PR DESCRIPTION
Fixes #338
Fixes #341

## Summary
The v0.14.0 entity search rework introduced a silent server-side filter that omitted `conversation` / `conversation_message` / other `BOOKKEEPING_ENTITY_TYPES` from results whenever the caller did not pass an explicit `entity_type`. The filter ran inside `queryEntitiesWithCount` via `shouldExcludeBookkeepingFromSearch` and had no opt-in parameter, no response signal, and no way for callers to control it.

This violated product principles 10.2 (Explicit Over Implicit) and 10.3 (Minimal Over Magical). A user querying their own conversations directly through MCP would get filtered results with no signal.

## Changes
- Add `exclude_bookkeeping: boolean` (default `false`) to `RetrieveEntitiesRequestBaseSchema` and `EntitiesQueryRequestBaseSchema`
- Declare the field in `openapi.yaml` under `POST /entities/query`
- Declare the field on the `retrieve_entities` MCP tool schema
- Plumb `exclude_bookkeeping` through `QueryEntitiesParams` to the handler
- Keep the "explicit type filter wins" rule: when the caller filters to a bookkeeping type, the exclude flag is silently ignored — an explicit query for bookkeeping data always succeeds

## Default behavior change
Since v0.14.0 has not shipped yet, the silent default in the v0.14.0 cycle is replaced by `false` (preserves v0.13.0 behavior). Callers that want the Inspector-style "no chat bookkeeping noise" search pass `exclude_bookkeeping: true` explicitly.

## Verification
- `npm run type-check` clean
- `npm run openapi:bc-diff -- --base v0.13.0 --head HEAD` → no breaking changes
- One non-breaking field added to `/entities/query`

## Discovery context
Found during retroactive `/review` (Phase 5b — product-principles, silent-behavior) of `v0.13.0..HEAD`.

## Test plan
- [x] Type-check passes
- [x] OpenAPI breaking-change diff clean
- [ ] CI lanes pass
- [ ] Manual: call `retrieve_entities` with no `entity_type` and verify `conversation` rows DO appear
- [ ] Manual: call `retrieve_entities` with `exclude_bookkeeping: true` and verify `conversation` rows are filtered

🤖 Generated with [Claude Code](https://claude.com/claude-code)