### PR TITLE
fix(entity-submission): steer specialized types (issue) to submit_issue with actionable error

### DIFF
--- a/src/services/entity_submission/submission_service.test.ts
+++ b/src/services/entity_submission/submission_service.test.ts
@@ -95,3 +95,48 @@ describe("submitEntity write-integrity", () => {
     ).rejects.toThrow(/No active submission_config/);
   });
 });
+
+describe("submitEntity submission-path steering", () => {
+  const configWithGithubMirror = {
+    ...configWithoutThreading,
+    external_mirrors: [{ provider: "github" as const, config: {} }],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("steers issue submissions to submit_issue and never reaches the store", async () => {
+    // A type whose submission_config declares a github mirror has a specialized
+    // path (submit_issue). submitEntity must refuse with an actionable error
+    // BEFORE attempting the generic store, so the caller gets redirected rather
+    // than a confusing downstream failure.
+    mockGetSubmissionConfigForTargetType.mockResolvedValue(configWithGithubMirror);
+
+    await expect(
+      submitEntity(ops, {
+        userId: "user-1",
+        entity_type: "issue",
+        fields: { title: "t", body: "b" },
+      })
+    ).rejects.toThrow(/submission_path_mismatch.*submit_issue.*redirect_to: submit_issue/s);
+
+    expect(mockStoreRootWithThread).not.toHaveBeenCalled();
+  });
+
+  it("does not steer types without a specialized mirror", async () => {
+    mockGetSubmissionConfigForTargetType.mockResolvedValue(configWithoutThreading);
+    mockStoreRootWithThread.mockResolvedValue({
+      structured: { entities: [{ entity_id: "ent_generic" }] },
+    });
+
+    const result = await submitEntity(ops, {
+      userId: "user-1",
+      entity_type: "feedback",
+      fields: { title: "t", body: "b" },
+    });
+
+    expect(result.entity_id).toBe("ent_generic");
+    expect(mockStoreRootWithThread).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/services/entity_submission/submission_service.ts
+++ b/src/services/entity_submission/submission_service.ts
@@ -44,6 +44,20 @@ function idempotencyForSubmit(entityType: string, fields: Record<string, unknown
   return `entity-submit-${entityType}-${h}`;
 }
 
+/**
+ * If the submission config declares a mirror provider that has a dedicated
+ * submission tool, return that tool's name so callers can be steered to it.
+ * Returns null when the generic submitEntity path is appropriate.
+ */
+function specializedSubmissionToolFor(cfg: {
+  external_mirrors: Array<{ provider: string }>;
+}): string | null {
+  for (const mirror of cfg.external_mirrors) {
+    if (mirror.provider === "github") return "submit_issue";
+  }
+  return null;
+}
+
 export async function submitEntity(
   ops: Operations,
   params: { userId: string } & SubmitEntityParams
@@ -53,6 +67,24 @@ export async function submitEntity(
   if (!cfg) {
     throw new Error(
       `No active submission_config for entity_type "${entity_type}". Create an active submission_config row for this type (operator-seeded).`
+    );
+  }
+
+  // Submission-path steering: some entity types have a specialized submission
+  // tool (e.g. `issue` → `submit_issue`, which runs the GitHub-first mirror and
+  // reporter/redaction flow). The generic submitEntity path does not run those
+  // steps, so routing such a type through here produces a confusing downstream
+  // failure with no guidance. Detect the specialized path from the config's
+  // external mirrors and steer the caller explicitly. This is schema-driven
+  // (keyed off the config's declared mirror provider), not a hardcoded type
+  // branch, so any future type with a github mirror gets the same treatment.
+  const specializedTool = specializedSubmissionToolFor(cfg);
+  if (specializedTool) {
+    throw new Error(
+      `submission_path_mismatch: entity_type "${entity_type}" has a specialized ` +
+        `submission path. Use ${specializedTool} instead of submit_entity, which ` +
+        `does not run the ${specializedTool} mirror/redaction flow. ` +
+        `(redirect_to: ${specializedTool})`
     );
   }
 


### PR DESCRIPTION
## Summary

Follow-up to the `submit_entity` write-integrity fix (#1462 / #943). A retest confirmed the silent write-loss is gone — `submit_entity(entity_type=issue)` now errors instead of returning an empty `entity_id`. But the error a caller hits is **opaque**: routing a GitHub-backed type through the generic `submitEntity` path surfaces a generic tool-execution failure with no guidance toward the correct tool (`submit_issue`).

This adds **submission-path steering**.

## Change

Before attempting the generic store, `submitEntity` detects when the target type's `submission_config` declares a `github` external mirror (the marker for a specialized `submit_issue` path) and throws an actionable error:

```
submission_path_mismatch: entity_type "issue" has a specialized submission path.
Use submit_issue instead of submit_entity, which does not run the submit_issue
mirror/redaction flow. (redirect_to: submit_issue)
```

The MCP `submit_entity` handler already propagates `err.message` (`submit_entity failed: <message>`), so this actionable text reaches the caller in-loop.

It is **schema-driven** — keyed off the config's declared mirror provider via a `specializedSubmissionToolFor(cfg)` helper, not a hardcoded `entity_type === "issue"` branch — so any future type with a github mirror gets the same treatment (per the schema-agnostic design rule).

## Tests

Two new regression cases (5 total in the file):
- `issue` (github-mirror config) → throws `submission_path_mismatch` and **never reaches the store**.
- a type without a specialized mirror → still uses the generic path and returns its `entity_id`.

Verified: `type-check` clean, Prettier clean, vitest 5/5.

## Stacking

This **stacks on #1462** (`fix/submit-entity-empty-entity-id`). Until #1462 merges, this PR's diff shows both commits; once #1462 lands, it narrows to just the steering commit. Merge #1462 first.

Addresses the "remaining work" called out in the retest of #943.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
