### PR TITLE
fix(client): read entities from top-level store response shape (#316)

### DIFF
--- a/packages/client/src/helpers.ts
+++ b/packages/client/src/helpers.ts
@@ -26,6 +26,25 @@
 import type { NeotomaTransport, StoreEntityInput, StoreInput, StoreResult, StoredEntityRef } from "./types.js";
 
 /**
+ * Extract the stored-entity list from a {@link StoreResult}, tolerating both
+ * the live transport shape and the legacy nested shape.
+ *
+ * The `/store` endpoint (`StoreStructuredResponse` in `openapi.yaml`) and both
+ * `HttpTransport` and `LocalTransport` return entities at the **top level**:
+ * `{ success, replayed, entities: [...] }`. There is no `structured` wrapper on
+ * the live response. Earlier helper code read `result.structured.entities`,
+ * which is always `undefined`, silently dropping every created `entity_id`
+ * (see issue #316).
+ *
+ * This reads `result.entities` first and falls back to
+ * `result.structured?.entities` so it keeps working against any pre-v0.x client
+ * that still nests the payload.
+ */
+export function extractStoredEntities(result: StoreResult | undefined): StoredEntityRef[] {
+  return result?.entities ?? result?.structured?.entities ?? [];
+}
+
+/**
  * Authoritative sender category for a chat message.
  *
  * `user` and `assistant` are the conventional chat roles. `agent` is used
@@ -157,7 +176,7 @@ export async function storeChatTurn(
     idempotency_key: `${keyPrefix}-turn`,
   });
 
-  const stored = storeResult.structured?.entities ?? [];
+  const stored = extractStoredEntities(storeResult);
   const conversationEntityId = stored[0]?.entity_id ?? "";
 
   return {
@@ -222,7 +241,7 @@ export async function retrieveOrStore(
     idempotency_key: input.idempotencyKey ?? `${input.entityType}-${input.identifier}`,
   });
 
-  const stored: StoredEntityRef | undefined = result.structured?.entities?.[0];
+  const stored: StoredEntityRef | undefined = extractStoredEntities(result)[0];
   if (!stored?.entity_id) {
     throw new Error(
       `retrieveOrStore: store returned no entity_id for ${input.entityType} identifier=${input.identifier}`
@@ -374,5 +393,5 @@ export async function recordConversationTurn(
     entities: [entity],
     idempotency_key: idempotencyKey,
   })) as StoreResult;
-  return { entityId: result.structured?.entities?.[0]?.entity_id };
+  return { entityId: extractStoredEntities(result)[0]?.entity_id };
 }

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -24,6 +24,7 @@ export {
 } from "./types.js";
 
 export {
+  extractStoredEntities,
   storeChatTurn,
   retrieveOrStore,
   snapshotOnUpdate,

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -41,6 +41,28 @@ export interface StoredEntityRef {
 }
 
 export interface StoreResult {
+  /**
+   * Stored entities, returned at the **top level** by the live `/store`
+   * endpoint (`StoreStructuredResponse` in `openapi.yaml`) and by both
+   * `HttpTransport` and `LocalTransport`. This is the canonical location to
+   * read created/updated entity_ids from.
+   */
+  entities?: StoredEntityRef[];
+  /** True when the request committed successfully. */
+  success?: boolean;
+  /**
+   * True when the response is an idempotency replay (no new observations or
+   * entities were written for this request).
+   */
+  replayed?: boolean;
+  source_id?: string;
+  relationships?: unknown[];
+  /**
+   * @deprecated Legacy nested shape. The live transport returns `entities` at
+   * the top level (see above); this wrapper does not appear on real responses.
+   * Retained only so helpers can tolerate pre-v0.x clients that nested the
+   * payload. New code should read {@link StoreResult.entities}.
+   */
   structured?: {
     entities: StoredEntityRef[];
     relationships?: unknown[];

--- a/tests/unit/client_helpers.test.ts
+++ b/tests/unit/client_helpers.test.ts
@@ -1,10 +1,46 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  extractStoredEntities,
+  recordConversationTurn,
   retrieveOrStore,
   snapshotOnUpdate,
   storeChatTurn,
 } from "../../packages/client/src/helpers.js";
 import type { NeotomaTransport, StoreInput, StoreResult } from "../../packages/client/src/types.js";
+
+describe("extractStoredEntities", () => {
+  it("reads entities from the top-level shape (real transport, #316)", () => {
+    const result = {
+      success: true,
+      entities: [{ entity_id: "ent-1", entity_type: "contact" }],
+    } as unknown as StoreResult;
+    expect(extractStoredEntities(result)).toEqual([
+      { entity_id: "ent-1", entity_type: "contact" },
+    ]);
+  });
+
+  it("falls back to the legacy nested `structured.entities` shape", () => {
+    const result = {
+      structured: { entities: [{ entity_id: "legacy-1", entity_type: "contact" }] },
+    } as StoreResult;
+    expect(extractStoredEntities(result)).toEqual([
+      { entity_id: "legacy-1", entity_type: "contact" },
+    ]);
+  });
+
+  it("prefers the top-level shape when both are present", () => {
+    const result = {
+      entities: [{ entity_id: "top-1", entity_type: "contact" }],
+      structured: { entities: [{ entity_id: "nested-1", entity_type: "contact" }] },
+    } as unknown as StoreResult;
+    expect(extractStoredEntities(result)[0]?.entity_id).toBe("top-1");
+  });
+
+  it("returns an empty array for a missing or empty response", () => {
+    expect(extractStoredEntities(undefined)).toEqual([]);
+    expect(extractStoredEntities({} as StoreResult)).toEqual([]);
+  });
+});
 
 function makeStubTransport(
   overrides: Partial<NeotomaTransport> = {}
@@ -28,7 +64,37 @@ function makeStubTransport(
 }
 
 describe("storeChatTurn", () => {
-  it("persists user + assistant messages with PART_OF relationships to the conversation", async () => {
+  it("extracts entity_ids from the top-level `entities` store response shape (real transport, #316)", async () => {
+    // The /store endpoint (StoreStructuredResponse in openapi.yaml) and both
+    // HttpTransport and LocalTransport return entities at the TOP level:
+    // { success, replayed, entities: [...] }. There is no `structured`
+    // wrapper on the live response. Helpers must read from result.entities.
+    const transport = makeStubTransport({
+      store: vi.fn(async () => ({
+        success: true,
+        entities: [
+          { entity_id: "conv-1", entity_type: "conversation" },
+          { entity_id: "msg-user-1", entity_type: "conversation_message" },
+          { entity_id: "msg-assistant-1", entity_type: "conversation_message" },
+        ],
+      } as unknown as StoreResult)),
+    });
+
+    const result = await storeChatTurn(transport, {
+      conversationId: "abc",
+      turnId: "1",
+      messages: [
+        { role: "user", content: "hello" },
+        { role: "assistant", content: "hi" },
+      ],
+    });
+
+    expect(result.conversationEntityId).toBe("conv-1");
+    expect(result.userMessageEntityId).toBe("msg-user-1");
+    expect(result.assistantMessageEntityId).toBe("msg-assistant-1");
+  });
+
+  it("falls back to the legacy nested `structured.entities` shape when present", async () => {
     let captured: StoreInput | undefined;
     const transport = makeStubTransport({
       store: vi.fn(async (input: StoreInput) => {
@@ -164,12 +230,13 @@ describe("retrieveOrStore", () => {
     expect(store).not.toHaveBeenCalled();
   });
 
-  it("stores when no existing entity is found and returns the new entity_id", async () => {
+  it("stores when no existing entity is found and returns the new entity_id (top-level shape, #316)", async () => {
     const transport = makeStubTransport({
       retrieveEntityByIdentifier: vi.fn(async () => null),
       store: vi.fn(async () => ({
-        structured: { entities: [{ entity_id: "new-1", entity_type: "contact" }] },
-      } as StoreResult)),
+        success: true,
+        entities: [{ entity_id: "new-1", entity_type: "contact" }],
+      } as unknown as StoreResult)),
     });
 
     const result = await retrieveOrStore(transport, {
@@ -180,6 +247,83 @@ describe("retrieveOrStore", () => {
 
     expect(result.entityId).toBe("new-1");
     expect(result.created).toBe(true);
+  });
+
+  it("falls back to the legacy nested `structured.entities` shape when storing", async () => {
+    const transport = makeStubTransport({
+      retrieveEntityByIdentifier: vi.fn(async () => null),
+      store: vi.fn(async () => ({
+        structured: { entities: [{ entity_id: "legacy-1", entity_type: "contact" }] },
+      } as StoreResult)),
+    });
+
+    const result = await retrieveOrStore(transport, {
+      identifier: "legacy@example.com",
+      entityType: "contact",
+      create: { email: "legacy@example.com" },
+    });
+
+    expect(result.entityId).toBe("legacy-1");
+    expect(result.created).toBe(true);
+  });
+
+  it("throws when the store response contains no entity_id in either shape", async () => {
+    const transport = makeStubTransport({
+      retrieveEntityByIdentifier: vi.fn(async () => null),
+      store: vi.fn(async () => ({ success: true, entities: [] } as unknown as StoreResult)),
+    });
+
+    await expect(
+      retrieveOrStore(transport, {
+        identifier: "empty@example.com",
+        entityType: "contact",
+        create: { email: "empty@example.com" },
+      })
+    ).rejects.toThrow(/no entity_id/);
+  });
+});
+
+describe("recordConversationTurn", () => {
+  it("returns the entity_id from the top-level `entities` store response shape (#316)", async () => {
+    const transport = makeStubTransport({
+      store: vi.fn(async () => ({
+        success: true,
+        entities: [{ entity_id: "turn-1", entity_type: "conversation_turn" }],
+      } as unknown as StoreResult)),
+    });
+
+    const result = await recordConversationTurn(transport, {
+      sessionId: "sess-1",
+      turnId: "1",
+      harness: "cursor",
+    });
+
+    expect(result.entityId).toBe("turn-1");
+  });
+
+  it("falls back to the legacy nested `structured.entities` shape", async () => {
+    const transport = makeStubTransport({
+      store: vi.fn(async () => ({
+        structured: { entities: [{ entity_id: "turn-legacy-1", entity_type: "conversation_turn" }] },
+      } as StoreResult)),
+    });
+
+    const result = await recordConversationTurn(transport, {
+      sessionId: "sess-2",
+      turnId: "2",
+    });
+
+    expect(result.entityId).toBe("turn-legacy-1");
+  });
+
+  it("returns an empty result without storing when sessionId or turnId is missing", async () => {
+    const store = vi.fn();
+    const transport = makeStubTransport({ store });
+
+    const result = await recordConversationTurn(transport, { sessionId: "", turnId: "1" });
+
+    expect(result).toEqual({});
+    expect(store).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
Fixes #316

## Problem

`@neotoma/client`'s `storeChatTurn`, `retrieveOrStore`, and `recordConversationTurn` read `result.structured?.entities`, but the live `/store` endpoint (`StoreStructuredResponse` in `openapi.yaml`) and both `HttpTransport` and `LocalTransport` return entities at the **top level**: `{ success, replayed, entities: [...] }`. There is no `structured` wrapper on the real response, so the helpers silently returned `entity_id: undefined` for every entity they created.

The `StoreResult` TypeScript type also declared `structured?: { entities }`, which did not match the runtime transport shape.

## Fix

- Add a shape-tolerant `extractStoredEntities(result)` reader that prefers top-level `result.entities` and falls back to `result.structured?.entities` (non-breaking across versions).
- Route all three helper call sites through it (`packages/client/src/helpers.ts`).
- Correct the `StoreResult` type to declare `entities` (plus `success`/`replayed`/`source_id`) at the top level, matching `StoreStructuredResponse`. The legacy nested `structured` field is retained but marked `@deprecated` so pre-v0.x clients still parse.
- Export `extractStoredEntities` from the package index so downstream consumers (e.g. `@neotoma/agent`, cursor-hooks) can reuse the tolerant reader instead of re-implementing it.

The fix aligns the client type to the existing OpenAPI contract; it does not change `openapi.yaml` or any request/response shape.

## Tests

Added to `tests/unit/client_helpers.test.ts` (test-first; the top-level-shape cases were confirmed RED against the old code before the fix, then GREEN after):

- `extractStoredEntities`: top-level shape, legacy nested fallback, both-present precedence (top-level wins), empty/undefined.
- `storeChatTurn`: extracts all three entity_ids from a top-level-`entities` response; legacy nested fallback retained.
- `retrieveOrStore`: returns new entity_id from top-level shape; legacy fallback; throws when no entity_id in either shape.
- `recordConversationTurn`: returns entity_id from top-level shape; legacy fallback; no-op when session/turn id missing.

## Verification

- `npm run type-check` — clean (0 errors).
- `npm run lint` — 0 errors (pre-existing warnings only, none in `packages/client/`).
- `npx vitest run tests/unit/client_helpers.test.ts` — 18 passed.
- Client unit suite (`client_helpers`, `client_diagnose`, `client_turn_report`) — 32 passed.
- Full `tests/unit` — 954 passed; the only 2 failing files (`external_actor_badge.test.ts`, `agent_badge_tier_icon.test.ts`) fail identically on clean `origin/main` and are unrelated to this change.

## Downstream note (out of scope)

The same root cause affects `packages/cursor-hooks/hooks/*` (several `r.structured?.entities` reads). Those are separate packages outside the `@neotoma/client` scope of #316 and should get their own follow-up using the now-exported `extractStoredEntities`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)