### PR TITLE
fix(release-skill): require @claude review on release candidate PR

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -186,6 +186,18 @@ Run after Step 3.6 passes. Push an RC branch and open a PR so the release can be
    ```
    The PR body gives reviewers the exact same narrative they will see in the GitHub Release notes.
 
+2b. **Post `@claude review` on the release PR** immediately after opening it:
+   ```bash
+   gh pr comment <PR_NUMBER> --body "@claude review"
+   ```
+   The automated Opus review (`claude_pr_review.yml`) will run the full `/review` skill against the release diff and post findings as a `github-actions[bot]` comment. Wait for the review to complete, then check for Blocking findings:
+   ```bash
+   gh api repos/{owner}/{repo}/issues/<PR_NUMBER>/comments \
+     --jq '[.[] | select(.user.login == "github-actions[bot]" and (.body | length > 300))] | last | .body' \
+     | grep -E "Blocker|MUST|request changes|NEEDS-CHANGES" || echo "No blockers found"
+   ```
+   **Hard gate:** If the review verdict is `NEEDS-CHANGES` or any finding is labeled `Blocker` / `MUST`, resolve those findings before proceeding to Step 4. A review that returns only `ADVISORY` / `NIT` findings is not blocking.
+
 3. **Surface the PR URL** to the user and **STOP**:
 
    > "Release candidate PR for **vX.Y.Z** is open at `<PR_URL>`. Review, comment, and approve — then reply **`execute`** (or confirm merge) to continue with tagging, npm publish, and sandbox deployment."

--- a/.cursor/skills/release/SKILL.md
+++ b/.cursor/skills/release/SKILL.md
@@ -184,6 +184,18 @@ Run after Step 3.6 passes. Push an RC branch and open a PR so the release can be
    ```
    The PR body gives reviewers the exact same narrative they will see in the GitHub Release notes.
 
+2b. **Post `@claude review` on the release PR** immediately after opening it:
+   ```bash
+   gh pr comment <PR_NUMBER> --body "@claude review"
+   ```
+   The automated Opus review (`claude_pr_review.yml`) will run the full `/review` skill against the release diff and post findings as a `github-actions[bot]` comment. Wait for the review to complete, then check for Blocking findings:
+   ```bash
+   gh api repos/{owner}/{repo}/issues/<PR_NUMBER>/comments \
+     --jq '[.[] | select(.user.login == "github-actions[bot]" and (.body | length > 300))] | last | .body' \
+     | grep -E "Blocker|MUST|request changes|NEEDS-CHANGES" || echo "No blockers found"
+   ```
+   **Hard gate:** If the review verdict is `NEEDS-CHANGES` or any finding is labeled `Blocker` / `MUST`, resolve those findings before proceeding to Step 4. A review that returns only `ADVISORY` / `NIT` findings is not blocking.
+
 3. **Surface the PR URL** to the user and **STOP**:
 
    > "Release candidate PR for **vX.Y.Z** is open at `<PR_URL>`. Review, comment, and approve — then reply **`execute`** (or confirm merge) to continue with tagging, npm publish, and sandbox deployment."


### PR DESCRIPTION
## Problems

The `/release` skill (Step 3.7) opens an RC PR (`release/vX.Y.Z` → `main`) but never posts `@claude review` on it or gates on the verdict before proceeding to Step 4 (execute). This means a release PR could be merged without automated holistic review, even though `/process_prs` enforces exactly this gate on all other PRs.

Identified during v0.14.0 release preparation.

## Solutions

Add Step 3.7.2b to both `.claude/skills/release/SKILL.md` and `.cursor/skills/release/SKILL.md`:

- Immediately after `gh pr create`, post `@claude review` on the PR
- Wait for `github-actions[bot]` to post a substantive review comment
- Hard gate: `NEEDS-CHANGES` verdict or any `Blocker`/`MUST` finding blocks Step 4
- `ADVISORY`/`NIT`-only findings are non-blocking

## Documentation

Both skill files updated in sync per `agent_instructions_sync_rules`.

## Test plan

- [x] Type check passes
- [x] Lint passes (0 errors)
- [x] Skill-only change — no runtime code changed, no contract tests affected

## Breaking changes

No breaking changes.

## Related

Identified during v0.14.0 release PR preparation ([#390](https://github.com/markmhendrickson/neotoma/pull/390)).