### PR TITLE
fix(mirror): content_field heading-skip in renderEntityMarkdown (resolves #262)

### DIFF
--- a/src/services/canonical_markdown.test.ts
+++ b/src/services/canonical_markdown.test.ts
@@ -140,6 +140,35 @@ describe("renderEntityMarkdown", () => {
     expect(md).not.toContain("## entity_type");
     expect(md).toContain("schema_version: 1.0"); // frontmatter is fine
   });
+
+  it("skips the ## heading for the content_field when opts.content_field is set (#262)", () => {
+    const entity: RenderEntityInput = {
+      ...BASE_ENTITY,
+      snapshot: {
+        title: "My Note",
+        body: "This is the body content.",
+        tags: ["a", "b"],
+      },
+    };
+    const md = renderEntityMarkdown(entity, ["title", "body", "tags"], {
+      content_field: "body",
+    });
+    // The body value is rendered without a ## body heading
+    expect(md).not.toContain("## body");
+    expect(md).toContain("This is the body content.");
+    // Other fields still get their headings
+    expect(md).toContain("## title");
+    expect(md).toContain("## tags");
+  });
+
+  it("still emits the content_field heading when opts.content_field is not set", () => {
+    const entity: RenderEntityInput = {
+      ...BASE_ENTITY,
+      snapshot: { title: "My Note", body: "Body text." },
+    };
+    const md = renderEntityMarkdown(entity, ["title", "body"], {});
+    expect(md).toContain("## body");
+  });
 });
 
 describe("renderEntityCompactText", () => {

--- a/src/services/canonical_markdown.ts
+++ b/src/services/canonical_markdown.ts
@@ -120,6 +120,13 @@ export interface RenderOpts {
    * do not blow a MEMORY.md line budget.
    */
   maxFieldChars?: number;
+  /**
+   * When set, the named snapshot field is treated as the document body.
+   * Its value is rendered directly (without a `## <field>` heading prefix).
+   * Mirrors the `content_field` option in ProfileRenderOpts for use in
+   * "entity" render mode profiles that still want heading-skip behaviour.
+   */
+  content_field?: string;
 }
 
 // ============================================================================
@@ -290,8 +297,13 @@ export function renderEntityMarkdown(
   for (const key of orderedKeys) {
     const value = snapshot[key];
     if (value === undefined) continue;
-    parts.push(`## ${key}`);
-    parts.push(formatFieldValueMarkdown(value));
+    if (opts.content_field && key === opts.content_field) {
+      // Render the content field directly without a ## heading prefix.
+      parts.push(formatFieldValueMarkdown(value));
+    } else {
+      parts.push(`## ${key}`);
+      parts.push(formatFieldValueMarkdown(value));
+    }
   }
 
   if (opts.includeProvenance && entity.provenance && Object.keys(entity.provenance).length > 0) {

--- a/src/services/canonical_mirror.ts
+++ b/src/services/canonical_mirror.ts
@@ -661,6 +661,7 @@ export async function mirrorEntity(entity: MirrorEntityRow, cfg?: MirrorConfig):
         };
         profileRendered = renderEntityMarkdown(profileInput, schemaFieldOrder, {
           includeProvenance: false,
+          content_field: profile.content_field,
         });
       }
       const profilePath = profileEntityFilePath(
@@ -1456,7 +1457,7 @@ async function rebuildProfile(
           provenance: undefined,
         },
         schemaFieldOrder,
-        { includeProvenance: false }
+        { includeProvenance: false, content_field: profile.content_field }
       );
     }
 


### PR DESCRIPTION
## Summary
- Adds `content_field` to `RenderOpts`
- `renderEntityMarkdown` skips the `## <field>` heading prefix when key matches `content_field`
- Wired through both `renderEntityMarkdown` call sites in `canonical_mirror.ts`
- Includes 2 unit tests

## Test plan
- [ ] Entity with `content_field` renders body without duplicate heading
- [ ] Existing mirror snapshots unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)