### PR TITLE
fix(issues): decode newlines in submit_issue body (#1484)

### DIFF
--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,8 +61,8 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **400**
-- Backend and repo Vitest files: **367**
+- Total automated test files: **401**
+- Backend and repo Vitest files: **368**
 - Frontend Vitest files: **9**
 - Playwright spec files: **24**
 
@@ -71,7 +71,7 @@ flowchart TD
 |---|---:|
 | Vitest unit tests | 99 |
 | Vitest service tests | 33 |
-| Source-adjacent tests | 46 |
+| Source-adjacent tests | 47 |
 | Vitest integration tests | 109 |
 | Vitest CLI tests | 59 |
 | Vitest contract tests | 11 |
@@ -253,7 +253,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- src`
 **Requirements:** Basic `.env` if required by the module under test.
-**Files (46):**
+**Files (47):**
 - `src/cli/parse_cli_corrected_value.test.ts`
 - `src/crypto/crypto.test.ts`
 - `src/record_types.test.ts`
@@ -282,6 +282,7 @@ flowchart TD
 - `src/services/docs/render.test.ts`
 - `src/services/docs/visibility.test.ts`
 - `src/services/guest_access_token.test.ts`
+- `src/services/issues/body_newline_decode.test.ts`
 - `src/services/issues/issue_operations.test.ts`
 - `src/services/issues/neotoma_client.test.ts`
 - `src/services/issues/redaction_guard.test.ts`

--- a/src/services/issues/body_newline_decode.test.ts
+++ b/src/services/issues/body_newline_decode.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import { decodeOverEscapedBody } from "./body_newline_decode.js";
+
+describe("decodeOverEscapedBody", () => {
+  it("decodes literal \\n sequences into real newlines (the #1484 bug)", () => {
+    const overEscaped =
+      "## Summary\\n\\nWhen a schema is updated...\\n\\n## Reproduction\\n\\n1. Register...";
+    const decoded = decodeOverEscapedBody(overEscaped);
+
+    expect(decoded).not.toContain("\\n");
+    expect(decoded).toContain("\n");
+    expect(decoded).toBe(
+      "## Summary\n\nWhen a schema is updated...\n\n## Reproduction\n\n1. Register..."
+    );
+    // The decoded body splits into the expected markdown lines.
+    expect(decoded.split("\n")[0]).toBe("## Summary");
+  });
+
+  it("decodes \\t into real tabs", () => {
+    expect(decodeOverEscapedBody("col1\\tcol2\\nrow")).toBe("col1\tcol2\nrow");
+  });
+
+  it("decodes \\r\\n CRLF sequences", () => {
+    expect(decodeOverEscapedBody("line1\\r\\nline2")).toBe("line1\r\nline2");
+  });
+
+  it("decodes escaped quotes", () => {
+    expect(decodeOverEscapedBody('say \\"hi\\"\\nthen leave')).toBe('say "hi"\nthen leave');
+  });
+
+  it("leaves a body that already has real newlines untouched", () => {
+    const correct = "## Summary\n\nAlready correct.\n";
+    expect(decodeOverEscapedBody(correct)).toBe(correct);
+  });
+
+  it("leaves a body with no escape sequences untouched", () => {
+    expect(decodeOverEscapedBody("single line, no escapes")).toBe("single line, no escapes");
+  });
+
+  it("does not corrupt an intentional literal backslash-n (escaped backslash)", () => {
+    // `\\n` in JSON-escaped form decodes to backslash + n, NOT backslash + newline.
+    // i.e. the source intent was a literal two characters backslash + 'n'.
+    const input = "use the sequence \\\\n to mean newline\\nbut this line breaks";
+    const decoded = decodeOverEscapedBody(input);
+    // The escaped backslash collapses to one backslash followed by a literal 'n'.
+    expect(decoded).toContain("\\n to mean newline");
+    // The genuine \n (single backslash) becomes a real newline.
+    expect(decoded.split("\n")).toEqual([
+      "use the sequence \\n to mean newline",
+      "but this line breaks",
+    ]);
+  });
+
+  it("preserves a Windows-style path fragment with no decodable escape", () => {
+    // No real newline and no decodable escape sequence → returned unchanged.
+    const input = "path is C:\\Users\\mark";
+    expect(decodeOverEscapedBody(input)).toBe(input);
+  });
+
+  it("preserves an unknown escape verbatim while decoding known ones", () => {
+    const input = "C:\\Users\\mark\\nthen next line";
+    const decoded = decodeOverEscapedBody(input);
+    // `\U` and `\m` are not JSON escapes → backslashes preserved.
+    // `\n` decodes to a real newline.
+    expect(decoded).toBe("C:\\Users\\mark\nthen next line");
+  });
+
+  it("returns empty and non-string inputs unchanged", () => {
+    expect(decodeOverEscapedBody("")).toBe("");
+    // @ts-expect-error exercising defensive guard for non-string inputs
+    expect(decodeOverEscapedBody(undefined)).toBe(undefined);
+  });
+
+  it("round-trips a multi-line body through JSON double-encoding", () => {
+    const original = "# Title\n\n- one\n- two\n\nDone.";
+    // Simulate the wire over-encoding: JSON.stringify once for transport, then
+    // the value is mistakenly delivered as the inner (still-escaped) string.
+    const overEncoded = JSON.stringify(original).slice(1, -1); // strip surrounding quotes
+    expect(overEncoded).toContain("\\n");
+    expect(decodeOverEscapedBody(overEncoded)).toBe(original);
+  });
+});

--- a/src/services/issues/body_newline_decode.ts
+++ b/src/services/issues/body_newline_decode.ts
@@ -1,0 +1,98 @@
+/**
+ * Body newline decode for the Issues subsystem.
+ *
+ * Some MCP / API clients double-encode the `body` argument: the agent intends a
+ * multi-line markdown body, but the value arrives at the server as a string that
+ * has been JSON-string-escaped one extra time. In that mode a real newline is
+ * delivered as the two characters backslash + `n` (`\n`), a tab as `\t`, a
+ * carriage return as `\r`, a literal backslash as `\\`, and a double quote as
+ * `\"`. When that string is then handed to the GitHub REST API (which
+ * `JSON.stringify`s it again) the literal `\n` is preserved verbatim and the
+ * issue renders as a single run-on block with no markdown structure.
+ *
+ * `github_client.createIssue` already serializes correctly with `JSON.stringify`,
+ * so the defect is upstream: the body retains the literal escape sequence and is
+ * never decoded back to real control characters. See issue #1484 (and #356).
+ *
+ * This module decodes exactly one JSON-string-escape layer, applied at the
+ * `submitIssue` / `addIssueMessage` service boundary so the same value reaches
+ * BOTH the GitHub mirror and the canonical Neotoma `conversation_message` record.
+ * The decode is conservative:
+ *
+ *   - It is a left-to-right escape scanner, not a naive `replace(/\\n/, "\n")`.
+ *     A literal backslash (`\\`) is consumed as one backslash before it can be
+ *     misread as the start of `\n`, so documentation that intentionally shows
+ *     the two characters backslash + `n` is preserved.
+ *   - It only runs when the body looks double-encoded: it contains a decodable
+ *     escape sequence AND no real newline. A body that already carries a real
+ *     `0x0A` was encoded correctly by the client and is returned untouched.
+ *   - It only recognizes the escape sequences a JSON encoder would have emitted
+ *     (`\n \r \t \" \\ \/`). Any other backslash run (e.g. a Windows path
+ *     fragment `C:\Users`, a regex `\d`, a LaTeX `\alpha`) contains no decodable
+ *     sequence on its own, so such bodies fall through unchanged.
+ */
+
+const DECODABLE_ESCAPE = /\\[nrt"\\/]/;
+const REAL_NEWLINE = /[\r\n]/;
+
+/**
+ * Decode one JSON-string-escape layer from an over-escaped issue/comment body.
+ *
+ * Returns the input unchanged when the body is not double-encoded (already has a
+ * real newline, or has no decodable escape sequence at all).
+ */
+export function decodeOverEscapedBody(body: string): string {
+  if (typeof body !== "string" || body.length === 0) return body;
+
+  // Already contains a real line break → the client encoded newlines correctly.
+  // Decoding here would risk corrupting intentional literal backslash content.
+  if (REAL_NEWLINE.test(body)) return body;
+
+  // No JSON-style escape sequence present → nothing to decode.
+  if (!DECODABLE_ESCAPE.test(body)) return body;
+
+  let decoded = "";
+  for (let i = 0; i < body.length; i += 1) {
+    const ch = body[i];
+    if (ch !== "\\" || i === body.length - 1) {
+      decoded += ch;
+      continue;
+    }
+    const next = body[i + 1];
+    switch (next) {
+      case "n":
+        decoded += "\n";
+        i += 1;
+        break;
+      case "r":
+        decoded += "\r";
+        i += 1;
+        break;
+      case "t":
+        decoded += "\t";
+        i += 1;
+        break;
+      case '"':
+        decoded += '"';
+        i += 1;
+        break;
+      case "/":
+        decoded += "/";
+        i += 1;
+        break;
+      case "\\":
+        // Consume the escaped backslash as a single literal backslash so the
+        // following character cannot be reinterpreted as an escape start.
+        decoded += "\\";
+        i += 1;
+        break;
+      default:
+        // Unknown escape (e.g. a Windows path `\U`) — preserve the backslash
+        // verbatim and let the next iteration handle the following character.
+        decoded += ch;
+        break;
+    }
+  }
+
+  return decoded;
+}

--- a/src/services/issues/issue_operations.test.ts
+++ b/src/services/issues/issue_operations.test.ts
@@ -405,6 +405,81 @@ describe("Issue Operations (Neotoma-canonical)", () => {
       expect(mockCreateRelationships).not.toHaveBeenCalled();
       expect(result.entity_id).toBeTruthy();
     });
+
+    // Regression: issue #1484 — over-escaped bodies (literal `\n` two-char
+    // sequences) must be decoded to real newlines before reaching the GitHub
+    // mirror AND the canonical Neotoma record, so the issue renders as markdown
+    // instead of a single run-on block.
+    it("decodes literal \\n in an over-escaped body before mirroring to GitHub (#1484)", async () => {
+      mockCreateIssue.mockResolvedValue({
+        number: 1484,
+        html_url: "https://github.com/test/repo/issues/1484",
+        user: { login: "tester" },
+        created_at: "2026-05-01T00:00:00Z",
+      });
+      mockSubmitIssueToRemote.mockResolvedValue({
+        entity_ids: ["remote-issue-1", "remote-conv-1", "remote-msg-1"],
+        issue_entity_id: "remote-issue-1",
+        conversation_id: "remote-conv-1",
+        access_token: "token-abc",
+      });
+
+      const overEscapedBody = "## Summary\\n\\nFirst paragraph.\\n\\n## Steps\\n\\n1. One\\n2. Two";
+
+      await submitIssue(ops, {
+        title: "Run-on body",
+        body: overEscapedBody,
+        visibility: "public",
+        reporter_git_sha: "abc1234",
+      });
+
+      // GitHub mirror receives real newlines, not the literal escape sequence.
+      const githubBody = mockCreateIssue.mock.calls[0]?.[0]?.body as string;
+      expect(githubBody).not.toContain("\\n");
+      expect(githubBody).toContain("\n");
+      expect(githubBody).toBe("## Summary\n\nFirst paragraph.\n\n## Steps\n\n1. One\n2. Two");
+      expect(githubBody.split("\n")[0]).toBe("## Summary");
+
+      // Canonical remote Neotoma submission receives the same decoded body.
+      const remoteBody = mockSubmitIssueToRemote.mock.calls[0]?.[0]?.body as string;
+      expect(remoteBody).not.toContain("\\n");
+      expect(remoteBody).toBe(githubBody);
+
+      // The locally-stored issue entity and conversation_message also carry
+      // real newlines, so reads from Neotoma match the rendered GitHub body.
+      const storeInput = mockStore.mock.calls[0]?.[0] as {
+        entities: Array<Record<string, unknown>>;
+      };
+      const [issueEntity, , messageEntity] = storeInput.entities;
+      expect(issueEntity.body).toBe(githubBody);
+      expect(messageEntity.content).toBe(githubBody);
+    });
+
+    it("leaves a correctly multi-line body untouched (#1484 no-regression)", async () => {
+      mockCreateIssue.mockResolvedValue({
+        number: 1485,
+        html_url: "https://github.com/test/repo/issues/1485",
+        user: { login: "tester" },
+        created_at: "2026-05-01T00:00:00Z",
+      });
+      mockSubmitIssueToRemote.mockResolvedValue({
+        entity_ids: ["remote-issue-1", "remote-conv-1", "remote-msg-1"],
+        issue_entity_id: "remote-issue-1",
+        conversation_id: "remote-conv-1",
+        access_token: "token-abc",
+      });
+
+      const properBody = "## Summary\n\nAlready has real newlines.\n";
+
+      await submitIssue(ops, {
+        title: "Proper body",
+        body: properBody,
+        visibility: "public",
+        reporter_git_sha: "abc1234",
+      });
+
+      expect(mockCreateIssue.mock.calls[0]?.[0]?.body).toBe(properBody);
+    });
   });
 
   describe("submitGuestIssue", () => {
@@ -511,6 +586,32 @@ describe("Issue Operations (Neotoma-canonical)", () => {
           issue_entity_id: "local-issue-1",
         })
       );
+    });
+
+    // Regression: issue #1484 — the same over-escaped-body decode applies to
+    // comments appended via add_issue_message.
+    it("decodes literal \\n in an over-escaped comment body before posting (#1484)", async () => {
+      mockAddMessageToRemote.mockResolvedValue({ message_entity_id: "remote-msg-1" });
+      mockAddIssueComment.mockResolvedValue({
+        id: 789,
+        body: "Comment",
+        user: { login: "commenter" },
+        created_at: "2026-05-01T10:00:00Z",
+        updated_at: "2026-05-01T10:00:00Z",
+        html_url: "https://github.com/test/repo/issues/1#issuecomment-789",
+      });
+
+      await addIssueMessage(ops, {
+        issue_number: 1,
+        body: "Update:\\n\\n- did the thing\\n- verified it",
+      });
+
+      const commentBody = mockAddIssueComment.mock.calls[0]?.[1] as string;
+      expect(commentBody).not.toContain("\\n");
+      expect(commentBody).toBe("Update:\n\n- did the thing\n- verified it");
+
+      const remoteBody = mockAddMessageToRemote.mock.calls[0]?.[0]?.body as string;
+      expect(remoteBody).toBe(commentBody);
     });
 
     it("resolves by entity_id and submits to remote with that id", async () => {

--- a/src/services/issues/issue_operations.ts
+++ b/src/services/issues/issue_operations.ts
@@ -40,6 +40,7 @@ import {
   structuredEntities,
   structuredEntityIdAt,
 } from "../submitted_thread/submitted_thread.js";
+import { decodeOverEscapedBody } from "./body_newline_decode.js";
 import { loadIssuesConfig } from "./config.js";
 import { IssueTransportError, IssueValidationError } from "./errors.js";
 import { runRedactionGuard } from "./redaction_guard.js";
@@ -539,6 +540,11 @@ export async function submitGuestIssue(
 ): Promise<GuestIssueSubmitResult> {
   await assertGuestWriteAllowed(["issue"], {});
 
+  // Guest submissions arriving directly at the operator endpoint are the only
+  // boundary for their body, so decode over-escaped `\n` here too. Idempotent
+  // for bodies forwarded from a remote `submitIssue` that already decoded. (#1484)
+  params = { ...params, body: decodeOverEscapedBody(params.body) };
+
   const config = await loadIssuesConfig();
   const now =
     typeof params.submission_timestamp === "string" && params.submission_timestamp.trim().length > 0
@@ -658,6 +664,10 @@ export async function appendGuestIssueMessage(
   ops: Operations,
   params: { issue_entity_id: string; body: string }
 ): Promise<{ message_entity_id: string }> {
+  // Decode over-escaped `\n` in guest-appended message bodies at this boundary.
+  // Idempotent for already-decoded bodies forwarded from a remote append. (#1484)
+  params = { ...params, body: decodeOverEscapedBody(params.body) };
+
   const raw = (await ops.retrieveEntitySnapshot({
     entity_id: params.issue_entity_id,
     format: "json",
@@ -788,6 +798,14 @@ export async function submitIssue(
   params: IssueCreateParams
 ): Promise<SubmitIssueResult> {
   assertSubmitIssueReporterEnvironment(params);
+
+  // Decode over-escaped bodies (literal `\n` two-char sequences) into real
+  // newlines before the body reaches the GitHub mirror or the canonical Neotoma
+  // record. Some clients double-encode the body argument; without this the issue
+  // renders as a single run-on block. Applied before redaction so the backstop
+  // scans the real text. See body_newline_decode.ts and issue #1484.
+  params = { ...params, body: decodeOverEscapedBody(params.body) };
+
   const config = await loadIssuesConfig();
   const now = new Date().toISOString();
   const visibility = params.visibility ?? "public";
@@ -1011,6 +1029,11 @@ export async function addIssueMessage(
   ops: Operations,
   params: IssueMessageParams
 ): Promise<AddMessageResult> {
+  // Decode over-escaped comment bodies (literal `\n`) into real newlines before
+  // the message reaches GitHub or the canonical Neotoma record, mirroring the
+  // submitIssue boundary. See body_newline_decode.ts and issue #1484.
+  params = { ...params, body: decodeOverEscapedBody(params.body) };
+
   const config = await loadIssuesConfig();
   const resolved = await resolveIssueRow(ops, params);
   const { issue_entity_id: issueEntityId, snapshot, githubNumber, localIssueId } = resolved;


### PR DESCRIPTION
## Summary

`submit_issue` (and `add_issue_message`) produced literal `\n` two-character sequences in GitHub issue bodies instead of real newlines, so issues rendered as a single run-on block with no markdown structure (see #1484, and the manually-corrected #356).

## Root cause

`github_client.createIssue` already serializes the request body correctly with `JSON.stringify`, which is the right way to call the GitHub REST API (a real newline becomes `\n` on the wire and GitHub decodes it back). So the defect was **upstream of the API call**: some MCP / API clients double-encode the `body` argument, delivering the value with one JSON-string-escape layer still applied. In that mode a real newline arrives at the server as the two characters backslash + `n`. Nothing decoded that literal sequence before it reached either the GitHub mirror or the canonical Neotoma `conversation_message` record, so `JSON.stringify` faithfully re-escaped the backslash and GitHub stored a literal `\n`.

## Fix

Added `src/services/issues/body_newline_decode.ts` — `decodeOverEscapedBody`, a conservative left-to-right escape scanner that inverts **exactly one** JSON-string-escape layer (`\n \r \t \" \\ \/`). It is deliberately not a naive `replace(/\\n/, "\n")`:

- It only runs when the body looks double-encoded: it contains a decodable escape sequence **and** no real newline. A body that already carries a real `0x0A` was encoded correctly and is returned untouched.
- An escaped backslash (`\\`) is consumed as one literal backslash *before* the following character can be misread as the start of `\n`, so intentional literal `\\n` and Windows paths like `C:\Users\mark` are preserved.

The decode is applied at all four issue-body service boundaries — `submitIssue`, `addIssueMessage`, `submitGuestIssue`, `appendGuestIssueMessage` — before the redaction guard, so the same decoded body reaches both the GitHub mirror and the canonical Neotoma store. The guest-path decodes are idempotent for bodies already decoded by a remote `submitIssue`, and necessary for guests submitting directly to an operator endpoint.

No contract or response-shape change: this is an internal body transformation, so no `openapi.yaml` / schema edits are required.

## Tests

Test-first: the two integration regression tests were written and confirmed failing against the buggy code before the fix.

- `src/services/issues/body_newline_decode.test.ts` (new, 11 cases): the #1484 over-escaped body, `\t`, CRLF, escaped quotes, the no-op cases (already-real newlines / no escapes), the escaped-backslash no-corruption case, a Windows-path no-corruption case, and a JSON double-encode **round-trip** (`JSON.stringify(original)` → decode → `original`).
- `src/services/issues/issue_operations.test.ts` (new cases):
  - `submitIssue` decodes literal `\n` before mirroring to GitHub, and the same decoded body reaches the remote Neotoma client and the local issue/`conversation_message` store (multi-line round-trip with real newlines).
  - `submitIssue` leaves an already-correctly-multi-line body untouched (no-regression).
  - `addIssueMessage` decodes literal `\n` in an over-escaped comment body before posting to GitHub and the remote client.

Verification: full issues subsystem suite green (70/70); `npm run type-check`, `npm run lint` (0 errors), and Prettier all clean. The 7 unrelated pre-existing test failures elsewhere in the repo (CLI smoke, cursor-hook integration, graph-neighborhood pagination, package_scripts contract, badge/tier UI) were confirmed to fail identically on clean `origin/main` with these changes stashed, so this PR introduces no regressions.

## Files changed

- `src/services/issues/body_newline_decode.ts` (new)
- `src/services/issues/body_newline_decode.test.ts` (new)
- `src/services/issues/issue_operations.ts`
- `src/services/issues/issue_operations.test.ts`

Fixes #1484

🤖 Generated with [Claude Code](https://claude.com/claude-code)