### PR TITLE
fix(review): trim Phase 2 always-load to 3 docs, raise max_turns to 60

### DIFF
--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -53,17 +53,11 @@ Perform a structured code review of a GitHub PR, a branch, or the current workin
 
 ### Phase 2 — Load docs
 
-**Always load** (establish invariants):
+**Always load** (3 docs — true invariant kernel only):
 
 - `docs/NEOTOMA_MANIFEST.md`
-- `docs/foundation/core_identity.md`
-- `docs/foundation/philosophy.md`
 - `docs/foundation/layered_architecture.md`
 - `.claude/rules/change_guardrails_rules.md`
-- `docs/foundation/schema_agnostic_design_rules.md`
-- `docs/architecture/determinism.md`
-- `docs/subsystems/errors.md`
-- `docs/security/threat_model.md`
 
 **Load conditionally** based on paths in the diff (per `docs/developer/pr_review_reading_list.md`):
 
@@ -84,9 +78,14 @@ Perform a structured code review of a GitHub PR, a branch, or the current workin
 | `src/tool_definitions.ts`, `src/server.ts`, `docs/developer/mcp/` | `docs/developer/mcp/instructions.md`, `docs/developer/agent_instructions_sync_rules.mdc` |
 | `src/cli/` | `docs/developer/cli_reference.md` |
 | `src/actions.ts`, `src/services/local_auth*`, `src/middleware/` | `docs/subsystems/auth.md`, `docs/security/advisories/2026-05-11-inspector-auth-bypass.md` |
-| `src/services/root_landing/` | `docs/security/threat_model.md` (already loaded) |
+| `src/actions.ts`, `src/server.ts`, any auth/middleware path | `docs/security/threat_model.md` |
 | Guest access, public routes | `docs/subsystems/guest_access_policy.md` |
-| New entity type or schema field | `docs/subsystems/record_types.md`, `docs/foundation/data_models.md` |
+| `src/services/root_landing/` | `docs/security/threat_model.md` |
+| New call to `registry.register()` (i.e. a new entity type being registered, not a schema field addition) | `docs/subsystems/record_types.md`, `docs/foundation/data_models.md` |
+| Any `if (entityType`, `switch (entity_type`, or hardcoded entity-type list in diff | `docs/foundation/schema_agnostic_design_rules.md` |
+| Any new error code, tightened validation, or changed error response shape | `docs/subsystems/errors.md` |
+| `Math.random`, `Date.now` in non-observability paths, new sort/grouping in stored-output path | `docs/architecture/determinism.md` |
+| Any change to stored fields, observation shape, or entity snapshot output | `docs/foundation/core_identity.md`, `docs/foundation/philosophy.md` |
 | Logging, metrics, tracing | `docs/observability/logging.md`, `docs/observability/metrics_standard.md`, `docs/subsystems/privacy.md` |
 | `tests/` | `docs/testing/testing_standard.md` |
 | `docs/releases/` | `docs/developer/github_release_process.md` |

--- a/.github/workflows/claude_pr_review.yml
+++ b/.github/workflows/claude_pr_review.yml
@@ -99,8 +99,8 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           model: claude-opus-4-7
-          timeout_minutes: 30
-          max_turns: 30
+          timeout_minutes: 60
+          max_turns: 60
           trigger_phrase: "@claude review"
           allowed_tools: "Edit,MultiEdit,Glob,Grep,LS,Read,Write,mcp__github_comment__update_claude_comment,Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git rm:*),Bash(git fetch:*)"
           direct_prompt: |

--- a/docs/developer/pr_review_reading_list.md
+++ b/docs/developer/pr_review_reading_list.md
@@ -4,20 +4,15 @@ This document is the authoritative reading list for the automated Claude PR revi
 
 ## Always read
 
-These establish the invariants every PR must respect regardless of what changed.
+These three docs are the invariant kernel — load on every PR regardless of what changed.
 
 | Doc | What it enforces |
 |-----|-----------------|
 | `docs/NEOTOMA_MANIFEST.md` | Root invariants: State Layer, determinism, immutability, schema-first, no PII, no synthetic data |
-| `docs/foundation/core_identity.md` | What Neotoma is and is not; State Layer scope boundaries |
-| `docs/foundation/philosophy.md` | Core principles and architectural invariants |
 | `docs/foundation/layered_architecture.md` | State Layer / Operational Layer boundaries; forbidden cross-layer logic |
 | `docs/architecture/change_guardrails_rules.mdc` | Cross-cutting change constraints; touchpoint matrix; pre-PR checklist |
-| `docs/foundation/schema_agnostic_design_rules.md` | No per-type branches; schema-driven behavior only |
-| `docs/architecture/determinism.md` | Deterministic IDs, stable ordering, no nondeterminism in business logic |
-| `docs/subsystems/errors.md` | Error envelope taxonomy; tightening-change hint obligation |
-| `docs/security/threat_model.md` | Auth bypass classes; proxy trust; local-dev shortcut regression patterns |
-| `docs/vocabulary/canonical_terms.md` | Canonical terminology; use consistently in review comments |
+
+All other docs are conditional — load only when the diff touches the listed paths (see below). The previous "always read" list was too broad: loading `core_identity`, `philosophy`, `schema_agnostic_design_rules`, `determinism`, `errors`, and `threat_model` on every PR consumed 6+ turns before any diff was read, causing reviews that touch `server.ts`/`actions.ts` to run out of budget at Phase 1.
 
 ## Read when these paths changed
 
@@ -61,7 +56,13 @@ Load only when the diff touches the listed files or directories.
 | Changed path | Read |
 |---|---|
 | Subsystem consistency model changes | `docs/architecture/consistency.md` |
-| Any new entity type or schema field | `docs/subsystems/record_types.md`, `docs/foundation/data_models.md` |
+| New call to `registry.register()` (new entity type registered, not just schema field addition) | `docs/subsystems/record_types.md`, `docs/foundation/data_models.md` |
+| Any `if (entityType`, `switch (entity_type`, or hardcoded entity-type list in diff | `docs/foundation/schema_agnostic_design_rules.md` |
+| Any new error code, tightened validation, or changed error response shape | `docs/subsystems/errors.md` |
+| `Math.random`, `Date.now` in non-observability code paths; new sort/grouping in stored-output path | `docs/architecture/determinism.md` |
+| Any change to stored fields, observation shape, or entity snapshot output | `docs/foundation/core_identity.md`, `docs/foundation/philosophy.md` |
+| Any auth/security-adjacent change (`src/actions.ts`, `src/server.ts`, middleware, root_landing) | `docs/security/threat_model.md` |
+| Naming of new fields, parameters, or error codes | `docs/vocabulary/canonical_terms.md` |
 
 ### Observability
 


### PR DESCRIPTION
## Summary

- **Phase 2 always-load reduced from 9 docs to 3**: `NEOTOMA_MANIFEST`, `layered_architecture`, `change_guardrails_rules`. The other 6 docs (`core_identity`, `philosophy`, `schema_agnostic_design_rules`, `determinism`, `errors`, `threat_model`) moved to conditional rows triggered only when the diff actually touches their surface.
- **`new entity type or schema field` trigger tightened**: now fires only on new `registry.register()` calls, not on any `SchemaDefinition` field addition. The old trigger loaded `record_types.md` + `data_models.md` on every schema change.
- **`max_turns` and `timeout_minutes` raised from 30 → 60** in `claude_pr_review.yml`: the 30-turn cap was exhausted by Phase 1+2+3 on 9-file high-risk PRs before any findings could be emitted.

These fixes land on main so the `issue_comment`-triggered review job uses the updated workflow (GH Actions uses the default branch's workflow for comment triggers).

## Test plan
- [ ] Trigger `@claude review` on an open PR and verify findings are emitted through Phase 6
- [ ] Confirm `pr_review_reading_list.md` conditional table matches SKILL.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)