### PR TITLE
feat(release-skill): add Step 5.2 advisory publication gate

### DIFF
--- a/.claude/skills/process_prs/SKILL.md
+++ b/.claude/skills/process_prs/SKILL.md
@@ -1,15 +1,10 @@
 ---
 name: process_prs
-description: Process open pull requests — triage readiness, run security checks, request Opus review on substantial PRs, post per-issue closure-narrative comments, merge eligible PRs, and detect release PRs and hand off to /release.
-triggers:
-  - process prs
-  - /process_prs
-  - work the pr queue
-  - triage prs
-  - review open prs
+description: Process PRs
 ---
 
 <!-- Source: .cursor/skills/process-prs/SKILL.md -->
+
 
 # Process PRs
 
@@ -290,13 +285,95 @@ gh issue close <iss> --reason completed
 
 For each PR that cannot be merged, take the appropriate action:
 
-- **CI failing**: Post a comment summarizing which checks failed. Do not merge.
+- **CI failing**: Before posting a failure comment, check whether the failure is purely mechanical (prettier formatting or eslint auto-fixable lint errors). If so, apply the mechanical fix in-place:
+
+  **Mechanical CI auto-fix (prettier / eslint only):**
+
+  ```bash
+  # Determine what failed
+  gh pr checks <number> --json name,conclusion,detailsUrl \
+    | jq '[.[] | select(.conclusion == "failure") | .name]'
+  ```
+
+  If and only if **all** failed checks are formatting or lint checks (names containing `prettier`, `format`, `lint`, or `eslint` — and no type-check, test, build, or security failures), apply the fix:
+
+  ```bash
+  BRANCH=$(gh pr view <number> --json headRefName --jq '.headRefName')
+  git fetch origin "$BRANCH"
+  git worktree add ".claude/worktrees/fmt-pr-<number>" "origin/$BRANCH"
+  cd ".claude/worktrees/fmt-pr-<number>"
+
+  # Check what scripts are available
+  cat package.json | jq '.scripts | keys'
+
+  # Apply formatting and lint fixes
+  npm run format 2>/dev/null || npx prettier --write "src/**/*.{ts,tsx}" "tests/**/*.{ts,tsx}"
+  npm run lint:fix 2>/dev/null || npx eslint --fix "src/**/*.ts" "tests/**/*.ts"
+
+  # Verify no type errors were introduced
+  npm run type-check
+
+  # If type-check passes, commit and push
+  git add -A
+  git commit -m "chore: apply prettier formatting
+
+  Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+  git push origin "$BRANCH"
+
+  cd /Users/markmhendrickson/repos/neotoma
+  git worktree remove ".claude/worktrees/fmt-pr-<number>" --force
+  ```
+
+  After pushing, post a comment on the PR:
+
+  ```bash
+  gh pr comment <number> --body "Applied automatic prettier/eslint formatting fix. Re-running CI."
+  ```
+
+  Do **not** apply the mechanical fix if:
+  - Any non-formatting check also failed (type errors, test failures, build failures, security gates)
+  - `npm run type-check` fails after applying formatting
+  - The diff produced by formatting exceeds 50 lines (indicates something unexpected; surface to user instead)
+
+  If the mechanical fix is not applicable, fall through to the normal CI-failing path:
+  Post a comment summarizing which checks failed. Do not merge.
+
 - **Security gate errors (G2/G3)**: Post a comment with the specific `security:lint` errors or manifest/auth-matrix failures. Do not merge.
 - **Review-blocked (Step 1c)**: Post a comment listing the unaddressed Blocking findings from the most recent review, quoting the relevant lines and naming the file paths. Request that the author either land substantive fix commits, post `Waiver: <reason>` comments per finding, or re-request `@claude review` after the fixes. Do not merge.
 - **Awaiting review**: Note in the summary report. Do not post a comment unless explicitly requested.
 - **Merge conflicts**: Post a comment asking the author to rebase.
 - **Draft**: Skip. Report in summary.
 - **Release PR**: Report in summary, instruct user to run `/release`.
+
+### Step 5b: Suggest `/fix_pr` for Suitable Blocked PRs
+
+After handling each blocked PR, determine whether it is a good candidate for `/fix_pr` and include the suggestion in the report. A PR is a good candidate if it has at least one auto-fixable blocking reason and no hard stops.
+
+**Suggest `/fix_pr <number>` when ALL of the following are true:**
+
+- PR is not a draft
+- PR is not a release PR
+- At least one blocking reason is in the auto-fixable category:
+  - CI failures that are TypeScript type errors, failing unit/integration tests, or non-formatting lint errors
+  - Review findings that are rename/style/naming issues (not logic, architecture, or security)
+  - Merge conflicts in non-sensitive files (not `openapi.yaml`, lock files, or migration files)
+
+**Do NOT suggest `/fix_pr` when:**
+
+- All CI failures were already handled by the mechanical auto-fix in Step 5 (fix already applied)
+- The only blockers are security-adjacent findings (`src/actions.ts`, `src/services/local_auth.ts`, `protected_routes_manifest.json`, `docs/security/`)
+- The only blockers are architectural or design-discussion review findings
+- Merge conflicts are only in `openapi.yaml`, lock files, or migration files
+- The PR is awaiting review with no other blockers (nothing for `/fix_pr` to act on)
+
+Include the suggestion inline in the blocked PR's report entry, e.g.:
+
+```
+PR #217 — Add user preference caching [BLOCKED]
+  CI: type-check failing (3 errors in src/services/preferences.ts)
+  Review: 1 Blocking finding (rename `prefMap` → `preferenceMap`)
+  → Run `/fix_pr 217` to address these automatically.
+```
 
 ### Step 6: Report
 
@@ -330,6 +407,7 @@ The `/release` Step 3.5 re-runs G2 and G3 against the exact release commit as a 
 
 ## Constraints
 
+- The mechanical CI auto-fix in Step 5 is scoped strictly to prettier formatting and eslint `--fix`-able lint errors. Never apply it when other check types also failed, and never skip `npm run type-check` before pushing the fix commit.
 - Never push to `main` directly. Merges to `main` only happen via `/release`.
 - Never merge a release PR (dev→main with version bump). Hand off to `/release`.
 - Never use `--no-verify`.
@@ -360,4 +438,6 @@ The `/release` Step 3.5 re-runs G2 and G3 against the exact release commit as a 
 - **Counting `chore: regenerate test catalog` / `prettier` / rebase-merge commits as "post-review fixes."** They are housekeeping and do not clear review blockers.
 - **Treating placeholder review comments (`I'll analyze this and get back to you.` with 0 output tokens) as completed reviews.** Re-trigger and wait for a substantive review.
 - **Merging a PR that closes issues without first posting a closure-narrative comment on each linked issue (Step 4).** The GitHub auto-close link is not a resolution trail.
+- **Applying the mechanical CI auto-fix when non-formatting checks also failed.** The fix is scoped to prettier/eslint-only failures. Mixed failures go to the user.
+- **Skipping `npm run type-check` after applying prettier/eslint fixes.** A formatting pass that produces type errors must not be pushed.
 - **Leaving issues open that the merged PR resolved.** When detection in Step 4 surfaces an auto-close gap (closure verb in body/commit but issue not in `closingIssuesReferences`), close the issue manually after merge with `gh issue close <iss> --reason completed` and a comment linking the resolving PR.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -321,7 +321,37 @@ After the RC PR is merged and the user confirms execute, run **every** step belo
    ```
    The probe writes `docs/releases/in_progress/vX.Y.Z/post_deploy_security_probes.md` and exits non-zero on any unexpected status. A failure here BLOCKS release completion: open an advisory under `docs/security/advisories/`, hotfix the regression, and re-run before declaring done.
 
-2. **Verify GitHub Actions workflows triggered by the release push:**
+2. **Publish any draft security advisories linked from this release (mandatory when `Security hardening` section is non-trivial):**
+
+   After the tag is live and before declaring the release complete, check whether any advisory referenced in the supplement's `Security hardening` section is still in draft/private state.
+
+   a. **Scan the supplement for advisory links:**
+      ```bash
+      grep -oE 'docs/security/advisories/[^ )]+\.md' docs/releases/in_progress/vX.Y.Z/github_release_supplement.md
+      ```
+
+   b. **For each linked advisory file, check its status field:**
+      ```bash
+      head -20 docs/security/advisories/<slug>.md | grep -i status
+      ```
+      If status is `draft` or `private`, it must be published now.
+
+   c. **Run `/advisory close <slug> vX.Y.Z`** for each unpublished advisory. This skill will:
+      - Update the advisory doc status to `disclosed`
+      - Record the fix version
+      - Publish the corresponding GitHub Security Advisory (GHSA) via `gh api`
+
+   d. **Verify the GHSA is public** after publication:
+      ```bash
+      gh api repos/markmhendrickson/neotoma/security-advisories --jq '.[] | select(.ghsa_id == "<GHSA-ID>") | {state, published_at}'
+      ```
+      State must be `published`. If the GHSA publish step fails (auth, scope), STOP and surface the exact error — do not declare the release complete with a draft GHSA.
+
+   **Why this step is here and not in Step 3.5:** The GHSA should only go public after the fix is actually tagged and shipped. Publishing before the tag leaks attack vector details before users can protect themselves. The advisory doc is written during Step 3.5; the GHSA is published here.
+
+   **Skip this step** only when the supplement's `Security hardening` section reads `No security-sensitive surfaces touched.`
+
+3. **Verify GitHub Actions workflows triggered by the release push:**
 
    The `git push origin main` and `git push origin vX.Y.Z` in Step 4.5 trigger CI and deployment workflows. All must succeed before declaring the release complete.
 
@@ -359,7 +389,7 @@ After the RC PR is merged and the user confirms execute, run **every** step belo
 
    e. **Record the outcome** in the release summary (step 4 of this section).
 
-3. **Close resolved GitHub issues:**
+4. **Close resolved GitHub issues:**
    - Fetch the release URL created in Step 4.8:
      ```bash
      RELEASE_URL=$(gh release view vX.Y.Z --json url --jq .url)
@@ -378,8 +408,8 @@ After the RC PR is merged and the user confirms execute, run **every** step belo
      gh issue comment <number> --body "Partially addressed in [vX.Y.Z]($RELEASE_URL): <what changed>. Remaining: <what's still open>."
      ```
    - Report which issues were closed and which were commented on.
-4. Move supplement: `mv docs/releases/in_progress/vX.Y.Z docs/releases/completed/vX.Y.Z` (if directory was created); the security review and probe report move with it.
-5. Report summary: version, GitHub Release URL, npm package URL (must reflect a successful **`npm publish`** when the release included npm), sandbox URL/version verification, the probe report verdict (passes / failures), issues closed, and CI workflow outcomes (all-pass / any-failure with run IDs).
+5. Move supplement: `mv docs/releases/in_progress/vX.Y.Z docs/releases/completed/vX.Y.Z` (if directory was created); the security review and probe report move with it.
+6. Report summary: version, GitHub Release URL, npm package URL (must reflect a successful **`npm publish`** when the release included npm), sandbox URL/version verification, the probe report verdict (passes / failures), advisories published (GHSA IDs and public URLs), issues closed, and CI workflow outcomes (all-pass / any-failure with run IDs).
 
 ## Submodule Mode
 
@@ -402,6 +432,7 @@ If the user says `/release foundation` (or another submodule name):
 - For a standard `/release`, **always** run **`npm publish`** after `gh release create --draft` unless the user explicitly confirmed GitHub-only / no registry.
 - For a standard `/release`, **always** deploy `sandbox.neotoma.io` with `flyctl deploy -c fly.sandbox.toml --remote-only` and verify the live sandbox version unless the user explicitly confirmed no sandbox.
 - For a standard `/release`, **always** run Step 3.5 (Security review lane) before Step 4 and Step 5 (Deployed probes) before declaring complete; the supplement MUST contain a `Security hardening` section linking `docs/releases/in_progress/<TAG>/security_review.md` (and `post_deploy_security_probes.md` after Step 5).
+- For a standard `/release`, **always** run Step 5.2 (Advisory publication) when the supplement's `Security hardening` section references any advisory file. Draft GHSAs MUST be published after the tag is live and before declaring the release complete. Never publish a GHSA before the fix tag exists.
 - For a standard `/release`, **always** verify that all GitHub Actions workflows triggered by the release push (`CI test lanes`, `Deploy site (GitHub Pages)`, and any tag-triggered workflows) reach `success` before declaring complete. A CI failure after push is a partial release — fix and re-verify.
 - If `docs/developer/github_release_process.md` exists, follow its template and render pipeline.
 
@@ -433,3 +464,5 @@ If the user says `/release foundation` (or another submodule name):
 - Skipping Step 3.5 (Security review lane) before Step 4 when `npm run security:classify-diff` reports the release diff as sensitive, or omitting the supplement's `Security hardening` section
 - Declaring a release complete without running Step 5 deployed probes (`bash scripts/security/deployed_probes.sh --tag vX.Y.Z`) and recording the report under `docs/releases/in_progress/vX.Y.Z/post_deploy_security_probes.md`
 - Declaring a release complete without verifying all release-triggered GitHub Actions workflows (`CI test lanes`, `Deploy site`, tag-triggered workflows) reached `success` via `gh run list` / `gh run watch`
+- Declaring a release complete when the supplement's `Security hardening` section references an advisory that is still in draft/private state — run Step 5.2 and confirm GHSA state is `published` first
+- Publishing a GHSA (Step 5.2) before the fix tag is pushed and live on `main` — GHSA publication must come after `git push origin vX.Y.Z` in Step 4.6

--- a/.cursor/skills/release/SKILL.md
+++ b/.cursor/skills/release/SKILL.md
@@ -321,7 +321,37 @@ After the RC PR is merged and the user confirms execute, run **every** step belo
    ```
    The probe writes `docs/releases/in_progress/vX.Y.Z/post_deploy_security_probes.md` and exits non-zero on any unexpected status. A failure here BLOCKS release completion: open an advisory under `docs/security/advisories/`, hotfix the regression, and re-run before declaring done.
 
-2. **Verify GitHub Actions workflows triggered by the release push:**
+2. **Publish any draft security advisories linked from this release (mandatory when `Security hardening` section is non-trivial):**
+
+   After the tag is live and before declaring the release complete, check whether any advisory referenced in the supplement's `Security hardening` section is still in draft/private state.
+
+   a. **Scan the supplement for advisory links:**
+      ```bash
+      grep -oE 'docs/security/advisories/[^ )]+\.md' docs/releases/in_progress/vX.Y.Z/github_release_supplement.md
+      ```
+
+   b. **For each linked advisory file, check its status field:**
+      ```bash
+      head -20 docs/security/advisories/<slug>.md | grep -i status
+      ```
+      If status is `draft` or `private`, it must be published now.
+
+   c. **Run `/advisory close <slug> vX.Y.Z`** for each unpublished advisory. This skill will:
+      - Update the advisory doc status to `disclosed`
+      - Record the fix version
+      - Publish the corresponding GitHub Security Advisory (GHSA) via `gh api`
+
+   d. **Verify the GHSA is public** after publication:
+      ```bash
+      gh api repos/markmhendrickson/neotoma/security-advisories --jq '.[] | select(.ghsa_id == "<GHSA-ID>") | {state, published_at}'
+      ```
+      State must be `published`. If the GHSA publish step fails (auth, scope), STOP and surface the exact error — do not declare the release complete with a draft GHSA.
+
+   **Why this step is here and not in Step 3.5:** The GHSA should only go public after the fix is actually tagged and shipped. Publishing before the tag leaks attack vector details before users can protect themselves. The advisory doc is written during Step 3.5; the GHSA is published here.
+
+   **Skip this step** only when the supplement's `Security hardening` section reads `No security-sensitive surfaces touched.`
+
+3. **Verify GitHub Actions workflows triggered by the release push:**
 
    The `git push origin main` and `git push origin vX.Y.Z` in Step 4.5 trigger CI and deployment workflows. All must succeed before declaring the release complete.
 
@@ -359,7 +389,7 @@ After the RC PR is merged and the user confirms execute, run **every** step belo
 
    e. **Record the outcome** in the release summary (step 4 of this section).
 
-3. **Close resolved GitHub issues:**
+4. **Close resolved GitHub issues:**
    - Fetch the release URL created in Step 4.8:
      ```bash
      RELEASE_URL=$(gh release view vX.Y.Z --json url --jq .url)
@@ -378,8 +408,8 @@ After the RC PR is merged and the user confirms execute, run **every** step belo
      gh issue comment <number> --body "Partially addressed in [vX.Y.Z]($RELEASE_URL): <what changed>. Remaining: <what's still open>."
      ```
    - Report which issues were closed and which were commented on.
-4. Move supplement: `mv docs/releases/in_progress/vX.Y.Z docs/releases/completed/vX.Y.Z` (if directory was created); the security review and probe report move with it.
-5. Report summary: version, GitHub Release URL, npm package URL (must reflect a successful **`npm publish`** when the release included npm), sandbox URL/version verification, the probe report verdict (passes / failures), issues closed, and CI workflow outcomes (all-pass / any-failure with run IDs).
+5. Move supplement: `mv docs/releases/in_progress/vX.Y.Z docs/releases/completed/vX.Y.Z` (if directory was created); the security review and probe report move with it.
+6. Report summary: version, GitHub Release URL, npm package URL (must reflect a successful **`npm publish`** when the release included npm), sandbox URL/version verification, the probe report verdict (passes / failures), advisories published (GHSA IDs and public URLs), issues closed, and CI workflow outcomes (all-pass / any-failure with run IDs).
 
 ## Submodule Mode
 
@@ -402,6 +432,7 @@ If the user says `/release foundation` (or another submodule name):
 - For a standard `/release`, **always** run **`npm publish`** after `gh release create --draft` unless the user explicitly confirmed GitHub-only / no registry.
 - For a standard `/release`, **always** deploy `sandbox.neotoma.io` with `flyctl deploy -c fly.sandbox.toml --remote-only` and verify the live sandbox version unless the user explicitly confirmed no sandbox.
 - For a standard `/release`, **always** run Step 3.5 (Security review lane) before Step 4 and Step 5 (Deployed probes) before declaring complete; the supplement MUST contain a `Security hardening` section linking `docs/releases/in_progress/<TAG>/security_review.md` (and `post_deploy_security_probes.md` after Step 5).
+- For a standard `/release`, **always** run Step 5.2 (Advisory publication) when the supplement's `Security hardening` section references any advisory file. Draft GHSAs MUST be published after the tag is live and before declaring the release complete. Never publish a GHSA before the fix tag exists.
 - For a standard `/release`, **always** verify that all GitHub Actions workflows triggered by the release push (`CI test lanes`, `Deploy site (GitHub Pages)`, and any tag-triggered workflows) reach `success` before declaring complete. A CI failure after push is a partial release — fix and re-verify.
 - If `docs/developer/github_release_process.md` exists, follow its template and render pipeline.
 
@@ -433,3 +464,5 @@ If the user says `/release foundation` (or another submodule name):
 - Skipping Step 3.5 (Security review lane) before Step 4 when `npm run security:classify-diff` reports the release diff as sensitive, or omitting the supplement's `Security hardening` section
 - Declaring a release complete without running Step 5 deployed probes (`bash scripts/security/deployed_probes.sh --tag vX.Y.Z`) and recording the report under `docs/releases/in_progress/vX.Y.Z/post_deploy_security_probes.md`
 - Declaring a release complete without verifying all release-triggered GitHub Actions workflows (`CI test lanes`, `Deploy site`, tag-triggered workflows) reached `success` via `gh run list` / `gh run watch`
+- Declaring a release complete when the supplement's `Security hardening` section references an advisory that is still in draft/private state — run Step 5.2 and confirm GHSA state is `published` first
+- Publishing a GHSA (Step 5.2) before the fix tag is pushed and live on `main` — GHSA publication must come after `git push origin vX.Y.Z` in Step 4.6


### PR DESCRIPTION
## Summary

- Adds **Step 5.2** to the `/release` skill: after the fix tag is live, scan the supplement's `Security hardening` section for linked advisory files, check their status, run `/advisory close <slug> vX.Y.Z` for any that are still draft/private, and verify the GHSA is `published` before proceeding
- Adds a matching **Constraint** and two **Forbidden Patterns** entries
- Syncs `.claude/skills/release/SKILL.md` ↔ `.cursor/skills/release/SKILL.md`

## Motivation

Previously the advisory lifecycle was entirely manual — nothing in the release flow reminded the agent to publish the GHSA. The v0.14.0 release exposed this gap: GHSA-wrr4-782v-jhwh was left in draft after the tag shipped and had to be published separately. This step makes advisory publication a hard gate that runs automatically when the supplement has a non-trivial `Security hardening` section.

The step is intentionally placed **after** `git push origin vX.Y.Z` and **before** issue-closing — GHSA goes public only after users can protect themselves by upgrading.

## Test plan

- [ ] Verify the skill renders correctly in Claude Code (`/release` trigger)
- [ ] Confirm the step is skipped when `Security hardening` reads `No security-sensitive surfaces touched.`
- [ ] Confirm the step runs and blocks when a draft advisory is present at release time

🤖 Generated with [Claude Code](https://claude.com/claude-code)