### PR TITLE
fix(openapi): format generated types in openapi:generate + CI freshness guard

### DIFF
--- a/.github/workflows/ci_test_lanes.yml
+++ b/.github/workflows/ci_test_lanes.yml
@@ -54,12 +54,14 @@ jobs:
       - name: Format check
         run: npm run format:check
 
+      # Must run AFTER format:check so a stale committed file cannot be silently
+      # re-formatted by `openapi:generate` (which runs prettier --write) before
+      # the format gate sees it. Do not move this step above format:check.
       - name: OpenAPI types are in sync with openapi.yaml
         run: |
           npm run openapi:generate
           if ! git diff --quiet -- src/shared/openapi_types.ts; then
-            echo "::error::src/shared/openapi_types.ts is out of sync with openapi.yaml."
-            echo "Run 'npm run openapi:generate' and commit the result."
+            echo "::error::src/shared/openapi_types.ts is out of sync with openapi.yaml. If you edited openapi.yaml, run 'npm run openapi:generate' and commit the regenerated src/shared/openapi_types.ts."
             git --no-pager diff -- src/shared/openapi_types.ts | head -100
             exit 1
           fi

--- a/.github/workflows/ci_test_lanes.yml
+++ b/.github/workflows/ci_test_lanes.yml
@@ -54,6 +54,16 @@ jobs:
       - name: Format check
         run: npm run format:check
 
+      - name: OpenAPI types are in sync with openapi.yaml
+        run: |
+          npm run openapi:generate
+          if ! git diff --quiet -- src/shared/openapi_types.ts; then
+            echo "::error::src/shared/openapi_types.ts is out of sync with openapi.yaml."
+            echo "Run 'npm run openapi:generate' and commit the result."
+            git --no-pager diff -- src/shared/openapi_types.ts | head -100
+            exit 1
+          fi
+
       - name: Lint site copy
         run: npm run lint:site-copy
 

--- a/docs/architecture/openapi_contract_flow.md
+++ b/docs/architecture/openapi_contract_flow.md
@@ -18,7 +18,7 @@ Handlers in `src/actions.ts` are **downstream**. When handlers and spec disagree
 Follow this order; do not skip steps:
 
 1. **Edit `openapi.yaml`.** Add the path, operationId, request body, responses, and any query/path parameters. Reuse existing `components/schemas` where possible.
-2. **Run `npm run openapi:generate`.** Regenerates `src/shared/openapi_types.ts`. Commit the regenerated file in the same change as the spec.
+2. **Run `npm run openapi:generate`.** Regenerates `src/shared/openapi_types.ts` and formats it with Prettier so the output is byte-stable and matches `npm run format:check`. Commit the regenerated file in the same change as the spec. CI re-runs this generate and fails if the committed file drifts (the "OpenAPI types are in sync with openapi.yaml" step in `ci_test_lanes.yml`), so always regenerate rather than hand-editing the file. Do not run the bare `openapi-typescript` binary without the format pass — its raw output uses a different indentation width and produces a spurious whole-file diff.
 3. **Update `src/shared/contract_mappings.ts`.** Every `operationId` needs a row declaring `adapter: "mcp" | "cli" | "both" | "infra"` and, where applicable, `mcpTool` and `cliCommand` names.
 4. **Implement / update the handler** in `src/actions.ts` (or wherever the route is registered). Use the generated types for the request and response shape.
 5. **Wire MCP / CLI surfaces** if `adapter` includes them:

--- a/docs/architecture/openapi_contract_flow.md
+++ b/docs/architecture/openapi_contract_flow.md
@@ -18,7 +18,9 @@ Handlers in `src/actions.ts` are **downstream**. When handlers and spec disagree
 Follow this order; do not skip steps:
 
 1. **Edit `openapi.yaml`.** Add the path, operationId, request body, responses, and any query/path parameters. Reuse existing `components/schemas` where possible.
-2. **Run `npm run openapi:generate`.** Regenerates `src/shared/openapi_types.ts` and formats it with Prettier so the output is byte-stable and matches `npm run format:check`. Commit the regenerated file in the same change as the spec. CI re-runs this generate and fails if the committed file drifts (the "OpenAPI types are in sync with openapi.yaml" step in `ci_test_lanes.yml`), so always regenerate rather than hand-editing the file. Do not run the bare `openapi-typescript` binary without the format pass — its raw output uses a different indentation width and produces a spurious whole-file diff.
+2. **Run `npm run openapi:generate`.** Regenerates `src/shared/openapi_types.ts` and formats it with Prettier so the output is byte-stable and matches `npm run format:check`. Commit the regenerated file in the same change as the spec. CI re-runs this generate and fails if the committed file drifts (the "OpenAPI types are in sync with openapi.yaml" step in `ci_test_lanes.yml`), so always regenerate rather than hand-editing the file.
+
+   > Note: Use `npm run openapi:generate`, not the bare `openapi-typescript` binary. The raw binary output uses a different indentation width than the committed file and produces a spurious whole-file diff; the npm script appends the Prettier pass that keeps the output stable.
 3. **Update `src/shared/contract_mappings.ts`.** Every `operationId` needs a row declaring `adapter: "mcp" | "cli" | "both" | "infra"` and, where applicable, `mcpTool` and `cliCommand` names.
 4. **Implement / update the handler** in `src/actions.ts` (or wherever the route is registered). Use the generated types for the request and response shape.
 5. **Wire MCP / CLI surfaces** if `adapter` includes them:

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "docs:build": "npm run build:docs",
     "docs:dev": "npm run dev:docs",
     "docs:serve": "npm run dev:docs:serve",
-    "openapi:generate": "openapi-typescript ./openapi.yaml --default-non-nullable false -o src/shared/openapi_types.ts",
+    "openapi:generate": "openapi-typescript ./openapi.yaml --default-non-nullable false -o src/shared/openapi_types.ts && prettier --write src/shared/openapi_types.ts",
     "openapi:bc-diff": "node scripts/openapi_bc_diff.js",
     "security:classify-diff": "node scripts/security/classify_diff.js",
     "security:lint": "node scripts/security/run_semgrep.js",


### PR DESCRIPTION
## Problem

`npm run openapi:generate` emitted **raw** `openapi-typescript` output, which uses 4-space indentation. The committed `src/shared/openapi_types.ts` is Prettier-formatted (2-space, `printWidth: 100`). So any regenerate produced a spurious **~13k-line whole-file diff** even when `openapi.yaml` was unchanged.

Consequences:
- The generated file looked chronically out of sync with the spec.
- Trivial rebases that touched `openapi.yaml` turned into massive conflicts in the generated file (hit while rebasing #946).
- A contributor regenerating "to be safe" would balloon their diff and risk a `format:check` failure.

Root cause confirmed: generate + the repo's Prettier config produces a file **byte-identical** to what's committed (diff collapses from ~13k lines to 0). The committed file was always correct; only the script was missing the format pass.

## Fix

- **`package.json`** — `openapi:generate` now pipes through `prettier --write src/shared/openapi_types.ts`. Regenerating against an unchanged `openapi.yaml` is now a true no-op.
- **`.github/workflows/ci_test_lanes.yml`** — new "OpenAPI types are in sync with openapi.yaml" step regenerates and fails if `src/shared/openapi_types.ts` drifts, so it can't silently fall out of sync again.
- **`docs/architecture/openapi_contract_flow.md`** — documents that generate self-formats, CI enforces freshness, and the bare binary must not be run without the format pass.

## No content change

`openapi_types.ts` content is identical to `main` (the fix is the script, not the file). No type or behavior change.

## Test plan

- [x] `npm run openapi:generate` against unchanged `openapi.yaml` → zero diff (verified locally).
- [x] CI guard logic dry-run locally: regenerate then `git diff --quiet` → PASS.
- [ ] CI green on this PR (the new step exercises itself).

🤖 Generated with [Claude Code](https://claude.com/claude-code)