### PR TITLE
Update mirror command in Claude settings to use new CLI

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,7 +8,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd /Users/markmhendrickson/repos/neotoma && npm run mirror:plans 2>&1 | tail -5"
+            "command": "npx neotoma mirror rebuild --profile neotoma-plans 2>&1 | tail -5"
           }
         ]
       }


### PR DESCRIPTION
## Summary

Updates the `.claude/settings.json` mirror hook to use the new `npx neotoma mirror rebuild` CLI command instead of the deprecated `npm run mirror:plans` npm script. This aligns the development environment configuration with the current CLI interface.

## Touchpoints

- [x] CLI command, flag, or runtime override
- [x] Release supplement or release tooling

## Pre-PR checklist

### API & contract

- [x] CLI command updated to reflect current `neotoma` CLI interface

### Release & process

- [x] Configuration change is non-breaking; existing workflow preserved with updated command syntax

## Test plan

No testing needed. This is a configuration update to the local development environment settings. The new command uses the same underlying mirror rebuild functionality with the `--profile neotoma-plans` flag, preserving the original behavior.

## Notes for reviewer

This change updates the development hook to use the current CLI command structure. The `npx neotoma mirror rebuild --profile neotoma-plans` command replaces the npm script with equivalent functionality and output filtering (`tail -5`).

https://claude.ai/code/session_01UkySJHBbZ6ZKSpfnK5b6tU