### PR TITLE
feat(sse): durable substrate-event log for restart-safe resume (#1464 Tier 2)

### DIFF
--- a/docs/subsystems/subscriptions.md
+++ b/docs/subsystems/subscriptions.md
@@ -99,10 +99,12 @@ The bridge is wired once at server startup by `installSubscriptionBridge`. The i
 ## SSE delivery contract
 
 - Endpoint: `GET /events/stream?subscription_id=<id>` (auth required; subscription must be owned by the caller). This is the canonical path (registered in `src/actions.ts` and exposed in `openapi.yaml`); the legacy `GET /subscriptions/sse` shorthand was dropped before v0.12.0 — update any older clients.
-- Frame format: `id: <ring_id>\nevent: <event_type>\ndata: <json>\n\n`.
-- Resume: clients should send `Last-Event-ID: <ring_id>` so the hub replays buffered events newer than that id (subject to the ring cap).
-- Buffer eviction and gap detection: when the ring exceeds `NEOTOMA_SSE_EVENT_BUFFER`, the oldest entries are dropped. If a reconnecting client sends a `Last-Event-ID` that is **no longer in the ring** — because it was evicted past the cap, or because the server restarted (the ring is in-memory and does not survive a restart) — the stream emits a one-time `event: gap` frame **before** replaying, with `data` of the form `{ reason: "cursor_not_in_buffer", requested_last_event_id, latest_ring_id, message }`. The hub then resumes from the current buffer head so the client still makes forward progress.
-- Delivery guarantee: SSE resume is **best-effort and non-durable**. Within the in-memory window it is gap-free; outside it (eviction or restart) the `gap` frame signals a discontinuity. A consumer that requires gap-free delivery — for example, projecting substrate events into an external index — must treat a `gap` frame as "reconcile via a full read" rather than trusting the replayed slice. Durable, restart-surviving replay (a persistent event log) is not yet implemented; see issue #1464.
+- Frame format: `id: <seq>\nevent: <event_type>\ndata: <json>\n\n`. The `id` is the durable event-log `seq` (monotonic, AUTOINCREMENT), not the in-memory ring counter — so a client's `Last-Event-ID` is a stable cursor that survives a server restart.
+- Resume order (`Last-Event-ID: <seq>`):
+  1. **In-memory ring** — if the cursor is still buffered, replay from the ring (hot path).
+  2. **Durable event log** — if the cursor has left the ring (restart, or a gap larger than `NEOTOMA_SSE_EVENT_BUFFER`) but is still within retention, replay from the `substrate_events` table. Resume is gap-free across restarts within the retention window.
+  3. **Gap signal** — only when the cursor predates the retained window (or is not a valid cursor), the stream emits a one-time `event: gap` frame (`reason: cursor_beyond_retention`) and resumes from the current head. A consumer requiring gap-free delivery treats this as "reconcile via a full read."
+- Durable event log (`substrate_events`): every emitted event is persisted **synchronously** in the same path as the ring push, so durability holds as soon as the event is emitted. Retention is a rolling window, `NEOTOMA_EVENT_RETENTION_DAYS` (default 7); a background prune runs on startup and every 6h. The ring remains the fast path; a log write/prune failure never blocks delivery.
 
 ## Loop prevention with peer sync
 
@@ -117,6 +119,7 @@ Environment variables:
 
 - `NEOTOMA_MAX_SUBSCRIPTIONS_PER_USER` — soft cap; default 50.
 - `NEOTOMA_SSE_EVENT_BUFFER` — ring capacity; clamped 100–10000, default 1000.
+- `NEOTOMA_EVENT_RETENTION_DAYS` — durable `substrate_events` retention window; min 1, default 7. Events older than this are pruned (startup + every 6h).
 - `NEOTOMA_ENV` / `NODE_ENV` — switches the production allow-list for webhook URLs.
 - `NEOTOMA_DEBUG_SUBSTRATE_EVENTS` — debug logging on the underlying bus.
 

--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,8 +61,8 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **409**
-- Backend and repo Vitest files: **376**
+- Total automated test files: **410**
+- Backend and repo Vitest files: **377**
 - Frontend Vitest files: **9**
 - Playwright spec files: **24**
 
@@ -76,7 +76,7 @@ flowchart TD
 | Vitest CLI tests | 59 |
 | Vitest contract tests | 12 |
 | Vitest security tests | 3 |
-| Vitest subscription tests | 4 |
+| Vitest subscription tests | 5 |
 | Vitest agent tests | 1 |
 | Vitest fixture tests | 1 |
 | Vitest helper tests | 1 |
@@ -523,7 +523,8 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npx vitest run tests/subscriptions`
 **Requirements:** Basic `.env`; some tests start an in-process HTTP server.
-**Files (4):**
+**Files (5):**
+- `tests/subscriptions/durable_event_log.test.ts`
 - `tests/subscriptions/guest_write_rate_limit_routing.test.ts`
 - `tests/subscriptions/sse_ring_gap_detection.test.ts`
 - `tests/subscriptions/subscription_guest_auth.test.ts`

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/markmhendrickson/repos/neotoma/node_modules

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -128,6 +128,7 @@ import {
 import { getSandboxTermsResponse } from "./services/sandbox/terms.js";
 import { resolveSandboxReportTransport } from "./services/sandbox/transport.js";
 import type { SandboxReportReason } from "./services/sandbox/types.js";
+import type { SubstrateEvent } from "./events/types.js";
 import { getSqliteDb } from "./repositories/sqlite/sqlite_client.js";
 import { getMcpAuthToken } from "./crypto/mcp_auth_token.js";
 import {
@@ -9412,10 +9413,12 @@ app.get("/events/stream", async (req, res) => {
       (await getAuthenticatedUserId(req, req.query.user_id as string | undefined));
     const { getSubscriptionStatus } =
       await import("./services/subscriptions/subscription_actions.js");
-    const { registerSseClient, resumeRingAfter } =
+    const { registerSseClient, getRingEntriesAfter, ringHasId } =
       await import("./services/subscriptions/sse_hub.js");
     const { subscriptionMatchesEvent } =
       await import("./services/subscriptions/subscription_types.js");
+    const { getEventsAfterSeq, hasDurableCursor } =
+      await import("./services/subscriptions/event_log.js");
 
     const sub = await getSubscriptionStatus({ userId, subscription_id });
     if (!sub) {
@@ -9444,32 +9447,59 @@ app.get("/events/stream", async (req, res) => {
     const lastEventIdHeader = req.headers["last-event-id"];
     const lastEventId = Array.isArray(lastEventIdHeader) ? lastEventIdHeader[0] : lastEventIdHeader;
 
-    const resume = resumeRingAfter(lastEventId, (ev) => subscriptionMatchesEvent(sub, ev));
+    // Resume strategy (#1464). The event id is the durable monotonic `seq`, so
+    // it survives restarts. Resolve resume against, in order:
+    //   1. the in-memory ring (hot path, fastest);
+    //   2. the durable event log, if the cursor is still within retention but
+    //      no longer in the ring (e.g. after a restart or a gap > buffer);
+    //   3. a one-time `gap` signal, only when the cursor predates the retained
+    //      window — a true unrecoverable gap that requires a full reconcile.
+    const writeEvent = (id: string, ev: SubstrateEvent): void => {
+      res.write(`id: ${id}\n`);
+      res.write(`event: ${ev.event_type}\n`);
+      res.write(`data: ${JSON.stringify(ev)}\n\n`);
+    };
 
-    // If the requested cursor fell out of the in-memory buffer (eviction past
-    // the cap, or a server restart), tell the client before replaying the
-    // current head. This converts silent drift into a recoverable signal: a
-    // consumer projecting events into an external index should treat a gap as
-    // "reconcile via a full read", not as a continuation from its last cursor.
-    if (resume.gap_detected) {
-      res.write(`event: gap\n`);
-      res.write(
-        `data: ${JSON.stringify({
-          reason: "cursor_not_in_buffer",
-          requested_last_event_id: lastEventId,
-          latest_ring_id: resume.latest_ring_id,
-          message:
-            "Requested Last-Event-ID is no longer in the in-memory event buffer " +
-            "(evicted or lost to a restart). Replaying from the current buffer head; " +
-            "reconcile via a full read if gap-free delivery is required.",
-        })}\n\n`
-      );
-    }
-
-    for (const entry of resume.entries) {
-      res.write(`id: ${entry.id}\n`);
-      res.write(`event: ${entry.event.event_type}\n`);
-      res.write(`data: ${JSON.stringify(entry.event)}\n\n`);
+    if (lastEventId !== undefined && !ringHasId(lastEventId)) {
+      const cursorSeq = Number(lastEventId);
+      if (Number.isFinite(cursorSeq) && hasDurableCursor(userId, cursorSeq)) {
+        // Recoverable from durable storage: replay from the log, paging until
+        // drained, then continue from the ring tail for anything newer.
+        let after = cursorSeq;
+        for (;;) {
+          const batch = getEventsAfterSeq(userId, after, 1000);
+          if (batch.length === 0) break;
+          for (const d of batch) {
+            if (subscriptionMatchesEvent(sub, d.event)) writeEvent(String(d.seq), d.event);
+          }
+          after = batch[batch.length - 1]!.seq;
+          if (batch.length < 1000) break;
+        }
+      } else {
+        // Cursor is gone (older than retention, or never valid): signal the gap
+        // so the client reconciles, then resume from the current ring head.
+        res.write(`event: gap\n`);
+        res.write(
+          `data: ${JSON.stringify({
+            reason: "cursor_beyond_retention",
+            requested_last_event_id: lastEventId,
+            message:
+              "Requested Last-Event-ID is older than the durable event-log " +
+              "retention window (or not a valid cursor). Replaying from the " +
+              "current head; reconcile via a full read for gap-free delivery.",
+          })}\n\n`
+        );
+        for (const entry of getRingEntriesAfter(undefined, (ev) => subscriptionMatchesEvent(sub, ev))) {
+          writeEvent(entry.id, entry.event);
+        }
+      }
+    } else {
+      // Cursor is in the ring (or this is a fresh subscriber): serve from ring.
+      for (const entry of getRingEntriesAfter(lastEventId, (ev) =>
+        subscriptionMatchesEvent(sub, ev)
+      )) {
+        writeEvent(entry.id, entry.event);
+      }
     }
 
     const client = {

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -9497,7 +9497,9 @@ app.get("/events/stream", async (req, res) => {
               "current head; reconcile via a full read for gap-free delivery.",
           })}\n\n`
         );
-        for (const entry of getRingEntriesAfter(undefined, (ev) => subscriptionMatchesEvent(sub, ev))) {
+        for (const entry of getRingEntriesAfter(undefined, (ev) =>
+          subscriptionMatchesEvent(sub, ev)
+        )) {
           writeEvent(entry.id, entry.event);
         }
       }

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -9465,9 +9465,17 @@ app.get("/events/stream", async (req, res) => {
       if (Number.isFinite(cursorSeq) && hasDurableCursor(userId, cursorSeq)) {
         // Recoverable from durable storage: replay from the log, paging until
         // drained, then continue from the ring tail for anything newer.
+        // Push the subscription's column-backed predicates into SQL so a narrow
+        // subscription does not scan the whole user log. Payload-only predicates
+        // (entity_type, peer-loop) are still enforced by subscriptionMatchesEvent
+        // below — the SQL filter only narrows, never widens.
+        const durableFilter = {
+          eventTypes: sub.watch_event_types,
+          entityIds: sub.watch_entity_ids,
+        };
         let after = cursorSeq;
         for (;;) {
-          const batch = getEventsAfterSeq(userId, after, 1000);
+          const batch = getEventsAfterSeq(userId, after, 1000, durableFilter);
           if (batch.length === 0) break;
           for (const d of batch) {
             if (subscriptionMatchesEvent(sub, d.event)) writeEvent(String(d.seq), d.event);

--- a/src/repositories/sqlite/sqlite_client.ts
+++ b/src/repositories/sqlite/sqlite_client.ts
@@ -296,6 +296,19 @@ const SCHEMA_STATEMENTS = [
     entity_type TEXT NOT NULL,
     merged INTEGER DEFAULT 0
   )`,
+  // Durable substrate-event log (#1464 Tier 2): persists every emitted
+  // SubstrateEvent so SSE resume survives a server restart or a gap larger than
+  // the in-memory ring. `seq` is the durable monotonic cursor (distinct from
+  // the in-memory ring id). Pruned to NEOTOMA_EVENT_RETENTION_DAYS (default 7).
+  `CREATE TABLE IF NOT EXISTS substrate_events (
+    seq INTEGER PRIMARY KEY AUTOINCREMENT,
+    ring_id TEXT,
+    event_type TEXT NOT NULL,
+    user_id TEXT,
+    entity_id TEXT,
+    payload TEXT NOT NULL,
+    created_at TEXT NOT NULL
+  )`,
 ];
 
 /** Legacy tables that may exist in older neotoma.db files. Dropped on open so DB matches canonical schema. */
@@ -410,6 +423,15 @@ function ensureSchema(db: SqliteDatabase): void {
     ).run();
     db.prepare(
       "CREATE INDEX IF NOT EXISTS idx_rel_snapshots_target_user ON relationship_snapshots(target_entity_id, user_id)"
+    ).run();
+
+    // Durable substrate-event log (#1464 Tier 2): resume queries read by
+    // (user_id, seq); pruning reads by created_at.
+    db.prepare(
+      "CREATE INDEX IF NOT EXISTS idx_substrate_events_user_seq ON substrate_events(user_id, seq)"
+    ).run();
+    db.prepare(
+      "CREATE INDEX IF NOT EXISTS idx_substrate_events_created ON substrate_events(created_at)"
     ).run();
 
     // Parity with Postgres: unique constraint on (content_hash, user_id) for deduplication

--- a/src/services/subscriptions/event_log.ts
+++ b/src/services/subscriptions/event_log.ts
@@ -160,8 +160,6 @@ export function pruneEventLog(retentionDays = EVENT_RETENTION_DAYS, nowMs?: numb
   const db = getSqliteDb();
   const cutoffMs = (nowMs ?? Date.now()) - retentionDays * 24 * 60 * 60 * 1000;
   const cutoffIso = new Date(cutoffMs).toISOString();
-  const info = db
-    .prepare(`DELETE FROM substrate_events WHERE created_at < ?`)
-    .run(cutoffIso);
+  const info = db.prepare(`DELETE FROM substrate_events WHERE created_at < ?`).run(cutoffIso);
   return Number(info.changes ?? 0);
 }

--- a/src/services/subscriptions/event_log.ts
+++ b/src/services/subscriptions/event_log.ts
@@ -1,0 +1,111 @@
+/**
+ * Durable substrate-event log (#1464 Tier 2).
+ *
+ * The in-memory SSE ring (`sse_hub.ts`) gives fast, gap-free resume within a
+ * bounded window, but it does not survive a server restart or a gap larger than
+ * the buffer. This module persists every emitted SubstrateEvent to the
+ * `substrate_events` table so resume can fall back to durable storage when the
+ * cursor has left the ring.
+ *
+ * Writes are synchronous (in the same path as the ring push) so an event is
+ * durable as soon as it is emitted. The log is pruned to a rolling retention
+ * window (NEOTOMA_EVENT_RETENTION_DAYS, default 7).
+ */
+
+import { getSqliteDb } from "../../repositories/sqlite/sqlite_client.js";
+import { logger } from "../../utils/logger.js";
+import type { SubstrateEvent } from "../../events/types.js";
+
+export const EVENT_RETENTION_DAYS = Math.max(
+  1,
+  parseInt(process.env.NEOTOMA_EVENT_RETENTION_DAYS ?? "7", 10) || 7
+);
+
+export interface DurableEvent {
+  seq: number;
+  event: SubstrateEvent;
+}
+
+/**
+ * Persist a substrate event to the durable log. Synchronous: returns the
+ * assigned durable `seq` (monotonic, distinct from the in-memory ring id).
+ * `nowIso` is injectable for deterministic tests; defaults to wall clock.
+ */
+export function persistSubstrateEvent(
+  event: SubstrateEvent,
+  ringId: string | null,
+  nowIso?: string
+): number {
+  const db = getSqliteDb();
+  const createdAt = nowIso ?? new Date().toISOString();
+  const info = db
+    .prepare(
+      `INSERT INTO substrate_events (ring_id, event_type, user_id, entity_id, payload, created_at)
+       VALUES (?, ?, ?, ?, ?, ?)`
+    )
+    .run(
+      ringId,
+      event.event_type,
+      event.user_id ?? null,
+      event.entity_id ?? null,
+      JSON.stringify(event),
+      createdAt
+    );
+  return Number(info.lastInsertRowid);
+}
+
+/**
+ * Read durable events strictly after `afterSeq` for a user, oldest first.
+ * Used as the resume fallback when the requested cursor is no longer in the
+ * in-memory ring. `limit` bounds a single read.
+ */
+export function getEventsAfterSeq(userId: string, afterSeq: number, limit = 1000): DurableEvent[] {
+  const db = getSqliteDb();
+  const rows = db
+    .prepare(
+      `SELECT seq, payload FROM substrate_events
+       WHERE user_id = ? AND seq > ?
+       ORDER BY seq ASC
+       LIMIT ?`
+    )
+    .all(userId, afterSeq, limit) as Array<{ seq: number; payload: string }>;
+  const out: DurableEvent[] = [];
+  for (const row of rows) {
+    try {
+      out.push({ seq: row.seq, event: JSON.parse(row.payload) as SubstrateEvent });
+    } catch {
+      // Skip a corrupt payload rather than fail the whole resume.
+      logger.warn("[event_log] skipping unparseable durable event", { seq: row.seq });
+    }
+  }
+  return out;
+}
+
+/**
+ * True when the durable log still holds an event at or before `seq` for the
+ * user — i.e. the requested cursor is within the retained window and resume is
+ * gap-free. False when the cursor predates the oldest retained event (a real
+ * gap that requires reconciliation).
+ */
+export function hasDurableCursor(userId: string, seq: number): boolean {
+  const db = getSqliteDb();
+  const row = db
+    .prepare(`SELECT MIN(seq) AS min_seq FROM substrate_events WHERE user_id = ?`)
+    .get(userId) as { min_seq: number | null } | undefined;
+  if (!row || row.min_seq === null) return false;
+  return seq >= row.min_seq;
+}
+
+/**
+ * Delete events older than the retention window. Returns the number of rows
+ * pruned. `nowMs` is injectable for deterministic tests.
+ */
+export function pruneEventLog(retentionDays = EVENT_RETENTION_DAYS, nowMs?: number): number {
+  const db = getSqliteDb();
+  const cutoffMs = (nowMs ?? Date.now()) - retentionDays * 24 * 60 * 60 * 1000;
+  const cutoffIso = new Date(cutoffMs).toISOString();
+  const info = db
+    .prepare(`DELETE FROM substrate_events WHERE created_at < ?`)
+    .run(cutoffIso);
+  return Number(info.changes ?? 0);
+}

--- a/src/services/subscriptions/event_log.ts
+++ b/src/services/subscriptions/event_log.ts
@@ -27,6 +27,20 @@ export interface DurableEvent {
 }
 
 /**
+ * SQL-pushable narrowing for a durable read. Only the columns the durable log
+ * materializes (`event_type`, `entity_id`) are pushed down; richer predicates
+ * (e.g. `entity_type`, which lives in the JSON payload) remain the caller's
+ * responsibility in JS. Narrowing is an optimization: it reduces rows scanned
+ * for a narrow subscription, never changes which events ultimately match.
+ */
+export interface DurableEventFilter {
+  /** Restrict to these event types (column `event_type`). Empty/undefined = no restriction. */
+  eventTypes?: readonly string[];
+  /** Restrict to these entity ids (column `entity_id`). Empty/undefined = no restriction. */
+  entityIds?: readonly string[];
+}
+
+/**
  * Persist a substrate event to the durable log. Synchronous: returns the
  * assigned durable `seq` (monotonic, distinct from the in-memory ring id).
  * `nowIso` is injectable for deterministic tests; defaults to wall clock.
@@ -58,17 +72,44 @@ export function persistSubstrateEvent(
  * Read durable events strictly after `afterSeq` for a user, oldest first.
  * Used as the resume fallback when the requested cursor is no longer in the
  * in-memory ring. `limit` bounds a single read.
+ *
+ * `filter` pushes the subscription's column-backed predicates (`event_type`,
+ * `entity_id`) into SQL so a narrow subscription does not scan the whole user
+ * log. It is purely an optimization — payload-only predicates (e.g.
+ * `entity_type`) MUST still be applied by the caller — and never widens the
+ * result set.
  */
-export function getEventsAfterSeq(userId: string, afterSeq: number, limit = 1000): DurableEvent[] {
+export function getEventsAfterSeq(
+  userId: string,
+  afterSeq: number,
+  limit = 1000,
+  filter?: DurableEventFilter
+): DurableEvent[] {
   const db = getSqliteDb();
+  const clauses: string[] = ["user_id = ?", "seq > ?"];
+  const params: Array<string | number> = [userId, afterSeq];
+
+  const eventTypes = filter?.eventTypes?.filter((t) => typeof t === "string" && t.length > 0);
+  if (eventTypes && eventTypes.length > 0) {
+    clauses.push(`event_type IN (${eventTypes.map(() => "?").join(", ")})`);
+    params.push(...eventTypes);
+  }
+
+  const entityIds = filter?.entityIds?.filter((i) => typeof i === "string" && i.length > 0);
+  if (entityIds && entityIds.length > 0) {
+    clauses.push(`entity_id IN (${entityIds.map(() => "?").join(", ")})`);
+    params.push(...entityIds);
+  }
+
+  params.push(limit);
   const rows = db
     .prepare(
       `SELECT seq, payload FROM substrate_events
-       WHERE user_id = ? AND seq > ?
+       WHERE ${clauses.join(" AND ")}
        ORDER BY seq ASC
        LIMIT ?`
     )
-    .all(userId, afterSeq, limit) as Array<{ seq: number; payload: string }>;
+    .all(...params) as Array<{ seq: number; payload: string }>;
   const out: DurableEvent[] = [];
   for (const row of rows) {
     try {
@@ -82,18 +123,33 @@ export function getEventsAfterSeq(userId: string, afterSeq: number, limit = 1000
 }
 
 /**
- * True when the durable log still holds an event at or before `seq` for the
- * user — i.e. the requested cursor is within the retained window and resume is
- * gap-free. False when the cursor predates the oldest retained event (a real
- * gap that requires reconciliation).
+ * True when the durable log can replay everything strictly after `seq` for the
+ * user without a gap — i.e. the cursor sits inside the retained window.
+ *
+ * The cursor is recoverable only when it falls in `[min_seq - 1, max_seq]`:
+ *  - below `min_seq - 1` → the cursor predates the oldest retained event, so
+ *    events between the cursor and the window were pruned (a real gap requiring
+ *    reconciliation);
+ *  - above `max_seq` → the cursor is newer than anything durable (a ring-only
+ *    id, or a future/foreign seq). Treating it as durably-recoverable would
+ *    enter the replay loop, read zero rows, and silently deliver nothing; it
+ *    MUST fall through to the ring instead. This is the quiet-user / ahead-of-
+ *    head false-positive the upper bound closes.
+ *
+ * Returns false for a user with no durable events (nothing to recover from).
  */
 export function hasDurableCursor(userId: string, seq: number): boolean {
   const db = getSqliteDb();
   const row = db
-    .prepare(`SELECT MIN(seq) AS min_seq FROM substrate_events WHERE user_id = ?`)
-    .get(userId) as { min_seq: number | null } | undefined;
-  if (!row || row.min_seq === null) return false;
-  return seq >= row.min_seq;
+    .prepare(
+      `SELECT MIN(seq) AS min_seq, MAX(seq) AS max_seq FROM substrate_events WHERE user_id = ?`
+    )
+    .get(userId) as { min_seq: number | null; max_seq: number | null } | undefined;
+  if (!row || row.min_seq === null || row.max_seq === null) return false;
+  // `seq` is the last delivered cursor; replay covers (seq, max]. The cursor is
+  // recoverable when at least one retained event is strictly newer than it
+  // (seq < max) and no retained event was skipped below it (seq >= min - 1).
+  return seq >= row.min_seq - 1 && seq <= row.max_seq;
 }
 
 /**

--- a/src/services/subscriptions/install_subscription_bridge.ts
+++ b/src/services/subscriptions/install_subscription_bridge.ts
@@ -1,8 +1,12 @@
 import { substrateEventBus } from "../../events/substrate_event_bus.js";
+import { logger } from "../../utils/logger.js";
 import { handleSubstrateEventForSubscriptions } from "./subscription_bridge.js";
 import { rebuildSubscriptionIndex } from "./subscription_index.js";
+import { pruneEventLog } from "./event_log.js";
 
 let installed = false;
+
+const EVENT_LOG_PRUNE_INTERVAL_MS = 6 * 60 * 60 * 1000; // 6h
 
 export function installSubscriptionBridge(): void {
   if (installed) return;
@@ -11,4 +15,21 @@ export function installSubscriptionBridge(): void {
   substrateEventBus.onSubstrateEvent((ev) => {
     void handleSubstrateEventForSubscriptions(ev);
   });
+
+  // Durable event-log retention (#1464 Tier 2): prune on startup and on a slow
+  // interval. Best-effort — a prune failure must never affect delivery.
+  const runPrune = (): void => {
+    try {
+      const removed = pruneEventLog();
+      if (removed > 0) logger.info("[subscriptions] pruned durable event log", { removed });
+    } catch (err) {
+      logger.warn("[subscriptions] event-log prune failed", {
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  };
+  runPrune();
+  const timer = setInterval(runPrune, EVENT_LOG_PRUNE_INTERVAL_MS);
+  // Do not keep the process alive solely for pruning.
+  if (typeof timer.unref === "function") timer.unref();
 }

--- a/src/services/subscriptions/sse_hub.ts
+++ b/src/services/subscriptions/sse_hub.ts
@@ -14,9 +14,19 @@ type RingEntry = { id: string; event: SubstrateEvent };
 const ring: RingEntry[] = [];
 let seq = 0n;
 
-export function pushSubstrateEventToRing(event: SubstrateEvent): string {
-  seq += 1n;
-  const id = seq.toString();
+export function pushSubstrateEventToRing(event: SubstrateEvent, explicitId?: string): string {
+  // Prefer a caller-supplied id so the ring shares the durable event log's id
+  // space (the AUTOINCREMENT `seq`). That id never resets across restarts,
+  // which is what makes a client's Last-Event-ID a stable, restart-surviving
+  // cursor. The internal counter is only a fallback for callers without a
+  // durable seq (e.g. tests that push directly).
+  let id: string;
+  if (explicitId !== undefined) {
+    id = explicitId;
+  } else {
+    seq += 1n;
+    id = seq.toString();
+  }
   ring.push({ id, event });
   while (ring.length > BUFFER_CAP) {
     ring.shift();
@@ -71,6 +81,11 @@ export function replayRingAfterLastId(
       void e;
     }
   }
+}
+
+/** True when the given event id is currently present in the in-memory ring. */
+export function ringHasId(eventId: string): boolean {
+  return ring.some((e) => e.id === eventId);
 }
 
 export function getRingEntriesAfter(

--- a/src/services/subscriptions/subscription_bridge.ts
+++ b/src/services/subscriptions/subscription_bridge.ts
@@ -5,11 +5,30 @@ import { listAllSubscriptions, refreshSubscriptionInIndex } from "./subscription
 import { subscriptionMatchesEvent } from "./subscription_types.js";
 import { queueWebhookDelivery } from "./webhook_delivery.js";
 import { broadcastSubstrateEventToSse, pushSubstrateEventToRing } from "./sse_hub.js";
+import { persistSubstrateEvent } from "./event_log.js";
 import { queuePeerSyncDelivery } from "../sync/sync_webhook_outbound.js";
 
 export async function handleSubstrateEventForSubscriptions(event: SubstrateEvent): Promise<void> {
   try {
-    const ringId = pushSubstrateEventToRing(event);
+    // Durable log (#1464 Tier 2): persist synchronously FIRST so the durable
+    // monotonic `seq` becomes the event's id everywhere — ring, SSE frame, and
+    // client Last-Event-ID. That id survives restarts (the in-memory ring's own
+    // counter resets), which is what makes resume restart-safe. A log failure
+    // must never break delivery, so fall back to the ring's own id.
+    let durableSeq: number | null = null;
+    try {
+      durableSeq = persistSubstrateEvent(event, null);
+    } catch (err) {
+      logger.warn("[subscriptions] durable event persist failed", {
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+    // Use the durable seq as the ring id when available; otherwise fall back to
+    // the ring's internal counter so delivery still works.
+    const ringId =
+      durableSeq !== null
+        ? pushSubstrateEventToRing(event, String(durableSeq))
+        : pushSubstrateEventToRing(event);
     broadcastSubstrateEventToSse(event, ringId);
 
     if (event.entity_type === SUBSCRIPTION_ENTITY_TYPE) {

--- a/tests/subscriptions/durable_event_log.test.ts
+++ b/tests/subscriptions/durable_event_log.test.ts
@@ -16,18 +16,21 @@ import {
   hasDurableCursor,
   pruneEventLog,
 } from "../../src/services/subscriptions/event_log.js";
-import type { SubstrateEvent } from "../../src/events/types.js";
+import type { SubstrateEvent, SubstrateEventType } from "../../src/events/types.js";
 
 const USER = "00000000-0000-0000-0000-000000000000";
 
-function ev(entityId: string): SubstrateEvent {
+function ev(
+  entityId: string,
+  opts?: { eventType?: SubstrateEventType; entityType?: string }
+): SubstrateEvent {
   return {
     event_id: `evt_${entityId}`,
-    event_type: "entity.created",
+    event_type: opts?.eventType ?? "entity.created",
     timestamp: "2026-01-01T00:00:00.000Z",
     user_id: USER,
     entity_id: entityId,
-    entity_type: "thing",
+    entity_type: opts?.entityType ?? "thing",
     action: "created",
   };
 }
@@ -104,5 +107,70 @@ describe("durable substrate-event log (#1464 Tier 2)", () => {
     expect(seq).toBeGreaterThan(0);
     // Stored with NULL user_id; a user-scoped read does not return it.
     expect(getEventsAfterSeq(USER, 0).length).toBe(0);
+  });
+
+  // --- Advisory 1: SQL-side narrowing (#1482 review) ---
+
+  it("narrows by event_type in SQL without widening the result set", () => {
+    persistSubstrateEvent(ev("created-1", { eventType: "entity.created" }), null);
+    persistSubstrateEvent(ev("updated-1", { eventType: "entity.updated" }), null);
+    persistSubstrateEvent(ev("created-2", { eventType: "entity.created" }), null);
+
+    const filtered = getEventsAfterSeq(USER, 0, 1000, {
+      eventTypes: ["entity.updated"],
+    });
+    expect(filtered.map((d) => d.event.entity_id)).toEqual(["updated-1"]);
+
+    // No filter still returns everything (narrowing never widens or hides).
+    expect(getEventsAfterSeq(USER, 0).length).toBe(3);
+  });
+
+  it("narrows by entity_id in SQL and combines with event_type", () => {
+    persistSubstrateEvent(ev("a", { eventType: "entity.created" }), null);
+    persistSubstrateEvent(ev("b", { eventType: "entity.created" }), null);
+    persistSubstrateEvent(ev("b", { eventType: "entity.updated" }), null);
+
+    expect(
+      getEventsAfterSeq(USER, 0, 1000, { entityIds: ["b"] }).length
+    ).toBe(2);
+    const combined = getEventsAfterSeq(USER, 0, 1000, {
+      entityIds: ["b"],
+      eventTypes: ["entity.updated"],
+    });
+    expect(combined.length).toBe(1);
+    expect(combined[0]!.event.event_type).toBe("entity.updated");
+  });
+
+  it("treats an empty filter array as no restriction", () => {
+    persistSubstrateEvent(ev("x"), null);
+    persistSubstrateEvent(ev("y"), null);
+    expect(getEventsAfterSeq(USER, 0, 1000, { eventTypes: [], entityIds: [] }).length).toBe(2);
+  });
+
+  // --- Advisory 2: cursor-ahead-of-head false positive (#1482 review) ---
+
+  it("hasDurableCursor is false when the cursor is ahead of the durable head", () => {
+    const seq = persistSubstrateEvent(ev("only"), null);
+    // Exactly at head: nothing strictly newer to replay, but it is the boundary —
+    // recoverable (replay returns empty, then falls through to ring).
+    expect(hasDurableCursor(USER, seq)).toBe(true);
+    // Ahead of head (e.g. a ring-only id or future seq): NOT durably recoverable,
+    // must fall through to the ring rather than silently deliver nothing.
+    expect(hasDurableCursor(USER, seq + 1)).toBe(false);
+    expect(hasDurableCursor(USER, seq + 50)).toBe(false);
+  });
+
+  it("hasDurableCursor is false for a quiet user with no durable events", () => {
+    // No rows persisted for this user at all.
+    expect(hasDurableCursor("11111111-1111-1111-1111-111111111111", 0)).toBe(false);
+    expect(hasDurableCursor("11111111-1111-1111-1111-111111111111", 999)).toBe(false);
+  });
+
+  it("hasDurableCursor still accepts a cursor one below the oldest retained seq", () => {
+    const seq = persistSubstrateEvent(ev("first"), null);
+    // Resuming from just before the oldest event replays it gap-free.
+    expect(hasDurableCursor(USER, seq - 1)).toBe(true);
+    // Two below the oldest means an event was pruned between cursor and window.
+    expect(hasDurableCursor(USER, seq - 2)).toBe(false);
   });
 });

--- a/tests/subscriptions/durable_event_log.test.ts
+++ b/tests/subscriptions/durable_event_log.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Durable substrate-event log round-trip tests (#1464 Tier 2).
+ *
+ * Covers the contract that makes SSE resume restart-safe:
+ *  - persist returns a monotonic durable seq;
+ *  - events are recoverable after the in-memory ring is gone (restart sim);
+ *  - hasDurableCursor distinguishes "within retention" from "beyond retention";
+ *  - pruning drops events older than the retention window and only those.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getSqliteDb } from "../../src/repositories/sqlite/sqlite_client.js";
+import {
+  persistSubstrateEvent,
+  getEventsAfterSeq,
+  hasDurableCursor,
+  pruneEventLog,
+} from "../../src/services/subscriptions/event_log.js";
+import type { SubstrateEvent } from "../../src/events/types.js";
+
+const USER = "00000000-0000-0000-0000-000000000000";
+
+function ev(entityId: string): SubstrateEvent {
+  return {
+    event_id: `evt_${entityId}`,
+    event_type: "entity.created",
+    timestamp: "2026-01-01T00:00:00.000Z",
+    user_id: USER,
+    entity_id: entityId,
+    entity_type: "thing",
+    action: "created",
+  };
+}
+
+describe("durable substrate-event log (#1464 Tier 2)", () => {
+  beforeEach(() => {
+    getSqliteDb().prepare("DELETE FROM substrate_events").run();
+  });
+  afterEach(() => {
+    getSqliteDb().prepare("DELETE FROM substrate_events").run();
+  });
+
+  it("persist returns a monotonically increasing seq", () => {
+    const s1 = persistSubstrateEvent(ev("a"), null);
+    const s2 = persistSubstrateEvent(ev("b"), null);
+    expect(s2).toBeGreaterThan(s1);
+  });
+
+  it("recovers events after the cursor even when the ring is gone (restart sim)", () => {
+    const s1 = persistSubstrateEvent(ev("r1"), null);
+    persistSubstrateEvent(ev("r2"), null);
+    persistSubstrateEvent(ev("r3"), null);
+
+    // Simulate a reconnect with a cursor that is no longer in any in-memory
+    // ring: read straight from the durable log.
+    const recovered = getEventsAfterSeq(USER, s1);
+    const ids = recovered.map((d) => d.event.entity_id);
+    expect(ids).toEqual(["r2", "r3"]);
+    // Returned seqs are strictly greater than the cursor.
+    expect(recovered.every((d) => d.seq > s1)).toBe(true);
+  });
+
+  it("hasDurableCursor is true within retention, false once pruned away", () => {
+    const oldNow = Date.parse("2026-01-01T00:00:00.000Z");
+    const seqOld = persistSubstrateEvent(ev("old"), null, new Date(oldNow).toISOString());
+
+    // Cursor is present, so it is recoverable.
+    expect(hasDurableCursor(USER, seqOld)).toBe(true);
+
+    // Prune relative to a "now" 8 days after the old event with a 7-day window:
+    // the old event falls outside retention and is removed.
+    const eightDaysLater = oldNow + 8 * 24 * 60 * 60 * 1000;
+    const pruned = pruneEventLog(7, eightDaysLater);
+    expect(pruned).toBe(1);
+
+    // With the row gone, the cursor is beyond retention → not recoverable.
+    expect(hasDurableCursor(USER, seqOld)).toBe(false);
+  });
+
+  it("pruning keeps events inside the window and drops only older ones", () => {
+    const base = Date.parse("2026-01-01T00:00:00.000Z");
+    // One old (10 days ago) and one recent (1 day ago) relative to `now`.
+    const now = base + 10 * 24 * 60 * 60 * 1000;
+    persistSubstrateEvent(ev("stale"), null, new Date(base).toISOString());
+    const recentSeq = persistSubstrateEvent(
+      ev("fresh"),
+      null,
+      new Date(now - 24 * 60 * 60 * 1000).toISOString()
+    );
+
+    const pruned = pruneEventLog(7, now);
+    expect(pruned).toBe(1); // only the stale one
+
+    const remaining = getEventsAfterSeq(USER, 0);
+    expect(remaining.map((d) => d.event.entity_id)).toEqual(["fresh"]);
+    expect(hasDurableCursor(USER, recentSeq)).toBe(true);
+  });
+
+  it("preserves NULL user_id / entity_id without crashing", () => {
+    const e = ev("n");
+    // @ts-expect-error intentional: exercise the NULL-coalescing path
+    e.user_id = undefined;
+    const seq = persistSubstrateEvent(e, null);
+    expect(seq).toBeGreaterThan(0);
+    // Stored with NULL user_id; a user-scoped read does not return it.
+    expect(getEventsAfterSeq(USER, 0).length).toBe(0);
+  });
+});


### PR DESCRIPTION
Tier 1 (#1480) made a missed-events gap **detectable**. Tier 2 makes the common cases **recoverable** by persisting events, so SSE resume survives a server restart or a gap larger than the in-memory ring.

## The core fix: a stable, restart-surviving cursor

The in-memory ring's id counter **reset to 0 on every restart**, so a client's `Last-Event-ID` from before a restart was meaningless against a fresh ring. This change makes the **durable event-log `seq`** (AUTOINCREMENT, never resets) the event id *everywhere* — ring, SSE frame, and client cursor. That alone is what makes restart-safe resume possible.

## What's added

- **`substrate_events` table**: durable monotonic `seq`, full event payload, indexed on `(user_id, seq)` for resume and `created_at` for pruning.
- **`event_log.ts`**: `persistSubstrateEvent` (synchronous), `getEventsAfterSeq` (durable resume), `hasDurableCursor` (within-retention check), `pruneEventLog`.
- **Synchronous persistence**: events are written in the same path as the ring push — durable the moment they're emitted. SQLite writes are serialized and fast, so the latency cost is negligible; a log failure falls back to the ring id and never blocks delivery.
- **Resume order** in `/events/stream`: in-memory ring (hot) → durable log (if the cursor is still within retention) → a one-time `event: gap` frame **only** when the cursor predates the retained window.
- **Retention**: `NEOTOMA_EVENT_RETENTION_DAYS` (default **7**), pruned on startup and every 6h.

## Tests

`durable_event_log.test.ts` is a round-trip suite (per the destructive/durable-op guardrail): monotonic seq, restart-simulated recovery after the ring is cleared, retention-boundary behavior, prune keeps-inside/drops-outside, and NULL `user_id` handling. The existing 52 subscription/events tests still pass.

## Relationship to #1480

Builds on Tier 1 (#1480) and **supersedes** its gap-only resume seam with the full ring → durable → gap strategy. Best merged after, or rebased onto, #1480.

## Notes
- Full typecheck clean; branch off `main`; pre-commit suite passes.
- Commit is unsigned (GPG pinentry could not prompt non-interactively) — flag if signed commits are required on merge.

Closes #1464

🤖 Generated with [Claude Code](https://claude.com/claude-code)