### PR TITLE
fix: graph source-table bug (#389/#394) + mirror import perf (#371) + Husky v9 deprecation (#400)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,3 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 pick_free_port() {
   node scripts/pick-port.js "$1"
 }

--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,8 +61,8 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **399**
-- Backend and repo Vitest files: **366**
+- Total automated test files: **400**
+- Backend and repo Vitest files: **367**
 - Frontend Vitest files: **9**
 - Playwright spec files: **24**
 
@@ -72,7 +72,7 @@ flowchart TD
 | Vitest unit tests | 99 |
 | Vitest service tests | 33 |
 | Source-adjacent tests | 46 |
-| Vitest integration tests | 108 |
+| Vitest integration tests | 109 |
 | Vitest CLI tests | 59 |
 | Vitest contract tests | 11 |
 | Vitest security tests | 2 |
@@ -306,7 +306,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm run test:integration` or `npx vitest run tests/integration`
 **Requirements:** Database configured; remote-dependent subsets additionally need `RUN_REMOTE_TESTS=1`.
-**Files (108):**
+**Files (109):**
 - `tests/integration/aauth_attribution_stamping.test.ts`
 - `tests/integration/aauth_resource_metadata.test.ts`
 - `tests/integration/aauth_revocation_e2e.test.ts`
@@ -339,6 +339,7 @@ flowchart TD
 - `tests/integration/fixture_mcp_store_replay.test.ts`
 - `tests/integration/gdpr_deletion.test.ts`
 - `tests/integration/graph_neighborhood_pagination.test.ts`
+- `tests/integration/graph_neighborhood_source_branch.test.ts`
 - `tests/integration/guest_invalid_bearer_routes.test.ts`
 - `tests/integration/guest_token_isolation.test.ts`
 - `tests/integration/guest_write_rate_limit.test.ts`

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -7998,7 +7998,7 @@ app.post("/retrieve_graph_neighborhood", async (req, res) => {
         const sourceIds = result.observations?.map((o: any) => o.source_id).filter(Boolean) || [];
         if (sourceIds.length > 0) {
           const { data: sources, error: srcError } = await db
-            .from("source")
+            .from("sources")
             .select("*")
             .in("id", sourceIds)
             .eq("user_id", userId);
@@ -8011,7 +8011,7 @@ app.post("/retrieve_graph_neighborhood", async (req, res) => {
     } else if (node_type === "source") {
       // Get source
       const { data: source, error: srcError } = await db
-        .from("source")
+        .from("sources")
         .select("*")
         .eq("id", node_id)
         .eq("user_id", userId)

--- a/src/services/canonical_mirror.ts
+++ b/src/services/canonical_mirror.ts
@@ -45,6 +45,7 @@ import {
   renderTimelineDayMarkdown,
   renderSchemaMarkdown,
   renderIndexMarkdown,
+  renderProfileEntity,
   type RenderEntityInput,
   type RenderRelationshipInput,
   type RenderSourceInput,
@@ -637,7 +638,6 @@ export async function mirrorEntity(entity: MirrorEntityRow, cfg?: MirrorConfig):
       const renderMode = profile.render_mode ?? "entity";
       let profileRendered: string;
       if (renderMode === "frontmatter_content" || renderMode === "content_only") {
-        const { renderProfileEntity } = await import("./canonical_markdown.js");
         profileRendered = renderProfileEntity(
           filteredSnapshot,
           {
@@ -1427,7 +1427,6 @@ async function rebuildProfile(
     const renderMode = profile.render_mode ?? "entity";
     let rendered: string;
     if (renderMode === "frontmatter_content" || renderMode === "content_only") {
-      const { renderProfileEntity } = await import("./canonical_markdown.js");
       rendered = renderProfileEntity(
         filteredSnapshot,
         {

--- a/tests/integration/graph_neighborhood_source_branch.test.ts
+++ b/tests/integration/graph_neighborhood_source_branch.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Integration regression test: retrieve_graph_neighborhood `node_type: "source"` branch.
+ *
+ * Guards against the singular-table regression (GH #389 / #394): the handler's
+ * source branch and the entity-branch `include_sources` sub-path must query the
+ * canonical `sources` table (plural). The prior `db.from("source")` (singular)
+ * silently returned no rows for every user, so the response omitted `source`
+ * even when a matching row existed.
+ *
+ * This exercises the real Express handler over HTTP (not a direct DB re-query),
+ * which is what the pre-existing `node_type: source` test in
+ * mcp_graph_variations.test.ts failed to do — letting the bug hide.
+ */
+
+import { createHash } from "node:crypto";
+import { createServer } from "node:http";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { app } from "../../src/actions.js";
+import { db } from "../../src/db.js";
+
+const TEST_USER_ID = "00000000-0000-0000-0000-000000000001";
+const API_PORT = 18121;
+const API_BASE = `http://127.0.0.1:${API_PORT}`;
+
+function makeEntityId(tag: string): string {
+  const hex = createHash("sha256").update(tag).digest("hex").slice(0, 24);
+  return `ent_${hex}`;
+}
+
+describe("retrieve_graph_neighborhood source branch (#389/#394)", () => {
+  let httpServer: ReturnType<typeof createServer>;
+  let sourceId: string;
+  const entityId = makeEntityId(`gns-entity-${Date.now()}`);
+  const contentHash = `gns_${Date.now()}`;
+
+  beforeAll(async () => {
+    httpServer = createServer(app);
+    await new Promise<void>((resolve, reject) => {
+      httpServer.listen(API_PORT, "127.0.0.1", () => resolve());
+      httpServer.once("error", reject);
+    });
+
+    // Seed a source row.
+    const { data: source, error: sourceError } = await db
+      .from("sources")
+      .insert({
+        user_id: TEST_USER_ID,
+        content_hash: contentHash,
+        storage_url: "file:///test/gns-source.txt",
+        mime_type: "text/plain",
+        file_size: 0,
+      })
+      .select()
+      .single();
+    expect(sourceError).toBeNull();
+    expect(source).toBeDefined();
+    sourceId = source!.id;
+
+    // Seed an entity and an observation linking it to the source so the
+    // entity-branch include_sources sub-path has something to resolve.
+    await db.from("entities").insert({
+      id: entityId,
+      user_id: TEST_USER_ID,
+      entity_type: "note",
+      canonical_name: "gns-entity",
+    });
+
+    await db.from("observations").insert({
+      id: createHash("sha256").update(`${entityId}:${sourceId}:obs`).digest("hex"),
+      entity_id: entityId,
+      source_id: sourceId,
+      user_id: TEST_USER_ID,
+      entity_type: "note",
+      schema_version: "1.0",
+      source_priority: 1,
+      observed_at: new Date().toISOString(),
+      fields: { canonical_name: "gns-entity" },
+    });
+  });
+
+  afterAll(async () => {
+    await db.from("observations").delete().eq("source_id", sourceId);
+    await db.from("entities").delete().eq("id", entityId);
+    await db.from("sources").delete().eq("id", sourceId);
+    await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+  });
+
+  async function callNeighborhood(params: Record<string, unknown>) {
+    const resp = await fetch(`${API_BASE}/retrieve_graph_neighborhood`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ user_id: TEST_USER_ID, ...params }),
+    });
+    return resp.json() as Promise<Record<string, unknown>>;
+  }
+
+  it("node_type: source returns the source row (not silently empty)", async () => {
+    const body = await callNeighborhood({
+      node_id: sourceId,
+      node_type: "source",
+      include_observations: true,
+    });
+
+    expect(body.source).toBeDefined();
+    expect((body.source as { id: string }).id).toBe(sourceId);
+    expect(Array.isArray(body.observations)).toBe(true);
+    expect((body.observations as unknown[]).length).toBeGreaterThan(0);
+  });
+
+  it("node_type: entity with include_sources resolves the linked source", async () => {
+    const body = await callNeighborhood({
+      node_id: entityId,
+      node_type: "entity",
+      include_observations: true,
+      include_sources: true,
+    });
+
+    expect(Array.isArray(body.sources)).toBe(true);
+    expect((body.sources as Array<{ id: string }>).some((s) => s.id === sourceId)).toBe(true);
+  });
+});


### PR DESCRIPTION
Pre-release quick fixes for the upcoming v0.15.0, landed as discrete commits so the release supplement can cite them as merged work.

## Fixes

- **#389 / #394 — `retrieve_graph_neighborhood` queried singular `source` table.** The `node_type:source` branch and the entity-branch `include_sources` sub-path used `db.from("source")` (singular), silently returning no rows for every user. Canonical table is `sources` (plural). Both sites fixed. Adds an HTTP-level integration regression (`tests/integration/graph_neighborhood_source_branch.test.ts`) that boots the Express app and asserts the source row is returned — coverage the pre-existing `mcp_graph_variations` test lacked because it re-queried the DB directly instead of exercising the handler. Verified the test fails against the singular table and passes after the fix.
- **#371 — dynamic import inside per-entity mirror render loop.** `canonical_mirror.ts` called `await import("./canonical_markdown.js")` once per entity × matching profile during a full re-mirror. `renderProfileEntity` is now a static import; both dynamic sites use it directly.
- **#400 — deprecated Husky v9 shebang.** Removed the two lines Husky v10 will reject from `.husky/pre-commit`.

## Verification

- `npm run type-check` clean
- lint 0 errors (only pre-existing `any` warnings), Prettier clean, site-copy lint OK
- New regression: 2/2 pass (and confirmed it catches the bug when reverted)
- Mirror + markdown suites: 54/54 pass

## Change-guardrails

No OpenAPI / contract-mapping changes (pure bug fixes to existing handler behavior), no schema changes, no new CLI commands, no PII surfaces. The graph endpoint's user-scoping (`.eq("user_id", userId)`) is preserved on both fixed queries.

Resolves #389, #394, #371, #400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)