### PR TITLE
fix(entity-submission): fail loud on empty entity_id from submitEntity

### DIFF
--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,8 +61,8 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **414**
-- Backend and repo Vitest files: **381**
+- Total automated test files: **415**
+- Backend and repo Vitest files: **382**
 - Frontend Vitest files: **9**
 - Playwright spec files: **24**
 
@@ -71,7 +71,7 @@ flowchart TD
 |---|---:|
 | Vitest unit tests | 102 |
 | Vitest service tests | 33 |
-| Source-adjacent tests | 47 |
+| Source-adjacent tests | 48 |
 | Vitest integration tests | 113 |
 | Vitest CLI tests | 60 |
 | Vitest contract tests | 12 |
@@ -257,7 +257,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- src`
 **Requirements:** Basic `.env` if required by the module under test.
-**Files (47):**
+**Files (48):**
 - `src/cli/parse_cli_corrected_value.test.ts`
 - `src/crypto/crypto.test.ts`
 - `src/record_types.test.ts`
@@ -285,6 +285,7 @@ flowchart TD
 - `src/services/docs/markdown_render.test.ts`
 - `src/services/docs/render.test.ts`
 - `src/services/docs/visibility.test.ts`
+- `src/services/entity_submission/submission_service.test.ts`
 - `src/services/guest_access_token.test.ts`
 - `src/services/issues/body_newline_decode.test.ts`
 - `src/services/issues/issue_operations.test.ts`

--- a/src/services/entity_submission/submission_service.test.ts
+++ b/src/services/entity_submission/submission_service.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import type { Operations } from "../../core/operations.js";
+
+const { mockGetSubmissionConfigForTargetType } = vi.hoisted(() => ({
+  mockGetSubmissionConfigForTargetType: vi.fn(),
+}));
+
+const { mockStoreRootWithThread } = vi.hoisted(() => ({
+  mockStoreRootWithThread: vi.fn(),
+}));
+
+vi.mock("./submission_config_loader.js", () => ({
+  getSubmissionConfigForTargetType: (...args: unknown[]) =>
+    mockGetSubmissionConfigForTargetType(...args),
+}));
+
+vi.mock("../submitted_thread/submitted_thread.js", () => ({
+  storeRootWithThread: (...args: unknown[]) => mockStoreRootWithThread(...args),
+  appendMessageToConversation: vi.fn(),
+  bootstrapConversationThreadForRoot: vi.fn(),
+  mintGuestReadBackToken: vi.fn(),
+  resolveConversationForRoot: vi.fn(),
+}));
+
+vi.mock("../access_policy.js", () => ({
+  assertGuestWriteAllowed: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../request_context.js", () => ({
+  getCurrentExternalActor: () => null,
+  runWithExternalActor: <T>(_actor: unknown, fn: () => T) => fn(),
+}));
+
+import { submitEntity } from "./submission_service.js";
+
+const configWithoutThreading = {
+  entity_id: "ent_cfg",
+  config_key: "issue",
+  target_entity_type: "issue",
+  access_policy: "open" as const,
+  active: true,
+  enable_conversation_threading: false,
+  enable_guest_read_back: false,
+  external_mirrors: [],
+};
+
+const ops = {
+  store: vi.fn(),
+} as unknown as Operations;
+
+describe("submitEntity write-integrity", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSubmissionConfigForTargetType.mockResolvedValue(configWithoutThreading);
+  });
+
+  it("fails loud when the store produces no primary entity (empty entity_id)", async () => {
+    // Reproduces the silent no-op: store returns no structured entities, so the
+    // primary entity_id would be "". This must throw, not return success.
+    mockStoreRootWithThread.mockResolvedValue({ structured: { entities: [] } });
+
+    await expect(
+      submitEntity(ops, {
+        userId: "user-1",
+        entity_type: "issue",
+        fields: { title: "t", body: "b" },
+      })
+    ).rejects.toThrow(/write-integrity failure/);
+  });
+
+  it("returns the entity_id when the store produces a primary entity", async () => {
+    mockStoreRootWithThread.mockResolvedValue({
+      structured: { entities: [{ entity_id: "ent_real" }] },
+    });
+
+    const result = await submitEntity(ops, {
+      userId: "user-1",
+      entity_type: "issue",
+      fields: { title: "t", body: "b" },
+    });
+
+    expect(result.entity_id).toBe("ent_real");
+  });
+
+  it("throws explicitly when no submission_config exists for the type", async () => {
+    mockGetSubmissionConfigForTargetType.mockResolvedValue(null);
+
+    await expect(
+      submitEntity(ops, {
+        userId: "user-1",
+        entity_type: "issue",
+        fields: { title: "t", body: "b" },
+      })
+    ).rejects.toThrow(/No active submission_config/);
+  });
+});

--- a/src/services/entity_submission/submission_service.ts
+++ b/src/services/entity_submission/submission_service.ts
@@ -115,6 +115,19 @@ export async function submitEntity(
 
   const structured = storeResult.structured?.entities ?? [];
   const entity_id = structured[0]?.entity_id ?? "";
+  // Write-integrity: an empty entity_id means the underlying store produced no
+  // primary entity. Returning it as a success is a silent write loss — the
+  // caller believes its entity was created when nothing persisted. Fail loud
+  // so the caller can recover instead of moving on against a phantom record.
+  if (!entity_id) {
+    throw new Error(
+      `submit_entity for entity_type "${entity_type}" produced no primary entity ` +
+        `(empty entity_id). The underlying store returned ${structured.length} ` +
+        `structured entit${structured.length === 1 ? "y" : "ies"}; expected the ` +
+        `primary entity at index 0. This is a write-integrity failure, not a ` +
+        `success — no record was persisted.`
+    );
+  }
   const conversation_id = cfg.enable_conversation_threading ? structured[1]?.entity_id : undefined;
 
   let guest_access_token: string | undefined;


### PR DESCRIPTION
## Summary

`submitEntity` returned `{ entity_id: structured[0]?.entity_id ?? "" }` as a success response. When the underlying store produced no primary entity, the caller received an empty `entity_id` **with no error** — a silent write loss: the caller believes its entity was created when nothing persisted.

This adds a write-integrity guard: when `entity_id` is empty, throw an explicit error naming the `entity_type` and the count of structured entities returned, stating it is a write-integrity failure and nothing persisted. The pre-existing guard only covered the *missing-`submission_config`* case; this covers a config that exists but yields zero structured entities (the `entity_type=issue` path that was reported).

## Changes

- `src/services/entity_submission/submission_service.ts` — write-integrity guard after `entity_id` extraction.
- `src/services/entity_submission/submission_service.test.ts` — new regression test (3 cases: empty→throws, populated→returns id, no-config→throws).
- `docs/testing/automated_test_catalog.md` — regenerated to include the new test.

## Verification

- `npm run type-check` — clean
- `npm run lint` / Prettier on changed files — clean
- `npx vitest run src/services/entity_submission/submission_service.test.ts` — 3/3 pass
- `npm run validate:test-catalog` — up to date

## Context

Reported in an Ateles agent review session for `entity_type=issue` (`submit_entity` returned `{entity_id:""}`); overlaps the documented-only behavior in closed #941.

Closes #943.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
