### PR TITLE
fix(plans): close #325 (plan body description) + #262 (mirror heading strip)

### DIFF
--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,15 +61,15 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **395**
-- Backend and repo Vitest files: **362**
+- Total automated test files: **397**
+- Backend and repo Vitest files: **364**
 - Frontend Vitest files: **9**
 - Playwright spec files: **24**
 
 ### Suite counts
 | Suite | Files |
 |---|---:|
-| Vitest unit tests | 96 |
+| Vitest unit tests | 98 |
 | Vitest service tests | 33 |
 | Source-adjacent tests | 46 |
 | Vitest integration tests | 108 |
@@ -107,7 +107,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/unit`
 **Requirements:** Basic `.env` if required by the module under test.
-**Files (96):**
+**Files (98):**
 - `tests/unit/aauth_admission.test.ts`
 - `tests/unit/aauth_attestation_apple_se.test.ts`
 - `tests/unit/aauth_attestation_revocation.test.ts`
@@ -130,6 +130,7 @@ flowchart TD
 - `tests/unit/attribution_policy.test.ts`
 - `tests/unit/bigint_serialization.test.ts`
 - `tests/unit/bundled_docs_nav.test.ts`
+- `tests/unit/canonical_markdown_body_heading.test.ts`
 - `tests/unit/cli_aauth_tbs_attestation.test.ts`
 - `tests/unit/cli_aauth_tpm2_attestation.test.ts`
 - `tests/unit/cli_aauth_yubikey_attestation.test.ts`
@@ -179,6 +180,7 @@ flowchart TD
 - `tests/unit/observation_reducer_provenance.test.ts`
 - `tests/unit/opencode_plugin.test.ts`
 - `tests/unit/parquet_reader.test.ts`
+- `tests/unit/plan_schema_body_field.test.ts`
 - `tests/unit/product_feedback_schema.test.ts`
 - `tests/unit/protected_entity_types.test.ts`
 - `tests/unit/relationship_batch_schemas.test.ts`

--- a/src/services/canonical_markdown.ts
+++ b/src/services/canonical_markdown.ts
@@ -643,7 +643,11 @@ export function renderProfileEntity(
   parts.push(fmLines.join("\n"));
 
   if (hasContent) {
-    parts.push(contentValue as string);
+    // Strip a spurious leading `## body` / `# body` heading that some harnesses
+    // emit when they serialise the plan body as markdown (e.g. "## body\n\n## Problem\n…").
+    // The heading is redundant: the mirror already knows which field is the body.
+    const strippedContent = (contentValue as string).replace(/^##?\s+body\s*\n+/i, "");
+    parts.push(strippedContent);
   } else {
     // No body — fall back: render all snapshot fields (except those already in frontmatter) as ## sections
     const bodyFields = Object.keys(snapshot).filter(

--- a/src/services/plans/seed_schema.ts
+++ b/src/services/plans/seed_schema.ts
@@ -83,7 +83,13 @@ const PLAN_FIELDS: FieldSpec = [
   {
     name: "body",
     type: "string",
-    description: "Full markdown body of the plan; preserves harness-authored content verbatim",
+    description:
+      "Primary long-form content field. Store the full plan markdown, spec, or prose here. " +
+      "Do not split content across `overview` or `goals` — those are for short summaries and " +
+      "structured sub-items only. This field is rendered as the document body in the markdown mirror. " +
+      "Note: a leading `# body` or `## body` heading is stripped from the mirror output (some harnesses " +
+      "emit it as part of serialization). `### body` and deeper headings pass through unchanged. " +
+      "If you intentionally want a top-level `## body` heading in your plan, use a different wording.",
   },
   {
     name: "public_overview",

--- a/tests/unit/canonical_markdown_body_heading.test.ts
+++ b/tests/unit/canonical_markdown_body_heading.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Regression tests for issue #262: mirror profile renderer emits spurious
+ * `## body` section heading when the harness stores plan body content that
+ * literally begins with "## body\n\n".
+ */
+import { describe, expect, it } from "vitest";
+import { renderProfileEntity } from "../../src/services/canonical_markdown.js";
+
+const BASE_META = {
+  entity_id: "ent_abc123",
+  entity_type: "plan",
+  schema_version: "1.0",
+};
+
+describe("renderProfileEntity — body heading stripping (issue #262)", () => {
+  it("strips leading '## body' heading from body content", () => {
+    const snapshot = {
+      title: "My Plan",
+      body: "## body\n\n## Problem\n\nThe widget is broken.\n",
+    };
+    const result = renderProfileEntity(snapshot, BASE_META, {
+      render_mode: "frontmatter_content",
+      content_field: "body",
+    });
+    expect(result).not.toContain("## body");
+    expect(result).toContain("## Problem");
+    expect(result).toContain("The widget is broken.");
+  });
+
+  it("strips leading '# body' heading (single hash) from body content", () => {
+    const snapshot = {
+      title: "My Plan",
+      body: "# body\n\n## Solution\n\nReplace the widget.\n",
+    };
+    const result = renderProfileEntity(snapshot, BASE_META, {
+      render_mode: "frontmatter_content",
+      content_field: "body",
+    });
+    expect(result).not.toMatch(/^# body/m);
+    expect(result).toContain("## Solution");
+  });
+
+  it("strips case-insensitively (## Body)", () => {
+    const snapshot = {
+      body: "## Body\n\n## Goals\n\nShip it.\n",
+    };
+    const result = renderProfileEntity(snapshot, BASE_META, {
+      render_mode: "frontmatter_content",
+      content_field: "body",
+    });
+    expect(result).not.toContain("## Body");
+    expect(result).toContain("## Goals");
+  });
+
+  it("does not strip an embedded '## body' that is not at the start", () => {
+    const snapshot = {
+      body: "## Overview\n\n## body\n\nSome content.\n",
+    };
+    const result = renderProfileEntity(snapshot, BASE_META, {
+      render_mode: "frontmatter_content",
+      content_field: "body",
+    });
+    // First heading is ## Overview, not ## body — the embedded one stays
+    expect(result).toContain("## Overview");
+    expect(result).toContain("## body");
+  });
+
+  it("preserves body content that does not start with '## body'", () => {
+    const snapshot = {
+      body: "## Problem\n\nSomething is wrong.\n",
+    };
+    const result = renderProfileEntity(snapshot, BASE_META, {
+      render_mode: "frontmatter_content",
+      content_field: "body",
+    });
+    expect(result).toContain("## Problem");
+    expect(result).not.toMatch(/## body/i);
+  });
+
+  it("does NOT strip '### body' (three or more hashes) — only matches `#` and `##`", () => {
+    // The strip regex is `^##?\s+body\s*\n+` so `###` and deeper headings pass through.
+    // Locks the boundary so a future regex change doesn't accidentally widen the strip.
+    const snapshot = {
+      body: "### body\n\n## Content\n\nKept.\n",
+    };
+    const result = renderProfileEntity(snapshot, BASE_META, {
+      render_mode: "frontmatter_content",
+      content_field: "body",
+    });
+    expect(result).toContain("### body");
+    expect(result).toContain("## Content");
+    expect(result).toContain("Kept.");
+  });
+
+  it("does NOT strip '## body' when there is no trailing newline (regex requires `\\n+`)", () => {
+    // The strip regex requires at least one trailing newline (`\n+`). If the
+    // entire content is literally "## body" with no body following it, the
+    // regex does not match and the heading is preserved. Locks this behavior
+    // so a future regex tweak doesn't introduce an "empty plan" lossy strip.
+    const snapshot = {
+      body: "## body",
+    };
+    const result = renderProfileEntity(snapshot, BASE_META, {
+      render_mode: "frontmatter_content",
+      content_field: "body",
+    });
+    expect(result).toContain("## body");
+  });
+
+  it("handles content_only render_mode without stripping (stripping only needed in frontmatter_content)", () => {
+    // content_only mode has a separate code path; stripping is not applied there
+    // (the heading would still be rendered, but that mode is used for raw export
+    // not the mirror renderer that triggered issue #262).
+    const snapshot = {
+      body: "## body\n\nRaw content.\n",
+    };
+    const result = renderProfileEntity(snapshot, BASE_META, {
+      render_mode: "content_only",
+      content_field: "body",
+    });
+    // content_only returns the raw value — no stripping in that path
+    expect(result).toContain("## body");
+    expect(result).toContain("Raw content.");
+  });
+});

--- a/tests/unit/plan_schema_body_field.test.ts
+++ b/tests/unit/plan_schema_body_field.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Regression test for issue #325: plan `body` field description was
+ * insufficient, causing agents to store content in `overview`/`goals`
+ * instead of `body`.
+ *
+ * Verifies that the body field description in PLAN_FIELD_SPECS explicitly:
+ * - calls `body` the primary long-form content field
+ * - warns against splitting content into `overview` or `goals`
+ * - mentions that the field is rendered as the document body in the mirror
+ */
+import { describe, expect, it } from "vitest";
+import { PLAN_FIELD_SPECS } from "../../src/services/plans/seed_schema.js";
+
+describe("plan seed schema — body field description (issue #325)", () => {
+  it("declares body as the primary long-form content field", () => {
+    const bodySpec = PLAN_FIELD_SPECS.find((f) => f.name === "body");
+    expect(bodySpec).toBeDefined();
+    expect(bodySpec!.description).toMatch(/primary/i);
+    expect(bodySpec!.description).toMatch(/long.form content/i);
+  });
+
+  it("warns against splitting content into overview or goals", () => {
+    const bodySpec = PLAN_FIELD_SPECS.find((f) => f.name === "body")!;
+    expect(bodySpec.description).toMatch(/overview/);
+    expect(bodySpec.description).toMatch(/goals/);
+    expect(bodySpec.description).toMatch(/do not split/i);
+  });
+
+  it("mentions the markdown mirror rendering", () => {
+    const bodySpec = PLAN_FIELD_SPECS.find((f) => f.name === "body")!;
+    expect(bodySpec.description).toMatch(/mirror/i);
+  });
+});


### PR DESCRIPTION
Closes #325 and #262. Splits the trivially-correct parts out of [PR #335](https://github.com/markmhendrickson/neotoma/pull/335) so they can ship in v0.14.0 without depending on the contested #326 unknown-fields tracking work (which has unresolved review blockers).

## What's in this PR

### #325 — Plan `body` field description

Rewrites \`src/services/plans/seed_schema.ts\` \`body\` field description to:
- Explicit that it is the primary long-form content field.
- Content must not be split across \`overview\` or \`goals\` — those are for short summaries / structured sub-items only.
- Documents the \`## body\` heading-strip behavior (so agents are not surprised).

### #262 — Mirror \`## body\` heading strip

In \`renderProfileEntity\` (\`src/services/canonical_markdown.ts\`), strip a leading \`## body\` / \`# body\` heading from the rendered body when using \`frontmatter_content\` render mode. Some harnesses (notably Claude Code) serialize the plan body with a literal \`## body\\n\\n\` prefix, which produces a redundant heading in the markdown mirror.

The strip is intentionally bounded per the #335 review feedback:
- only matches \`#\` or \`##\` (\`###\` and deeper pass through unchanged)
- only at the start of content
- requires trailing newline(s) (so the entire-content-is-just-\`## body\` case preserves the heading)

## Tests

- \`tests/unit/canonical_markdown_body_heading.test.ts\` — 8 tests including 2 boundary cases per #335 review: \`### body\` not stripped, \`## body\` with no trailing newline not stripped.
- \`tests/unit/plan_schema_body_field.test.ts\` — 3 tests locking the description language.

## Not included

The #326 portion of PR #335 (HTTP API store path unknown_fields tracking) is intentionally NOT in this PR. That change has unresolved blockers from the [2026-05-21 review](https://github.com/markmhendrickson/neotoma/pull/335#issuecomment):

1. **Double-write bug**: \`createObservation\` is called with the full payload (including unknown keys) AND \`storeUnknownFields\` is called on the same keys — same data persists in two places, breaking the \"raw_fragments exclusively\" contract that the MCP path enforces.
2. **Identity-hoist stripping omitted**: \`name\`, \`full_name\`, \`title\`, \`email\`, \`url\`, \`canonical_name\` should be stripped from \`unknown_fields\` before counting, matching the MCP path's behavior.
3. **Schema registry loaded 2-3× per entity in hot loop**.

Those need real rework. Recommend closing PR #335 in favor of:
- This PR (#325 + #262)
- A separate focused PR for #326 that factors the validate/strip-identity-hoist/split-validFields-vs-unknowns sequence into a shared helper between MCP and HTTP paths.

## Verification

- [x] \`npm run type-check\` clean.
- [x] \`npm run format:check\` clean.
- [x] \`npx vitest run tests/unit/canonical_markdown_body_heading.test.ts tests/unit/plan_schema_body_field.test.ts\` — 11/11 pass.