### PR TITLE
fix(errors): stabilize cold-start schema hint text

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -3553,8 +3553,8 @@ export class NeotomaServer {
           error_code: "ERR_NO_SCHEMA_FOR_ENTITY_TYPE",
           no_schema_for_entity_type: true,
           hint:
-            `No schema is registered for entity_type "${parsed.entity_type}". ` +
-            "update_schema_incremental requires an existing schema to extend. " +
+            "No schema is registered for this entity_type. " +
+            "update_schema_incremental requires an existing SchemaDefinition to extend. " +
             "Call register_schema first with a full schema_definition that includes " +
             "canonical_name_fields (or identity_opt_out), then optionally call " +
             "update_schema_incremental to add more fields. " +
@@ -3605,7 +3605,7 @@ export class NeotomaServer {
           entity_type: parsed.entity_type,
           error_code: "ERR_SCHEMA_MISSING_IDENTITY_CONFIG",
           hint:
-            `The existing schema for entity_type "${parsed.entity_type}" does not declare ` +
+            "The existing SchemaDefinition for this entity_type does not declare " +
             "canonical_name_fields or identity_opt_out, which are required before fields can " +
             "be added incrementally. Call register_schema with a full schema_definition that " +
             'includes canonical_name_fields (or identity_opt_out: "heuristic_canonical_name") ' +


### PR DESCRIPTION
Fixes #345
Fixes #347

## Summary
The cold-start hint strings for `ERR_NO_SCHEMA_FOR_ENTITY_TYPE` and `ERR_SCHEMA_MISSING_IDENTITY_CONFIG` interpolated the user-supplied `parsed.entity_type` into the message body, making the hint string non-stable across calls — an agent regex-matching `'No schema is registered for entity_type "X"'` had to know X at match time.

The structured envelope already exposes `entity_type` as a separate field, so callers can resolve the type from `envelope.entity_type` without parsing the hint. This PR:
- Replaces the interpolated `"X"` form with stable `"this entity_type"` wording
- Uses `SchemaDefinition` (PascalCase) to match the canonical vocabulary (`docs/vocabulary/canonical_terms.md`)

## Behavior preserved
Existing integration tests in `tests/integration/update_schema_incremental_cold_start.test.ts` assert substrings `register_schema`, `analyze_schema_candidates`, and `canonical_name_fields`. All three remain in the new hint text.

## Discovery context
- #345 (hint quality) found during retroactive `/review` (Phase 5b — hint quality) of `v0.13.0..HEAD`
- #347 (naming nit) found in the same pass — `schema_definition` → `SchemaDefinition`

## Test plan
- [x] Type-check passes
- [x] Hint text retains assertion substrings used by integration tests
- [ ] CI lanes pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)