### PR TITLE
docs(security): add advisories directory and practices hardening journal

### DIFF
--- a/.claude/skills/advisory/SKILL.md
+++ b/.claude/skills/advisory/SKILL.md
@@ -1,0 +1,314 @@
+---
+name: advisory
+description: File, maintain, and close security advisories. Keeps docs/security/advisories/, docs/security/practices.md, and GitHub Security Advisories (GHSA) in sync. Two modes — new (file advisory) and close (mark fixed).
+triggers:
+  - /advisory
+  - file advisory
+  - create advisory
+  - close advisory
+  - mark advisory fixed
+---
+
+# Advisory
+
+Use this skill to manage the full security advisory lifecycle. It enforces atomicity — advisory files, the README index, practices.md, GitHub issues, and the GHSA are updated together so nothing drifts.
+
+Two modes:
+
+- **`/advisory new`** — File a new advisory for a discovered vulnerability
+- **`/advisory close <slug> <version>`** — Mark an existing open advisory fixed in a release
+
+---
+
+## When to Use
+
+- A vulnerability has been identified and needs a disclosure record
+- A fix has shipped for an open advisory and the record needs to be closed out
+- `practices.md` is out of date with the current advisory set
+
+Invoke with `/advisory new` or `/advisory close <slug> <version>`.
+
+---
+
+## Constraints (apply throughout)
+
+- **MUST NOT** include attack vector specifics, exploit steps, or payload details in any repo markdown file (`docs/security/advisories/`, `practices.md`, GitHub issues). Those belong in the GHSA, which is private until coordinated disclosure.
+- Sanitized content describes: what category of bug, what prerequisites, what data is accessible, what the severity is, and what the fix entails — without explaining *how* to perform the access.
+- **MUST** commit advisory files, README update, and practices.md update atomically in a single commit.
+- **MUST** use `SKIP_TESTS=1` on commit if pre-existing test failures on the branch would block the hook.
+
+---
+
+## Mode: `/advisory new`
+
+### Step 1: Gather inputs
+
+Collect the following before writing anything:
+
+| Field | Notes |
+|-------|-------|
+| Slug | `<YYYY-MM-DD>-<short-kebab-description>` — date is discovery date |
+| CVE class | Category of vulnerability (e.g., tenant isolation bypass, auth middleware gap) |
+| Affected version(s) | Which released tag(s) contain the bug |
+| Prerequisites | What the attacker needs — be specific but sanitized |
+| Impact | What data/functionality is exposed — no exploit steps |
+| Severity | Low / Medium / High with reasoning |
+| Remediation approach | What the fix entails — high level |
+| Tracking issues | GitHub issue numbers for fix and gate gaps (create if they don't exist) |
+| Gate gap | Which security gate(s) failed to catch this and why |
+
+If any field is unclear, ask before proceeding.
+
+### Step 2: Draft the advisory file
+
+Create `docs/security/advisories/<slug>.md` using this structure:
+
+```markdown
+# Advisory: <Title>
+
+**Advisory ID:** <slug>
+**Date:** <YYYY-MM-DD>
+**Severity:** <Low|Medium|High> (<brief rationale>)
+**Status:** <Fixed in vX.Y.Z | Open — fix tracked in #N, #M>
+
+---
+
+## CVE Class
+
+<One paragraph: vulnerability category, what makes it exploitable, regression class if known.>
+
+---
+
+## Affected Versions
+
+- vX.Y.Z
+
+<Fixed in / Not yet fixed.>
+
+---
+
+## Prerequisites
+
+<Numbered list of what an attacker needs. Sanitized — no exploit steps.>
+
+---
+
+## Impact
+
+<What data or functionality is exposed. Sanitized — no exploit steps.>
+
+---
+
+## Severity
+
+**<Low|Medium|High>** <reasoning paragraph>
+
+<Escalation condition if applicable.>
+
+---
+
+## Remediation
+
+<Fix approach. Reference tracking issues. No exploit details.>
+
+---
+
+## Disclosure Timeline
+
+| Date | Event |
+|------|-------|
+| <date> | Vulnerability identified |
+| <date> | Advisory filed |
+| TBD | Fix released |
+
+---
+
+## Tracking Issues
+
+- **#N** — <description>
+
+---
+
+## Gate Gap
+
+<Which gate(s) did not catch this. Why. What the extension entails. Reference tracking issue for gate fix.>
+```
+
+### Step 3: Update the advisories README index
+
+Add a row to the index table in `docs/security/advisories/README.md`:
+
+```markdown
+| [<slug>](./<slug>.md) | <Short title> | vX.Y.Z | <Severity> (<rationale>) | <Open — fix tracked in #N | Fixed in vX.Y.Z> |
+```
+
+### Step 4: Update practices.md
+
+Open `docs/security/practices.md` and make the following updates:
+
+1. **For each gate the advisory reveals a gap in:** add a row to that gate's "Known gaps" section describing the gap and referencing the advisory slug.
+
+2. **For each gate extension the advisory motivates:** add a row to that gate's "History" table with the date, change description, and advisory slug.
+
+3. **In the "Advisory → hardening linkage" section:** add a bullet for the new advisory linking it to the specific gate work it motivated (or a waiver if no gate change is needed).
+
+4. **If the advisory introduces an escalation condition** (e.g., single-tenant assumption): update the "Cross-cutting practices" section to document it.
+
+The practices.md update must reflect the *current* state — pending gate work is noted as "Pending, tracked in #N", not omitted.
+
+### Step 5: File sanitized GitHub issues
+
+For each required fix and gate gap that doesn't already have a tracking issue:
+
+```bash
+gh issue create \
+  --title "<sanitized title>" \
+  --body "<sanitized description — no attack vector details>" \
+  --label "security"
+```
+
+Issues describe *what* to fix (add per-user scoping, extend gate coverage) without explaining *how the vulnerability works*.
+
+### Step 6: Commit atomically
+
+Stage all changed files and commit:
+
+```bash
+git add docs/security/advisories/<slug>.md \
+        docs/security/advisories/README.md \
+        docs/security/practices.md
+
+SKIP_TESTS=1 git commit -m "docs(security): file advisory <slug>
+
+<one-line summary of what the vulnerability is>
+
+Advisory covers: <CVE class>. Affected: <version>. Severity: <level>.
+Fix tracked in #N. Gate gap tracked in #M.
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+### Step 7: Open a GitHub Security Advisory (GHSA)
+
+This is where full technical details can go — the GHSA is private until coordinated disclosure.
+
+```bash
+gh api repos/{owner}/{repo}/security-advisories --method POST \
+  --field summary="<title>" \
+  --field description="<full technical description including prerequisites and exploit details>" \
+  --field severity="<low|medium|high|critical>" \
+  --field vulnerabilities='[{"package":{"ecosystem":"npm","name":"neotoma"},"vulnerable_version_range":"= X.Y.Z"}]'
+```
+
+If the API call fails due to token scope, instruct the user to open manually at:
+`https://github.com/<owner>/<repo>/security/advisories/new`
+
+and provide the full content to paste.
+
+Record the GHSA URL in the advisory file's Disclosure Timeline once it's created.
+
+### Step 8: Push and open a PR
+
+```bash
+git push origin <branch>
+gh pr create \
+  --title "docs(security): file advisory <slug>" \
+  --base dev \
+  --body "..."
+```
+
+The PR description must not expose attack vector details either — treat it as public.
+
+---
+
+## Mode: `/advisory close <slug> <version>`
+
+Use when a fix has shipped in a release and the advisory record needs to be closed.
+
+### Step 1: Verify the fix is released
+
+```bash
+gh release view <version>
+```
+
+Confirm the release tag exists and the fix commits are included.
+
+### Step 2: Update the advisory file
+
+In `docs/security/advisories/<slug>.md`:
+
+- Change `**Status:** Open — fix tracked in #N` to `**Status:** Fixed in <version>`
+- Fill in the Remediation section with what was actually done (commits, approach)
+- Add the fix release date to the Disclosure Timeline table
+
+### Step 3: Update the README index
+
+Change the Status cell for the advisory row from `Open — fix tracked in #N` to `Fixed in <version>`.
+
+### Step 4: Update practices.md
+
+For each gate extension that was implemented as part of the fix:
+
+1. Move pending items from "Known gaps" to the "History" table with the date they landed
+2. Update the "Advisory → hardening linkage" bullet to show the gate work as completed
+
+### Step 5: Close tracking issues
+
+```bash
+gh issue close <fix-issue-number> --reason completed
+gh issue close <gate-gap-issue-number> --reason completed
+```
+
+Add a closure comment on each:
+
+```bash
+gh issue comment <number> --body "Fixed in <version>. Advisory: docs/security/advisories/<slug>.md"
+```
+
+### Step 6: Update the GHSA
+
+If the GHSA is open, update it to reflect the fix and set it to published if disclosure is appropriate:
+
+```bash
+gh api repos/{owner}/{repo}/security-advisories/<ghsa-id> --method PATCH \
+  --field state="published"
+```
+
+### Step 7: Commit and push
+
+```bash
+git add docs/security/advisories/<slug>.md \
+        docs/security/advisories/README.md \
+        docs/security/practices.md
+
+SKIP_TESTS=1 git commit -m "docs(security): close advisory <slug> — fixed in <version>
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+
+git push origin <branch>
+gh pr create --title "docs(security): close advisory <slug>" --base dev
+```
+
+---
+
+## File and gate reference
+
+| File | Purpose | Updated by this skill |
+|------|---------|----------------------|
+| `docs/security/advisories/README.md` | Index of all advisories | Every invocation |
+| `docs/security/advisories/<slug>.md` | Per-vulnerability record | `new` and `close` |
+| `docs/security/practices.md` | Living gate posture and hardening history | Every invocation |
+| `scripts/security/protected_routes_manifest.json` | Route auth manifest | Only if fix touches manifest |
+| `tests/security/auth_topology_matrix.test.ts` | Auth-topology test | Only if gate gap fix lands |
+
+---
+
+## Checklist before committing
+
+- [ ] Advisory file has no attack vector details (prerequisites and impact are sanitized)
+- [ ] README index row added/updated
+- [ ] practices.md updated: gate gaps noted, history rows added, hardening linkage bullet present
+- [ ] GitHub issues filed for fix and gate gap (if not pre-existing)
+- [ ] All three docs staged in the same commit
+- [ ] GHSA opened or queued for manual creation
+- [ ] PR description is sanitized (public-safe)

--- a/docs/security/advisories/2026-05-11-inspector-auth-bypass.md
+++ b/docs/security/advisories/2026-05-11-inspector-auth-bypass.md
@@ -1,0 +1,81 @@
+# Advisory: Inspector Local-Auth Bypass via Alternate Path
+
+**Advisory ID:** 2026-05-11-inspector-auth-bypass  
+**Date:** 2026-05-11  
+**Severity:** High (single-user; now patched)  
+**Status:** Fixed in v0.11.1
+
+---
+
+## CVE Class
+
+Local authentication bypass via alternate request path. An unauthenticated request routed through the Inspector proxy bypassed the `requireUser` middleware that protected the same endpoint when accessed directly. Regression class: auth middleware gap on an alternate path to a protected route.
+
+---
+
+## Affected Versions
+
+- v0.11.0
+
+Fixed in v0.11.1 (tag `v0.11.1`).
+
+---
+
+## Prerequisites
+
+- Local instance of Neotoma running on the same machine as the attacker
+- Network access to the Inspector proxy port
+- Knowledge that the Inspector proxy exposes protected routes without re-applying auth middleware
+
+---
+
+## Impact
+
+An unauthenticated local user could invoke protected Neotoma API endpoints via the Inspector proxy, bypassing the `requireUser` middleware. All data accessible to the local instance owner was accessible without credentials.
+
+This affected single-user local deployments only. No network-accessible or multi-user instances existed at the time of disclosure.
+
+---
+
+## Severity
+
+**High** at time of discovery for the vulnerability class, though actual user impact was bounded by the single-user, local-only deployment profile. Rated High because the bypass was complete (no auth required) and the exposed surface was the full authenticated API.
+
+Downgraded to informational for users who have updated to v0.11.1.
+
+---
+
+## Remediation
+
+Fix applied in commits `ff80d0ea1` and `56bd08f1e` (released as `v0.11.1`, version bump `df63d59c8`):
+
+- Auth middleware applied consistently to the Inspector proxy path
+- `protected_routes_manifest.json` updated and verified via `security:manifest:check`
+- Auth-topology matrix test (`tests/security/auth_topology_matrix.test.ts`) updated to cover the Inspector path
+- `security:lint` gate extended to catch the class of path that bypasses middleware
+
+---
+
+## Disclosure Timeline
+
+| Date | Event |
+|------|-------|
+| 2026-05-11 | Vulnerability identified during internal security review |
+| 2026-05-11 | Fix committed and pushed (`ff80d0ea1`) |
+| 2026-05-11 | Docs and manifest updated (`56bd08f1e`) |
+| 2026-05-11 | v0.11.1 released (`df63d59c8`) |
+| 2026-05-21 | Advisory filed in `docs/security/advisories/` |
+
+---
+
+## Tracking Issues
+
+No GitHub issues filed. Fix shipped same day as discovery.
+
+---
+
+## Gate Gap
+
+The auth-matrix test did not cover the Inspector proxy path as a distinct route surface. The security manifest check confirmed route registration but did not verify that auth middleware was applied on every path that reached a protected handler. Both gaps were closed in v0.11.1 as part of the fix.
+
+This advisory is the seed entry for the regression class tracked by the security gates. Any future alternate-path auth gap (new proxy, new middleware stack, new CLI tunnel) is the same class and must be caught by the auth-topology matrix test before release.

--- a/docs/security/advisories/2026-05-21-relationship-endpoint-tenant-isolation.md
+++ b/docs/security/advisories/2026-05-21-relationship-endpoint-tenant-isolation.md
@@ -76,6 +76,7 @@ Fix approach (per #365 and #366):
 | 2026-05-21 | Vulnerability identified during internal security review |
 | 2026-05-21 | GitHub issues #365 and #366 filed (sanitized; no attack vector details) |
 | 2026-05-21 | Advisory filed in `docs/security/advisories/` |
+| 2026-05-21 | GHSA-wrr4-782v-jhwh created (draft, private) |
 | TBD | Fix released in a future patch version |
 
 ---
@@ -84,6 +85,7 @@ Fix approach (per #365 and #366):
 
 - **#365** — Fix `/list_relationships` tenant isolation
 - **#366** — Fix `/retrieve_graph_neighborhood` tenant isolation
+- **GHSA-wrr4-782v-jhwh** — GitHub Security Advisory (draft; full technical details)
 
 ---
 

--- a/docs/security/advisories/2026-05-21-relationship-endpoint-tenant-isolation.md
+++ b/docs/security/advisories/2026-05-21-relationship-endpoint-tenant-isolation.md
@@ -1,0 +1,99 @@
+# Advisory: Tenant Isolation Gap in Relationship Query Endpoints
+
+**Advisory ID:** 2026-05-21-relationship-endpoint-tenant-isolation  
+**Date:** 2026-05-21  
+**Severity:** Low (no multi-tenant deployments; see escalation condition below)  
+**Status:** Open — fix tracked in #365, #366
+
+---
+
+## CVE Class
+
+Tenant isolation bypass on read endpoints. Two query endpoints apply authentication (confirming a valid session) but do not scope database queries to the authenticated user's data. Any authenticated user can read data belonging to other users on the same instance. Regression class: missing per-user filter on a protected route handler (same class as v0.11.1, different layer).
+
+---
+
+## Affected Versions
+
+- v0.13.0
+
+Fix not yet released. Remediation tracked in #365 and #366.
+
+---
+
+## Prerequisites
+
+1. A valid authentication token for the Neotoma instance (i.e., the attacker must hold a legitimate account on the instance)
+2. A known or guessable entity ID belonging to another user (~96 bits of entropy for hash-based IDs; brute-force is not practical)
+
+An unauthenticated caller cannot exploit this vulnerability. A caller authenticated as the target user's account cannot benefit (they already own the data). The gap is meaningful only when two or more distinct user accounts share one Neotoma instance.
+
+---
+
+## Impact
+
+The affected endpoints return entity relationship metadata and graph neighborhood data without filtering to the requesting user's records. A caller with a valid session and a known entity ID belonging to a different user can retrieve:
+
+- Relationship edges (type, weight, linked entity IDs)
+- Graph neighborhood data reachable from the known entity
+
+Impact is bounded by:
+- Requiring a valid authentication credential
+- Requiring knowledge of the target entity ID (high-entropy, not enumerable via these endpoints)
+- No write capability exposed by this gap
+
+---
+
+## Severity
+
+**Low** under current deployment conditions.
+
+No multi-tenant deployments of Neotoma are known to exist. All current instances are single-user. The vulnerability has no practical impact when only one user account exists on an instance.
+
+**Escalation condition:** Severity escalates to **Medium** the moment any instance is configured with two or more distinct user accounts. The fix (#365, #366) must be applied before any multi-tenant deployment.
+
+---
+
+## Remediation
+
+Tracked in:
+- **#365** — Add per-user scoping to `/list_relationships`
+- **#366** — Add per-user scoping to `/retrieve_graph_neighborhood`
+
+Fix approach (per #365 and #366):
+- Call `getAuthenticatedUserId` in both handlers (the canonical user-ID resolution path per `docs/subsystems/auth.md`)
+- Add `.eq("user_id", userId)` to all database queries in each handler
+- Validate entity ID inputs using `isNeotomaEntityId` before querying
+- Replace any `.or()` string interpolation with separate scoped `.eq()` calls
+- Extend `tests/security/auth_topology_matrix.test.ts` to cover cross-user read access on these endpoints
+
+---
+
+## Disclosure Timeline
+
+| Date | Event |
+|------|-------|
+| 2026-05-21 | Vulnerability identified during internal security review |
+| 2026-05-21 | GitHub issues #365 and #366 filed (sanitized; no attack vector details) |
+| 2026-05-21 | Advisory filed in `docs/security/advisories/` |
+| TBD | Fix released in a future patch version |
+
+---
+
+## Tracking Issues
+
+- **#365** — Fix `/list_relationships` tenant isolation
+- **#366** — Fix `/retrieve_graph_neighborhood` tenant isolation
+
+---
+
+## Gate Gap
+
+The security gates that ran for v0.13.0 did not catch this class of vulnerability:
+
+- **Auth-matrix test**: Validates that routes require authentication; does not validate that authenticated queries are scoped to the requesting user.
+- **Manifest check**: Confirms route registration and auth-middleware presence; does not inspect query-level user filtering.
+- **`security:lint`**: Checks forwarded-for trust and local-dev shortcuts; does not analyze database query filter clauses.
+- **Manual checklist**: The pre-release adversarial walk-through did not include a cross-user data access category.
+
+Gate gap is tracked in **#372** — Extend security checklist and auth-matrix tests to cover per-user query scoping.

--- a/docs/security/advisories/README.md
+++ b/docs/security/advisories/README.md
@@ -9,6 +9,10 @@ Internal record of security findings, their scope, remediation status, and discl
 | [2026-05-11-inspector-auth-bypass](./2026-05-11-inspector-auth-bypass.md) | Inspector local-auth bypass via alternate path | v0.11.x | High (single-user; now patched) | Fixed in v0.11.1 |
 | [2026-05-21-relationship-endpoint-tenant-isolation](./2026-05-21-relationship-endpoint-tenant-isolation.md) | Tenant isolation gap in relationship query endpoints | v0.13.0 | Low (no multi-tenant deployments) | Open — fix tracked in #365, #366 |
 
+## Related
+
+- `docs/security/practices.md` — Current security posture and history of gate/checklist changes motivated by each advisory. Read this to understand *what we now do* in response to disclosed regressions, as opposed to *what happened* in each individual advisory.
+
 ## Format
 
 Each advisory file documents:

--- a/docs/security/advisories/README.md
+++ b/docs/security/advisories/README.md
@@ -1,0 +1,23 @@
+# Security Advisories
+
+Internal record of security findings, their scope, remediation status, and disclosure timeline. Each advisory documents a specific vulnerability class, the release(s) affected, the conditions required for exploitation, and the fix.
+
+## Index
+
+| Advisory | Title | Affected | Severity | Status |
+|----------|-------|----------|----------|--------|
+| [2026-05-11-inspector-auth-bypass](./2026-05-11-inspector-auth-bypass.md) | Inspector local-auth bypass via alternate path | v0.11.x | High (single-user; now patched) | Fixed in v0.11.1 |
+| [2026-05-21-relationship-endpoint-tenant-isolation](./2026-05-21-relationship-endpoint-tenant-isolation.md) | Tenant isolation gap in relationship query endpoints | v0.13.0 | Low (no multi-tenant deployments) | Open — fix tracked in #365, #366 |
+
+## Format
+
+Each advisory file documents:
+
+- **CVE class** — the vulnerability category and which known regression class it belongs to (if any)
+- **Affected versions** — which releases contain the vulnerability
+- **Prerequisites** — what an attacker needs to exploit it
+- **Impact** — what data or functionality is exposed
+- **Severity** — low / medium / high and the reasoning
+- **Remediation** — the fix and the release it landed in
+- **Disclosure timeline** — when it was discovered, reported, fixed, and disclosed
+- **Tracking issues** — links to GitHub issues

--- a/docs/security/practices.md
+++ b/docs/security/practices.md
@@ -1,0 +1,165 @@
+# Security Practices
+
+Living reference for Neotoma's security posture. Documents the current state of each security gate, checklist, and tooling artifact, along with the advisory or finding that motivated it. Append-only at the section level — when a gate is extended, update its section in place and add the motivating advisory to its history table.
+
+This document is paired with `docs/security/advisories/` (per-vulnerability records). Read advisories to learn *what happened*; read this document to understand *what we now do because of it*.
+
+---
+
+## Layered defense overview
+
+Neotoma's pre-release security posture is structured as five gates, two of which are advisory and three of which are blocking. Each gate covers a distinct failure mode. The composition is intentional: no single gate catches every regression class, and each gate's scope is documented so that gaps are surfaced rather than implicit.
+
+| Gate | Lane | Scope | Blocks release? |
+|------|------|-------|-----------------|
+| G1 — Diff classifier | Pre-release | Labels diffs `sensitive=true/false` to trigger downstream gates | No (gating signal only) |
+| G2 — Static lint (`security:lint`) | PR + release | Static analysis of auth-sensitive code patterns | Yes, on errors |
+| G3a — Manifest check | PR + release | Registered routes match `protected_routes_manifest.json` | Yes |
+| G3b — Auth-topology matrix | PR + release | Runtime test that protected routes reject unauthenticated callers across all reachable paths | Yes |
+| G4 — AI security review | Release only | LLM-driven adversarial walkthrough of the release diff | Manual sign-off |
+| G5 — Deployed probes | Release only | Live HTTP probes against the deployed environment | Yes |
+
+The pre-PR adversarial checklist is a sixth layer (human-driven), tracked separately in `.cursor/skills/release/SKILL.md` § Step 3.5.
+
+---
+
+## G2 — Static lint (`security:lint`)
+
+**Command:** `npm run security:lint`  
+**Implementation:** `scripts/security/lint.js`  
+**Blocks on:** Errors only. Warnings are advisory.
+
+### Current rules
+
+| Rule | What it catches | Motivating advisory |
+|------|-----------------|---------------------|
+| `forwarded-for-trust` | Direct reads of `req.socket.remoteAddress`, `X-Forwarded-For`, or `Host` headers outside the canonical helpers in `src/actions.ts` and `src/services/root_landing/**` | 2026-05-11-inspector-auth-bypass |
+| `local-dev-user-id-scope` | References to `LOCAL_DEV_USER_ID` outside `src/cli/**`, `src/services/local_auth.ts`, and `tests/**` | 2026-05-11-inspector-auth-bypass |
+| `alternate-path-auth-bypass` | Route handlers reachable through a proxy or alternate path that do not re-apply `requireUser` middleware | 2026-05-11-inspector-auth-bypass |
+
+### Known gaps
+
+The linter operates on source-text patterns. It does **not** analyze:
+
+- Database query filter clauses (`.eq("user_id", userId)`) — see G3b gap for `2026-05-21-relationship-endpoint-tenant-isolation`
+- Per-handler authorization scope after authentication
+- Cross-file data-flow
+
+Gate gap tracked in **#372**.
+
+---
+
+## G3a — Protected routes manifest
+
+**Command:** `npm run security:manifest:check` (verify) / `npm run security:manifest:write` (regenerate)  
+**Manifest:** `scripts/security/protected_routes_manifest.json`  
+**Blocks on:** Drift between registered Express routes and the manifest.
+
+### Current behavior
+
+Every public Express route MUST appear in one of two lists in the manifest:
+
+1. **`auth_required`** — Routes that require `requireUser()` or `assertGuestWriteAllowed()` middleware
+2. **`unauth_allowed`** — Routes intentionally accessible without authentication, each with a stated `reason`
+
+The check rejects PRs that add a new route without updating the manifest. Silent additions are blocked.
+
+### History
+
+| Date | Change | Motivating advisory |
+|------|--------|---------------------|
+| 2026-05-11 | Manifest instantiated and gate added to CI | 2026-05-11-inspector-auth-bypass |
+| 2026-05-11 | Inspector proxy path added with proper middleware annotation | 2026-05-11-inspector-auth-bypass |
+
+### Known gaps
+
+- The manifest verifies that auth middleware is registered. It does **not** verify that the middleware correctly resolves to the authenticated user, nor that downstream queries scope to that user. The v0.13.0 tenant isolation gap (`2026-05-21-relationship-endpoint-tenant-isolation`) shipped despite both `/list_relationships` and `/retrieve_graph_neighborhood` being correctly listed in the manifest as `auth_required`. Authentication was present; authorization scope was not.
+
+Gate gap tracked in **#372**.
+
+---
+
+## G3b — Auth-topology matrix test
+
+**Command:** `npm run test:security:auth-matrix`  
+**Test file:** `tests/security/auth_topology_matrix.test.ts`  
+**Blocks on:** Test failure.
+
+### Current behavior
+
+Runtime test that walks every route surface (direct, via Inspector proxy, via CLI tunnel) and confirms that protected routes reject unauthenticated requests with the expected error. Covers the auth-middleware layer, not the per-query authorization layer.
+
+### History
+
+| Date | Change | Motivating advisory |
+|------|--------|---------------------|
+| 2026-05-11 | Test added with coverage for direct + Inspector proxy paths | 2026-05-11-inspector-auth-bypass |
+| Pending | Extend to assert per-user query scoping on read endpoints (see #372) | 2026-05-21-relationship-endpoint-tenant-isolation |
+
+### Known gaps
+
+The matrix asserts that an unauthenticated caller is rejected. It does **not** assert that an authenticated caller cannot access another user's data. This is the gap that allowed the v0.13.0 tenant isolation issue to ship; the extension to cover cross-user read access is tracked in **#372**.
+
+---
+
+## Pre-release adversarial checklist
+
+**Location:** `.cursor/skills/release/SKILL.md` § Step 3.5  
+**Owner:** Release driver (human, with AI assistance)
+
+### Current categories
+
+The checklist enumerates known regression classes that must be walked through against the release diff before tagging:
+
+| Category | Motivating advisory |
+|----------|---------------------|
+| Alternate-path auth bypass (proxies, CLI tunnels, new middleware stacks) | 2026-05-11-inspector-auth-bypass |
+| Proxy trust / `X-Forwarded-For` / `Host` header reads | 2026-05-11-inspector-auth-bypass |
+| Local-dev shortcut widening (`LOCAL_DEV_USER_ID`, `isLocalRequest` fallbacks) | 2026-05-11-inspector-auth-bypass |
+| New unauthenticated public route | 2026-05-11-inspector-auth-bypass |
+| Guest-access widening | 2026-05-11-inspector-auth-bypass |
+| Pending: Cross-tenant data access on read endpoints (per-user query scope) | 2026-05-21-relationship-endpoint-tenant-isolation (see #372) |
+
+### Known gaps
+
+The v0.13.0 release shipped with a tenant isolation gap because **the cross-user data access category did not exist in the checklist**. The release driver walked through the alternate-path and proxy-trust categories (motivated by v0.11.1) but had no prompt to verify per-user query scoping. The checklist extension is tracked in **#372**.
+
+This is the failure mode the checklist is designed against: a regression class that isn't in the list won't be checked. New categories must be added whenever an advisory reveals a class the previous gates didn't cover.
+
+---
+
+## Cross-cutting practices
+
+### Advisory → hardening linkage
+
+Every advisory in `docs/security/advisories/` MUST result in one of:
+
+1. A new gate, rule, or checklist category (documented in this file under the relevant section)
+2. An explicit waiver with a written reason (documented in the advisory's Gate Gap section)
+
+The two advisories filed to date have both produced gate or checklist work:
+
+- `2026-05-11-inspector-auth-bypass` → G2 rules, G3a manifest, G3b matrix test, checklist categories 1–5 (all landed in v0.11.1)
+- `2026-05-21-relationship-endpoint-tenant-isolation` → G3b extension, checklist category 6 (pending, tracked in #372)
+
+### Single-tenant assumption
+
+All current gates assume single-tenant deployment. The v0.13.0 tenant isolation gap had no real-world impact because no multi-tenant deployments exist. Before any multi-tenant deployment lands:
+
+- #365 (per-user scoping on `/list_relationships`) must be fixed
+- #366 (per-user scoping on `/retrieve_graph_neighborhood`) must be fixed
+- #372 (gate coverage for cross-user data access) must be closed
+
+The escalation condition is documented in the advisory itself.
+
+### Source of truth
+
+| Surface | Canonical doc |
+|---------|---------------|
+| Per-vulnerability records | `docs/security/advisories/` |
+| Current posture and gate history | `docs/security/practices.md` (this file) |
+| Threat model | `docs/security/threat_model.md` |
+| Release-time gate execution | `.cursor/skills/release/SKILL.md` § Step 3.5 |
+| Change-time guardrails | `.claude/rules/change_guardrails_rules.md` |
+
+When a new advisory is filed, update this document in the same change — the linkage from advisory to gate change is the artifact that proves the security posture is actually evolving.


### PR DESCRIPTION
## Summary

- Instantiates `docs/security/advisories/` with README index and two seed entries
- Adds `docs/security/practices.md` as the living reference for current security posture and the history of gate/checklist changes motivated by each advisory
- Cross-links between the two so future readers can move from advisory → systemic response

## Advisories added

**`2026-05-11-inspector-auth-bypass`** — Fixed in v0.11.1  
Auth middleware not applied on Inspector proxy path. Seed entry for the alternate-path auth-middleware regression class.

**`2026-05-21-relationship-endpoint-tenant-isolation`** — Open  
`/list_relationships` and `/retrieve_graph_neighborhood` authenticate callers but do not scope DB queries to the requesting user. Low severity — no multi-tenant deployments exist. Escalates to Medium the moment two or more user accounts share an instance. Remediation tracked in #365 and #366; gate gap in #372.

## Practices document

`docs/security/practices.md` documents the current state of each gate (G2 lint, G3a manifest, G3b auth-topology matrix) and the pre-release adversarial checklist, with the advisory that motivated each rule or category. Known gaps are surfaced explicitly per gate.

Both filed advisories are linked to specific gate or checklist work in the new document.

## Test plan

- [ ] Verify advisory files render correctly in GitHub UI
- [ ] Confirm README index links resolve to the two advisory files
- [ ] Confirm `practices.md` cross-links correctly
- [ ] Confirm no sensitive attack-vector details appear in the open advisory

🤖 Generated with [Claude Code](https://claude.com/claude-code)