### PR TITLE
docs: document existing isolation, consistency, and concurrency guarantees (#1468, #1465, #1466)

### DIFF
--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -652,9 +652,10 @@ Application layer MUST distinguish and signal retry eligibility.
 - MCP connections authenticated via session tokens
 - No anonymous access
 **Authorization:**
-- Row-level security (RLS) in PostgreSQL
-- User can only access their own records, entities, events
-- Application layer enforces user_id filtering
+- Per-`user_id` isolation is enforced **today** in the application layer: every user-scoped query applies `.eq("user_id", userId)` (`src/services/entity_queries.ts`), and `getAuthenticatedUserId` rejects a mismatched caller-supplied id, so a token cannot read across tenants
+- Covers graph and relationship reads, not just flat lists; regression-tested in `tests/security/tenant_isolation_matrix.test.ts` (advisory GHSA-wrr4-782v-jhwh)
+- A user can only access their own records, entities, events
+- Database-level row-level security (RLS) is a possible future defense-in-depth layer, not the current line of defense — see [`docs/subsystems/auth.md`](../subsystems/auth.md#authorization) for the enforced contract and the two multi-tenant models
 ### 7.2 Data Security
 **At Rest:**
 - Database encryption at rest
@@ -706,7 +707,7 @@ Application layer MUST distinguish and signal retry eligibility.
 3. **All errors MUST use ErrorEnvelope structure**
 4. **All external calls MUST go through Infrastructure layer**
 5. **All database writes MUST be transactional**
-6. **All user data MUST be isolated by user_id** (RLS)
+6. **All user data MUST be isolated by user_id** (enforced in the application layer on every query; see `docs/subsystems/auth.md`)
 7. **All MCP actions MUST validate inputs**
 8. **All timeline events MUST trace to source fields**
 9. **All entities MUST have canonical IDs**
@@ -790,7 +791,7 @@ Load `docs/architecture/architecture.md` when:
 3. **Use ErrorEnvelope:** All errors follow structured format
 4. **Validate inputs:** Every layer validates its inputs
 5. **Transactional writes:** All graph writes in transactions
-6. **User isolation:** RLS enforced for all user data
+6. **User isolation:** per-`user_id` scoping enforced in the application layer on every user-scoped read (see `docs/subsystems/auth.md`)
 7. **No global state:** Dependency injection for all services
 8. **State Layer purity:** No strategy, execution, or agent logic in Neotoma
 9. **Event-sourced updates:** All state changes via Domain Events → Reducers

--- a/docs/architecture/consistency.md
+++ b/docs/architecture/consistency.md
@@ -63,11 +63,22 @@ Neotoma MVP uses **bounded eventual consistency** where needed, never unbounded 
 | **Graph Edges** (record→entity, record→event, relationships) | Strong            | 0s        | Immediate display          |
 | **Entities** (creation, linking)                             | Strong            | 0s        | Immediate display          |
 | **Timeline Events**                                          | Strong            | 0s        | Immediate display          |
-| **Full-Text Search Index**                                   | Bounded Eventual  | 5s        | "Indexing..." message      |
-| **Vector Embeddings Index**                                  | Bounded Eventual  | 10s       | "Generating embeddings..." |
-| **Cross-Entity Search**                                      | Bounded Eventual  | 5s        | "Indexing..." message      |
+| **Full-Text Search Index**                                   | Strong            | 0s        | Immediate display          |
+| **Vector Embeddings Index**                                  | Strong¹           | 0s        | Immediate display          |
+| **Cross-Entity Search**                                      | Strong¹           | 0s        | Immediate display          |
 | **Provenance Metadata**                                      | Strong            | 0s        | Immediate display          |
 | **Auth Permissions**                                         | Strong            | 0s        | Block on permission change |
+
+¹ **Embeddings are generated synchronously during snapshot upsert**, not on a deferred/async lag. `prepareEntitySnapshotWithEmbedding` (`src/services/entity_snapshot_embedding.ts`) awaits `generateEmbedding` inline, and every caller (`src/server.ts`, `src/actions.ts`, `src/services/interpretation.ts`) awaits it before the `entity_snapshots` upsert. The embedding is committed in the same store path as the snapshot, so an entity is semantically searchable as soon as its store call returns — provided an embedding provider is configured (`OPENAI_API_KEY`). When no provider is configured, embedding is skipped and semantic search degrades to keyword/lexical matching (still strongly consistent, just not vector-ranked). This is a change from an earlier design that treated embeddings as bounded-eventual (~10s); the synchronous behavior is the current contract.
+
+### 2.1.1 Read-after-write contract (for interactive callers)
+
+For callers issuing a query immediately after a store in the same turn (e.g. an interactive chat assistant), the guarantee is:
+
+- **Structured retrieval is strongly consistent.** `retrieve_entities` (by id, by canonical name, by filter), `retrieve_entity_snapshot`, `retrieve_related_entities`, and `retrieve_graph_neighborhood` reflect a just-completed store with no lag. A fact stored in this turn is readable in this turn.
+- **Semantic search is strongly consistent with respect to the write when an embedding provider is configured**, because the embedding is written in the same synchronous path (¹ above). With no provider configured, `search` falls back to keyword matching.
+- **Practical guidance:** for read-after-write correctness in an interactive path, query the *structured* surface (id / canonical-name / filter), which is always strongly consistent. Treat semantic ranking as a best-effort relevance layer on top, not as the consistency boundary. No freshness token or "block until indexed" call is required — the structured read already reflects the write.
+
 ### 2.2 Subsystem Details
 #### 2.2.1 Core Records (Strong Consistency)
 **What:**

--- a/docs/infrastructure/deployment.md
+++ b/docs/infrastructure/deployment.md
@@ -523,6 +523,28 @@ flyctl releases rollback <release-id>
 # Rollback to previous release
 flyctl releases rollback
 ```
+## SQLite concurrency and the multi-writer model
+
+Neotoma's default storage backend is SQLite (`better-sqlite3`), configured in `src/repositories/sqlite/sqlite_client.ts`. For anyone running a single hosted instance that serves multiple users, the concurrency envelope is:
+
+**What is configured today**
+
+- **WAL mode is enabled** (`PRAGMA journal_mode = WAL`). Under WAL, readers do not block the writer and the writer does not block readers — concurrent reads proceed while a write is in flight. This is the property that makes one instance safely serve many concurrent read requests.
+- **`PRAGMA foreign_keys = ON`** for referential integrity.
+- **A single cached connection per server process** (`cachedDb` singleton). `better-sqlite3` is a synchronous, in-process driver, so all writes from the server process are **serialized through one connection** — there is no in-process write contention to tune, and no connection pool to size.
+
+**The practical envelope**
+
+- **Reads:** effectively unbounded concurrency. WAL lets many reads run against a consistent snapshot while writes continue.
+- **Writes:** serialized in-process. A web backend that fans many requests into one Neotoma server process gets correct, ordered writes without extra configuration. Throughput is bounded by single-writer SQLite write speed, which is high for the row sizes Neotoma stores (observations, snapshots, relationships) but is not horizontally scalable within one DB file.
+- **Multi-process access is the real caveat:** if a *second* process opens the same database file concurrently with the server (e.g. a CLI `backup`, a `doctor` run, or an out-of-band migration), the two processes contend for the WAL write lock. `busy_timeout` is **not** currently set, so a second writer can see `SQLITE_BUSY` immediately rather than waiting. Guidance: run write-heavy maintenance (backup, vacuum, migration) against a quiesced instance, or serialize it with the server, rather than concurrently. Read-only out-of-process access (a reporting query) is safe under WAL.
+
+**When this envelope is not enough**
+
+For a deployment that needs multiple *writer processes* against shared state, or write throughput beyond a single SQLite file, SQLite is off its primary path. The options, in increasing order of effort, are: (1) one Neotoma instance per tenant (physical isolation — see `docs/plans/multi-tenant-operational-patterns.md`), (2) front all writes through the single server process (the current model — keep maintenance writes serialized), or (3) a Postgres-backed storage adapter (not yet implemented; tracked separately). For most single-instance multi-user web backends, option (2) with WAL is sufficient and is what ships today.
+
+> Note: a `busy_timeout` PRAGMA would make out-of-process writers wait rather than fail fast on `SQLITE_BUSY`. Adding one is a small, safe hardening step for deployments that knowingly run concurrent maintenance processes; it is not currently set because the single-server-process model does not require it.
+
 ## Agent Instructions
 ### When to Load This Document
 Load when:

--- a/docs/subsystems/auth.md
+++ b/docs/subsystems/auth.md
@@ -28,14 +28,24 @@ Resolution order:
 - The `LOCAL_DEV_USER_ID` override is a deliberate dev-flow affordance; widening it to other users requires an explicit security review.
 
 ## Authorization
-**MVP:** All authenticated users can access all records (no per-user isolation).
-**Future:** Row-Level Security (RLS) by `user_id`.
-```sql
--- Future RLS policy
-CREATE POLICY "Users see only their records" ON records
-  FOR SELECT
-  USING (user_id = auth.uid());
-```
+
+**Per-user isolation is enforced today, in application code, on every user-scoped read.** This is not a future RLS aspiration — it ships and is regression-tested.
+
+- Every user-scoped query applies `.eq("user_id", userId)` before returning rows. The `userId` is the value resolved by `getAuthenticatedUserId` (see [User-ID Resolution](#user-id-resolution)), never a raw body/query field. Enforcement lives in `src/services/entity_queries.ts` (observations, entities, snapshots, relationships) and the per-handler query builders in `src/server.ts`.
+- A caller cannot read across tenants by supplying someone else's id: `getAuthenticatedUserId` rejects a `providedUserId` that differs from the authenticated identity (the only exception is the `LOCAL_DEV_USER_ID` dev stub overriding to an explicit test user).
+- The protection covers **graph and relationship reads**, not just flat entity lists. Cross-user `entity_id` / `source_id` lookups, `/list_relationships`, and `/retrieve_graph_neighborhood` all return empty rather than leaking another tenant's data.
+- This is asserted by `tests/security/tenant_isolation_matrix.test.ts` (regression coverage for advisory **GHSA-wrr4-782v-jhwh**): user A, knowing a cross-user identifier, cannot reach user B's data through any read path.
+
+**Two distinct multi-tenant models** — do not conflate them:
+
+| Model | Isolation mechanism | Use |
+| --- | --- | --- |
+| **One instance, many users** | Per-`user_id` scoping enforced on every query (above), with AAuth binding the request to an identity | A single hosted server backing multiple users/tenants — the SaaS-memory-backend case |
+| **Instance-per-tenant** | Physical: each tenant is a separate SQLite database / data directory | Fleet of independent deployments; see [`docs/plans/multi-tenant-operational-patterns.md`](../plans/multi-tenant-operational-patterns.md) |
+
+The **local single-user default** (`LOCAL_DEV_USER_ID`, no credentials) is a convenience for one-machine development, not the multi-user contract. Under authenticated access (OAuth, Bearer, or AAuth), the per-`user_id` scoping above is what governs who can read what.
+
+**Database-level RLS** (a Postgres `auth.uid()` policy) remains a possible future hardening layer that would enforce the same boundary *below* the application. It is defense-in-depth, not the current line of defense — the application-layer scoping above is the enforced contract today.
 ## AAuth (Agent Authentication) and the Trust-Tier Contract
 
 AAuth gives every write a cryptographically verifiable *agent identity* that is orthogonal to the human `user_id` above. Where `user_id` answers "whose data is this?", AAuth answers "which agent wrote it?". The two live side-by-side on every durable row.

--- a/frontend/src/components/subpages/HostedLandingPage.tsx
+++ b/frontend/src/components/subpages/HostedLandingPage.tsx
@@ -141,9 +141,17 @@ export function HostedLandingPageBody() {
 
       <IntegrationSection title="Local first" sectionKey="local-first">
         <p className="text-[15px] leading-7 text-muted-foreground mb-3">
-          Most Neotoma users run locally. Your data stays on your machine, every agent on that
-          machine shares one dataset, and you can expose it to remote agents later via a{" "}
+          Most Neotoma users run locally. Your data stays on your machine, and in the default
+          single-user setup every agent on that machine shares one dataset. You can expose it to
+          remote agents later via a{" "}
           <Link to="/tunnel" className={extLink}>tunnel</Link> without migrating storage.
+        </p>
+        <p className="text-[14px] leading-6 text-muted-foreground mb-3">
+          The shared-dataset default is a single-user convenience, not a limitation. Under
+          authenticated access, Neotoma enforces per-user isolation server-side: every query is
+          scoped to the requesting user&apos;s <code>user_id</code> (including graph and
+          relationship reads), a token cannot read another user&apos;s data, and that boundary is
+          regression-tested. One hosted instance can safely back many users.
         </p>
         <p className="text-[14px] leading-6 text-muted-foreground">
           <Link to="/install" className={extLink}>Install guide →</Link>


### PR DESCRIPTION
Three documentation fixes where the docs **understated guarantees Neotoma already provides**. An evaluating multi-user adopter, reading the docs, treated three shipped capabilities as missing — isolation, read-after-write consistency, and safe concurrency. This PR closes that gap by documenting what the code already does.

## #1468 — per-user tenant isolation (was understated as "no isolation / future RLS")

- `docs/subsystems/auth.md`: replaced the stale *"MVP: all authenticated users can access all records (no per-user isolation). Future: RLS"* block with the **enforced contract**: every user-scoped query applies `.eq("user_id", userId)`, `getAuthenticatedUserId` rejects a mismatched caller id (cross-tenant reads blocked), graph/relationship reads are covered, asserted by `tests/security/tenant_isolation_matrix.test.ts` (GHSA-wrr4-782v-jhwh). Added a table distinguishing the two multi-tenant models (one-instance-many-users vs instance-per-tenant).
- `docs/architecture/architecture.md`: corrected three "RLS (future/Postgres)" framings to state application-layer per-`user_id` enforcement today, with RLS as future defense-in-depth.
- `frontend/.../HostedLandingPage.tsx`: qualified "every agent shares one dataset" as the single-user default and added that authenticated access enforces per-user isolation server-side.

## #1465 — read-after-write consistency (embeddings were doc'd as ~10s eventual)

- `docs/architecture/consistency.md`: embeddings are generated **synchronously at snapshot upsert** (`prepareEntitySnapshotWithEmbedding` awaits `generateEmbedding` inline; every caller awaits it before the upsert), not bounded-eventual. Flipped the Vector Embeddings / Cross-Entity / FTS rows to **Strong**, added a footnote and an explicit **read-after-write contract**: structured reads are strongly consistent; semantic search is strongly consistent w.r.t. the write when an embedding provider is configured, else degrades to keyword. No freshness token / block-until-indexed call is needed.

## #1466 — SQLite concurrency envelope (multi-writer story was undocumented)

- `docs/infrastructure/deployment.md`: documented the multi-writer model — WAL enabled, a single cached in-process connection (writes serialized via `better-sqlite3`, no pool to size), readers effectively unbounded under WAL, **multi-process write contention is the real caveat** (`busy_timeout` unset), and when to reach for instance-per-tenant or a future Postgres adapter.

## Notes

- Docs-only + one frontend copy string. No behavior change.
- Branch is off `main`; pre-commit suite passes.
- The commit is unsigned: GPG signing could not prompt in the non-interactive environment (pinentry TTY error). Flagging in case the repo requires signed commits on merge.

Closes #1468
Closes #1465
Closes #1466

🤖 Generated with [Claude Code](https://claude.com/claude-code)