### PR TITLE
fix(security): scope /list_relationships queries to authenticated user (#365)

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -6096,9 +6096,18 @@ app.post("/list_relationships", async (req, res) => {
   const { relationshipsService } = await import("./services/relationships.js");
 
   try {
+    // Tenant isolation: resolve authenticated user and scope all queries to
+    // their records. See docs/security/advisories/2026-05-21-relationship-
+    // endpoint-tenant-isolation.md (GHSA-wrr4-782v-jhwh) for context.
+    const userId = await getAuthenticatedUserId(req, parsed.data.user_id);
+
     let relationships;
     if (relationship_type) {
-      relationships = await relationshipsService.getRelationshipsByType(relationship_type as any);
+      relationships = await relationshipsService.getRelationshipsByType(
+        relationship_type as any,
+        false,
+        userId
+      );
       // Filter by entity_id
       relationships = relationships.filter(
         (rel) => rel.source_entity_id === entity_id || rel.target_entity_id === entity_id
@@ -6106,7 +6115,9 @@ app.post("/list_relationships", async (req, res) => {
     } else {
       relationships = await relationshipsService.getRelationshipsForEntity(
         entity_id,
-        normalizedDirection
+        normalizedDirection,
+        false,
+        userId
       );
     }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -2259,6 +2259,12 @@ export class NeotomaServer {
     args: unknown
   ): Promise<{ content: Array<{ type: string; text: string }> }> {
     const parsed = ListRelationshipsRequestSchema.parse(args ?? {});
+
+    // Tenant isolation: scope all queries to the authenticated user.
+    // See docs/security/advisories/2026-05-21-relationship-endpoint-
+    // tenant-isolation.md (GHSA-wrr4-782v-jhwh) for context.
+    const userId = this.getAuthenticatedUserId(parsed.user_id);
+
     const normalizedDirection =
       parsed.direction === "incoming" || parsed.direction === "inbound"
         ? "inbound"
@@ -2273,7 +2279,8 @@ export class NeotomaServer {
       let outboundQuery = db
         .from("relationship_snapshots")
         .select("*")
-        .eq("source_entity_id", parsed.entity_id);
+        .eq("source_entity_id", parsed.entity_id)
+        .eq("user_id", userId);
 
       if (parsed.relationship_type) {
         outboundQuery = outboundQuery.eq("relationship_type", parsed.relationship_type);
@@ -2306,7 +2313,8 @@ export class NeotomaServer {
       let inboundQuery = db
         .from("relationship_snapshots")
         .select("*")
-        .eq("target_entity_id", parsed.entity_id);
+        .eq("target_entity_id", parsed.entity_id)
+        .eq("user_id", userId);
 
       if (parsed.relationship_type) {
         inboundQuery = inboundQuery.eq("relationship_type", parsed.relationship_type);

--- a/src/services/relationships.ts
+++ b/src/services/relationships.ts
@@ -244,6 +244,7 @@ export class RelationshipsService {
     entityId: string,
     direction: "outgoing" | "incoming" | "both" = "both",
     includeDeleted: boolean = false,
+    userId?: string,
   ): Promise<RelationshipSnapshot[]> {
     let query;
 
@@ -262,6 +263,13 @@ export class RelationshipsService {
         .from("relationship_snapshots")
         .select("*")
         .or(`source_entity_id.eq.${entityId},target_entity_id.eq.${entityId}`);
+    }
+
+    // Tenant isolation: scope to authenticated user when provided.
+    // The `userId` argument is required by all production callers; legacy
+    // internal callers (e.g. tests, system jobs) may omit it.
+    if (userId) {
+      query = query.eq("user_id", userId);
     }
 
     const { data, error } = await query.order("last_observation_at", {
@@ -327,12 +335,21 @@ export class RelationshipsService {
   async getRelationshipsByType(
     type: RelationshipType,
     includeDeleted: boolean = false,
+    userId?: string,
   ): Promise<RelationshipSnapshot[]> {
-    const { data, error } = await db
+    let query = db
       .from("relationship_snapshots")
       .select("*")
-      .eq("relationship_type", type)
-      .order("last_observation_at", { ascending: false });
+      .eq("relationship_type", type);
+
+    // Tenant isolation: scope to authenticated user when provided.
+    if (userId) {
+      query = query.eq("user_id", userId);
+    }
+
+    const { data, error } = await query.order("last_observation_at", {
+      ascending: false,
+    });
 
     if (error) {
       throw new Error(`Failed to get relationships by type: ${error.message}`);

--- a/src/shared/action_schemas.ts
+++ b/src/shared/action_schemas.ts
@@ -108,6 +108,8 @@ export const ListRelationshipsRequestSchema = z.object({
   relationship_type: RelationshipTypeSchema.optional(),
   limit: z.number().int().positive().optional().default(100),
   offset: z.number().int().nonnegative().optional().default(0),
+  // Optional override honored only for LOCAL_DEV_USER_ID (see getAuthenticatedUserId).
+  user_id: z.string().optional(),
 });
 
 export const TimelineEventsRequestSchema = z.object({

--- a/tests/services/relationships_tenant_isolation.test.ts
+++ b/tests/services/relationships_tenant_isolation.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Regression test for GHSA-wrr4-782v-jhwh /
+ * docs/security/advisories/2026-05-21-relationship-endpoint-tenant-isolation.md
+ *
+ * Invariant: getRelationshipsForEntity and getRelationshipsByType MUST apply
+ * an .eq("user_id", userId) filter on the relationship_snapshots query when
+ * a userId is provided. Without this filter, callers can read relationship
+ * edges belonging to other users on the same instance.
+ *
+ * The test records the chained calls against a mock db and asserts the
+ * expected filter clauses are present.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+type Call = { method: string; args: unknown[] };
+const recordedCalls: Call[] = [];
+
+function makeChainable() {
+  const proxy: any = new Proxy(
+    {},
+    {
+      get(_target, prop: string) {
+        if (prop === "then" || typeof prop === "symbol") return undefined;
+        return (...args: unknown[]) => {
+          recordedCalls.push({ method: prop, args });
+          if (prop === "order") {
+            // terminal: resolve with empty data
+            return Promise.resolve({ data: [], error: null });
+          }
+          return proxy;
+        };
+      },
+    }
+  );
+  return proxy;
+}
+
+vi.mock("../../src/db.js", () => ({
+  db: {
+    from: (table: string) => {
+      recordedCalls.push({ method: "from", args: [table] });
+      return makeChainable();
+    },
+  },
+}));
+
+import { relationshipsService } from "../../src/services/relationships.js";
+
+describe("relationships tenant isolation (GHSA-wrr4-782v-jhwh)", () => {
+  beforeEach(() => {
+    recordedCalls.length = 0;
+  });
+
+  it("getRelationshipsForEntity outgoing applies user_id filter when userId provided", async () => {
+    await relationshipsService.getRelationshipsForEntity(
+      "ent_abc",
+      "outgoing",
+      true, // includeDeleted to skip the deletion-observation second query
+      "user-1"
+    );
+
+    const eqCalls = recordedCalls.filter((c) => c.method === "eq");
+    const hasUserIdEq = eqCalls.some(
+      (c) => c.args[0] === "user_id" && c.args[1] === "user-1"
+    );
+    expect(hasUserIdEq).toBe(true);
+  });
+
+  it("getRelationshipsForEntity incoming applies user_id filter when userId provided", async () => {
+    await relationshipsService.getRelationshipsForEntity(
+      "ent_abc",
+      "incoming",
+      true,
+      "user-1"
+    );
+
+    const eqCalls = recordedCalls.filter((c) => c.method === "eq");
+    const hasUserIdEq = eqCalls.some(
+      (c) => c.args[0] === "user_id" && c.args[1] === "user-1"
+    );
+    expect(hasUserIdEq).toBe(true);
+  });
+
+  it("getRelationshipsForEntity both directions applies user_id filter when userId provided", async () => {
+    await relationshipsService.getRelationshipsForEntity(
+      "ent_abc",
+      "both",
+      true,
+      "user-1"
+    );
+
+    const eqCalls = recordedCalls.filter((c) => c.method === "eq");
+    const hasUserIdEq = eqCalls.some(
+      (c) => c.args[0] === "user_id" && c.args[1] === "user-1"
+    );
+    expect(hasUserIdEq).toBe(true);
+  });
+
+  it("getRelationshipsByType applies user_id filter when userId provided", async () => {
+    await relationshipsService.getRelationshipsByType(
+      "WORKS_AT" as any,
+      true,
+      "user-1"
+    );
+
+    const eqCalls = recordedCalls.filter((c) => c.method === "eq");
+    const hasUserIdEq = eqCalls.some(
+      (c) => c.args[0] === "user_id" && c.args[1] === "user-1"
+    );
+    expect(hasUserIdEq).toBe(true);
+  });
+
+  it("does NOT apply user_id filter when userId omitted (back-compat for internal callers)", async () => {
+    await relationshipsService.getRelationshipsForEntity("ent_abc", "outgoing", true);
+
+    const eqCalls = recordedCalls.filter((c) => c.method === "eq");
+    const hasUserIdEq = eqCalls.some((c) => c.args[0] === "user_id");
+    expect(hasUserIdEq).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #365. Relates to GHSA-wrr4-782v-jhwh.

## Summary

The `/list_relationships` HTTP endpoint and the MCP `listRelationships` handler both queried `relationship_snapshots` without scoping to the authenticated user. This PR adds `.eq("user_id", userId)` to the relevant queries and routes user resolution through `getAuthenticatedUserId`.

## Changes

- `src/actions.ts` — HTTP handler resolves authenticated user and passes userId into service methods
- `src/server.ts` — MCP handler applies `.eq("user_id", userId)` to inbound and outbound queries
- `src/services/relationships.ts` — `getRelationshipsForEntity` and `getRelationshipsByType` accept optional `userId`; applies filter when present
- `src/shared/action_schemas.ts` — `ListRelationshipsRequestSchema` accepts optional `user_id` (honored only for `LOCAL_DEV_USER_ID`)
- `tests/services/relationships_tenant_isolation.test.ts` — regression test

## Severity

Low under current single-tenant deployments. Escalates to Medium for multi-tenant. No multi-tenant deployments exist.

## Verification

- [x] Type check passes
- [x] Lint clean (0 errors)
- [x] New regression test passes (5/5)
- [x] Existing relationship tests pass (22/22 across snapshots, MCP variations, CLI→MCP)

## Test plan

- [ ] Confirm `/list_relationships` returns only the requesting user's relationships
- [ ] Confirm an authenticated user with a known cross-user `entity_id` receives an empty result
- [ ] Confirm CLI usage via `neotoma list_relationships` continues to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)