### PR TITLE
fix(security): scope /retrieve_graph_neighborhood queries to authenticated user (#366)

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -6316,6 +6316,11 @@ app.post("/retrieve_graph_neighborhood", async (req, res) => {
       include_observations = false,
     } = parsed.data;
 
+    // Tenant isolation: scope all queries to the authenticated user.
+    // See docs/security/advisories/2026-05-21-relationship-endpoint-
+    // tenant-isolation.md (GHSA-wrr4-782v-jhwh) for context.
+    const userId = await getAuthenticatedUserId(req, parsed.data.user_id);
+
     const result: any = { node_id, node_type };
 
     if (node_type === "entity") {
@@ -6324,6 +6329,7 @@ app.post("/retrieve_graph_neighborhood", async (req, res) => {
         .from("entities")
         .select("*")
         .eq("id", node_id)
+        .eq("user_id", userId)
         .single();
 
       if (!entityError && entity) {
@@ -6335,7 +6341,8 @@ app.post("/retrieve_graph_neighborhood", async (req, res) => {
         const { data: relationships, error: relError } = await db
           .from("relationship_snapshots")
           .select("*")
-          .or(`source_entity_id.eq.${node_id},target_entity_id.eq.${node_id}`);
+          .or(`source_entity_id.eq.${node_id},target_entity_id.eq.${node_id}`)
+          .eq("user_id", userId);
 
         if (!relError) {
           result.relationships = relationships || [];
@@ -6356,7 +6363,8 @@ app.post("/retrieve_graph_neighborhood", async (req, res) => {
             const { data: relatedEntities, error: relatedEntitiesError } = await db
               .from("entities")
               .select("*")
-              .in("id", relatedEntityIds);
+              .in("id", relatedEntityIds)
+              .eq("user_id", userId);
 
             if (!relatedEntitiesError) {
               result.related_entities = relatedEntities || [];
@@ -6370,7 +6378,8 @@ app.post("/retrieve_graph_neighborhood", async (req, res) => {
         const { data: observations, error: obsError } = await db
           .from("observations")
           .select("*")
-          .eq("entity_id", node_id);
+          .eq("entity_id", node_id)
+          .eq("user_id", userId);
 
         if (!obsError) {
           result.observations = observations || [];
@@ -6384,7 +6393,8 @@ app.post("/retrieve_graph_neighborhood", async (req, res) => {
           const { data: sources, error: srcError } = await db
             .from("source")
             .select("*")
-            .in("id", sourceIds);
+            .in("id", sourceIds)
+            .eq("user_id", userId);
 
           if (!srcError) {
             result.sources = sources || [];
@@ -6397,6 +6407,7 @@ app.post("/retrieve_graph_neighborhood", async (req, res) => {
         .from("source")
         .select("*")
         .eq("id", node_id)
+        .eq("user_id", userId)
         .single();
 
       if (!srcError && source) {
@@ -6408,7 +6419,8 @@ app.post("/retrieve_graph_neighborhood", async (req, res) => {
         const { data: observations, error: obsError } = await db
           .from("observations")
           .select("*")
-          .eq("source_id", node_id);
+          .eq("source_id", node_id)
+          .eq("user_id", userId);
 
         if (!obsError) {
           result.observations = observations || [];

--- a/src/server.ts
+++ b/src/server.ts
@@ -2654,6 +2654,11 @@ export class NeotomaServer {
   ): Promise<{ content: Array<{ type: string; text: string }> }> {
     const parsed = RetrieveGraphNeighborhoodSchema.parse(args ?? {});
 
+    // Tenant isolation: scope all queries to the authenticated user.
+    // See docs/security/advisories/2026-05-21-relationship-endpoint-
+    // tenant-isolation.md (GHSA-wrr4-782v-jhwh) for context.
+    const userId = this.getAuthenticatedUserId(parsed.user_id);
+
     const includeSources = parsed.include_sources;
 
     const result: any = {
@@ -2667,6 +2672,7 @@ export class NeotomaServer {
         .from("entities")
         .select("*")
         .eq("id", parsed.node_id)
+        .eq("user_id", userId)
         .single();
 
       if (entityError || !entity) {
@@ -2680,6 +2686,7 @@ export class NeotomaServer {
         .from("entity_snapshots")
         .select("*")
         .eq("entity_id", parsed.node_id)
+        .eq("user_id", userId)
         .single();
 
       if (!snapError && snapshot) {
@@ -2691,7 +2698,8 @@ export class NeotomaServer {
         const { data: relationships, error: relError } = await db
           .from("relationship_snapshots")
           .select("*")
-          .or(`source_entity_id.eq.${parsed.node_id},target_entity_id.eq.${parsed.node_id}`);
+          .or(`source_entity_id.eq.${parsed.node_id},target_entity_id.eq.${parsed.node_id}`)
+          .eq("user_id", userId);
 
         if (!relError && relationships) {
           result.relationships = relationships;
@@ -2710,7 +2718,8 @@ export class NeotomaServer {
             const { data: relatedEntities, error: relEntError } = await db
               .from("entities")
               .select("*")
-              .in("id", Array.from(relatedEntityIds));
+              .in("id", Array.from(relatedEntityIds))
+              .eq("user_id", userId);
 
             if (!relEntError && relatedEntities) {
               result.related_entities = relatedEntities;
@@ -2725,6 +2734,7 @@ export class NeotomaServer {
           .from("observations")
           .select("*")
           .eq("entity_id", parsed.node_id)
+          .eq("user_id", userId)
           .order("observed_at", { ascending: false })
           .limit(100);
 
@@ -2740,7 +2750,8 @@ export class NeotomaServer {
               const { data: sources, error: sourceError } = await db
                 .from("sources")
                 .select("id, mime_type, file_size, original_filename, created_at")
-                .in("id", sourceIds);
+                .in("id", sourceIds)
+                .eq("user_id", userId);
 
               if (!sourceError && sources) {
                 result.related_sources = sources;
@@ -2750,7 +2761,8 @@ export class NeotomaServer {
                   const { data: events, error: evtError } = await db
                     .from("timeline_events")
                     .select("*")
-                    .in("source_id", sourceIds);
+                    .in("source_id", sourceIds)
+                    .eq("user_id", userId);
 
                   if (!evtError && events) {
                     result.timeline_events = events;
@@ -2767,6 +2779,7 @@ export class NeotomaServer {
         .from("sources")
         .select("*")
         .eq("id", parsed.node_id)
+        .eq("user_id", userId)
         .single();
 
       if (sourceError || !source) {
@@ -2780,7 +2793,8 @@ export class NeotomaServer {
         const { data: events, error: evtError } = await db
           .from("timeline_events")
           .select("*")
-          .eq("source_id", parsed.node_id);
+          .eq("source_id", parsed.node_id)
+          .eq("user_id", userId);
 
         if (!evtError && events) {
           result.timeline_events = events;
@@ -2791,7 +2805,8 @@ export class NeotomaServer {
       const { data: observations, error: obsError } = await db
         .from("observations")
         .select("*")
-        .eq("source_id", parsed.node_id);
+        .eq("source_id", parsed.node_id)
+        .eq("user_id", userId);
 
       if (!obsError && observations) {
         result.observations = observations;
@@ -2805,7 +2820,8 @@ export class NeotomaServer {
             const { data: entities, error: entError } = await db
               .from("entities")
               .select("*")
-              .in("id", entityIds);
+              .in("id", entityIds)
+              .eq("user_id", userId);
 
             if (!entError && entities) {
               result.related_entities = entities;
@@ -2820,6 +2836,7 @@ export class NeotomaServer {
                       ","
                     )}),target_entity_id.in.(${entityIds.join(",")})`
                   )
+                  .eq("user_id", userId)
                   .limit(1000);
 
                 if (!relError && relationships) {

--- a/src/shared/action_schemas.ts
+++ b/src/shared/action_schemas.ts
@@ -474,6 +474,8 @@ export const RetrieveGraphNeighborhoodSchema = z.object({
   include_sources: z.boolean().optional().default(true),
   include_events: z.boolean().optional().default(true),
   include_observations: z.boolean().optional().default(false),
+  // Optional override honored only for LOCAL_DEV_USER_ID (see getAuthenticatedUserId).
+  user_id: z.string().optional(),
 });
 
 export const RelationshipSnapshotRequestSchema = z.object({

--- a/tests/integration/retrieve_graph_neighborhood_tenant_isolation.test.ts
+++ b/tests/integration/retrieve_graph_neighborhood_tenant_isolation.test.ts
@@ -17,6 +17,8 @@ import { db } from "../../src/db.js";
 import { randomUUID } from "node:crypto";
 
 const TEST_PREFIX = "rgn_tenant_iso_test";
+const PORT = process.env.NEOTOMA_SESSION_DEV_PORT ?? "18099";
+const BASE_URL = `http://127.0.0.1:${PORT}`;
 
 describe("retrieve_graph_neighborhood tenant isolation (GHSA-wrr4-782v-jhwh)", () => {
   const userA = randomUUID();
@@ -48,7 +50,7 @@ describe("retrieve_graph_neighborhood tenant isolation (GHSA-wrr4-782v-jhwh)", (
   });
 
   it("user A querying their own entity returns it", async () => {
-    const res = await fetch("http://localhost:18099/retrieve_graph_neighborhood", {
+    const res = await fetch(`${BASE_URL}/retrieve_graph_neighborhood`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -64,7 +66,7 @@ describe("retrieve_graph_neighborhood tenant isolation (GHSA-wrr4-782v-jhwh)", (
   });
 
   it("user A querying user B's entity does NOT return user B's data", async () => {
-    const res = await fetch("http://localhost:18099/retrieve_graph_neighborhood", {
+    const res = await fetch(`${BASE_URL}/retrieve_graph_neighborhood`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -81,7 +83,7 @@ describe("retrieve_graph_neighborhood tenant isolation (GHSA-wrr4-782v-jhwh)", (
   });
 
   it("user B querying their own entity returns it", async () => {
-    const res = await fetch("http://localhost:18099/retrieve_graph_neighborhood", {
+    const res = await fetch(`${BASE_URL}/retrieve_graph_neighborhood`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({

--- a/tests/integration/retrieve_graph_neighborhood_tenant_isolation.test.ts
+++ b/tests/integration/retrieve_graph_neighborhood_tenant_isolation.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Regression test for GHSA-wrr4-782v-jhwh /
+ * docs/security/advisories/2026-05-21-relationship-endpoint-tenant-isolation.md
+ *
+ * Invariant: the /retrieve_graph_neighborhood HTTP endpoint MUST scope all
+ * database queries to the authenticated user. Specifically, when invoked
+ * by user A with an entity_id belonging to user B, the endpoint MUST NOT
+ * return user B's entity, relationships, observations, or sources.
+ *
+ * This test seeds two distinct user_ids' worth of data in the database
+ * and verifies that calls authenticated as user A only see user A's data,
+ * regardless of which node_id is queried.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { db } from "../../src/db.js";
+import { randomUUID } from "node:crypto";
+
+const TEST_PREFIX = "rgn_tenant_iso_test";
+
+describe("retrieve_graph_neighborhood tenant isolation (GHSA-wrr4-782v-jhwh)", () => {
+  const userA = randomUUID();
+  const userB = randomUUID();
+  const entityA = `${TEST_PREFIX}_ent_a_${Date.now()}`;
+  const entityB = `${TEST_PREFIX}_ent_b_${Date.now()}`;
+
+  beforeAll(async () => {
+    // Seed two entities, one per user
+    await db.from("entities").insert([
+      {
+        id: entityA,
+        user_id: userA,
+        entity_type: "test",
+        canonical_name: "Alice's Entity",
+      },
+      {
+        id: entityB,
+        user_id: userB,
+        entity_type: "test",
+        canonical_name: "Bob's Entity",
+      },
+    ]);
+  });
+
+  afterAll(async () => {
+    await db.from("entities").delete().eq("id", entityA);
+    await db.from("entities").delete().eq("id", entityB);
+  });
+
+  it("user A querying their own entity returns it", async () => {
+    const res = await fetch("http://localhost:18099/retrieve_graph_neighborhood", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        node_id: entityA,
+        node_type: "entity",
+        user_id: userA,
+      }),
+    });
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.entity).toBeDefined();
+    expect(json.entity.id).toBe(entityA);
+  });
+
+  it("user A querying user B's entity does NOT return user B's data", async () => {
+    const res = await fetch("http://localhost:18099/retrieve_graph_neighborhood", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        node_id: entityB,
+        node_type: "entity",
+        user_id: userA,
+      }),
+    });
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    // Either entity is undefined or it does not match userB's entity
+    // (the .single() should not find a row scoped to userA)
+    expect(json.entity).toBeUndefined();
+  });
+
+  it("user B querying their own entity returns it", async () => {
+    const res = await fetch("http://localhost:18099/retrieve_graph_neighborhood", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        node_id: entityB,
+        node_type: "entity",
+        user_id: userB,
+      }),
+    });
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.entity).toBeDefined();
+    expect(json.entity.id).toBe(entityB);
+  });
+});


### PR DESCRIPTION
Closes #366. Relates to GHSA-wrr4-782v-jhwh.

## Summary

The `/retrieve_graph_neighborhood` HTTP endpoint and the MCP `retrieveGraphNeighborhood` handler queried entities, sources, observations, relationship_snapshots, and timeline_events without scoping to the authenticated user. This PR adds `.eq("user_id", userId)` to every query and routes user resolution through `getAuthenticatedUserId`.

## Changes

- `src/actions.ts` — HTTP handler resolves authenticated user and applies user_id filter to every query
- `src/server.ts` — MCP handler applies user_id filter to entity, entity_snapshot, relationship_snapshots, observations, sources, timeline_events, related_entities, and second-hop relationship queries
- `src/shared/action_schemas.ts` — `RetrieveGraphNeighborhoodSchema` accepts optional `user_id` (honored only for `LOCAL_DEV_USER_ID`)
- `tests/integration/retrieve_graph_neighborhood_tenant_isolation.test.ts` — integration regression test seeds two users' entities and verifies cross-user access is blocked

## Severity

Low under current single-tenant deployments. Escalates to Medium for multi-tenant. No multi-tenant deployments exist.

## Verification

- [x] Type check passes
- [x] Lint clean (0 errors)
- [x] New integration regression test passes (3/3)

## Test plan

- [ ] Confirm `/retrieve_graph_neighborhood` with a cross-user entity_id returns no entity
- [ ] Confirm own-user queries continue to return entity, relationships, observations, sources
- [ ] Confirm source-type queries respect user scoping

🤖 Generated with [Claude Code](https://claude.com/claude-code)