### PR TITLE
fix(search): graceful fallback when schema_registry query fails

### DIFF
--- a/src/shared/action_handlers/entity_handlers.ts
+++ b/src/shared/action_handlers/entity_handlers.ts
@@ -190,7 +190,14 @@ async function resolveEntityTypesForTypeFilters(typeFilterTokens: Set<string>): 
 
   const { data, error } = await db.from("schema_registry").select("entity_type").eq("active", true);
   if (error) {
-    throw new Error(`Failed to resolve entity types for search filters: ${error.message}`);
+    // Degrade gracefully: a transient schema_registry hiccup should not 500
+    // the entire search request. Returning an empty set falls back to the
+    // unfiltered candidate query (capped at MAX_LEXICAL_CANDIDATES), matching
+    // the symmetric loadKnownEntityTypes behavior just above.
+    logger.warn(
+      `[lexicalSearch] Failed to resolve entity types for search filters: ${error.message}`
+    );
+    return [];
   }
 
   const matched = new Set<string>();


### PR DESCRIPTION
Fixes #342

## Summary
`resolveEntityTypesForTypeFilters` in `src/shared/action_handlers/entity_handlers.ts` threw a hard `Error` on `schema_registry` DB error, which propagated up through `queryEntitiesWithCount` and turned a transient DB hiccup into a 500 response for the search caller.

The sibling helper `loadKnownEntityTypes` (called a few lines above, hitting the same table for the same purpose) already degrades gracefully — `logger.warn` + empty result, falling back to the unfiltered candidate query path.

This PR mirrors that behavior. Returning an empty set drops the type-filter narrowing and lets the search proceed via the `MAX_LEXICAL_CANDIDATES`-capped candidate query rather than failing the request.

## Discovery context
Found during retroactive `/review` (Phase 5 — architectural review, error handling) of `v0.13.0..HEAD`.

## Test plan
- [x] Type-check clean
- [ ] CI lanes pass
- [ ] Manual: simulate `schema_registry` error and verify search returns results from unfiltered candidate path

🤖 Generated with [Claude Code](https://claude.com/claude-code)