### PR TITLE
fix(relationships): deterministic pagination order on list_relationships and retrieve_graph_neighborhood (#368)

### DIFF
--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,8 +61,8 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **401**
-- Backend and repo Vitest files: **368**
+- Total automated test files: **403**
+- Backend and repo Vitest files: **370**
 - Frontend Vitest files: **9**
 - Playwright spec files: **24**
 
@@ -72,7 +72,7 @@ flowchart TD
 | Vitest unit tests | 99 |
 | Vitest service tests | 33 |
 | Source-adjacent tests | 47 |
-| Vitest integration tests | 109 |
+| Vitest integration tests | 110 |
 | Vitest CLI tests | 59 |
 | Vitest contract tests | 12 |
 | Vitest security tests | 2 |
@@ -307,7 +307,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm run test:integration` or `npx vitest run tests/integration`
 **Requirements:** Database configured; remote-dependent subsets additionally need `RUN_REMOTE_TESTS=1`.
-**Files (109):**
+**Files (110):**
 - `tests/integration/aauth_attribution_stamping.test.ts`
 - `tests/integration/aauth_resource_metadata.test.ts`
 - `tests/integration/aauth_revocation_e2e.test.ts`
@@ -394,6 +394,7 @@ flowchart TD
 - `tests/integration/public_key_registry.test.ts`
 - `tests/integration/record_activity_attribution.test.ts`
 - `tests/integration/relationship_agent_attribution_api.test.ts`
+- `tests/integration/relationship_pagination_determinism.test.ts`
 - `tests/integration/relationship_snapshots.test.ts`
 - `tests/integration/retrieval_transport_reliability.test.ts`
 - `tests/integration/root_landing.test.ts`

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -4065,8 +4065,13 @@ app.get("/relationships", async (req, res) => {
       query = query.eq("target_entity_id", targetEntityId);
     }
 
+    // Stable pagination: tiebreak on the `relationship_key` primary key so rows
+    // sharing a `last_observation_at` value (batch upserts) keep a fixed order
+    // across paginated calls (docs/architecture/determinism.md). Same defect
+    // class as issue #368 on /list_relationships and /retrieve_graph_neighborhood.
     const { data, error, count } = await query
       .order("last_observation_at", { ascending: false })
+      .order("relationship_key", { ascending: true })
       .range(offset, offset + limit - 1);
 
     if (error) throw error;
@@ -7685,7 +7690,16 @@ app.post("/list_relationships", async (req, res) => {
       query = query.eq("relationship_type", relationship_type);
     }
 
-    query = query.order("last_observation_at", { ascending: false });
+    // Deterministic ordering: `last_observation_at` is mutable and produces ties
+    // for rows upserted within the same millisecond (common in batch ingestion).
+    // `relationship_key` is the table's primary key — a stable, unique, monotonic
+    // tiebreaker that fully determines order. Without it, tied rows can move
+    // between pages across successive calls, breaking pagination stability and
+    // violating the determinism invariant (docs/architecture/determinism.md §
+    // "Sorting MUST use deterministic tiebreakers"). See issue #368.
+    query = query
+      .order("last_observation_at", { ascending: false })
+      .order("relationship_key", { ascending: true });
 
     const { data, error } = await query;
     if (error) {
@@ -7941,11 +7955,19 @@ app.post("/retrieve_graph_neighborhood", async (req, res) => {
         result.total_count = total;
         result.has_more = offset + limit < total;
 
+        // Deterministic ordering before paginating: this query previously had no
+        // `.order()` clause, so Postgres scan order (unspecified) decided which
+        // rows landed on each page — non-deterministic across calls. Order by the
+        // mutable `last_observation_at` first, then by the primary key
+        // `relationship_key` as a stable, unique tiebreaker so pagination is
+        // reproducible (docs/architecture/determinism.md). See issue #368.
         const { data: relationships, error: relError } = await db
           .from("relationship_snapshots")
           .select("*")
           .or(`source_entity_id.eq.${node_id},target_entity_id.eq.${node_id}`)
           .eq("user_id", userId)
+          .order("last_observation_at", { ascending: false })
+          .order("relationship_key", { ascending: true })
           .range(offset, offset + limit - 1);
 
         if (!relError) {

--- a/tests/integration/relationship_pagination_determinism.test.ts
+++ b/tests/integration/relationship_pagination_determinism.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Integration test: deterministic pagination order for relationship endpoints.
+ *
+ * Regression coverage for issue #368 — non-deterministic pagination order on
+ * /list_relationships and /retrieve_graph_neighborhood.
+ *
+ * The key fixture property here is that EVERY relationship row shares the SAME
+ * `last_observation_at` value. This is the tie case: the primary sort key
+ * (`last_observation_at DESC`) cannot disambiguate any two rows, so ordering is
+ * fully determined by the stable secondary sort key (`relationship_key ASC`).
+ *
+ * Without a stable tiebreaker, the underlying store is free to return tied rows
+ * in any order across calls, which breaks pagination stability (items drift
+ * between pages). These tests assert:
+ *   1. Identical ordering across repeated calls (stability).
+ *   2. Disjoint, gap-free page boundaries that cover the full result set
+ *      (correct pagination under a tie).
+ *   3. The order matches the deterministic convention (relationship_key ASC),
+ *      per docs/architecture/determinism.md (stable secondary sort key).
+ */
+
+import { createHash } from "node:crypto";
+import { createServer } from "node:http";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { app } from "../../src/actions.js";
+import { db } from "../../src/db.js";
+
+const TEST_USER_ID = "00000000-0000-0000-0000-000000000371";
+const API_PORT = 18121;
+const API_BASE = `http://127.0.0.1:${API_PORT}`;
+
+// Every relationship row gets THIS exact timestamp — the tie that forces the
+// secondary sort key to decide ordering.
+const SHARED_OBSERVED_AT = "2026-01-01T00:00:00.000Z";
+
+/** Build a stable fake Neotoma entity id from a short tag. */
+function makeEntityId(tag: string): string {
+  const hex = createHash("sha256").update(tag).digest("hex").slice(0, 24);
+  return `ent_${hex}`;
+}
+
+describe("relationship pagination determinism (#368)", () => {
+  let httpServer: ReturnType<typeof createServer>;
+
+  const runTag = `pgd-${Date.now()}`;
+  const centerEntityId = makeEntityId(`${runTag}-center`);
+  const REL_COUNT = 5;
+  const spokeEntityIds: string[] = [];
+  const createdRelationshipKeys: string[] = [];
+
+  beforeAll(async () => {
+    httpServer = createServer(app);
+    await new Promise<void>((resolve, reject) => {
+      httpServer.listen(API_PORT, "127.0.0.1", () => resolve());
+      httpServer.once("error", reject);
+    });
+
+    await db.from("entities").insert({
+      id: centerEntityId,
+      user_id: TEST_USER_ID,
+      entity_type: "note",
+      canonical_name: "pgd-center",
+    });
+
+    // Insert spokes and relationships. All snapshots share SHARED_OBSERVED_AT so
+    // last_observation_at cannot break ties; relationship_key must.
+    for (let i = 0; i < REL_COUNT; i++) {
+      const spokeId = makeEntityId(`${runTag}-spoke-${i}`);
+      spokeEntityIds.push(spokeId);
+
+      await db.from("entities").insert({
+        id: spokeId,
+        user_id: TEST_USER_ID,
+        entity_type: "note",
+        canonical_name: `pgd-spoke-${i}`,
+      });
+
+      const relationshipType = "REFERS_TO";
+      const relationshipKey = `${relationshipType}:${centerEntityId}:${spokeId}`;
+      createdRelationshipKeys.push(relationshipKey);
+
+      await db.from("relationship_observations").insert({
+        id: createHash("sha256").update(`${relationshipKey}:obs`).digest("hex"),
+        relationship_key: relationshipKey,
+        source_entity_id: centerEntityId,
+        target_entity_id: spokeId,
+        relationship_type: relationshipType,
+        source_priority: 1,
+        metadata: {},
+        canonical_hash: createHash("sha256").update(relationshipKey).digest("hex"),
+        user_id: TEST_USER_ID,
+        observed_at: SHARED_OBSERVED_AT,
+        provenance: {},
+      });
+
+      await db.from("relationship_snapshots").upsert({
+        relationship_key: relationshipKey,
+        relationship_type: relationshipType,
+        source_entity_id: centerEntityId,
+        target_entity_id: spokeId,
+        schema_version: "1.0",
+        snapshot: {},
+        computed_at: SHARED_OBSERVED_AT,
+        observation_count: 1,
+        last_observation_at: SHARED_OBSERVED_AT,
+        provenance: {},
+        user_id: TEST_USER_ID,
+      });
+    }
+  });
+
+  afterAll(async () => {
+    await db.from("relationship_snapshots").delete().in("relationship_key", createdRelationshipKeys);
+    await db
+      .from("relationship_observations")
+      .delete()
+      .in("relationship_key", createdRelationshipKeys);
+    await db.from("entities").delete().in("id", [centerEntityId, ...spokeEntityIds]);
+    await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+  });
+
+  async function listRelationships(params: Record<string, unknown>) {
+    const resp = await fetch(`${API_BASE}/list_relationships`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ user_id: TEST_USER_ID, ...params }),
+    });
+    return resp.json() as Promise<Record<string, unknown>>;
+  }
+
+  async function neighborhood(params: Record<string, unknown>) {
+    const resp = await fetch(`${API_BASE}/retrieve_graph_neighborhood`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        node_id: centerEntityId,
+        user_id: TEST_USER_ID,
+        ...params,
+      }),
+    });
+    return resp.json() as Promise<Record<string, unknown>>;
+  }
+
+  function keysOf(body: Record<string, unknown>): string[] {
+    return (body.relationships as Array<{ relationship_key: string }>).map(
+      (r) => r.relationship_key
+    );
+  }
+
+  // The deterministic order under the tie: relationship_key ascending.
+  // Computed lazily inside each test because `createdRelationshipKeys` is
+  // populated in `beforeAll`, which runs after the describe body is evaluated.
+  const expectedOrder = (): string[] =>
+    [...createdRelationshipKeys].sort((a, b) => a.localeCompare(b));
+
+  describe("/list_relationships", () => {
+    it("returns an identical full-page order across repeated calls (tie on last_observation_at)", async () => {
+      const a = keysOf(await listRelationships({ entity_id: centerEntityId, limit: REL_COUNT }));
+      const b = keysOf(await listRelationships({ entity_id: centerEntityId, limit: REL_COUNT }));
+      const c = keysOf(await listRelationships({ entity_id: centerEntityId, limit: REL_COUNT }));
+
+      expect(a).toHaveLength(REL_COUNT);
+      expect(b).toEqual(a);
+      expect(c).toEqual(a);
+    });
+
+    it("orders tied rows by the stable secondary key (relationship_key ASC)", async () => {
+      const keys = keysOf(await listRelationships({ entity_id: centerEntityId, limit: REL_COUNT }));
+      expect(keys).toEqual(expectedOrder());
+    });
+
+    it("pages with a tie are disjoint, gap-free, and cover the full set", async () => {
+      // Page across the tied rows two at a time.
+      const page1 = keysOf(
+        await listRelationships({ entity_id: centerEntityId, limit: 2, offset: 0 })
+      );
+      const page2 = keysOf(
+        await listRelationships({ entity_id: centerEntityId, limit: 2, offset: 2 })
+      );
+      const page3 = keysOf(
+        await listRelationships({ entity_id: centerEntityId, limit: 2, offset: 4 })
+      );
+
+      expect(page1).toHaveLength(2);
+      expect(page2).toHaveLength(2);
+      expect(page3).toHaveLength(1);
+
+      const concatenated = [...page1, ...page2, ...page3];
+      // No row appears on two pages.
+      expect(new Set(concatenated).size).toBe(REL_COUNT);
+      // Concatenating pages reproduces the single-page deterministic order.
+      expect(concatenated).toEqual(expectedOrder());
+    });
+
+    it("page boundaries are stable across repeated paginated calls", async () => {
+      const first = keysOf(
+        await listRelationships({ entity_id: centerEntityId, limit: 2, offset: 2 })
+      );
+      const second = keysOf(
+        await listRelationships({ entity_id: centerEntityId, limit: 2, offset: 2 })
+      );
+      expect(second).toEqual(first);
+    });
+  });
+
+  describe("/retrieve_graph_neighborhood", () => {
+    it("returns an identical relationship order across repeated calls (tie on last_observation_at)", async () => {
+      const a = keysOf(await neighborhood({ limit: REL_COUNT }));
+      const b = keysOf(await neighborhood({ limit: REL_COUNT }));
+      const c = keysOf(await neighborhood({ limit: REL_COUNT }));
+
+      expect(a).toHaveLength(REL_COUNT);
+      expect(b).toEqual(a);
+      expect(c).toEqual(a);
+    });
+
+    it("orders tied rows by the stable secondary key (relationship_key ASC)", async () => {
+      const keys = keysOf(await neighborhood({ limit: REL_COUNT }));
+      expect(keys).toEqual(expectedOrder());
+    });
+
+    it("pages with a tie are disjoint, gap-free, and cover the full set", async () => {
+      const page1 = keysOf(await neighborhood({ limit: 2, offset: 0 }));
+      const page2 = keysOf(await neighborhood({ limit: 2, offset: 2 }));
+      const page3 = keysOf(await neighborhood({ limit: 2, offset: 4 }));
+
+      expect(page1).toHaveLength(2);
+      expect(page2).toHaveLength(2);
+      expect(page3).toHaveLength(1);
+
+      const concatenated = [...page1, ...page2, ...page3];
+      expect(new Set(concatenated).size).toBe(REL_COUNT);
+      expect(concatenated).toEqual(expectedOrder());
+    });
+
+    it("page boundaries are stable across repeated paginated calls", async () => {
+      const first = keysOf(await neighborhood({ limit: 2, offset: 2 }));
+      const second = keysOf(await neighborhood({ limit: 2, offset: 2 }));
+      expect(second).toEqual(first);
+    });
+  });
+});


### PR DESCRIPTION
Fixes #368

## Problem

Relationship pagination ordered only by `last_observation_at`, a **mutable** column that ties for rows upserted within the same millisecond (common in batch ingestion). With no stable tiebreaker, tied rows could move between pages across successive calls — breaking pagination stability and violating the determinism invariant (`docs/architecture/determinism.md` § "Sorting MUST use deterministic tiebreakers").

- `/list_relationships` ordered by `last_observation_at DESC` only.
- `/retrieve_graph_neighborhood` had **no `.order()` clause at all** on its relationship query before `.range()`, so Postgres scan order (unspecified) decided which rows landed on each page. The existing integration test only passed by luck of small, single-batch fixtures with distinct timestamps.

## Fix

Add `relationship_key ASC` as a stable secondary sort key. `relationship_key` is the `relationship_snapshots` PRIMARY KEY — a stable, unique, monotonic tiebreaker that fully determines order (the table has no `id` column).

- `/list_relationships`: `last_observation_at DESC, relationship_key ASC`.
- `/retrieve_graph_neighborhood`: add explicit `last_observation_at DESC, relationship_key ASC` before `.range()`.
- `GET /relationships`: same defect class on the same table (also paginates via `.range()`); given the same `relationship_key` tiebreaker for consistency.

This is a **purely internal ordering change**. No declared OpenAPI response field or order semantics change, so no `openapi.yaml` / contract update is required (ordering is not a declared contract; both endpoints already declare their response shape without an order guarantee). Verified against the full contract suite (70/70 pass).

## Scope

Only the determinism fix for #368 (stable sort). The unbounded-fetch concern (#367) and OpenAPI field-declaration / `total` vs `total_count` naming (#369) are intentionally **not** addressed here.

## Tests (test-first)

Added `tests/integration/relationship_pagination_determinism.test.ts`. The fixture inserts multiple relationship rows that all share an **identical** `last_observation_at` value — the tie case — so ordering is fully determined by the secondary key. For **both** endpoints it asserts:

1. Identical ordering across repeated calls (stability).
2. Ordering by the stable secondary key (`relationship_key ASC`).
3. Disjoint, gap-free page boundaries that cover the full result set when paging two-at-a-time across the tie.

Confirmed test-first: the new test **fails without the fix** (4 assertions across the two endpoints) and **passes with it** (8/8).

## Verification

- `npm run type-check` — clean (0 errors)
- `npm run lint` — 0 errors (pre-existing `no-explicit-any` warnings only, none in changed code)
- `npm run format:check` — clean
- `npm run test:contract` — 70/70 pass (excluding `package_scripts.test.ts`, which requires the `inspector` submodule not checked out in the worktree; unaffected by this change)
- New determinism test — 8/8 pass; proven to fail without the fix

Note: a handful of pre-existing, environment-specific test files fail in this worktree (uninitialized `inspector` submodule, cursor-hooks build artifacts); the **same files fail on clean `origin/main`** and are unrelated to this change. They are not in the gating CI lane (`npm run test:unit`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)