### PR TITLE
fix(issues): retry submit_issue as unsigned guest on AUTH_REQUIRED

### DIFF
--- a/src/services/issues/neotoma_client.test.ts
+++ b/src/services/issues/neotoma_client.test.ts
@@ -114,6 +114,67 @@ describe("Neotoma Issue Client", () => {
       expect(String(request.body.local_issue_id)).toMatch(/^local:test\/repo:/);
     });
 
+    it("retries unsigned when the signed submission returns AUTH_REQUIRED", async () => {
+      const signedPost = vi.fn().mockResolvedValueOnce({
+        error: { error_code: "AUTH_REQUIRED", message: "agent grant missing" },
+      });
+      const unsignedPost = vi.fn().mockResolvedValueOnce({
+        data: {
+          entity_ids: ["issue-entity-2", "conversation-entity-2"],
+          issue_entity_id: "issue-entity-2",
+          conversation_id: "conversation-entity-2",
+          guest_access_token: "guest-token-after-retry",
+        },
+      });
+      vi.mocked(createApiClient)
+        .mockReturnValueOnce({
+          POST: signedPost,
+          GET: vi.fn(),
+        } as unknown as ReturnType<typeof createApiClient>)
+        .mockReturnValueOnce({
+          POST: unsignedPost,
+          GET: vi.fn(),
+        } as unknown as ReturnType<typeof createApiClient>);
+
+      const result = await submitIssueToRemote({
+        title: "Issue",
+        body: "Body",
+        visibility: "public",
+      });
+
+      expect(result.issue_entity_id).toBe("issue-entity-2");
+      expect(result.access_token).toBe("guest-token-after-retry");
+      expect(signedPost).toHaveBeenCalledTimes(1);
+      expect(unsignedPost).toHaveBeenCalledTimes(1);
+      expect(createApiClient).toHaveBeenNthCalledWith(2, {
+        baseUrl: "https://neotoma.example.com",
+        signWithCliAAuth: false,
+      });
+    });
+
+    it("surfaces AUTH_REQUIRED when both signed and unsigned attempts fail", async () => {
+      const signedPost = vi.fn().mockResolvedValueOnce({
+        error: { error_code: "AUTH_REQUIRED", message: "agent grant missing" },
+      });
+      const unsignedPost = vi.fn().mockResolvedValueOnce({
+        error: { error_code: "AUTH_REQUIRED", message: "guest path disabled" },
+      });
+      vi.mocked(createApiClient)
+        .mockReturnValueOnce({
+          POST: signedPost,
+          GET: vi.fn(),
+        } as unknown as ReturnType<typeof createApiClient>)
+        .mockReturnValueOnce({
+          POST: unsignedPost,
+          GET: vi.fn(),
+        } as unknown as ReturnType<typeof createApiClient>);
+
+      await expect(
+        submitIssueToRemote({ title: "Issue", body: "Body", visibility: "public" })
+      ).rejects.toThrow(/AUTH_REQUIRED/);
+      expect(unsignedPost).toHaveBeenCalledTimes(1);
+    });
+
     it("returns guest token from the guest issue submit endpoint", async () => {
       const post = vi.fn().mockResolvedValueOnce({
         data: {

--- a/src/services/issues/neotoma_client.ts
+++ b/src/services/issues/neotoma_client.ts
@@ -78,7 +78,8 @@ export async function submitIssueToRemote(params: {
     );
   }
 
-  const client = createRemoteClient(config.target_url.trim());
+  const targetUrl = config.target_url.trim();
+  const client = createRemoteClient(targetUrl);
   const now =
     typeof params.submission_timestamp === "string" && params.submission_timestamp.trim().length > 0
       ? params.submission_timestamp.trim()
@@ -112,9 +113,7 @@ export async function submitIssueToRemote(params: {
     guestBody.local_issue_id = localId;
   }
 
-  const { data, error } = (await client.POST("/issues/submit" as any, {
-    body: guestBody,
-  })) as {
+  type SubmitResponse = {
     data?: {
       entity_ids?: string[];
       issue_entity_id?: string;
@@ -124,10 +123,38 @@ export async function submitIssueToRemote(params: {
     error?: unknown;
   };
 
+  let { data, error } = (await client.POST("/issues/submit" as any, {
+    body: guestBody,
+  })) as SubmitResponse;
+
   if (error) {
-    // Surface the actionable hint when the remote returns AUTH_REQUIRED so the
-    // agent (and user) know exactly what step to take instead of seeing a raw
-    // JSON blob. (closes #183, #206)
+    // The remote `/issues/submit` handler accepts unsigned guest submissions for
+    // payloads carrying `local_issue_id` or `submission_timestamp` (both
+    // present here). When AAuth signing produces a signature the remote cannot
+    // verify (e.g. no agent grant), retry once as an unsigned guest before
+    // surfacing AUTH_REQUIRED. (closes #936)
+    const errObj = error && typeof error === "object" ? (error as Record<string, unknown>) : null;
+    if (errObj?.["error_code"] === "AUTH_REQUIRED") {
+      const signingDisabled = process.env.NEOTOMA_CLI_AAUTH_DISABLE === "1";
+      if (!signingDisabled) {
+        const unsignedClient = createApiClient({
+          baseUrl: targetUrl,
+          signWithCliAAuth: false,
+        });
+        const retry = (await unsignedClient.POST("/issues/submit" as any, {
+          body: guestBody,
+        })) as SubmitResponse;
+        if (!retry.error) {
+          data = retry.data;
+          error = undefined;
+        } else {
+          error = retry.error;
+        }
+      }
+    }
+  }
+
+  if (error) {
     const errObj = error && typeof error === "object" ? (error as Record<string, unknown>) : null;
     if (errObj?.["error_code"] === "AUTH_REQUIRED") {
       const hint =


### PR DESCRIPTION
## Summary

- Closes #936
- When `submitIssueToRemote` receives `AUTH_REQUIRED` from the AAuth-signed POST to `/issues/submit`, retry once with an unsigned client so the remote's guest path can accept the submission.
- Guest fallback is safe here: the payload already carries `submission_timestamp` (and `local_issue_id` for non-GitHub-backed issues), which the remote handler routes to `submitGuestIssue` via `resolveRoutePrincipal(req, [\"user\", \"guest\"])`. The retry is skipped when `NEOTOMA_CLI_AAUTH_DISABLE=1` (signed call already unsigned).

## Test plan

- [x] `npx vitest run src/services/issues/neotoma_client.test.ts` — 12/12 pass, including two new cases: AUTH_REQUIRED retry succeeds; AUTH_REQUIRED retry also fails surfaces the hint
- [x] `npm run type-check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)