### PR TITLE
feat(graph,cli): HTTP multi-hop traversal parity + bulk entity import (#1470)

### DIFF
--- a/docs/developer/cli_reference.md
+++ b/docs/developer/cli_reference.md
@@ -533,6 +533,12 @@ See `docs/developer/agent_cli_configuration.md` for the rule text and strategy.
   - Preferred: positional `identifier` or `--identifier <id>`
   - Compatibility alias: `--query <id>` (equivalent to `--identifier`)
   - If both `--identifier` and `--query` are provided, they must match
+- `neotoma entities import <file>`: bulk-import entities from a JSONL file (one entity JSON object per line) by chunking them into batched `POST /store` calls.
+  - `--batch-size <n>`: entities per store call (default `200`). Lower it if a request exceeds the server body limit.
+  - `--idempotency-prefix <prefix>`: prefix for the per-chunk idempotency key (default derived from the file name). Re-running with the same prefix and file is a safe no-op, so a large backfill can be replayed without duplicating data.
+  - `--user-id <userId>`: store under a specific user.
+  - `--commit`: actually write. Without it the command runs in dry-run/plan mode.
+  - The `/store` endpoint already writes each batch transactionally; this command owns file reading, chunking, and per-chunk idempotency. For very large backfills, this is the supported "replay from an external source" path.
 
 ### Sources
 

--- a/docs/security/reviews/2026-06-02-pr1479-tenant-isolation.md
+++ b/docs/security/reviews/2026-06-02-pr1479-tenant-isolation.md
@@ -1,0 +1,22 @@
+# Security Review: PR #1479 — Multi-Hop Graph Traversal + Bulk Entity Import
+
+**Verdict:** Tenant isolation holds across all four examined cross-tenant leak vectors; 2 regression tests added, 2 vectors covered by existing tests.
+
+## Vector results
+
+| Vector                 | Hypothesis                                                                 | Result | Enforcing test                                                                                                                          |
+| ---------------------- | -------------------------------------------------------------------------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------- |
+| seed-entity-ownership  | A caller can seed multi-hop traversal from an entity owned by another user | Safe   | existing coverage                                                                                                                       |
+| edge-scoping-escape    | Per-hop BFS expansion follows an edge into another user's subgraph         | Safe   | `tests/security/tenant_isolation_matrix.test.ts` — "planted cross-tenant edge does NOT leak user B's edges or entity via multi-hop BFS" |
+| bulk-import-cross-user | Bulk `/store` import writes entities attributed to another user            | Safe   | `tests/security/tenant_isolation_matrix.test.ts` — "/store bulk import (bulk-import-cross-user)"                                        |
+| unauth-and-guest       | Unauthenticated or guest callers reach the new traversal/import surfaces   | Safe   | existing coverage                                                                                                                       |
+
+## What was probed
+
+The adversarial pass examined four angles against the new traversal and bulk-import surfaces. First, seed-entity ownership: whether a traversal can be rooted at an entity belonging to another tenant. Second, per-hop edge scoping: whether BFS expansion across hops can follow a planted cross-tenant edge into another user's entities or edges. Third, bulk-import cross-user write: whether a batched `/store` import can attribute writes to, or overwrite data owned by, a different user. Fourth, unauthenticated and guest reach: whether these surfaces are accessible without proper authentication or via guest credentials.
+
+For the edge-scoping and bulk-import vectors, an explicit cross-tenant fixture was planted (user B data, user A request) and a regression test added asserting no leak or misattribution. The seed-entity-ownership and unauth/guest vectors were already covered by existing tests in the security suite; those tests were cited and confirmed passing.
+
+## What this is and isn't
+
+This note records an independent adversarial agent pass that converted each examined attack into a durable regression test (or cited existing coverage where present). It is NOT a substitute for human code review. It does not assert the absence of vulnerabilities outside the four vectors listed above, and it does not evaluate non-isolation concerns (correctness, performance, denial of service). Reviewers SHOULD treat the added tests as the enforceable contract for these four vectors and MUST NOT interpret a passing run as blanket security sign-off for the PR.

--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,8 +61,8 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **412**
-- Backend and repo Vitest files: **379**
+- Total automated test files: **414**
+- Backend and repo Vitest files: **381**
 - Frontend Vitest files: **9**
 - Playwright spec files: **24**
 
@@ -72,8 +72,8 @@ flowchart TD
 | Vitest unit tests | 102 |
 | Vitest service tests | 33 |
 | Source-adjacent tests | 47 |
-| Vitest integration tests | 112 |
-| Vitest CLI tests | 59 |
+| Vitest integration tests | 113 |
+| Vitest CLI tests | 60 |
 | Vitest contract tests | 12 |
 | Vitest security tests | 3 |
 | Vitest subscription tests | 5 |
@@ -311,7 +311,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm run test:integration` or `npx vitest run tests/integration`
 **Requirements:** Database configured; remote-dependent subsets additionally need `RUN_REMOTE_TESTS=1`.
-**Files (112):**
+**Files (113):**
 - `tests/integration/aauth_attribution_stamping.test.ts`
 - `tests/integration/aauth_resource_metadata.test.ts`
 - `tests/integration/aauth_revocation_e2e.test.ts`
@@ -349,6 +349,7 @@ flowchart TD
 - `tests/integration/guest_token_isolation.test.ts`
 - `tests/integration/guest_write_rate_limit.test.ts`
 - `tests/integration/hook_failure_hint.test.ts`
+- `tests/integration/http_related_entities_multihop.test.ts`
 - `tests/integration/idempotency_collision.test.ts`
 - `tests/integration/idempotency_key_content_mismatch.test.ts`
 - `tests/integration/inspector_bundled_mount.test.ts`
@@ -430,7 +431,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/cli`
 **Requirements:** Basic `.env`; some tests provision temp config homes automatically.
-**Files (59):**
+**Files (60):**
 - `tests/cli/api_client_offline_fallback.test.ts`
 - `tests/cli/backup_verify.test.ts`
 - `tests/cli/cli_access_commands.test.ts`
@@ -444,6 +445,7 @@ flowchart TD
 - `tests/cli/cli_direct_invocation_parity.test.ts`
 - `tests/cli/cli_doctor_setup.test.ts`
 - `tests/cli/cli_edit_commands.test.ts`
+- `tests/cli/cli_entities_import.test.ts`
 - `tests/cli/cli_entity_commands.test.ts`
 - `tests/cli/cli_entity_subcommands.test.ts`
 - `tests/cli/cli_infra_commands.test.ts`

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -7971,77 +7971,102 @@ app.post("/retrieve_related_entities", async (req, res) => {
       entity_id,
       relationship_types,
       direction = "both",
-      max_hops: _max_hops = 1,
+      max_hops = 1,
       include_entities = true,
     } = parsed.data;
     const userId = await getAuthenticatedUserId(req, undefined);
 
-    // Simple 1-hop query implementation
+    // Breadth-first traversal up to max_hops. Mirrors the MCP handler
+    // (server.ts retrieveRelatedEntities): a visited set provides cycle
+    // protection and de-duplicates entities discovered via multiple paths.
+    // max_hops defaults to 1, so single-hop callers see identical results.
     const relationships: any[] = [];
+    const visited = new Set<string>([entity_id]);
+    const relatedIds = new Set<string>();
+    let currentLevel = [entity_id];
 
-    // Get outbound relationships
-    if (direction === "outbound" || direction === "both") {
-      let query = db
-        .from("relationship_snapshots")
-        .select("*")
-        .eq("source_entity_id", entity_id)
-        .eq("user_id", userId)
-        .order("relationship_key", { ascending: true });
+    for (let hop = 0; hop < max_hops; hop++) {
+      const nextLevel: string[] = [];
 
-      if (relationship_types && relationship_types.length > 0) {
-        query = query.in("relationship_type", relationship_types);
+      for (const currentId of currentLevel) {
+        // Get outbound relationships
+        if (direction === "outbound" || direction === "both") {
+          let query = db
+            .from("relationship_snapshots")
+            .select("*")
+            .eq("source_entity_id", currentId)
+            .eq("user_id", userId)
+            .order("relationship_key", { ascending: true });
+
+          if (relationship_types && relationship_types.length > 0) {
+            query = query.in("relationship_type", relationship_types);
+          }
+
+          const { data, error } = await query;
+          if (!error && data) {
+            relationships.push(...data);
+            for (const rel of data) {
+              if (!visited.has(rel.target_entity_id)) {
+                visited.add(rel.target_entity_id);
+                relatedIds.add(rel.target_entity_id);
+                nextLevel.push(rel.target_entity_id);
+              }
+            }
+          }
+        }
+
+        // Get inbound relationships
+        if (direction === "inbound" || direction === "both") {
+          let query = db
+            .from("relationship_snapshots")
+            .select("*")
+            .eq("target_entity_id", currentId)
+            .eq("user_id", userId)
+            .order("relationship_key", { ascending: true });
+
+          if (relationship_types && relationship_types.length > 0) {
+            query = query.in("relationship_type", relationship_types);
+          }
+
+          const { data, error } = await query;
+          if (!error && data) {
+            relationships.push(...data);
+            for (const rel of data) {
+              if (!visited.has(rel.source_entity_id)) {
+                visited.add(rel.source_entity_id);
+                relatedIds.add(rel.source_entity_id);
+                nextLevel.push(rel.source_entity_id);
+              }
+            }
+          }
+        }
       }
 
-      const { data, error } = await query;
-      if (!error && data) {
-        relationships.push(...data);
-      }
-    }
-
-    // Get inbound relationships
-    if (direction === "inbound" || direction === "both") {
-      let query = db
-        .from("relationship_snapshots")
-        .select("*")
-        .eq("target_entity_id", entity_id)
-        .eq("user_id", userId)
-        .order("relationship_key", { ascending: true });
-
-      if (relationship_types && relationship_types.length > 0) {
-        query = query.in("relationship_type", relationship_types);
-      }
-
-      const { data, error } = await query;
-      if (!error && data) {
-        relationships.push(...data);
-      }
+      if (nextLevel.length === 0) break;
+      currentLevel = nextLevel;
     }
 
     // Get entities if requested
     let entities: any[] = [];
-    if (include_entities && relationships.length > 0) {
-      const relatedIds = new Set<string>();
-      relationships.forEach((rel) => {
-        if (rel.source_entity_id !== entity_id) relatedIds.add(rel.source_entity_id);
-        if (rel.target_entity_id !== entity_id) relatedIds.add(rel.target_entity_id);
-      });
+    if (include_entities && relatedIds.size > 0) {
+      const { data, error } = await db
+        .from("entities")
+        .select("*")
+        .eq("user_id", userId)
+        .order("canonical_name", { ascending: true })
+        .order("id", { ascending: true })
+        .in("id", Array.from(relatedIds));
 
-      if (relatedIds.size > 0) {
-        const { data, error } = await db
-          .from("entities")
-          .select("*")
-          .eq("user_id", userId)
-          .order("canonical_name", { ascending: true })
-          .order("id", { ascending: true })
-          .in("id", Array.from(relatedIds));
-
-        if (!error && data) {
-          entities = data;
-        }
+      if (!error && data) {
+        entities = data;
       }
     }
 
-    logDebug("Success:retrieve_related_entities", req, { entity_id, count: relationships.length });
+    logDebug("Success:retrieve_related_entities", req, {
+      entity_id,
+      count: relationships.length,
+      max_hops,
+    });
     return res.json({ relationships, entities });
   } catch (error) {
     return handleApiError(

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -12046,10 +12046,14 @@ entitiesCommand
         token,
       });
 
-      const batchSize = Number.isFinite(opts.batchSize) && opts.batchSize > 0 ? opts.batchSize : 200;
+      const batchSize =
+        Number.isFinite(opts.batchSize) && opts.batchSize > 0 ? opts.batchSize : 200;
       const commit = Boolean(opts.commit);
       const raw = await fs.readFile(file, "utf8");
-      const lines = raw.split("\n").map((l) => l.trim()).filter((l) => l.length > 0);
+      const lines = raw
+        .split("\n")
+        .map((l) => l.trim())
+        .filter((l) => l.length > 0);
 
       const entities: Record<string, unknown>[] = [];
       lines.forEach((line, idx) => {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -12007,6 +12007,105 @@ entitiesCommand
   );
 
 entitiesCommand
+  .command("import")
+  .description(
+    "Bulk-import entities from a JSONL file (one entity JSON object per line) by " +
+      "chunking them into batched POST /store calls. The store endpoint already writes " +
+      "each batch transactionally; this command handles file reading, chunking, and " +
+      "per-chunk idempotency so a large backfill can be replayed safely."
+  )
+  .argument("<file>", "Path to a JSONL file: one entity object per line")
+  .option(
+    "--batch-size <n>",
+    "Entities per POST /store call (default 200). Lower this if requests exceed the server body limit.",
+    (v) => Number(v),
+    200
+  )
+  .option(
+    "--idempotency-prefix <prefix>",
+    "Prefix for the per-chunk idempotency key (default: derived from the file name). " +
+      "Re-running with the same prefix and file is a safe no-op."
+  )
+  .option("--user-id <userId>", "Store under this user ID")
+  .option("--commit", "Actually write. Without this flag the command runs in dry-run/plan mode.")
+  .action(
+    async (
+      file: string,
+      opts: {
+        batchSize: number;
+        idempotencyPrefix?: string;
+        userId?: string;
+        commit?: boolean;
+      }
+    ) => {
+      const outputMode = resolveOutputMode();
+      const config = await readConfig();
+      const token = await getCliToken();
+      const api = createApiClient({
+        baseUrl: await resolveBaseUrl(program.opts().baseUrl, config),
+        token,
+      });
+
+      const batchSize = Number.isFinite(opts.batchSize) && opts.batchSize > 0 ? opts.batchSize : 200;
+      const commit = Boolean(opts.commit);
+      const raw = await fs.readFile(file, "utf8");
+      const lines = raw.split("\n").map((l) => l.trim()).filter((l) => l.length > 0);
+
+      const entities: Record<string, unknown>[] = [];
+      lines.forEach((line, idx) => {
+        try {
+          entities.push(JSON.parse(line) as Record<string, unknown>);
+        } catch {
+          throw new Error(`Invalid JSON on line ${idx + 1} of ${file}`);
+        }
+      });
+
+      if (entities.length === 0) {
+        throw new Error(`No entities found in ${file} (expected one JSON object per line)`);
+      }
+
+      // Stable prefix so re-running the same file is idempotent. Derived from
+      // the file's base name when not supplied; chunk index is appended below.
+      const baseName = file.split("/").pop() ?? file;
+      const prefix = opts.idempotencyPrefix ?? `import:${baseName}`;
+
+      const totalChunks = Math.ceil(entities.length / batchSize);
+      const results: Array<Record<string, unknown>> = [];
+
+      for (let chunkIndex = 0; chunkIndex < totalChunks; chunkIndex++) {
+        const chunk = entities.slice(chunkIndex * batchSize, (chunkIndex + 1) * batchSize);
+        const { data, error } = await api.POST("/store", {
+          body: {
+            entities: chunk,
+            idempotency_key: `${prefix}:${chunkIndex}`,
+            user_id: opts.userId,
+            commit,
+          },
+        });
+        if (error) {
+          throw new Error(
+            `Failed to store chunk ${chunkIndex + 1}/${totalChunks}: ${JSON.stringify(error)}`
+          );
+        }
+        results.push({ chunk: chunkIndex + 1, size: chunk.length, result: data });
+      }
+
+      writeOutput(
+        {
+          file,
+          total_entities: entities.length,
+          batch_size: batchSize,
+          chunks: totalChunks,
+          committed: commit,
+          idempotency_prefix: prefix,
+          results,
+        },
+        outputMode
+      );
+    }
+  );
+
+entitiesCommand
   .command("related")
   .description("Get entities related to a given entity via relationships")
   .argument("<entityId>", "Entity ID")

--- a/src/server.ts
+++ b/src/server.ts
@@ -3087,6 +3087,7 @@ export class NeotomaServer {
     const relatedEntityIds = new Set<string>();
     const allRelationships: any[] = [];
     let currentLevel = [parsed.entity_id];
+    let hopsTraversed = 0;
 
     // Traverse relationships up to max_hops
     for (let hop = 0; hop < parsed.max_hops; hop++) {
@@ -3148,6 +3149,9 @@ export class NeotomaServer {
         }
       }
 
+      // This hop produced at least one relationship lookup over a non-empty
+      // frontier, so count it as traversed.
+      hopsTraversed = hop + 1;
       if (nextLevel.length === 0) break;
       currentLevel = nextLevel;
     }
@@ -3190,7 +3194,7 @@ export class NeotomaServer {
       relationships: allRelationships,
       total_entities: entities.length,
       total_relationships: allRelationships.length,
-      hops_traversed: Math.min(parsed.max_hops, Array.from(visited).length > 1 ? 1 : 0),
+      hops_traversed: hopsTraversed,
     });
   }
 

--- a/tests/cli/cli_entities_import.test.ts
+++ b/tests/cli/cli_entities_import.test.ts
@@ -1,0 +1,193 @@
+/**
+ * CLI `entities import` tests (in-process, mock-fetch).
+ *
+ * Covers issue #1470: a bulk-import path that reads a JSONL file, chunks the
+ * entities into batched POST /store calls, and is idempotent on re-run. The
+ * store endpoint already writes each batch transactionally; this command owns
+ * file reading, chunking, and per-chunk idempotency keys.
+ *
+ * Verifies the user-observable behavior end-to-end: file -> chunked /store
+ * calls with correct batch boundaries, idempotency keys, and a dry-run default.
+ */
+
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, it, expect, afterEach, vi } from "vitest";
+
+type CliModule = { runCli: (argv: string[]) => Promise<void> };
+
+async function loadCli(): Promise<CliModule> {
+  vi.resetModules();
+  return (await import("../../src/cli/index.ts")) as CliModule;
+}
+
+function captureStdout(): { output: string[]; restore: () => void } {
+  const output: string[] = [];
+  const spy = vi.spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
+    output.push(typeof chunk === "string" ? chunk : Buffer.from(chunk as Uint8Array).toString());
+    return true;
+  });
+  return { output, restore: () => spy.mockRestore() };
+}
+
+interface StoreCall {
+  entities: unknown[];
+  idempotency_key: string;
+  commit: boolean;
+}
+
+async function withStoreMock<T>(
+  callback: (storeCalls: StoreCall[]) => Promise<T>
+): Promise<T> {
+  const storeCalls: StoreCall[] = [];
+  const fetchMock = vi.fn(async (input: RequestInfo | Request, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : (input as Request).url;
+    if (url.includes("/store")) {
+      // The api client may pass the body via init.body (string) or as a
+      // Request object (first arg). Read whichever is present.
+      let bodyText: string | undefined;
+      if (typeof init?.body === "string") {
+        bodyText = init.body;
+      } else if (typeof input !== "string" && typeof (input as Request).clone === "function") {
+        bodyText = await (input as Request).clone().text();
+      }
+      if (bodyText) {
+        try {
+          storeCalls.push(JSON.parse(bodyText) as StoreCall);
+        } catch {
+          /* ignore */
+        }
+      }
+    }
+    return new Response(JSON.stringify({ entities: [], unknown_fields_count: 0 }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  try {
+    return await callback(storeCalls);
+  } finally {
+    vi.unstubAllGlobals();
+  }
+}
+
+async function withTempHome<T>(callback: (homeDir: string) => Promise<T>): Promise<T> {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "neotoma-import-"));
+  const prevHome = process.env.HOME;
+  const prevProfile = process.env.USERPROFILE;
+  process.env.HOME = tempDir;
+  process.env.USERPROFILE = tempDir;
+  const configDir = path.join(tempDir, ".config", "neotoma");
+  await fs.mkdir(configDir, { recursive: true });
+  await fs.writeFile(
+    path.join(configDir, "config.json"),
+    JSON.stringify({
+      base_url: "http://localhost:9999",
+      access_token: "token-test",
+      expires_at: "2099-01-01T00:00:00Z",
+    })
+  );
+  try {
+    return await callback(tempDir);
+  } finally {
+    process.env.HOME = prevHome;
+    process.env.USERPROFILE = prevProfile;
+  }
+}
+
+async function writeJsonl(dir: string, count: number): Promise<string> {
+  const file = path.join(dir, "entities.jsonl");
+  const lines = Array.from({ length: count }, (_, i) =>
+    JSON.stringify({ entity_type: "thing", canonical_name: `thing-${i}` })
+  );
+  await fs.writeFile(file, lines.join("\n") + "\n");
+  return file;
+}
+
+describe("CLI entities import (#1470 bulk import)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("chunks a JSONL file into batched /store calls with per-chunk idempotency keys", async () => {
+    await withTempHome(async (home) => {
+      const file = await writeJsonl(home, 5);
+      await withStoreMock(async (storeCalls) => {
+        const { runCli } = await loadCli();
+        const stdout = captureStdout();
+        try {
+          await runCli([
+            "node",
+            "cli",
+            "entities",
+            "import",
+            file,
+            "--batch-size",
+            "2",
+            "--commit",
+            "--json",
+          ]);
+        } finally {
+          stdout.restore();
+        }
+
+        // 5 entities at batch size 2 => 3 chunks (2, 2, 1)
+        expect(storeCalls.length).toBe(3);
+        expect((storeCalls[0].entities as unknown[]).length).toBe(2);
+        expect((storeCalls[1].entities as unknown[]).length).toBe(2);
+        expect((storeCalls[2].entities as unknown[]).length).toBe(1);
+
+        // Per-chunk idempotency keys are distinct and stable (indexed)
+        const keys = storeCalls.map((c) => c.idempotency_key);
+        expect(new Set(keys).size).toBe(3);
+        expect(keys[0].endsWith(":0")).toBe(true);
+        expect(keys[2].endsWith(":2")).toBe(true);
+
+        // --commit was honored
+        expect(storeCalls.every((c) => c.commit === true)).toBe(true);
+      });
+    });
+  });
+
+  it("defaults to dry-run (commit=false) when --commit is omitted", async () => {
+    await withTempHome(async (home) => {
+      const file = await writeJsonl(home, 3);
+      await withStoreMock(async (storeCalls) => {
+        const { runCli } = await loadCli();
+        const stdout = captureStdout();
+        try {
+          await runCli(["node", "cli", "entities", "import", file, "--json"]);
+        } finally {
+          stdout.restore();
+        }
+        expect(storeCalls.length).toBe(1);
+        expect(storeCalls[0].commit).toBe(false);
+      });
+    });
+  });
+
+  it("re-running with the same file uses identical idempotency keys (safe replay)", async () => {
+    await withTempHome(async (home) => {
+      const file = await writeJsonl(home, 4);
+      await withStoreMock(async (storeCalls) => {
+        const { runCli } = await loadCli();
+        const run = async () => {
+          const stdout = captureStdout();
+          try {
+            await runCli(["node", "cli", "entities", "import", file, "--batch-size", "2", "--json"]);
+          } finally {
+            stdout.restore();
+          }
+        };
+        await run();
+        const firstKeys = storeCalls.map((c) => c.idempotency_key);
+        await run();
+        const secondKeys = storeCalls.slice(firstKeys.length).map((c) => c.idempotency_key);
+        expect(secondKeys).toEqual(firstKeys);
+      });
+    });
+  });
+});

--- a/tests/integration/http_related_entities_multihop.test.ts
+++ b/tests/integration/http_related_entities_multihop.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Integration test: HTTP POST /retrieve_related_entities honours max_hops.
+ *
+ * Regression coverage for bringing the Express handler to parity with the MCP
+ * handler (server.ts retrieveRelatedEntities), which already did breadth-first
+ * multi-hop traversal. Before this, the HTTP endpoint ignored max_hops and
+ * returned only 1-hop neighbours.
+ *
+ * Seeds a directed chain A -> B -> C -> D plus a back-edge D -> A to exercise
+ * cycle protection, then asserts that traversal depth tracks max_hops.
+ */
+
+import { createServer } from "node:http";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { app } from "../../src/actions.js";
+import { db } from "../../src/db.js";
+
+const TEST_USER_ID = "00000000-0000-0000-0000-000000000000";
+const API_PORT = 18137;
+const API_BASE = `http://127.0.0.1:${API_PORT}`;
+
+describe("HTTP /retrieve_related_entities multi-hop traversal", () => {
+  let httpServer: ReturnType<typeof createServer>;
+  const suffix = String(process.hrtime.bigint());
+  const a = `ent_mh_a_${suffix}`;
+  const b = `ent_mh_b_${suffix}`;
+  const c = `ent_mh_c_${suffix}`;
+  const d = `ent_mh_d_${suffix}`;
+  const entityIds = [a, b, c, d];
+
+  // Directed chain a->b->c->d, plus a back-edge d->a to form a cycle.
+  const edges: Array<{ source: string; target: string }> = [
+    { source: a, target: b },
+    { source: b, target: c },
+    { source: c, target: d },
+    { source: d, target: a },
+  ];
+  const relationshipKeys = edges.map((e) => `related_to:${e.source}:${e.target}`);
+
+  beforeAll(async () => {
+    httpServer = createServer(app);
+    await new Promise<void>((resolve, reject) => {
+      httpServer.listen(API_PORT, "127.0.0.1", () => resolve());
+      httpServer.once("error", reject);
+    });
+
+    await db.from("entities").insert(
+      entityIds.map((id) => ({
+        id,
+        entity_type: "thing",
+        canonical_name: id,
+        user_id: TEST_USER_ID,
+      }))
+    );
+
+    await db.from("relationship_snapshots").insert(
+      edges.map((e) => ({
+        relationship_key: `related_to:${e.source}:${e.target}`,
+        relationship_type: "related_to",
+        source_entity_id: e.source,
+        target_entity_id: e.target,
+        schema_version: "1.0",
+        snapshot: {},
+        user_id: TEST_USER_ID,
+      }))
+    );
+  });
+
+  afterAll(async () => {
+    for (const key of relationshipKeys) {
+      await db.from("relationship_snapshots").delete().eq("relationship_key", key);
+    }
+    for (const id of entityIds) {
+      await db.from("entities").delete().eq("id", id);
+    }
+    await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+  });
+
+  async function relatedOutbound(maxHops: number): Promise<Set<string>> {
+    const res = await fetch(`${API_BASE}/retrieve_related_entities`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        entity_id: a,
+        direction: "outbound",
+        max_hops: maxHops,
+        include_entities: true,
+      }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { entities: Array<{ id: string }> };
+    return new Set(body.entities.map((e) => e.id));
+  }
+
+  it("1-hop outbound returns only the direct neighbour", async () => {
+    const ids = await relatedOutbound(1);
+    expect(ids.has(b)).toBe(true);
+    expect(ids.has(c)).toBe(false);
+    expect(ids.has(d)).toBe(false);
+  });
+
+  it("2-hop outbound reaches the second-level neighbour", async () => {
+    const ids = await relatedOutbound(2);
+    expect(ids.has(b)).toBe(true);
+    expect(ids.has(c)).toBe(true);
+    expect(ids.has(d)).toBe(false);
+  });
+
+  it("3-hop outbound reaches the third-level neighbour", async () => {
+    const ids = await relatedOutbound(3);
+    expect(ids.has(b)).toBe(true);
+    expect(ids.has(c)).toBe(true);
+    expect(ids.has(d)).toBe(true);
+  });
+
+  it("does not loop forever on a cycle (d->a back-edge) and excludes the origin", async () => {
+    // 4 hops would revisit `a` via d->a; visited-set must prevent re-expansion
+    // and the origin entity must never appear in its own related set.
+    const ids = await relatedOutbound(4);
+    expect(ids.has(b)).toBe(true);
+    expect(ids.has(c)).toBe(true);
+    expect(ids.has(d)).toBe(true);
+    expect(ids.has(a)).toBe(false);
+  });
+});

--- a/tests/security/tenant_isolation_matrix.test.ts
+++ b/tests/security/tenant_isolation_matrix.test.ts
@@ -233,5 +233,288 @@ describe("Tenant isolation matrix (GHSA-wrr4-782v-jhwh)", () => {
       expect(json.relationships).toEqual([]);
       expect(json.entities ?? []).toEqual([]);
     });
+
+    // Vector: edge-scoping-escape via a planted cross-tenant edge.
+    //
+    // createRelationship (src/services/relationships.ts) does NOT validate
+    // that both endpoints are owned by the caller, so user A can write a
+    // relationship row (user_id=A) whose target_entity_id is user B's
+    // private entity. The risk would be that the multi-hop BFS in
+    // /retrieve_related_entities (src/actions.ts:7964-8039) uses B's id as a
+    // hop frontier and then surfaces B's edges or B's entity row.
+    //
+    // This MUST NOT happen: the per-hop relationship_snapshots queries are
+    // user-scoped INSIDE the loop body (actions.ts:7974, 8000), so they only
+    // ever return A-owned rows; and the final entities fetch is
+    // .eq("user_id", A) (actions.ts:8031), so B's entity row is dropped even
+    // though B's id appears as a frontier endpoint. The only echo is the id
+    // string A planted themselves — not disclosure of B's data.
+    //
+    // This locks isolation in: a regression that moves the user_id filter
+    // out of the loop, or drops it from the entities fetch, fails here.
+    it("planted cross-tenant edge does NOT leak user B's edges or entity via multi-hop BFS", async () => {
+      const plantedKey = `${TEST_PREFIX}_planted_${Date.now()}_${Math.random()
+        .toString(36)
+        .slice(2, 6)}`;
+      try {
+        // As user A: write an edge A.entityId -> userB.entityId into A's scope.
+        // userB.entityId is a foreign endpoint A does not own.
+        await db.from("relationship_snapshots").insert({
+          relationship_key: plantedKey,
+          relationship_type: "REFERS_TO",
+          source_entity_id: userA.entityId,
+          target_entity_id: userB.entityId,
+          schema_version: "1",
+          snapshot: JSON.stringify({}),
+          user_id: userA.userId,
+        });
+
+        // As user A: multi-hop traversal from A's root that reaches the
+        // foreign frontier id (userB.entityId) at hop 1, then attempts hop 2.
+        const { status, json } = await callEndpoint("/retrieve_related_entities", {
+          entity_id: userA.entityId,
+          user_id: userA.userId,
+          max_hops: 2,
+          direction: "both",
+        });
+        expect(status).toBe(200);
+
+        const rels: any[] = json.relationships ?? [];
+        // Every returned relationship row MUST be owned by user A.
+        for (const rel of rels) {
+          expect(rel.user_id).toBe(userA.userId);
+        }
+        // User B's pre-seeded edge MUST NOT surface, even though hop 2
+        // queries with userB.entityId as a frontier id.
+        const relKeys = rels.map((r) => r.relationship_key);
+        expect(relKeys).not.toContain(userB.relationshipKey);
+
+        const entities: any[] = json.entities ?? [];
+        // No entity owned by user B may appear in the results.
+        for (const ent of entities) {
+          expect(ent.user_id).toBe(userA.userId);
+        }
+        // userB.entityId is an endpoint of the planted edge but is owned by
+        // user B, so it MUST be absent from the materialized entities.
+        const entityIds = entities.map((e) => e.id);
+        expect(entityIds).not.toContain(userB.entityId);
+      } finally {
+        await db.from("relationship_snapshots").delete().eq("relationship_key", plantedKey);
+      }
+    });
+  });
+
+  // Vector: bulk-import-cross-user.
+  //
+  // The bulk `entities import` CLI path (src/cli/index.ts) sends a body
+  // user_id plus an array of raw JSONL lines as entities[]. A red-team pass
+  // probed whether an attacker authenticated as user A could write into,
+  // overwrite, or read user B's tenant by:
+  //   (1) overriding the request body/flag user_id to user B, or
+  //   (2) smuggling a per-line `user_id: <userB>` inside an entity object.
+  //
+  // handleStorePost (src/actions.ts:6767) resolves a SINGLE batch userId via
+  // getAuthenticatedUserId, and the per-entity destructure
+  // (src/actions.ts:6196) only strips entity_type/intent/target_id — any
+  // stray `user_id` lands in `...fields` as inert observation data and the
+  // observation is written with `user_id: <batch userId>`
+  // (createObservation). Isolation is enforced by the `user_id` column on
+  // every row, not by the entity_id (generateEntityId is user-agnostic:
+  // type+canonical_name only), so the per-line override cannot redirect a
+  // write into another tenant's scope.
+  //
+  // These tests lock that in: a regression that lets the per-entity user_id
+  // win, or that drops the batch-level user scoping on the write, surfaces a
+  // user-B-scoped row here and fails.
+  describe("/store bulk import (bulk-import-cross-user)", () => {
+    it("per-line user_id override is inert: observation is written under the batch user only", async () => {
+      const suffix = `${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+      const canonicalName = `${TEST_PREFIX}_bulk_${suffix}`;
+      const createdEntityIds: string[] = [];
+      const createdObservationIds: string[] = [];
+      const createdSourceIds: string[] = [];
+
+      try {
+        // As user A (batch user_id = A), smuggle a per-line user_id = B.
+        const { status, json } = await callEndpoint("/store", {
+          user_id: userA.userId,
+          idempotency_key: `${TEST_PREFIX}_bulk_${suffix}`,
+          commit: true,
+          entities: [
+            {
+              entity_type: "test",
+              canonical_name: canonicalName,
+              // Attacker-smuggled cross-tenant override. MUST be inert.
+              user_id: userB.userId,
+            },
+          ],
+        });
+        expect(status).toBe(200);
+
+        const stored = (json.entities ?? [])[0] as
+          | { entity_id?: string; observation_id?: string }
+          | undefined;
+        expect(stored?.entity_id).toBeDefined();
+        if (stored?.entity_id) createdEntityIds.push(stored.entity_id);
+        if (stored?.observation_id) createdObservationIds.push(stored.observation_id);
+        if (typeof json.source_id === "string") createdSourceIds.push(json.source_id);
+
+        const entityId = stored!.entity_id!;
+
+        // The written observation MUST belong to user A, never user B.
+        const { data: obsRows } = await db
+          .from("observations")
+          .select("*")
+          .eq("entity_id", entityId);
+        expect((obsRows ?? []).length).toBeGreaterThan(0);
+        for (const obs of obsRows ?? []) {
+          expect(obs.user_id).toBe(userA.userId);
+          expect(obs.user_id).not.toBe(userB.userId);
+        }
+
+        // The entity row itself MUST be scoped to user A.
+        const { data: entRows } = await db.from("entities").select("*").eq("id", entityId);
+        for (const ent of entRows ?? []) {
+          expect(ent.user_id).toBe(userA.userId);
+        }
+
+        // No row for this batch import may exist under user B's scope:
+        // zero entities and zero observations enumerable as user B.
+        const { data: bobEntities } = await db
+          .from("entities")
+          .select("id")
+          .eq("id", entityId)
+          .eq("user_id", userB.userId);
+        expect(bobEntities ?? []).toEqual([]);
+
+        const { data: bobObs } = await db
+          .from("observations")
+          .select("id")
+          .eq("entity_id", entityId)
+          .eq("user_id", userB.userId);
+        expect(bobObs ?? []).toEqual([]);
+      } finally {
+        for (const id of createdObservationIds) {
+          await db.from("observations").delete().eq("id", id);
+        }
+        for (const id of createdEntityIds) {
+          await db.from("observations").delete().eq("entity_id", id);
+          await db.from("entity_snapshots").delete().eq("entity_id", id);
+          await db.from("entities").delete().eq("id", id);
+        }
+        for (const id of createdSourceIds) {
+          await db.from("sources").delete().eq("id", id);
+        }
+      }
+    });
+
+    it("body user_id override does not let user A write into user B's relationship scope", async () => {
+      // A bulk batch authored as user A that references user B's entity_id as
+      // a relationship target MUST produce only a user-A-scoped
+      // relationship_snapshot. User B's relationship reads MUST NOT surface
+      // it (no enumeration oracle across the tenant boundary).
+      const suffix = `${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+      const srcName = `${TEST_PREFIX}_bulkrel_${suffix}`;
+      // The store relationships[] schema requires target_entity_id to match
+      // the canonical Neotoma entity_id format (ent_ + 24 hex). Seed a real,
+      // user-B-owned entity with such an id to act as the cross-tenant target.
+      const bobTargetId = `ent_${randomUUID().replace(/-/g, "").slice(0, 24)}`;
+      const createdEntityIds: string[] = [];
+      const createdObservationIds: string[] = [];
+      const createdSourceIds: string[] = [];
+      const relKeysBefore = new Set<string>();
+
+      await db.from("entities").insert({
+        id: bobTargetId,
+        user_id: userB.userId,
+        entity_type: "test",
+        canonical_name: `${TEST_PREFIX}_bobtarget_${suffix}`,
+      });
+
+      // Capture user B's existing relationship keys to detect any new leak.
+      const { json: bobBefore } = await callEndpoint("/list_relationships", {
+        entity_id: bobTargetId,
+        user_id: userB.userId,
+      });
+      for (const r of bobBefore.relationships ?? []) {
+        relKeysBefore.add(r.relationship_key);
+      }
+
+      try {
+        const { status, json } = await callEndpoint("/store", {
+          user_id: userA.userId,
+          idempotency_key: `${TEST_PREFIX}_bulkrel_${suffix}`,
+          commit: true,
+          entities: [
+            {
+              entity_type: "test",
+              canonical_name: srcName,
+            },
+          ],
+          relationships: [
+            {
+              relationship_type: "REFERS_TO",
+              source_index: 0,
+              // Cross-tenant reference: user B's private entity.
+              target_entity_id: bobTargetId,
+            },
+          ],
+        });
+        expect(status).toBe(200);
+
+        const stored = (json.entities ?? [])[0] as
+          | { entity_id?: string; observation_id?: string }
+          | undefined;
+        if (stored?.entity_id) createdEntityIds.push(stored.entity_id);
+        if (stored?.observation_id) createdObservationIds.push(stored.observation_id);
+        if (typeof json.source_id === "string") createdSourceIds.push(json.source_id);
+
+        // Any relationship_snapshot pointing at user B's entity that was
+        // created by this batch MUST be scoped to user A (the batch author),
+        // never silently re-homed into user B's tenant.
+        const { data: snaps } = await db
+          .from("relationship_snapshots")
+          .select("*")
+          .eq("target_entity_id", bobTargetId);
+        expect((snaps ?? []).length).toBeGreaterThan(0);
+        for (const snap of snaps ?? []) {
+          expect(snap.user_id).toBe(userA.userId);
+          expect(snap.user_id).not.toBe(userB.userId);
+        }
+
+        // The cross-tenant reference MUST NOT appear in user B's reads.
+        const { json: bobAfter } = await callEndpoint("/list_relationships", {
+          entity_id: bobTargetId,
+          user_id: userB.userId,
+        });
+        const bobKeysAfter: string[] = (bobAfter.relationships ?? []).map(
+          (r: any) => r.relationship_key
+        );
+        for (const key of bobKeysAfter) {
+          // No NEW relationship key appeared in user B's scope as a result of
+          // user A's cross-tenant write.
+          expect(relKeysBefore.has(key)).toBe(true);
+        }
+        // Every relationship user B can read MUST be owned by user B.
+        for (const rel of bobAfter.relationships ?? []) {
+          expect(rel.user_id).toBe(userB.userId);
+        }
+      } finally {
+        for (const id of createdObservationIds) {
+          await db.from("observations").delete().eq("id", id);
+        }
+        for (const id of createdEntityIds) {
+          await db.from("relationship_snapshots").delete().eq("source_entity_id", id);
+          await db.from("observations").delete().eq("entity_id", id);
+          await db.from("entity_snapshots").delete().eq("entity_id", id);
+          await db.from("entities").delete().eq("id", id);
+        }
+        for (const id of createdSourceIds) {
+          await db.from("sources").delete().eq("id", id);
+        }
+        await db.from("relationship_snapshots").delete().eq("target_entity_id", bobTargetId);
+        await db.from("entities").delete().eq("id", bobTargetId);
+      }
+    });
   });
 });


### PR DESCRIPTION
Two pieces from a real-world multi-user integration backlog, both verified with tests.

## Multi-hop HTTP traversal — corrects a parity gap (and a misstatement)

The MCP handler (`server.ts` `retrieveRelatedEntities`) **already** did breadth-first n-hop traversal, but the HTTP endpoint `POST /retrieve_related_entities` was a *"Simple 1-hop"* stub that silently ignored `max_hops`. Since an HTTP-API consumer would only see 1-hop, "Neotoma does native multi-hop traversal" was only half-true — true on MCP, false on HTTP.

- **Ported the BFS** (level frontier + `visited` set for cycle protection) from the MCP handler into the Express handler, so the HTTP path honors `max_hops` at parity.
- `max_hops` still **defaults to 1** — existing callers are byte-for-byte unaffected. No OpenAPI/contract change (the param was already declared).
- **Fixed a cosmetic bug** in the MCP handler: `hops_traversed` was capped at 1 even when traversal went deeper; it now reports the actual depth reached.
- **Test:** `tests/integration/http_related_entities_multihop.test.ts` seeds `a→b→c→d` with a `d→a` back-edge and asserts depth tracks `max_hops` (1-hop→b, 2-hop→c, 3-hop→d) and the cycle neither loops nor includes the origin.

This is also what unblocks a real **#1467** benchmark — there is now a true n-hop target on both transports to measure.

## Bulk entity import (#1470)

New `neotoma entities import <file>`:
- Reads a JSONL file (one entity object per line), chunks into batched `POST /store` calls (`--batch-size`, default 200).
- Stamps a **stable per-chunk idempotency key** (`--idempotency-prefix`, default derived from file name) so a large backfill can be **replayed safely** without duplicating data.
- **Dry-run by default**; `--commit` to write.
- The `/store` endpoint already writes each batch transactionally; this command owns file reading, chunking, and idempotency — the supported "replay from an external source" path. Pure client-side wrapper over existing `/store`: **no new operationId, no contract change**.
- **Test:** `tests/cli/cli_entities_import.test.ts` covers chunk boundaries, dry-run default, and idempotent re-run.
- Documented in `docs/developer/cli_reference.md`.

## Notes
- Full typecheck clean; CLI command-coverage guard, contract-mapping, MCP graph, and the two new tests all pass (34 tests across touched surfaces).
- Branch off `main`; pre-commit suite passes.
- Commit is unsigned (GPG pinentry could not prompt in the non-interactive environment) — flagging in case signed commits are required on merge.

Closes #1470

🤖 Generated with [Claude Code](https://claude.com/claude-code)
