### PR TITLE
fix(mcp): add SSE keepalive to /mcp transport so the stream survives proxy/client idle (#1483)

### DIFF
--- a/docs/developer/cli_reference.md
+++ b/docs/developer/cli_reference.md
@@ -271,6 +271,18 @@ These are read by the Neotoma HTTP server (not the CLI `preAction` hook) for out
 
 `GET /peers/{peer_id}` returns `remote_health` from probing `{peer_url}/health` and semver compat vs the local package version (same rules as `neotoma compat`). See `docs/subsystems/peer_sync.md`.
 
+### MCP / SSE transport tuning (server process)
+
+These are read by the Neotoma HTTP server when it serves the MCP StreamableHTTP transport at `/mcp`. They keep the long-lived SSE stream alive behind reverse proxies (Cloudflare Tunnel, nginx, ngrok) and clients with idle timeouts. See issue #1483 and `docs/security/threat_model.md`.
+
+| Environment variable | Default | Purpose |
+|----------------------|---------|---------|
+| `NEOTOMA_MCP_SSE_KEEPALIVE_MS` | `25000` | Interval (ms) between SSE comment heartbeat frames (`: hb\n\n`) on the MCP GET SSE stream. The frames keep proxies and clients from treating the stream as idle and silently closing it. Set to `0` to disable the heartbeat (restores prior behavior). |
+| `NEOTOMA_KEEPALIVE_TIMEOUT_MS` | `120000` | Node HTTP `server.keepAliveTimeout` (ms). Extended from Node's 5 s default so idle keep-alive sockets are not closed before typical proxy idle windows (60–300 s), which otherwise surfaces as a mid-stream RST / 502 reconnect cycle. |
+| `NEOTOMA_HEADERS_TIMEOUT_MS` | `125000` | Node HTTP `server.headersTimeout` (ms). Must exceed `NEOTOMA_KEEPALIVE_TIMEOUT_MS` to avoid a Node bug where the socket is closed before the headers timeout fires. |
+
+The MCP transport tuning vars are server-process knobs read in `src/actions.ts`, not CLI `preAction` overrides; they have no paired flag.
+
 ### MCP signed shim (`mcp.json` — not CLI `preAction`)
 
 Cursor reads these from the **`env`** block for **`run_neotoma_mcp_signed_stdio_dev_shim.sh`** (they are **not** parsed by `neotoma` CLI `preAction`; document them here for discoverability).

--- a/docs/developer/cli_reference.md
+++ b/docs/developer/cli_reference.md
@@ -273,11 +273,11 @@ These are read by the Neotoma HTTP server (not the CLI `preAction` hook) for out
 
 ### MCP / SSE transport tuning (server process)
 
-These are read by the Neotoma HTTP server when it serves the MCP StreamableHTTP transport at `/mcp`. They keep the long-lived SSE stream alive behind reverse proxies (Cloudflare Tunnel, nginx, ngrok) and clients with idle timeouts. See issue #1483 and `docs/security/threat_model.md`.
+These are read by the Neotoma HTTP server when it serves the MCP StreamableHTTP transport at `/mcp`. They keep the long-lived SSE stream alive behind reverse proxies (Cloudflare Tunnel, nginx, ngrok) and clients with idle timeouts. This is a reliability/transport concern; see issue #1483 and the [v0.15.1 release supplement](../releases/in_progress/v0.15.1/github_release_supplement.md).
 
 | Environment variable | Default | Purpose |
 |----------------------|---------|---------|
-| `NEOTOMA_MCP_SSE_KEEPALIVE_MS` | `25000` | Interval (ms) between SSE comment heartbeat frames (`: hb\n\n`) on the MCP GET SSE stream. The frames keep proxies and clients from treating the stream as idle and silently closing it. Set to `0` to disable the heartbeat (restores prior behavior). |
+| `NEOTOMA_MCP_SSE_KEEPALIVE_MS` | `25000` | Interval (ms) between SSE comment heartbeat frames (`: hb\n\n`) on the MCP GET SSE stream. The frames keep proxies and clients from treating the stream as idle and silently closing it. Set to `0` (or any value `<= 0`) to disable the heartbeat (restores prior behavior); an unset, empty, or non-numeric value uses the default. TCP keepalive on the socket stays enabled regardless. |
 | `NEOTOMA_KEEPALIVE_TIMEOUT_MS` | `120000` | Node HTTP `server.keepAliveTimeout` (ms). Extended from Node's 5 s default so idle keep-alive sockets are not closed before typical proxy idle windows (60–300 s), which otherwise surfaces as a mid-stream RST / 502 reconnect cycle. |
 | `NEOTOMA_HEADERS_TIMEOUT_MS` | `125000` | Node HTTP `server.headersTimeout` (ms). Must exceed `NEOTOMA_KEEPALIVE_TIMEOUT_MS` to avoid a Node bug where the socket is closed before the headers timeout fires. |
 

--- a/docs/releases/in_progress/v0.15.1/github_release_supplement.md
+++ b/docs/releases/in_progress/v0.15.1/github_release_supplement.md
@@ -1,32 +1,64 @@
-# v0.15.1
+# v0.15.1 Release Supplement
 
 ## Summary
 
-This patch makes `retrieve_graph_neighborhood` expose the canonical `entity_id` on its `related_entities` items while restoring the legacy `id` field as a deprecated alias, so callers can correlate related entities against `relationships[].source_entity_id` / `target_entity_id` and existing `id`-keyed callers keep working.
+v0.15.1 is a patch release bundling two transport/contract fixes:
+
+1. **MCP SSE keepalive (#1483)** — the MCP StreamableHTTP `/mcp` GET SSE stream now emits an application-level heartbeat so it survives reverse-proxy and client idle timeouts instead of silently dropping under load.
+2. **`retrieve_graph_neighborhood` `entity_id` (#276)** — `related_entities` items now expose the canonical `entity_id`, with the legacy `id` field restored as a deprecated alias.
 
 ## What changed for npm package users
 
-- **`retrieve_graph_neighborhood` related_entities now carry `entity_id`.** Each item in the `related_entities` array exposes the canonical `entity_id`, matching `relationships[].source_entity_id` / `target_entity_id` and every other Neotoma response surface (resolves #276). The raw database `id` column is still present as a deprecated alias with the same value for one minor release; prefer `entity_id` and stop reading `id`.
+### MCP `/mcp` SSE keepalive (#1483)
+
+The MCP server holds a long-lived GET SSE stream open for server-initiated messages, but the SDK emits no application-level heartbeat on that stream, and Node's `keepAliveTimeout` only governs socket reuse. A reverse proxy (Cloudflare Tunnel, nginx, ngrok) or the client's own idle timeout could then silently close the idle stream mid-session — the process stayed healthy (`/health` green) but the client lost the Neotoma tool registry ("tools not registered") with no recovery short of a manual disconnect/reconnect.
+
+- The long-lived GET SSE stream now emits a periodic SSE comment heartbeat frame (`: hb\n\n`, default every 25 s), sets `X-Accel-Buffering: no` on the `text/event-stream` response so buffering proxies flush each frame immediately, and enables a bounded TCP keepalive on the socket. Heartbeat frames are SSE comment lines, ignored by clients per the spec, and interleave safely with the SDK's own events. This keeps proxies and clients from treating the stream as idle and silently closing it.
+- On by default; no configuration required.
+
+#### New runtime configuration (server process)
+
+Read by the Neotoma HTTP server when it serves `/mcp`. Documented in `docs/developer/cli_reference.md` § MCP / SSE transport tuning.
+
+| Environment variable | Default | Purpose |
+|----------------------|---------|---------|
+| `NEOTOMA_MCP_SSE_KEEPALIVE_MS` | `25000` | Interval (ms) between SSE comment heartbeat frames on the MCP GET SSE stream. Set to `0` (or any value `<= 0`) to disable the heartbeat; an unset, empty, or non-numeric value uses the default. TCP keepalive on the socket stays enabled regardless (probe delay clamped to `[15s, 60s]`). |
+
+(The pre-existing `NEOTOMA_KEEPALIVE_TIMEOUT_MS` / `NEOTOMA_HEADERS_TIMEOUT_MS` socket-level knobs from v0.13.0 are now also documented in the same table.)
+
+The SDK's `retryInterval` transport option was evaluated and deliberately not used: in SDK 1.29 it only emits an SSE `retry:` field inside the priming event, which is written solely on the POST→SSE path and solely when an `eventStore` is configured. Neotoma configures no event store, and the stream that drops is the standalone GET SSE stream, so setting `retryInterval` would be an inert knob with no runtime effect.
+
+### `retrieve_graph_neighborhood` related_entities now carry `entity_id` (#276)
+
+- Each item in the `related_entities` array exposes the canonical `entity_id`, matching `relationships[].source_entity_id` / `target_entity_id` and every other Neotoma response surface (resolves #276). The raw database `id` column is still present as a deprecated alias with the same value for one minor release; prefer `entity_id` and stop reading `id`.
+- This patch also restores the `id` field that v0.15.0 silently dropped from `related_entities` when it renamed `id` → `entity_id` (bundled, undocumented, in the #262 mirror change). Re-adding `id` un-breaks any v0.15.0 caller that depended on the legacy field.
 
 ## API surface & contracts
 
-- Additive only. `openapi.yaml` declares both `entity_id` (canonical) and `id` (`deprecated: true`) on `related_entities` items; no request or response shape is narrowed and no field is removed.
-- This patch also restores the `id` field that v0.15.0 silently dropped from `related_entities` when it renamed `id` → `entity_id` (bundled, undocumented, in the #262 mirror change). Re-adding `id` un-breaks any v0.15.0 caller that depended on the legacy field.
+- **#1483:** transport-level only — no `openapi.yaml` surface, no request/response/error fields added or changed.
+- **#276:** additive only. `openapi.yaml` declares both `entity_id` (canonical) and `id` (`deprecated: true`) on `related_entities` items; no request or response shape is narrowed and no field is removed.
 
 ## Behavior changes
 
-- Callers reading `related_entities[].entity_id` now receive a value instead of `undefined`.
-- Callers still reading `related_entities[].id` continue to receive the same value (now formally deprecated).
+- **#1483:** the MCP GET SSE stream emits `: hb\n\n` comment frames (invisible to clients per the SSE spec) and carries `X-Accel-Buffering: no`.
+- **#276:** callers reading `related_entities[].entity_id` now receive a value instead of `undefined`; callers still reading `related_entities[].id` continue to receive the same value (now formally deprecated).
 
 ## Fixes
 
+- #1483 — Neotoma MCP SSE connection drops under load. Added an application-level heartbeat (`: hb\n\n` comment frames), `X-Accel-Buffering: no`, and a bounded TCP keepalive to the MCP StreamableHTTP transport's GET SSE stream so it survives proxy and client idle timeouts without manual reconnection. This is the application-level layer above the v0.13.0 `keepAliveTimeout` fix (#148), which addressed socket reuse but not SSE stream idle. The `NEOTOMA_MCP_SSE_KEEPALIVE_MS` disable knob parses defensively so a literal `0` (or negative) value disables the heartbeat rather than silently falling back to the default.
 - #276 — `retrieve_graph_neighborhood` `related_entities` exposed only the raw `id`; now exposes the canonical `entity_id`, with `id` retained as a deprecated alias.
 
 ## Tests and validation
 
-- Extended `tests/integration/graph_neighborhood_pagination.test.ts` with a regression that boots the Express app and asserts every `related_entities` item carries a string `entity_id`, that `id === entity_id`, and that `entity_id` values match the relationship target ids exactly.
-- `npm run openapi:generate` regenerated `src/shared/openapi_types.ts`; `npm run type-check` and the contract suite pass.
+- **#1483:** new unit regression (`tests/unit/mcp_sse_keepalive.test.ts`, 16 tests) drives the real `attachMcpSseKeepalive` lifecycle and the pure `parseMcpSseKeepaliveMs` env parser with fake timers, asserting runtime behavior (not source strings): heartbeat frames written only after the event-stream is established; `X-Accel-Buffering: no` injected on `text/event-stream` and never on JSON; no heartbeat written into a non-SSE (JSON-RPC POST) body; bounded TCP keepalive enabled; heartbeat stops and `writeHead` restored on close; the env parse matrix (`undefined`/`""`/`"abc"` → default, `"0"` → 0, `"-1"` → -1, `"5000"` → 5000); an env value of `0` reaches the disable guard and writes no heartbeat; and a one-shot warn when the stream ticks without `X-Accel-Buffering` landing. Satisfies the `docs/architecture/change_guardrails_rules.mdc` requirement that new HTTP runtime-config knobs assert observable runtime behavior.
+- **#1483:** existing `/mcp` handler integration coverage (`tests/integration/mcp_invalid_bearer_auth.test.ts`) passes unchanged, confirming the keepalive wiring does not alter the auth/initialize path. `npm run security:classify-diff` → `sensitive=false`; `npm run security:manifest:check` in sync (no new routes added).
+- **#276:** extended `tests/integration/graph_neighborhood_pagination.test.ts` with a regression that boots the Express app and asserts every `related_entities` item carries a string `entity_id`, that `id === entity_id`, and that `entity_id` values match the relationship target ids exactly. `npm run openapi:generate` regenerated `src/shared/openapi_types.ts`.
+- `npm run type-check` clean; lint 0 errors (pre-existing `no-explicit-any` warnings only, none in the changed code).
+
+## Security hardening
+
+No security-sensitive surface changed by either fix. The #1483 diff classifier returned `sensitive=false`; the change adds keepalive framing on an already-authenticated stream and does not touch auth, proxy-trust, local-dev, public-route, or guest-access surfaces. No advisories opened or referenced.
 
 ## Breaking changes
 
-No breaking changes. Re-adding the `id` alias is additive; the field is now marked deprecated and will be removed in a future minor release after callers migrate to `entity_id`.
+No breaking changes. Re-adding the `related_entities[].id` alias (#276) is additive; the field is now marked deprecated and will be removed in a future minor release after callers migrate to `entity_id`.

--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,22 +61,22 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **401**
-- Backend and repo Vitest files: **368**
+- Total automated test files: **415**
+- Backend and repo Vitest files: **382**
 - Frontend Vitest files: **9**
 - Playwright spec files: **24**
 
 ### Suite counts
 | Suite | Files |
 |---|---:|
-| Vitest unit tests | 100 |
+| Vitest unit tests | 103 |
 | Vitest service tests | 33 |
-| Source-adjacent tests | 46 |
-| Vitest integration tests | 109 |
-| Vitest CLI tests | 59 |
-| Vitest contract tests | 11 |
-| Vitest security tests | 2 |
-| Vitest subscription tests | 3 |
+| Source-adjacent tests | 47 |
+| Vitest integration tests | 113 |
+| Vitest CLI tests | 60 |
+| Vitest contract tests | 12 |
+| Vitest security tests | 3 |
+| Vitest subscription tests | 5 |
 | Vitest agent tests | 1 |
 | Vitest fixture tests | 1 |
 | Vitest helper tests | 1 |
@@ -84,6 +84,7 @@ flowchart TD
 | Frontend Vitest tests | 9 |
 | Playwright E2E tests | 22 |
 | Playwright Inspector E2E tests | 2 |
+| Tests Performance | 1 |
 | Tests Scripts | 1 |
 
 ## Primary validation commands
@@ -107,7 +108,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/unit`
 **Requirements:** Basic `.env` if required by the module under test.
-**Files (100):**
+**Files (103):**
 - `tests/unit/aauth_admission.test.ts`
 - `tests/unit/aauth_attestation_apple_se.test.ts`
 - `tests/unit/aauth_attestation_revocation.test.ts`
@@ -140,6 +141,7 @@ flowchart TD
 - `tests/unit/client_turn_report.test.ts`
 - `tests/unit/compliance_scorecard.test.ts`
 - `tests/unit/config_data_dir_resolution.test.ts`
+- `tests/unit/content_field_store_warning.test.ts`
 - `tests/unit/conversation_schema_bootstrap.test.ts`
 - `tests/unit/conversation_session_uuid_bridge.test.ts`
 - `tests/unit/cursor_hooks_context.test.ts`
@@ -187,6 +189,7 @@ flowchart TD
 - `tests/unit/pull_request_schema.test.ts`
 - `tests/unit/relationship_batch_schemas.test.ts`
 - `tests/unit/relationship_reducer.test.ts`
+- `tests/unit/relationship_traversal_indexes.test.ts`
 - `tests/unit/request_context.test.ts`
 - `tests/unit/root_landing_harness_snippets.test.ts`
 - `tests/unit/root_landing_site_nav_drift.test.ts`
@@ -201,6 +204,7 @@ flowchart TD
 - `tests/unit/session_info.test.ts`
 - `tests/unit/site_page_markdown.test.ts`
 - `tests/unit/spa_path.test.ts`
+- `tests/unit/sqlite_connection_pragmas.test.ts`
 - `tests/unit/store_alias_dispatch.test.ts`
 - `tests/unit/submit_issue_dx.test.ts`
 - `tests/unit/subscription_types.test.ts`
@@ -254,7 +258,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- src`
 **Requirements:** Basic `.env` if required by the module under test.
-**Files (46):**
+**Files (47):**
 - `src/cli/parse_cli_corrected_value.test.ts`
 - `src/crypto/crypto.test.ts`
 - `src/record_types.test.ts`
@@ -283,6 +287,7 @@ flowchart TD
 - `src/services/docs/render.test.ts`
 - `src/services/docs/visibility.test.ts`
 - `src/services/guest_access_token.test.ts`
+- `src/services/issues/body_newline_decode.test.ts`
 - `src/services/issues/issue_operations.test.ts`
 - `src/services/issues/neotoma_client.test.ts`
 - `src/services/issues/redaction_guard.test.ts`
@@ -307,7 +312,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm run test:integration` or `npx vitest run tests/integration`
 **Requirements:** Database configured; remote-dependent subsets additionally need `RUN_REMOTE_TESTS=1`.
-**Files (109):**
+**Files (113):**
 - `tests/integration/aauth_attribution_stamping.test.ts`
 - `tests/integration/aauth_resource_metadata.test.ts`
 - `tests/integration/aauth_revocation_e2e.test.ts`
@@ -345,9 +350,11 @@ flowchart TD
 - `tests/integration/guest_token_isolation.test.ts`
 - `tests/integration/guest_write_rate_limit.test.ts`
 - `tests/integration/hook_failure_hint.test.ts`
+- `tests/integration/http_related_entities_multihop.test.ts`
 - `tests/integration/idempotency_collision.test.ts`
 - `tests/integration/idempotency_key_content_mismatch.test.ts`
 - `tests/integration/inspector_bundled_mount.test.ts`
+- `tests/integration/inspector_content_negotiation.test.ts`
 - `tests/integration/interpretation_fragment_ordering.test.ts`
 - `tests/integration/interpretation_no_schema_fallback.test.ts`
 - `tests/integration/interpretation_store.test.ts`
@@ -394,6 +401,8 @@ flowchart TD
 - `tests/integration/public_key_registry.test.ts`
 - `tests/integration/record_activity_attribution.test.ts`
 - `tests/integration/relationship_agent_attribution_api.test.ts`
+- `tests/integration/relationship_pagination_determinism.test.ts`
+- `tests/integration/relationship_query_determinism.test.ts`
 - `tests/integration/relationship_snapshots.test.ts`
 - `tests/integration/retrieval_transport_reliability.test.ts`
 - `tests/integration/root_landing.test.ts`
@@ -423,7 +432,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/cli`
 **Requirements:** Basic `.env`; some tests provision temp config homes automatically.
-**Files (59):**
+**Files (60):**
 - `tests/cli/api_client_offline_fallback.test.ts`
 - `tests/cli/backup_verify.test.ts`
 - `tests/cli/cli_access_commands.test.ts`
@@ -437,6 +446,7 @@ flowchart TD
 - `tests/cli/cli_direct_invocation_parity.test.ts`
 - `tests/cli/cli_doctor_setup.test.ts`
 - `tests/cli/cli_edit_commands.test.ts`
+- `tests/cli/cli_entities_import.test.ts`
 - `tests/cli/cli_entity_commands.test.ts`
 - `tests/cli/cli_entity_subcommands.test.ts`
 - `tests/cli/cli_infra_commands.test.ts`
@@ -489,13 +499,14 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/contract`
 **Requirements:** Generated contract artifacts present when the suite expects them.
-**Files (11):**
+**Files (12):**
 - `tests/contract/cli_handler_dist_smoke.test.ts`
 - `tests/contract/contract_mapping.test.ts`
 - `tests/contract/contract_mcp_cli_parity.test.ts`
 - `tests/contract/ironclaw_integration.test.ts`
 - `tests/contract/legacy_payloads/replay.test.ts`
 - `tests/contract/mcp_stdio_output_safety.test.ts`
+- `tests/contract/mcp_tool_dispatch_coverage.test.ts`
 - `tests/contract/openapi_schema.test.ts`
 - `tests/contract/openclaw_plugin.test.ts`
 - `tests/contract/package_contents.test.ts`
@@ -507,8 +518,9 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npx vitest run tests/security`
 **Requirements:** Use alongside the dedicated security validation scripts when changing auth or route protection.
-**Files (2):**
+**Files (3):**
 - `tests/security/auth_topology_matrix.test.ts`
+- `tests/security/sandbox_mode_resolver.test.ts`
 - `tests/security/tenant_isolation_matrix.test.ts`
 
 ### Vitest subscription tests
@@ -516,8 +528,10 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npx vitest run tests/subscriptions`
 **Requirements:** Basic `.env`; some tests start an in-process HTTP server.
-**Files (3):**
+**Files (5):**
+- `tests/subscriptions/durable_event_log.test.ts`
 - `tests/subscriptions/guest_write_rate_limit_routing.test.ts`
+- `tests/subscriptions/sse_ring_gap_detection.test.ts`
 - `tests/subscriptions/subscription_guest_auth.test.ts`
 - `tests/subscriptions/subscription_loop_prevention.test.ts`
 
@@ -606,6 +620,14 @@ flowchart TD
 **Files (2):**
 - `playwright/tests/inspector/inspector-entity-detail.spec.ts`
 - `playwright/tests/inspector/inspector-issues.spec.ts`
+
+### Tests Performance
+**Directory:** `tests/performance/`
+**Runner:** `vitest`
+**Command:** `npx vitest run tests/performance`
+**Requirements:** Basic `.env` if required by the module under test.
+**Files (1):**
+- `tests/performance/graph_traversal.bench.test.ts`
 
 ### Tests Scripts
 **Directory:** `tests/scripts/`

--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,22 +61,22 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **414**
-- Backend and repo Vitest files: **381**
+- Total automated test files: **401**
+- Backend and repo Vitest files: **368**
 - Frontend Vitest files: **9**
 - Playwright spec files: **24**
 
 ### Suite counts
 | Suite | Files |
 |---|---:|
-| Vitest unit tests | 102 |
+| Vitest unit tests | 100 |
 | Vitest service tests | 33 |
-| Source-adjacent tests | 47 |
-| Vitest integration tests | 113 |
-| Vitest CLI tests | 60 |
-| Vitest contract tests | 12 |
-| Vitest security tests | 3 |
-| Vitest subscription tests | 5 |
+| Source-adjacent tests | 46 |
+| Vitest integration tests | 109 |
+| Vitest CLI tests | 59 |
+| Vitest contract tests | 11 |
+| Vitest security tests | 2 |
+| Vitest subscription tests | 3 |
 | Vitest agent tests | 1 |
 | Vitest fixture tests | 1 |
 | Vitest helper tests | 1 |
@@ -84,7 +84,6 @@ flowchart TD
 | Frontend Vitest tests | 9 |
 | Playwright E2E tests | 22 |
 | Playwright Inspector E2E tests | 2 |
-| Tests Performance | 1 |
 | Tests Scripts | 1 |
 
 ## Primary validation commands
@@ -108,7 +107,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/unit`
 **Requirements:** Basic `.env` if required by the module under test.
-**Files (102):**
+**Files (100):**
 - `tests/unit/aauth_admission.test.ts`
 - `tests/unit/aauth_attestation_apple_se.test.ts`
 - `tests/unit/aauth_attestation_revocation.test.ts`
@@ -141,7 +140,6 @@ flowchart TD
 - `tests/unit/client_turn_report.test.ts`
 - `tests/unit/compliance_scorecard.test.ts`
 - `tests/unit/config_data_dir_resolution.test.ts`
-- `tests/unit/content_field_store_warning.test.ts`
 - `tests/unit/conversation_schema_bootstrap.test.ts`
 - `tests/unit/conversation_session_uuid_bridge.test.ts`
 - `tests/unit/cursor_hooks_context.test.ts`
@@ -174,6 +172,7 @@ flowchart TD
 - `tests/unit/mcp_proxy.test.ts`
 - `tests/unit/mcp_resource_uri.test.ts`
 - `tests/unit/mcp_server_card.test.ts`
+- `tests/unit/mcp_sse_keepalive.test.ts`
 - `tests/unit/mirror_profiles.test.ts`
 - `tests/unit/neotoma_entity_id.test.ts`
 - `tests/unit/observation_reducer_converters.test.ts`
@@ -188,7 +187,6 @@ flowchart TD
 - `tests/unit/pull_request_schema.test.ts`
 - `tests/unit/relationship_batch_schemas.test.ts`
 - `tests/unit/relationship_reducer.test.ts`
-- `tests/unit/relationship_traversal_indexes.test.ts`
 - `tests/unit/request_context.test.ts`
 - `tests/unit/root_landing_harness_snippets.test.ts`
 - `tests/unit/root_landing_site_nav_drift.test.ts`
@@ -203,7 +201,6 @@ flowchart TD
 - `tests/unit/session_info.test.ts`
 - `tests/unit/site_page_markdown.test.ts`
 - `tests/unit/spa_path.test.ts`
-- `tests/unit/sqlite_connection_pragmas.test.ts`
 - `tests/unit/store_alias_dispatch.test.ts`
 - `tests/unit/submit_issue_dx.test.ts`
 - `tests/unit/subscription_types.test.ts`
@@ -257,7 +254,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- src`
 **Requirements:** Basic `.env` if required by the module under test.
-**Files (47):**
+**Files (46):**
 - `src/cli/parse_cli_corrected_value.test.ts`
 - `src/crypto/crypto.test.ts`
 - `src/record_types.test.ts`
@@ -286,7 +283,6 @@ flowchart TD
 - `src/services/docs/render.test.ts`
 - `src/services/docs/visibility.test.ts`
 - `src/services/guest_access_token.test.ts`
-- `src/services/issues/body_newline_decode.test.ts`
 - `src/services/issues/issue_operations.test.ts`
 - `src/services/issues/neotoma_client.test.ts`
 - `src/services/issues/redaction_guard.test.ts`
@@ -311,7 +307,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm run test:integration` or `npx vitest run tests/integration`
 **Requirements:** Database configured; remote-dependent subsets additionally need `RUN_REMOTE_TESTS=1`.
-**Files (113):**
+**Files (109):**
 - `tests/integration/aauth_attribution_stamping.test.ts`
 - `tests/integration/aauth_resource_metadata.test.ts`
 - `tests/integration/aauth_revocation_e2e.test.ts`
@@ -349,11 +345,9 @@ flowchart TD
 - `tests/integration/guest_token_isolation.test.ts`
 - `tests/integration/guest_write_rate_limit.test.ts`
 - `tests/integration/hook_failure_hint.test.ts`
-- `tests/integration/http_related_entities_multihop.test.ts`
 - `tests/integration/idempotency_collision.test.ts`
 - `tests/integration/idempotency_key_content_mismatch.test.ts`
 - `tests/integration/inspector_bundled_mount.test.ts`
-- `tests/integration/inspector_content_negotiation.test.ts`
 - `tests/integration/interpretation_fragment_ordering.test.ts`
 - `tests/integration/interpretation_no_schema_fallback.test.ts`
 - `tests/integration/interpretation_store.test.ts`
@@ -400,8 +394,6 @@ flowchart TD
 - `tests/integration/public_key_registry.test.ts`
 - `tests/integration/record_activity_attribution.test.ts`
 - `tests/integration/relationship_agent_attribution_api.test.ts`
-- `tests/integration/relationship_pagination_determinism.test.ts`
-- `tests/integration/relationship_query_determinism.test.ts`
 - `tests/integration/relationship_snapshots.test.ts`
 - `tests/integration/retrieval_transport_reliability.test.ts`
 - `tests/integration/root_landing.test.ts`
@@ -431,7 +423,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/cli`
 **Requirements:** Basic `.env`; some tests provision temp config homes automatically.
-**Files (60):**
+**Files (59):**
 - `tests/cli/api_client_offline_fallback.test.ts`
 - `tests/cli/backup_verify.test.ts`
 - `tests/cli/cli_access_commands.test.ts`
@@ -445,7 +437,6 @@ flowchart TD
 - `tests/cli/cli_direct_invocation_parity.test.ts`
 - `tests/cli/cli_doctor_setup.test.ts`
 - `tests/cli/cli_edit_commands.test.ts`
-- `tests/cli/cli_entities_import.test.ts`
 - `tests/cli/cli_entity_commands.test.ts`
 - `tests/cli/cli_entity_subcommands.test.ts`
 - `tests/cli/cli_infra_commands.test.ts`
@@ -498,14 +489,13 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/contract`
 **Requirements:** Generated contract artifacts present when the suite expects them.
-**Files (12):**
+**Files (11):**
 - `tests/contract/cli_handler_dist_smoke.test.ts`
 - `tests/contract/contract_mapping.test.ts`
 - `tests/contract/contract_mcp_cli_parity.test.ts`
 - `tests/contract/ironclaw_integration.test.ts`
 - `tests/contract/legacy_payloads/replay.test.ts`
 - `tests/contract/mcp_stdio_output_safety.test.ts`
-- `tests/contract/mcp_tool_dispatch_coverage.test.ts`
 - `tests/contract/openapi_schema.test.ts`
 - `tests/contract/openclaw_plugin.test.ts`
 - `tests/contract/package_contents.test.ts`
@@ -517,9 +507,8 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npx vitest run tests/security`
 **Requirements:** Use alongside the dedicated security validation scripts when changing auth or route protection.
-**Files (3):**
+**Files (2):**
 - `tests/security/auth_topology_matrix.test.ts`
-- `tests/security/sandbox_mode_resolver.test.ts`
 - `tests/security/tenant_isolation_matrix.test.ts`
 
 ### Vitest subscription tests
@@ -527,10 +516,8 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npx vitest run tests/subscriptions`
 **Requirements:** Basic `.env`; some tests start an in-process HTTP server.
-**Files (5):**
-- `tests/subscriptions/durable_event_log.test.ts`
+**Files (3):**
 - `tests/subscriptions/guest_write_rate_limit_routing.test.ts`
-- `tests/subscriptions/sse_ring_gap_detection.test.ts`
 - `tests/subscriptions/subscription_guest_auth.test.ts`
 - `tests/subscriptions/subscription_loop_prevention.test.ts`
 
@@ -619,14 +606,6 @@ flowchart TD
 **Files (2):**
 - `playwright/tests/inspector/inspector-entity-detail.spec.ts`
 - `playwright/tests/inspector/inspector-issues.spec.ts`
-
-### Tests Performance
-**Directory:** `tests/performance/`
-**Runner:** `vitest`
-**Command:** `npx vitest run tests/performance`
-**Requirements:** Basic `.env` if required by the module under test.
-**Files (1):**
-- `tests/performance/graph_traversal.bench.test.ts`
 
 ### Tests Scripts
 **Directory:** `tests/scripts/`

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -836,8 +836,8 @@ const mcpServerInstances = new Map<string, NeotomaServer>();
 // ignored by the client per the spec and interleave safely between the SDK's
 // own events because Node serializes writes on the response stream.
 //
-// The heartbeat interval is env-configurable; a value of 0 disables the
-// heartbeat for parity with the prior behavior.
+// The heartbeat interval is env-configurable; a value of 0 (or any value <= 0)
+// disables the heartbeat for parity with the prior behavior.
 //
 // Note on the SDK's `retryInterval` option: it is intentionally NOT used here.
 // In SDK 1.29 `retryInterval` only emits an SSE `retry:` field inside the
@@ -846,8 +846,29 @@ const mcpServerInstances = new Map<string, NeotomaServer>();
 // configure an event store, and the stream that drops is the standalone GET
 // SSE stream, which never emits a priming event. Setting `retryInterval` would
 // therefore be an inert knob with no runtime effect, so it is omitted.
-const MCP_SSE_KEEPALIVE_MS =
-  Number.parseInt(process.env.NEOTOMA_MCP_SSE_KEEPALIVE_MS || "", 10) || 25_000;
+
+/** Default MCP SSE heartbeat interval in ms when the env var is unset/invalid. */
+export const MCP_SSE_KEEPALIVE_DEFAULT_MS = 25_000;
+
+/**
+ * Parse the `NEOTOMA_MCP_SSE_KEEPALIVE_MS` env value into a heartbeat interval.
+ *
+ * Only an unset / empty / non-numeric value falls back to the default. A
+ * literal `0` (or any negative number) is a VALID, intentional "disable the
+ * heartbeat" sentinel and MUST flow through unchanged to the `keepaliveMs <= 0`
+ * guard in `attachMcpSseKeepalive` — using `parseInt(...) || DEFAULT` would
+ * silently coerce `0`/negatives back to the default and break the documented
+ * disable knob (issue #1483 review BLOCKING finding).
+ */
+export function parseMcpSseKeepaliveMs(raw: string | undefined): number {
+  if (raw === undefined) return MCP_SSE_KEEPALIVE_DEFAULT_MS;
+  const trimmed = raw.trim();
+  if (trimmed === "") return MCP_SSE_KEEPALIVE_DEFAULT_MS;
+  const parsed = Number.parseInt(trimmed, 10);
+  return Number.isFinite(parsed) ? parsed : MCP_SSE_KEEPALIVE_DEFAULT_MS;
+}
+
+const MCP_SSE_KEEPALIVE_MS = parseMcpSseKeepaliveMs(process.env.NEOTOMA_MCP_SSE_KEEPALIVE_MS);
 
 /**
  * Attach SSE keepalive behavior to a `/mcp` GET request before the transport
@@ -859,9 +880,10 @@ const MCP_SSE_KEEPALIVE_MS =
 export function attachMcpSseKeepalive(
   req: express.Request,
   res: express.Response,
-  options?: { keepaliveMs?: number }
+  options?: { keepaliveMs?: number; logger?: { warn: (msg: string) => void } }
 ): void {
   const keepaliveMs = options?.keepaliveMs ?? MCP_SSE_KEEPALIVE_MS;
+  const log = options?.logger ?? logger;
 
   // Inject X-Accel-Buffering only when the SDK actually opens an SSE stream.
   // The @hono/node-server adapter calls res.writeHead() with a fresh header
@@ -892,10 +914,19 @@ export function attachMcpSseKeepalive(
 
   // Enable OS-level TCP keepalive so the kernel probes the peer and the
   // connection is not reaped by an idle NAT/proxy before our heartbeat fires.
+  // Bound the probe delay independently of the app-level heartbeat: even when
+  // the heartbeat is disabled (keepaliveMs <= 0) we still want a sane,
+  // proxy-survivable TCP probe interval, so clamp into [15s, 60s].
+  const TCP_KEEPALIVE_MIN_MS = 15_000;
+  const TCP_KEEPALIVE_MAX_MS = 60_000;
+  const tcpKeepaliveDelay =
+    keepaliveMs > 0
+      ? Math.min(Math.max(keepaliveMs, TCP_KEEPALIVE_MIN_MS), TCP_KEEPALIVE_MAX_MS)
+      : TCP_KEEPALIVE_MIN_MS;
   const socket = res.socket ?? req.socket;
   if (socket && typeof socket.setKeepAlive === "function") {
     try {
-      socket.setKeepAlive(true, Math.min(keepaliveMs, 60_000));
+      socket.setKeepAlive(true, tcpKeepaliveDelay);
     } catch {
       // Non-fatal: heartbeat frames below are the primary mechanism.
     }
@@ -912,6 +943,17 @@ export function attachMcpSseKeepalive(
       heartbeat = undefined;
     }
   };
+
+  // Runtime guard for the X-Accel-Buffering injection. The writeHead patch
+  // assumes the @hono/node-server adapter calls our patched res.writeHead; a
+  // future adapter that snapshots the original method reference before we patch
+  // would silently no-op the header, re-enabling proxy buffering. FakeRes in
+  // the unit test cannot reproduce that adapter behavior, so warn once at
+  // runtime if the SSE stream has ticked several times without the header
+  // landing — operators learn the proxy-flush path regressed.
+  const ACCEL_BUFFERING_WARN_AFTER_TICKS = 5;
+  let ticksOnStream = 0;
+  let accelBufferingWarned = false;
 
   heartbeat = setInterval(() => {
     // Only write once the SSE stream is established (headers sent) and still
@@ -931,6 +973,19 @@ export function attachMcpSseKeepalive(
       // alive. Stop so we never corrupt a non-SSE body.
       stop();
       return;
+    }
+    ticksOnStream += 1;
+    if (
+      !accelBufferingWarned &&
+      ticksOnStream >= ACCEL_BUFFERING_WARN_AFTER_TICKS &&
+      !res.getHeader("x-accel-buffering")
+    ) {
+      accelBufferingWarned = true;
+      log.warn(
+        "[MCP HTTP] SSE stream is alive but X-Accel-Buffering header is absent after " +
+          `${ticksOnStream} heartbeats; a buffering proxy may delay frames. The ` +
+          "res.writeHead patch may not be reaching the SDK adapter (possible @hono/node-server upgrade)."
+      );
     }
     try {
       // Bare SSE comment frame: ignored by clients, keeps the stream warm.

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -816,6 +816,145 @@ const mcpTransports = new Map<string, StreamableHTTPServerTransport>();
 // Store server instances by session ID to preserve authentication state
 const mcpServerInstances = new Map<string, NeotomaServer>();
 
+// ----------------------------------------------------------------------------
+// MCP SSE keepalive (issue #1483)
+//
+// The MCP StreamableHTTP transport (SDK >= 1.29) holds a long-lived GET SSE
+// stream open for server-initiated messages, but the SDK emits no heartbeat
+// frames on that stream and Node's `keepAliveTimeout` only governs socket
+// reuse, not application-level idle. A reverse proxy (Cloudflare Tunnel,
+// nginx, ngrok) or the client's own idle timeout then silently closes the
+// idle stream mid-session; `/health` stays green because the process is alive,
+// only the stream is gone. The client loses the tool registry and the only
+// recovery is a manual disconnect/reconnect.
+//
+// Fix: for the standalone GET SSE stream we (1) inject `X-Accel-Buffering: no`
+// onto the SDK's `text/event-stream` response so buffering proxies flush each
+// frame immediately, (2) enable TCP keepalive on the socket, and (3) write a
+// periodic SSE comment frame (`: hb\n\n`) so intermediaries and clients see
+// regular traffic and never treat the stream as idle. SSE comment lines are
+// ignored by the client per the spec and interleave safely between the SDK's
+// own events because Node serializes writes on the response stream.
+//
+// The heartbeat interval is env-configurable; a value of 0 disables the
+// heartbeat for parity with the prior behavior.
+//
+// Note on the SDK's `retryInterval` option: it is intentionally NOT used here.
+// In SDK 1.29 `retryInterval` only emits an SSE `retry:` field inside the
+// *priming event*, which the transport writes solely on the POST->SSE path and
+// solely when an `eventStore` is configured (resumability opt-in). We do not
+// configure an event store, and the stream that drops is the standalone GET
+// SSE stream, which never emits a priming event. Setting `retryInterval` would
+// therefore be an inert knob with no runtime effect, so it is omitted.
+const MCP_SSE_KEEPALIVE_MS =
+  Number.parseInt(process.env.NEOTOMA_MCP_SSE_KEEPALIVE_MS || "", 10) || 25_000;
+
+/**
+ * Attach SSE keepalive behavior to a `/mcp` GET request before the transport
+ * takes over the response. Safe to call on every GET `/mcp`; it is a no-op
+ * once the response finishes and tears itself down when the stream closes.
+ *
+ * Exported for unit testing of the heartbeat lifecycle. See issue #1483.
+ */
+export function attachMcpSseKeepalive(
+  req: express.Request,
+  res: express.Response,
+  options?: { keepaliveMs?: number }
+): void {
+  const keepaliveMs = options?.keepaliveMs ?? MCP_SSE_KEEPALIVE_MS;
+
+  // Inject X-Accel-Buffering only when the SDK actually opens an SSE stream.
+  // The @hono/node-server adapter calls res.writeHead() with a fresh header
+  // record built from the SDK's Web Response, so headers set earlier via
+  // res.setHeader() would be discarded; patching writeHead is the only place
+  // that survives. We add the header solely for text/event-stream responses
+  // so plain JSON-RPC POST replies are unaffected.
+  const originalWriteHead = res.writeHead as typeof res.writeHead;
+  let writeHeadPatched = true;
+  (res as express.Response).writeHead = function patchedWriteHead(
+    this: express.Response,
+    ...args: Parameters<typeof res.writeHead>
+  ): express.Response {
+    try {
+      const contentType = String(res.getHeader("content-type") || "").toLowerCase();
+      if (
+        writeHeadPatched &&
+        contentType.includes("text/event-stream") &&
+        !res.getHeader("x-accel-buffering")
+      ) {
+        res.setHeader("X-Accel-Buffering", "no");
+      }
+    } catch {
+      // Header inspection is best-effort; never block the response.
+    }
+    return originalWriteHead.apply(this, args) as express.Response;
+  } as typeof res.writeHead;
+
+  // Enable OS-level TCP keepalive so the kernel probes the peer and the
+  // connection is not reaped by an idle NAT/proxy before our heartbeat fires.
+  const socket = res.socket ?? req.socket;
+  if (socket && typeof socket.setKeepAlive === "function") {
+    try {
+      socket.setKeepAlive(true, Math.min(keepaliveMs, 60_000));
+    } catch {
+      // Non-fatal: heartbeat frames below are the primary mechanism.
+    }
+  }
+
+  if (keepaliveMs <= 0) {
+    return;
+  }
+
+  let heartbeat: ReturnType<typeof setInterval> | undefined;
+  const stop = () => {
+    if (heartbeat) {
+      clearInterval(heartbeat);
+      heartbeat = undefined;
+    }
+  };
+
+  heartbeat = setInterval(() => {
+    // Only write once the SSE stream is established (headers sent) and still
+    // writable. For non-SSE responses (plain POST replies) headersSent flips
+    // after a synchronous write and writableEnded becomes true, so this stops
+    // on its own without ever emitting a stray frame into a JSON body.
+    if (res.writableEnded || res.destroyed) {
+      stop();
+      return;
+    }
+    if (!res.headersSent) {
+      return;
+    }
+    const contentType = String(res.getHeader("content-type") || "").toLowerCase();
+    if (!contentType.includes("text/event-stream")) {
+      // Not an SSE stream (e.g. a buffered JSON-RPC reply); nothing to keep
+      // alive. Stop so we never corrupt a non-SSE body.
+      stop();
+      return;
+    }
+    try {
+      // Bare SSE comment frame: ignored by clients, keeps the stream warm.
+      res.write(": hb\n\n");
+    } catch {
+      stop();
+    }
+  }, keepaliveMs);
+  if (typeof heartbeat.unref === "function") {
+    heartbeat.unref();
+  }
+
+  const cleanup = () => {
+    stop();
+    if (writeHeadPatched) {
+      writeHeadPatched = false;
+      (res as express.Response).writeHead = originalWriteHead;
+    }
+  };
+  res.on("close", cleanup);
+  res.on("finish", cleanup);
+  req.on("close", cleanup);
+}
+
 function isLoopbackAddress(value: string | undefined): boolean {
   const remote = (value || "").trim().toLowerCase();
   if (!remote) return false;
@@ -1571,6 +1710,15 @@ app.all("/mcp", async (req, res) => {
         connectionId: typeof connId === "string" ? connId : undefined,
       });
     })();
+
+    // For the long-lived GET SSE stream, attach keepalive (heartbeat frames +
+    // X-Accel-Buffering + TCP keepalive) before the transport takes over the
+    // response, so the stream survives proxy/client idle timeouts (#1483).
+    // The helper inspects the response content-type at write time and is a
+    // no-op for buffered JSON-RPC POST replies.
+    if (req.method === "GET") {
+      attachMcpSseKeepalive(req, res);
+    }
 
     // Handle request with the transport inside the attribution context.
     const attributionDecision = getAttributionDecisionFromRequest(req);

--- a/tests/unit/mcp_sse_keepalive.test.ts
+++ b/tests/unit/mcp_sse_keepalive.test.ts
@@ -1,0 +1,172 @@
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { attachMcpSseKeepalive } from "../../src/actions.js";
+
+/**
+ * Minimal Express-shaped response stub backed by an EventEmitter so we can
+ * exercise the real heartbeat lifecycle in attachMcpSseKeepalive without
+ * standing up an HTTP server. Captures res.write payloads and header state so
+ * tests assert observable runtime behavior (frames written, header injected),
+ * per docs/architecture/change_guardrails_rules.md (HTTP runtime-config knobs
+ * must assert runtime behavior, not source strings).
+ */
+class FakeSocket extends EventEmitter {
+  public keepAlive: { enable: boolean; initialDelay: number } | null = null;
+  setKeepAlive(enable: boolean, initialDelay?: number): this {
+    this.keepAlive = { enable, initialDelay: initialDelay ?? 0 };
+    return this;
+  }
+}
+
+class FakeRes extends EventEmitter {
+  public headers: Record<string, string> = {};
+  public writes: string[] = [];
+  public headersSent = false;
+  public writableEnded = false;
+  public destroyed = false;
+  public socket = new FakeSocket();
+  public writeHeadCalls = 0;
+
+  setHeader(name: string, value: string): void {
+    this.headers[name.toLowerCase()] = value;
+  }
+  getHeader(name: string): string | undefined {
+    return this.headers[name.toLowerCase()];
+  }
+  // Mirrors the @hono/node-server adapter: writeHead is invoked once with the
+  // status built from the SDK's Web Response. The real adapter passes a fresh
+  // header record; here we only need to observe that the patch ran.
+  writeHead(_status?: number): this {
+    this.writeHeadCalls += 1;
+    this.headersSent = true;
+    return this;
+  }
+  write(chunk: string): boolean {
+    this.writes.push(chunk);
+    return true;
+  }
+}
+
+class FakeReq extends EventEmitter {
+  public method: string;
+  public socket = new FakeSocket();
+  constructor(method = "GET") {
+    super();
+    this.method = method;
+  }
+}
+
+function makeReqRes(method = "GET"): { req: FakeReq; res: FakeRes } {
+  return { req: new FakeReq(method), res: new FakeRes() };
+}
+
+describe("attachMcpSseKeepalive (issue #1483)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("writes periodic SSE comment heartbeat frames once the event-stream is established", () => {
+    const { req, res } = makeReqRes("GET");
+    attachMcpSseKeepalive(req as never, res as never, { keepaliveMs: 1000 });
+
+    // Before headers are sent, no frame should be written.
+    vi.advanceTimersByTime(3000);
+    expect(res.writes).toHaveLength(0);
+
+    // SDK opens the SSE stream: set content-type and flush headers.
+    res.setHeader("Content-Type", "text/event-stream");
+    res.writeHead(200);
+
+    vi.advanceTimersByTime(1000);
+    expect(res.writes).toEqual([": hb\n\n"]);
+
+    vi.advanceTimersByTime(2000);
+    expect(res.writes).toEqual([": hb\n\n", ": hb\n\n", ": hb\n\n"]);
+  });
+
+  it("injects X-Accel-Buffering: no on the event-stream response via writeHead patch", () => {
+    const { req, res } = makeReqRes("GET");
+    attachMcpSseKeepalive(req as never, res as never, { keepaliveMs: 1000 });
+
+    res.setHeader("Content-Type", "text/event-stream");
+    expect(res.getHeader("x-accel-buffering")).toBeUndefined();
+
+    res.writeHead(200);
+    expect(res.getHeader("x-accel-buffering")).toBe("no");
+  });
+
+  it("does NOT inject X-Accel-Buffering on non-SSE (JSON) responses", () => {
+    const { req, res } = makeReqRes("GET");
+    attachMcpSseKeepalive(req as never, res as never, { keepaliveMs: 1000 });
+
+    res.setHeader("Content-Type", "application/json");
+    res.writeHead(200);
+    expect(res.getHeader("x-accel-buffering")).toBeUndefined();
+  });
+
+  it("never writes a heartbeat into a non-SSE (JSON-RPC POST) body and stops the timer", () => {
+    const { req, res } = makeReqRes("GET");
+    attachMcpSseKeepalive(req as never, res as never, { keepaliveMs: 1000 });
+
+    res.setHeader("Content-Type", "application/json");
+    res.writeHead(200);
+
+    vi.advanceTimersByTime(5000);
+    expect(res.writes).toHaveLength(0);
+  });
+
+  it("enables TCP keepalive on the socket", () => {
+    const { req, res } = makeReqRes("GET");
+    attachMcpSseKeepalive(req as never, res as never, { keepaliveMs: 30000 });
+
+    expect(res.socket.keepAlive?.enable).toBe(true);
+    // Capped at 60s to keep probe interval below typical proxy idle windows.
+    expect(res.socket.keepAlive?.initialDelay).toBe(30000);
+  });
+
+  it("stops the heartbeat and restores writeHead when the stream closes", () => {
+    const { req, res } = makeReqRes("GET");
+    const originalWriteHead = res.writeHead;
+    attachMcpSseKeepalive(req as never, res as never, { keepaliveMs: 1000 });
+    expect(res.writeHead).not.toBe(originalWriteHead);
+
+    res.setHeader("Content-Type", "text/event-stream");
+    res.writeHead(200);
+    vi.advanceTimersByTime(1000);
+    expect(res.writes).toHaveLength(1);
+
+    res.emit("close");
+    expect(res.writeHead).toBe(originalWriteHead);
+
+    vi.advanceTimersByTime(5000);
+    expect(res.writes).toHaveLength(1); // no further frames after close
+  });
+
+  it("stops the heartbeat when the response has already ended", () => {
+    const { req, res } = makeReqRes("GET");
+    attachMcpSseKeepalive(req as never, res as never, { keepaliveMs: 1000 });
+
+    res.setHeader("Content-Type", "text/event-stream");
+    res.writeHead(200);
+    res.writableEnded = true;
+
+    vi.advanceTimersByTime(5000);
+    expect(res.writes).toHaveLength(0);
+  });
+
+  it("disables the heartbeat when keepaliveMs <= 0 but still enables TCP keepalive", () => {
+    const { req, res } = makeReqRes("GET");
+    attachMcpSseKeepalive(req as never, res as never, { keepaliveMs: 0 });
+
+    res.setHeader("Content-Type", "text/event-stream");
+    res.writeHead(200);
+    vi.advanceTimersByTime(60000);
+    expect(res.writes).toHaveLength(0);
+    expect(res.socket.keepAlive?.enable).toBe(true);
+  });
+});

--- a/tests/unit/mcp_sse_keepalive.test.ts
+++ b/tests/unit/mcp_sse_keepalive.test.ts
@@ -1,7 +1,11 @@
 import { EventEmitter } from "node:events";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { attachMcpSseKeepalive } from "../../src/actions.js";
+import {
+  attachMcpSseKeepalive,
+  parseMcpSseKeepaliveMs,
+  MCP_SSE_KEEPALIVE_DEFAULT_MS,
+} from "../../src/actions.js";
 
 /**
  * Minimal Express-shaped response stub backed by an EventEmitter so we can
@@ -159,7 +163,7 @@ describe("attachMcpSseKeepalive (issue #1483)", () => {
     expect(res.writes).toHaveLength(0);
   });
 
-  it("disables the heartbeat when keepaliveMs <= 0 but still enables TCP keepalive", () => {
+  it("disables the heartbeat when keepaliveMs <= 0 but still enables a bounded TCP keepalive", () => {
     const { req, res } = makeReqRes("GET");
     attachMcpSseKeepalive(req as never, res as never, { keepaliveMs: 0 });
 
@@ -168,5 +172,99 @@ describe("attachMcpSseKeepalive (issue #1483)", () => {
     vi.advanceTimersByTime(60000);
     expect(res.writes).toHaveLength(0);
     expect(res.socket.keepAlive?.enable).toBe(true);
+    // Even with the heartbeat disabled, the TCP probe delay is floored to 15s
+    // (not 0 / "OS default") so the socket survives proxy idle windows.
+    expect(res.socket.keepAlive?.initialDelay).toBe(15000);
+  });
+
+  it("floors a tiny positive keepaliveMs to the 15s TCP keepalive minimum", () => {
+    const { req, res } = makeReqRes("GET");
+    attachMcpSseKeepalive(req as never, res as never, { keepaliveMs: 1000 });
+    // App-level heartbeat still uses 1000ms, but the TCP probe delay is floored.
+    expect(res.socket.keepAlive?.initialDelay).toBe(15000);
+  });
+
+  it("warns once if the SSE stream ticks repeatedly without X-Accel-Buffering landing", () => {
+    const warn = vi.fn();
+    const { req, res } = makeReqRes("GET");
+    // Simulate an adapter that snapshotted the original writeHead: bypass the
+    // patch by setting the content-type and headersSent directly without the
+    // X-Accel-Buffering header ever being injected.
+    attachMcpSseKeepalive(req as never, res as never, { keepaliveMs: 1000, logger: { warn } });
+    res.setHeader("Content-Type", "text/event-stream");
+    res.headersSent = true; // headers "sent" without writeHead patch running
+
+    vi.advanceTimersByTime(5000); // 5 ticks -> warn threshold
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toMatch(/X-Accel-Buffering/);
+
+    vi.advanceTimersByTime(5000); // still only warned once
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT warn when X-Accel-Buffering is present", () => {
+    const warn = vi.fn();
+    const { req, res } = makeReqRes("GET");
+    attachMcpSseKeepalive(req as never, res as never, { keepaliveMs: 1000, logger: { warn } });
+    res.setHeader("Content-Type", "text/event-stream");
+    res.writeHead(200); // patch injects X-Accel-Buffering
+
+    vi.advanceTimersByTime(10000);
+    expect(warn).not.toHaveBeenCalled();
+  });
+});
+
+describe("parseMcpSseKeepaliveMs (issue #1483 review BLOCKING fix)", () => {
+  it("falls back to the default for unset / empty / non-numeric values", () => {
+    expect(parseMcpSseKeepaliveMs(undefined)).toBe(MCP_SSE_KEEPALIVE_DEFAULT_MS);
+    expect(parseMcpSseKeepaliveMs("")).toBe(MCP_SSE_KEEPALIVE_DEFAULT_MS);
+    expect(parseMcpSseKeepaliveMs("   ")).toBe(MCP_SSE_KEEPALIVE_DEFAULT_MS);
+    expect(parseMcpSseKeepaliveMs("abc")).toBe(MCP_SSE_KEEPALIVE_DEFAULT_MS);
+  });
+
+  it("passes a literal 0 through as the disable sentinel (NOT coerced to default)", () => {
+    // This is the BLOCKING regression: `parseInt("0",10) || 25000` returned
+    // 25000. The disable knob must yield 0.
+    expect(parseMcpSseKeepaliveMs("0")).toBe(0);
+  });
+
+  it("passes negative values through (also disable, via the <= 0 guard)", () => {
+    expect(parseMcpSseKeepaliveMs("-1")).toBe(-1);
+    expect(parseMcpSseKeepaliveMs("-1000")).toBe(-1000);
+  });
+
+  it("returns the parsed value for valid positive integers", () => {
+    expect(parseMcpSseKeepaliveMs("5000")).toBe(5000);
+    expect(parseMcpSseKeepaliveMs("25000")).toBe(25000);
+    expect(parseMcpSseKeepaliveMs(" 5000 ")).toBe(5000);
+  });
+});
+
+describe("attachMcpSseKeepalive env-driven disable (issue #1483 review)", () => {
+  const ORIG = process.env.NEOTOMA_MCP_SSE_KEEPALIVE_MS;
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    if (ORIG === undefined) delete process.env.NEOTOMA_MCP_SSE_KEEPALIVE_MS;
+    else process.env.NEOTOMA_MCP_SSE_KEEPALIVE_MS = ORIG;
+  });
+
+  // The module-level MCP_SSE_KEEPALIVE_MS is bound at import time, so this test
+  // exercises the env-path end-to-end by passing the parsed env value the same
+  // way the module computes it — proving 0 from the env reaches the disable
+  // guard rather than being coerced to the default.
+  it("writes no heartbeat when the env value parses to 0", () => {
+    process.env.NEOTOMA_MCP_SSE_KEEPALIVE_MS = "0";
+    const keepaliveMs = parseMcpSseKeepaliveMs(process.env.NEOTOMA_MCP_SSE_KEEPALIVE_MS);
+    expect(keepaliveMs).toBe(0);
+
+    const { req, res } = makeReqRes("GET");
+    attachMcpSseKeepalive(req as never, res as never, { keepaliveMs });
+    res.setHeader("Content-Type", "text/event-stream");
+    res.writeHead(200);
+    vi.advanceTimersByTime(60000);
+    expect(res.writes).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary

Fixes [#1483](https://github.com/markmhendrickson/neotoma/issues/1483): the MCP `/mcp` SSE stream silently drops under load behind reverse proxies and clients with idle timeouts, losing the tool registry until a manual reconnect. Adds an application-level keepalive (heartbeat frames + `X-Accel-Buffering: no` + TCP keepalive) to the long-lived GET SSE stream so it survives proxy/client idle.

The MCP `StreamableHTTPServerTransport` (SDK 1.29) holds the GET SSE stream open for server-initiated messages but emits no heartbeat. Node's `keepAliveTimeout` (set to 120s in v0.13.0 for #148) only governs socket reuse, not application-level SSE idle. A proxy (Cloudflare Tunnel, nginx, ngrok) or the client's idle timeout then closes the idle stream while `/health` stays green — the documented failure mode in the issue.

## Touchpoints

- [x] HTTP endpoint / request / response field <!-- GET /mcp SSE stream behavior; no request/response field changes -->
- [x] MCP tool definition or behavior <!-- transport-level keepalive, no tool signature changes -->
- [x] CLI command, flag, or runtime override <!-- new server-process env var NEOTOMA_MCP_SSE_KEEPALIVE_MS -->
- [x] Release supplement or release tooling <!-- v0.15.1 in_progress supplement -->
- [x] Logging, metrics, events, traces <!-- SSE keepalive frames -->

## What changed

- **`src/actions.ts`** — new `attachMcpSseKeepalive(req, res)`, wired for `GET /mcp`:
  - Periodic bare SSE comment heartbeat frame `: hb\n\n` (default 25s, `NEOTOMA_MCP_SSE_KEEPALIVE_MS`, `0` disables). Comment frames are ignored by clients per the SSE spec and interleave safely with the SDK's events because Node serializes writes on the response stream.
  - `X-Accel-Buffering: no` injected via a `res.writeHead` patch. The `@hono/node-server` adapter rebuilds headers from the SDK's Web `Response`, so a header set via `res.setHeader()` before `handleRequest` would be discarded; patching `writeHead` is the only injection point that survives.
  - TCP keepalive on the socket; self-teardown + `writeHead` restore on stream close/finish.
- **`docs/developer/cli_reference.md`** — new "MCP / SSE transport tuning (server process)" table documenting `NEOTOMA_MCP_SSE_KEEPALIVE_MS` plus the pre-existing `NEOTOMA_KEEPALIVE_TIMEOUT_MS` / `NEOTOMA_HEADERS_TIMEOUT_MS` socket knobs.
- **`docs/releases/in_progress/v0.15.1/github_release_supplement.md`** — new supplement (post-release fix → next patch) with the mandatory "Breaking changes" section (`No breaking changes.`).
- **`tests/unit/mcp_sse_keepalive.test.ts`** — 8 new unit tests.
- **`docs/testing/automated_test_catalog.md`** — regenerated for the new test.

`retryInterval` (the issue's fix #3) was evaluated and **deliberately omitted**: in SDK 1.29 it only emits an SSE `retry:` field inside the POST→SSE priming event, which fires solely when an `eventStore` is configured (none here) and never on the GET standalone stream — so it would be an inert knob with no runtime effect. Rationale is documented in the code and the supplement.

## Pre-PR checklist

### API & contract

- [x] No `openapi.yaml` changes needed — transport-level behavior only, no request/response/error fields added or changed.
- [x] No new `operationId`, MCP tool, or CLI command, so no `contract_mappings.ts` change.
- [x] New env var is `NEOTOMA_`-prefixed. It is a **server-process** knob read in `src/actions.ts` (not a CLI `preAction` override), documented in the new cli_reference "MCP / SSE transport tuning" table; it has no paired flag by design (consistent with the existing `NEOTOMA_KEEPALIVE_TIMEOUT_MS`).

### Security

- [x] `npm run security:classify-diff` → `sensitive=false` (keepalive framing on an already-authenticated stream; no auth / proxy-trust / local-dev / public-route / guest-access surface touched).
- [x] No new Express routes; `npm run security:manifest:check` in sync (108 routes).
- [x] No bare `req.socket.remoteAddress` / `X-Forwarded-For` / `Host` reads added. The helper reads `res.socket` / `req.socket` only to call `setKeepAlive` (not for auth/trust decisions).

### Release & process

- [x] Release-visible behavior documented in a supplement under `docs/releases/in_progress/v0.15.1/`; historical supplements untouched. Supplement contains the explicit `No breaking changes.` line.

## Test plan

- `npx vitest run tests/unit/mcp_sse_keepalive.test.ts` → 8 passing. Fake-timer tests assert **runtime** behavior (per `change_guardrails_rules` — HTTP runtime-config knobs must assert observable behavior, not source strings): heartbeat frames written only after the event-stream is established; `X-Accel-Buffering: no` injected on `text/event-stream` and never on JSON; no heartbeat written into a non-SSE (JSON-RPC POST) body; TCP keepalive enabled; heartbeat stops and `writeHead` restored on close; `keepaliveMs=0` disables the heartbeat while still enabling TCP keepalive.
- `npm run type-check` clean; `npm run lint` 0 errors; `npm run format:check` clean; `npm run lint:site-copy` OK.
- `npx vitest run tests/integration/mcp_invalid_bearer_auth.test.ts tests/integration/mcp_oauth_token_endpoint.test.ts tests/security/auth_topology_matrix.test.ts` → pass (confirms the `/mcp` auth/initialize path is unaffected).

## Notes for reviewer

- **Why heartbeat injection is safe against the SDK's stream:** the Node SDK transport wraps a Web-Standard transport via `@hono/node-server`, which pumps the SDK's `ReadableStream` into the Express `res`. My `res.write(": hb\n\n")` calls share that `res`; Node serializes writes, and each heartbeat is a complete SSE comment frame, so it slots safely between the SDK's events. The guard checks `res.writableEnded` / `res.destroyed` and the `text/event-stream` content-type before every write, so it never corrupts a non-SSE (JSON-RPC POST) body and stops itself once the stream ends.
- **CI note:** the pre-commit hook's full unit + integration suite was skipped for the commit (`NEOTOMA_SKIP_TESTS=1`) because this worktree has no `dist/` build and no `inspector/` assets, so a set of unrelated suites (`cli_smoke`, `cursor_hook_*`, `graph_neighborhood_pagination`, `package_scripts`, badge tests) fail as environment noise — confirmed identical on a stashed baseline. CI with a full build should run them green; please re-run the full suite in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
