### PR TITLE
Add docs link to header nav and fix mobile FAB visibility on marketing home

### DIFF
--- a/frontend/src/components/SiteHeaderNav.tsx
+++ b/frontend/src/components/SiteHeaderNav.tsx
@@ -314,6 +314,7 @@ function useMobileNavFabVisibility(
   }, [pathname, forceVisible]);
 
   if (forceVisible) return true;
+  if (marketingHomeChrome) return true;
 
   const blockedByHomeSection = introInView || evaluateInView;
   return fabShownByScroll && !blockedByHomeSection;
@@ -649,7 +650,7 @@ export function SiteHeaderNav(props: SiteHeaderNavProps) {
   const homeEvaluateScrollBannerVisible = useSiteHomeEvaluateScrollBannerVisible();
   const mobileNavFabVisible =
     mobileMenuOpen ||
-    (mobileNavFabBaseVisible && !homeEvaluateScrollBannerVisible);
+    (mobileNavFabBaseVisible && (isMarketingHomeChrome || !homeEvaluateScrollBannerVisible));
   const setAppNavBarVisible = useSiteAppNavBarVisibleSetter();
   useEffect(() => {
     setAppNavBarVisible(headerScrollVisible);

--- a/frontend/src/components/SiteHeaderNav.tsx
+++ b/frontend/src/components/SiteHeaderNav.tsx
@@ -772,6 +772,13 @@ export function SiteHeaderNav(props: SiteHeaderNavProps) {
         >
           {dict.architecture}
         </Link>
+        <Link
+          to={localizePath("/docs", locale)}
+          className="inline-flex rounded-md px-1.5 py-1.5 text-ui text-sidebar-foreground no-underline hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
+          onClick={() => sendCtaClick("header_docs")}
+        >
+          {dict.docs}
+        </Link>
       </nav>
 
       {/*

--- a/frontend/src/utils/analytics.ts
+++ b/frontend/src/utils/analytics.ts
@@ -200,6 +200,7 @@ export type CtaName =
   | "personal_data_case_study_install"
   | "header_evaluate"
   | "header_install"
+  | "header_docs"
   | "footer_install"
   | "docs_evaluate_getting_started"
   | "docs_install_getting_started"


### PR DESCRIPTION
## Summary

Adds a "Docs" link to the site header navigation and fixes mobile navigation FAB visibility on the marketing home page. The FAB now correctly displays when viewing the marketing home chrome, and a new docs navigation link is available in the header.

## Touchpoints

- [ ] HTTP endpoint / request / response field
- [ ] MCP tool definition or behavior
- [ ] CLI command, flag, or runtime override
- [ ] Error envelope / hint / validation tightening
- [ ] Auth / user-id resolution / proxy trust / local-dev shortcut
- [ ] Schema registry, entity type, or per-type behavior
- [ ] Ingestion / store / correction path
- [ ] Source / observation lifecycle (immutability)
- [ ] Reducer / merge / snapshot
- [ ] Relationships
- [ ] Timeline / events
- [ ] Release supplement or release tooling
- [ ] Logging, metrics, events, traces
- [ ] File / folder rename, npm script rename
- [x] None — pure docs / tests / internal refactor

## Changes

### Frontend Navigation (`SiteHeaderNav.tsx`)

1. **Mobile FAB visibility fix**: Updated `useMobileNavFabVisibility()` to return `true` when `marketingHomeChrome` is active, ensuring the floating action button displays on the marketing home page.

2. **Mobile nav FAB logic**: Modified the `mobileNavFabVisible` condition to show the FAB when either `isMarketingHomeChrome` is true OR the evaluate scroll banner is not visible, allowing proper navigation access on the marketing home.

3. **Docs navigation link**: Added a new "Docs" link to the header navigation menu with:
   - Proper localization support via `localizePath()`
   - Consistent styling with other nav links
   - CTA tracking via `sendCtaClick("header_docs")`
   - Accessibility and hover states

### Configuration (`settings.json`)

Removed absolute path from the `mirror:plans` npm script hook, making it portable across different development environments.

## Test Plan

- Verify the "Docs" link appears in the header navigation and navigates to the correct localized docs path
- Verify the mobile navigation FAB displays when viewing the marketing home page
- Verify the FAB visibility logic respects the existing scroll-based visibility rules on other pages
- Verify CTA tracking fires when clicking the docs link

## Notes for reviewer

The changes are isolated to frontend navigation UI and configuration. The mobile FAB visibility fix ensures consistent navigation access across all page types, particularly on the marketing home where it was previously hidden.

https://claude.ai/code/session_01FyN2FSxcLoPStTb3NLAEDt