### PR TITLE
feat(schema): seed pull_request entity type (resolves #158)

### DIFF
--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,15 +61,15 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **398**
-- Backend and repo Vitest files: **365**
+- Total automated test files: **399**
+- Backend and repo Vitest files: **366**
 - Frontend Vitest files: **9**
 - Playwright spec files: **24**
 
 ### Suite counts
 | Suite | Files |
 |---|---:|
-| Vitest unit tests | 98 |
+| Vitest unit tests | 99 |
 | Vitest service tests | 33 |
 | Source-adjacent tests | 46 |
 | Vitest integration tests | 108 |
@@ -107,7 +107,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/unit`
 **Requirements:** Basic `.env` if required by the module under test.
-**Files (98):**
+**Files (99):**
 - `tests/unit/aauth_admission.test.ts`
 - `tests/unit/aauth_attestation_apple_se.test.ts`
 - `tests/unit/aauth_attestation_revocation.test.ts`
@@ -183,6 +183,7 @@ flowchart TD
 - `tests/unit/plan_schema_body_field.test.ts`
 - `tests/unit/product_feedback_schema.test.ts`
 - `tests/unit/protected_entity_types.test.ts`
+- `tests/unit/pull_request_schema.test.ts`
 - `tests/unit/relationship_batch_schemas.test.ts`
 - `tests/unit/relationship_reducer.test.ts`
 - `tests/unit/request_context.test.ts`

--- a/src/services/schema_definitions.ts
+++ b/src/services/schema_definitions.ts
@@ -3153,6 +3153,64 @@ export const ENTITY_SCHEMAS: Record<string, EntitySchema> = {
       },
     },
   },
+
+  pull_request: {
+    entity_type: "pull_request",
+    schema_version: "1.0",
+    metadata: {
+      label: "Pull Request",
+      description: "A GitHub pull request.",
+      category: "knowledge",
+      aliases: ["pr", "github_pr"],
+    },
+    schema_definition: {
+      fields: {
+        schema_version: { type: "string", required: true },
+        // GitHub PR number — primary identifier within a repo.
+        pr_number: { type: "number", required: true },
+        title: { type: "string", required: true, preserveCase: true },
+        // Current state: open | closed | merged | draft.
+        status: { type: "string", required: false },
+        // Target branch the PR merges into.
+        base_branch: { type: "string", required: false },
+        // Source branch the PR is merging from.
+        head_branch: { type: "string", required: false },
+        // Canonical URL for the PR on GitHub.
+        github_url: { type: "string", required: false },
+        // PR description body (markdown).
+        body: { type: "string", required: false, preserveCase: true },
+        // ISO timestamp when the PR was merged; null/absent when not merged.
+        merged_at: { type: "string", required: false },
+        // Repository slug in owner/repo format (e.g. "markmhendrickson/neotoma").
+        repo: { type: "string", required: false },
+        // GitHub login of the PR author.
+        author: { type: "string", required: false },
+      },
+      // A pull request is uniquely identified by its number within a repo.
+      // The composite [pr_number, repo] is the primary rule; title is a
+      // fallback for cases where only the title is supplied.
+      canonical_name_fields: [{ composite: ["pr_number", "repo"] }, "title"],
+      agent_instructions:
+        "A pull_request entity represents a single GitHub pull request. " +
+        "Use pr_number and repo together as the primary identifier. " +
+        "The status field should reflect the current state: open, closed, merged, or draft. " +
+        "Set merged_at to the ISO timestamp when the PR was merged.",
+    },
+    reducer_config: {
+      merge_policies: {
+        pr_number: { strategy: "last_write" },
+        title: { strategy: "highest_priority", tie_breaker: "source_priority" },
+        status: { strategy: "last_write" },
+        base_branch: { strategy: "last_write" },
+        head_branch: { strategy: "last_write" },
+        github_url: { strategy: "last_write" },
+        body: { strategy: "highest_priority", tie_breaker: "source_priority" },
+        merged_at: { strategy: "last_write" },
+        repo: { strategy: "last_write" },
+        author: { strategy: "last_write" },
+      },
+    },
+  },
 };
 
 /**

--- a/tests/unit/pull_request_schema.test.ts
+++ b/tests/unit/pull_request_schema.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Unit tests for pull_request entity schema registration (issue #158).
+ *
+ * Verifies that:
+ * - The `pull_request` schema is present in ENTITY_SCHEMAS after bootstrap
+ * - `canonical_name_fields` has a composite rule for ["pr_number", "repo"] and a "title" fallback
+ * - Required fields (pr_number, title) are declared as required
+ * - All expected fields are declared with correct types
+ * - reducer_config has merge policies covering all declared fields
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  ENTITY_SCHEMAS,
+  getRegisteredEntityTypes,
+  getSchemaDefinition,
+} from "../../src/services/schema_definitions.js";
+
+describe("pull_request schema (#158)", () => {
+  const schema = ENTITY_SCHEMAS["pull_request"];
+
+  it("is registered in ENTITY_SCHEMAS", () => {
+    expect(schema).toBeDefined();
+    expect(schema.entity_type).toBe("pull_request");
+  });
+
+  it("is retrievable via getSchemaDefinition", () => {
+    const result = getSchemaDefinition("pull_request");
+    expect(result).not.toBeNull();
+    expect(result?.entity_type).toBe("pull_request");
+  });
+
+  it("has pr_number declared as a required number field", () => {
+    const { fields } = schema.schema_definition;
+    expect(fields.pr_number).toBeDefined();
+    expect(fields.pr_number.type).toBe("number");
+    expect(fields.pr_number.required).toBe(true);
+  });
+
+  it("has title declared as a required string field", () => {
+    const { fields } = schema.schema_definition;
+    expect(fields.title).toBeDefined();
+    expect(fields.title.type).toBe("string");
+    expect(fields.title.required).toBe(true);
+  });
+
+  it("has all expected optional fields with correct types", () => {
+    const { fields } = schema.schema_definition;
+    expect(fields.status?.type).toBe("string");
+    expect(fields.base_branch?.type).toBe("string");
+    expect(fields.head_branch?.type).toBe("string");
+    expect(fields.github_url?.type).toBe("string");
+    expect(fields.body?.type).toBe("string");
+    expect(fields.merged_at?.type).toBe("string");
+    expect(fields.repo?.type).toBe("string");
+    expect(fields.author?.type).toBe("string");
+  });
+
+  it("canonical_name_fields includes a composite rule for [pr_number, repo]", () => {
+    const cnf = schema.schema_definition.canonical_name_fields;
+    expect(cnf).toBeDefined();
+    expect(Array.isArray(cnf)).toBe(true);
+    const rules = cnf as Array<string | { composite: string[] }>;
+    const hasComposite = rules.some(
+      (r) =>
+        typeof r === "object" &&
+        "composite" in r &&
+        r.composite.includes("pr_number") &&
+        r.composite.includes("repo"),
+    );
+    expect(hasComposite).toBe(true);
+  });
+
+  it("canonical_name_fields includes 'title' as a fallback rule", () => {
+    const cnf = schema.schema_definition.canonical_name_fields;
+    const rules = cnf as Array<string | { composite: string[] }>;
+    expect(rules.some((r) => r === "title")).toBe(true);
+  });
+
+  it("reducer_config has merge policies for all declared fields (no dangling policies)", () => {
+    const fields = schema.schema_definition.fields;
+    const policies = schema.reducer_config.merge_policies;
+    for (const key of Object.keys(policies)) {
+      expect(fields, `merge policy references undeclared field '${key}'`).toHaveProperty(key);
+    }
+  });
+
+  it("appears in list of registered entity types", () => {
+    const types: string[] = getRegisteredEntityTypes();
+    expect(types).toContain("pull_request");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `pull_request` schema with 10 fields: pr_number, title, status, base_branch, head_branch, github_url, body, merged_at, repo, author
- `canonical_name_fields`: composite [pr_number, repo] + title
- 9 unit tests, all passing

## Test plan
- [ ] `npm test` passes
- [ ] `pull_request` entity type visible in Neotoma

🤖 Generated with [Claude Code](https://claude.com/claude-code)