### PR TITLE
test(security): add tenant isolation matrix and require coverage for new query endpoints (#372)

### DIFF
--- a/.claude/rules/change_guardrails_rules.md
+++ b/.claude/rules/change_guardrails_rules.md
@@ -78,7 +78,7 @@ These rules sit between subsystems. Each canonical doc covers its own surface; o
 2. Every `operationId` has a `src/shared/contract_mappings.ts` row; every new MCP tool or CLI command is reachable from that table.
 3. Behavioral rules that affect agents appear in both `docs/developer/mcp/instructions.md` and `docs/developer/cli_agent_instructions.md`, mirrored via the anchor rule.
 4. Runtime overrides follow `flag > env > default`, are read in the `preAction` hook with a `NEOTOMA_`-prefixed name, and appear in the `cli_reference.md` Runtime overrides table.
-5. Authorization goes through `getAuthenticatedUserId`. Body / query `user_id` is never read directly for access control.
+5. Authorization goes through `getAuthenticatedUserId`. Body / query `user_id` is never read directly for access control. Authentication alone is insufficient — every authenticated query that reads user-owned tables (entities, observations, sources, relationship_snapshots, timeline_events, entity_snapshots) MUST apply `.eq("user_id", userId)` to scope the query to the requesting user's data. New query endpoints MUST add a row to `tests/security/tenant_isolation_matrix.test.ts` asserting cross-user reads are blocked. See `docs/security/advisories/2026-05-21-relationship-endpoint-tenant-isolation.md` (GHSA-wrr4-782v-jhwh) for the regression class.
 6. New response or error fields are declared in `openapi.yaml` first; clients gate on declared fields, not on the presence or absence of ambient rich properties.
 7. Post-release fixes ship as a new patch (or higher) version. Historical supplements under `docs/releases/completed/` are not rewritten.
 8. New top-level CLI commands are added to `tests/cli/cli_command_coverage_guard.test.ts` in the same change.

--- a/docs/architecture/change_guardrails_rules.mdc
+++ b/docs/architecture/change_guardrails_rules.mdc
@@ -75,7 +75,7 @@ These rules sit between subsystems. Each canonical doc covers its own surface; o
 2. Every `operationId` has a `src/shared/contract_mappings.ts` row; every new MCP tool or CLI command is reachable from that table.
 3. Behavioral rules that affect agents appear in both `docs/developer/mcp/instructions.md` and `docs/developer/cli_agent_instructions.md`, mirrored via the anchor rule.
 4. Runtime overrides follow `flag > env > default`, are read in the `preAction` hook with a `NEOTOMA_`-prefixed name, and appear in the `cli_reference.md` Runtime overrides table.
-5. Authorization goes through `getAuthenticatedUserId`. Body / query `user_id` is never read directly for access control.
+5. Authorization goes through `getAuthenticatedUserId`. Body / query `user_id` is never read directly for access control. Authentication alone is insufficient — every authenticated query that reads user-owned tables (entities, observations, sources, relationship_snapshots, timeline_events, entity_snapshots) MUST apply `.eq("user_id", userId)` to scope the query to the requesting user's data. New query endpoints MUST add a row to `tests/security/tenant_isolation_matrix.test.ts` asserting cross-user reads are blocked. See `docs/security/advisories/2026-05-21-relationship-endpoint-tenant-isolation.md` (GHSA-wrr4-782v-jhwh) for the regression class.
 6. New response or error fields are declared in `openapi.yaml` first; clients gate on declared fields, not on the presence or absence of ambient rich properties.
 7. Post-release fixes ship as a new patch (or higher) version. Historical supplements under `docs/releases/completed/` are not rewritten.
 8. New top-level CLI commands are added to `tests/cli/cli_command_coverage_guard.test.ts` in the same change.

--- a/tests/security/tenant_isolation_matrix.test.ts
+++ b/tests/security/tenant_isolation_matrix.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Tenant isolation matrix.
+ *
+ * Companion to (and conceptually parallel with) any future
+ * auth_topology_matrix that verifies unauthenticated callers are rejected.
+ * This suite covers a different threat model: an authenticated caller
+ * MUST NOT be able to read another user's data, even when they know a
+ * cross-user entity_id, source_id, or relationship key.
+ *
+ * Motivated by GHSA-wrr4-782v-jhwh /
+ * docs/security/advisories/2026-05-21-relationship-endpoint-tenant-isolation.md
+ *
+ * Every authenticated query endpoint that touches user-owned data MUST be
+ * covered here. Adding a new endpoint to the codebase without adding a
+ * row to this matrix is a regression that must be caught in review.
+ *
+ * NOTE: Some endpoints listed below are pending tenant-isolation fixes
+ * (#365 /list_relationships, #366 /retrieve_graph_neighborhood). Those
+ * cases are marked `.todo` or `.skip` until the fix PRs land; the matrix
+ * landing first ensures the fixes are verified against this suite.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { db } from "../../src/db.js";
+import { randomUUID } from "node:crypto";
+
+const TEST_PREFIX = "tenant_iso_matrix_test";
+const BASE_URL = "http://localhost:18099";
+
+interface FixtureUserData {
+  userId: string;
+  entityId: string;
+  sourceId: string;
+}
+
+async function seedUserData(label: string): Promise<FixtureUserData> {
+  const userId = randomUUID();
+  const entityId = `${TEST_PREFIX}_ent_${label}_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`;
+  const sourceId = randomUUID();
+
+  await db.from("entities").insert({
+    id: entityId,
+    user_id: userId,
+    entity_type: "test",
+    canonical_name: `${label}'s Entity`,
+  });
+
+  await db.from("sources").insert({
+    id: sourceId,
+    user_id: userId,
+    content_hash: `${TEST_PREFIX}_hash_${label}_${Date.now()}`,
+    mime_type: "text/plain",
+    storage_url: `internal://test/${label}`,
+    file_size: 0,
+  });
+
+  return { userId, entityId, sourceId };
+}
+
+async function cleanupUserData(data: FixtureUserData): Promise<void> {
+  await db.from("entities").delete().eq("id", data.entityId);
+  await db.from("sources").delete().eq("id", data.sourceId);
+}
+
+async function callEndpoint(
+  path: string,
+  body: Record<string, unknown>
+): Promise<{ status: number; json: any }> {
+  const res = await fetch(`${BASE_URL}${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const json = await res.json().catch(() => ({}));
+  return { status: res.status, json };
+}
+
+describe("Tenant isolation matrix (GHSA-wrr4-782v-jhwh)", () => {
+  let userA: FixtureUserData;
+  let userB: FixtureUserData;
+
+  beforeAll(async () => {
+    userA = await seedUserData("alice");
+    userB = await seedUserData("bob");
+  });
+
+  afterAll(async () => {
+    await cleanupUserData(userA);
+    await cleanupUserData(userB);
+  });
+
+  describe("/retrieve_related_entities", () => {
+    it("user A querying their own entity_id returns user A's data", async () => {
+      const { status, json } = await callEndpoint("/retrieve_related_entities", {
+        entity_id: userA.entityId,
+        user_id: userA.userId,
+      });
+      expect(status).toBe(200);
+      // Empty relationships is fine — what matters is no error and no cross-user leak
+      expect(Array.isArray(json.relationships)).toBe(true);
+    });
+
+    it("user A querying user B's entity_id returns no data (scoped to user A)", async () => {
+      const { status, json } = await callEndpoint("/retrieve_related_entities", {
+        entity_id: userB.entityId,
+        user_id: userA.userId,
+      });
+      expect(status).toBe(200);
+      // User A's scope means no relationships involving user B's entity
+      expect(json.relationships).toEqual([]);
+      expect(json.entities ?? []).toEqual([]);
+    });
+  });
+
+  describe("/list_relationships", () => {
+    it.todo("Add coverage once #365 lands — verify cross-user entity_id returns empty");
+  });
+
+  describe("/retrieve_graph_neighborhood", () => {
+    it.todo("Add coverage once #366 lands — verify cross-user node_id returns no entity");
+  });
+});

--- a/tests/security/tenant_isolation_matrix.test.ts
+++ b/tests/security/tenant_isolation_matrix.test.ts
@@ -25,7 +25,8 @@ import { db } from "../../src/db.js";
 import { randomUUID } from "node:crypto";
 
 const TEST_PREFIX = "tenant_iso_matrix_test";
-const BASE_URL = "http://localhost:18099";
+const PORT = process.env.NEOTOMA_SESSION_DEV_PORT ?? "18099";
+const BASE_URL = `http://127.0.0.1:${PORT}`;
 
 interface FixtureUserData {
   userId: string;


### PR DESCRIPTION
Closes #372. Companion to PRs #376 (#365) and #377 (#366).

## Summary

The pre-release security gates that ran for v0.13.0 verified that protected endpoints reject unauthenticated callers, but did not verify that authenticated endpoints scope queries to the requesting user. Two endpoints shipped with a tenant isolation gap (GHSA-wrr4-782v-jhwh) because the existing test suite did not cover cross-user data access.

This PR closes the gate gap.

## Changes

- `tests/security/tenant_isolation_matrix.test.ts` — new test suite. Seeds two distinct users' worth of data and asserts authenticated endpoints scope responses to the requesting user. Currently covers `/retrieve_related_entities` (which already scopes correctly on dev). `/list_relationships` and `/retrieve_graph_neighborhood` are marked `.todo` pending PRs #376 and #377; those entries become real assertions once the fixes land.
- `docs/architecture/change_guardrails_rules.mdc` — extends MUST rule 5 (Authorization) to require `.eq("user_id", userId)` on all user-owned table queries and require tenant-isolation matrix coverage for new query endpoints.
- `.claude/rules/change_guardrails_rules.md` — mirrored update.

## Why this lands before the fixes

The matrix landing first ensures #376 and #377 are verified against this suite. When those PRs merge, they should also flip the `.todo` entries here to real assertions covering their endpoints. The guardrails rule now blocks future endpoints from shipping without coverage.

## Verification

- [x] Type check passes
- [x] Lint clean
- [x] Matrix test passes (2 passed, 2 todo)

## Test plan

- [ ] Confirm `tests/security/tenant_isolation_matrix.test.ts` runs in CI
- [ ] Once #376 and #377 merge, flip the `.todo` entries here to real `it()` assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)