### PR TITLE
feat(mcp): expose split_entity in the MCP tool surface (#330)

### DIFF
--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,8 +61,8 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **400**
-- Backend and repo Vitest files: **367**
+- Total automated test files: **401**
+- Backend and repo Vitest files: **368**
 - Frontend Vitest files: **9**
 - Playwright spec files: **24**
 
@@ -74,7 +74,7 @@ flowchart TD
 | Source-adjacent tests | 46 |
 | Vitest integration tests | 109 |
 | Vitest CLI tests | 59 |
-| Vitest contract tests | 11 |
+| Vitest contract tests | 12 |
 | Vitest security tests | 2 |
 | Vitest subscription tests | 3 |
 | Vitest agent tests | 1 |
@@ -488,13 +488,14 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/contract`
 **Requirements:** Generated contract artifacts present when the suite expects them.
-**Files (11):**
+**Files (12):**
 - `tests/contract/cli_handler_dist_smoke.test.ts`
 - `tests/contract/contract_mapping.test.ts`
 - `tests/contract/contract_mcp_cli_parity.test.ts`
 - `tests/contract/ironclaw_integration.test.ts`
 - `tests/contract/legacy_payloads/replay.test.ts`
 - `tests/contract/mcp_stdio_output_safety.test.ts`
+- `tests/contract/mcp_tool_dispatch_coverage.test.ts`
 - `tests/contract/openapi_schema.test.ts`
 - `tests/contract/openclaw_plugin.test.ts`
 - `tests/contract/package_contents.test.ts`

--- a/src/server.ts
+++ b/src/server.ts
@@ -34,6 +34,7 @@ import {
   ListObservationsRequestSchema,
   ListRelationshipsRequestSchema,
   MergeEntitiesRequestSchema,
+  SplitEntityRequestSchema,
   DeleteEntityRequestSchema,
   DeleteRelationshipRequestSchema,
   RestoreEntityRequestSchema,
@@ -1748,6 +1749,8 @@ export class NeotomaServer {
         return await this.correct(args);
       case "merge_entities":
         return await this.mergeEntities(args);
+      case "split_entity":
+        return await this.splitEntity(args);
       case "list_potential_duplicates":
         return await this.listPotentialDuplicates(args);
       case "delete_entity":
@@ -5376,6 +5379,66 @@ export class NeotomaServer {
       throw new McpError(
         ErrorCode.InternalError,
         `Failed to merge entities: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  }
+
+  // R5: MCP split_entity() Tool — inverse of merge_entities. Re-points a
+  // predicate-selected subset of an entity's observations onto a new (or
+  // pre-existing) entity to repair over-merges. Mirrors the HTTP
+  // POST /entities/split handler in actions.ts and the mergeEntities() shape.
+  private async splitEntity(
+    args: unknown
+  ): Promise<{ content: Array<{ type: string; text: string }> }> {
+    const parsed = SplitEntityRequestSchema.parse(args);
+    const userId = this.getAuthenticatedUserId(parsed.user_id);
+
+    const {
+      splitEntity: splitEntityService,
+      EntityNotFoundError,
+      EntityAlreadyMergedError,
+      SplitPredicateMatchedNothingError,
+      SplitPredicateMatchedAllError,
+      IdempotencyMismatchError,
+    } = await import("./services/entity_split.js");
+
+    try {
+      const result = await splitEntityService({
+        sourceEntityId: parsed.source_entity_id,
+        userId,
+        predicate: parsed.predicate,
+        newEntity: {
+          entity_type: parsed.new_entity.entity_type,
+          canonical_name: parsed.new_entity.canonical_name,
+          target_entity_id: parsed.new_entity.target_entity_id,
+        },
+        idempotencyKey: parsed.idempotency_key,
+        reason: parsed.reason,
+        splitBy: "mcp",
+      });
+
+      return this.buildTextResponse({
+        split_id: result.split_id,
+        source_entity_id: result.source_entity_id,
+        new_entity_id: result.new_entity_id,
+        observations_moved: result.observations_moved,
+        split_at: result.split_at,
+        replayed: result.replayed,
+        reason: parsed.reason,
+      });
+    } catch (err) {
+      if (
+        err instanceof EntityNotFoundError ||
+        err instanceof EntityAlreadyMergedError ||
+        err instanceof SplitPredicateMatchedNothingError ||
+        err instanceof SplitPredicateMatchedAllError ||
+        err instanceof IdempotencyMismatchError
+      ) {
+        throw new McpError(ErrorCode.InvalidParams, err.message);
+      }
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to split entity: ${err instanceof Error ? err.message : String(err)}`
       );
     }
   }

--- a/tests/contract/mcp_tool_dispatch_coverage.test.ts
+++ b/tests/contract/mcp_tool_dispatch_coverage.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Advertised-but-unregistered guard (issue #330).
+ *
+ * `split_entity` shipped in the MCP tool registry (`buildToolDefinitions`),
+ * the contract mappings, and the OpenAPI spec — but the `executeTool` dispatch
+ * switch in `src/server.ts` had no `case "split_entity":`, so calling it
+ * returned `MCP error -32601: Unknown tool: split_entity`. The pre-existing
+ * contract tests validated the *mappings* but never that an advertised tool is
+ * actually *dispatchable*, so the gap slipped through.
+ *
+ * This guard closes that class for every tool: each name returned by
+ * `buildToolDefinitions()` MUST appear as a `case` in the `executeTool`
+ * dispatch switch (directly, or grouped with another case that shares a
+ * handler — the `store` / `store_structured` / `store_unstructured` pattern).
+ * If a tool is advertised but missing from dispatch, this fails before a user
+ * ever hits the `Unknown tool` runtime error.
+ */
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+import { buildToolDefinitions } from "../../src/tool_definitions.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const serverSrc = readFileSync(join(__dirname, "../../src/server.ts"), "utf-8");
+
+/**
+ * Extract the body of the `executeTool` dispatch switch — from the method
+ * declaration to the `default:` branch that throws `Unknown tool`.
+ */
+function extractExecuteToolDispatch(source: string): string {
+  const start = source.indexOf("private async executeTool(");
+  expect(start, "executeTool method must exist in server.ts").toBeGreaterThan(-1);
+  const end = source.indexOf("Unknown tool: ${name}", start);
+  expect(end, "executeTool default branch (Unknown tool) must exist").toBeGreaterThan(start);
+  return source.slice(start, end);
+}
+
+describe("MCP tool dispatch coverage — advertised tools must be dispatchable", () => {
+  const dispatchBody = extractExecuteToolDispatch(serverSrc);
+  const advertisedToolNames = buildToolDefinitions().map((def) => def.name);
+
+  it("advertises a non-empty tool set", () => {
+    expect(advertisedToolNames.length).toBeGreaterThan(0);
+  });
+
+  it("registers a dispatch case for split_entity (issue #330)", () => {
+    expect(advertisedToolNames).toContain("split_entity");
+    expect(dispatchBody).toMatch(/case\s+"split_entity"\s*:/);
+  });
+
+  it.each(advertisedToolNames)("registers a dispatch case for advertised tool %s", (toolName) => {
+    const casePattern = new RegExp(
+      `case\\s+"${toolName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}"\\s*:`
+    );
+    expect(
+      casePattern.test(dispatchBody),
+      `Tool "${toolName}" is advertised by buildToolDefinitions() but has no case in the executeTool dispatch switch. ` +
+        `Calling it via MCP would return "Unknown tool: ${toolName}". Add a case in src/server.ts.`
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

`split_entity` was advertised in the MCP tool registry but returned `MCP error -32601: Unknown tool: split_entity` when called, because the `executeTool` dispatch switch in `src/server.ts` had no `case "split_entity":`.

Everything else for the tool already existed on `main`:
- tool definition in `src/tool_definitions.ts` (name, description, OpenAPI-derived input schema)
- contract-mappings row in `src/shared/contract_mappings.ts` (`mcpTool: "split_entity"` → `operationId: "splitEntity"`)
- OpenAPI `splitEntity` operation + `SplitEntityRequestSchema`
- the domain service `src/services/entity_split.ts` and the HTTP `POST /entities/split` handler in `src/actions.ts`

The single missing link was the MCP dispatch binding. This PR adds it.

## Changes

- **`src/server.ts`**: import `SplitEntityRequestSchema`; add `case "split_entity": return await this.splitEntity(args);` to the `executeTool` switch; add a private `splitEntity()` handler that mirrors `mergeEntities()` exactly — parses the request, resolves the authenticated user via `getAuthenticatedUserId`, calls the existing `entity_split` service with `splitBy: "mcp"`, and maps the service's typed errors (`EntityNotFoundError`, `EntityAlreadyMergedError`, `SplitPredicateMatchedNothingError`, `SplitPredicateMatchedAllError`, `IdempotencyMismatchError`) to `McpError(InvalidParams)`, with a generic `InternalError` fallback.
- **`tests/contract/mcp_tool_dispatch_coverage.test.ts`** (new): an advertised-but-unregistered guard. It asserts every tool returned by `buildToolDefinitions()` has a matching `case` in the `executeTool` dispatch switch, plus a dedicated assertion for `split_entity`. This closes the regression class at test time — the pre-existing contract tests validated the mappings but never actual dispatchability, which is exactly why #330 slipped through.

No OpenAPI, contract-mapping, or schema change was needed (all already present), so no `openapi:generate` run was required.

## Tests

- New guard: 57 tests pass; verified it **fails** when the dispatch case is removed (catches the #330 regression) and **passes** when present.
- `npm run type-check`: clean.
- `npm test -- tests/contract/`: 12 files / 130 tests pass (after `git submodule update --init inspector`).
- Pre-existing, unrelated failures on `main` (`tests/integration/graph_neighborhood_pagination.test.ts`, `tests/cli/cli_smoke.test.ts`) are out of scope for this change; verified they fail identically on a clean `origin/main` checkout without these edits.

Fixes #330

🤖 Generated with [Claude Code](https://claude.com/claude-code)