### PR TITLE
fix(submit_issue): normalise literal \n sequences in issue body to real newlines

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -966,9 +966,13 @@ export class NeotomaServer {
     args: unknown,
     userId: string
   ): Promise<{ content: Array<{ type: string; text: string }> }> {
+    // Normalize escape sequences that MCP clients sometimes send as literal
+    // two-character sequences (e.g. backslash-n) instead of real control chars.
+    const unescapeBody = (s: string) => s.replace(/\\n/g, "\n").replace(/\\t/g, "\t");
+
     const schema = z.object({
       title: z.string().min(1),
-      body: z.string().min(1),
+      body: z.string().min(1).transform(unescapeBody),
       labels: z.array(z.string()).optional(),
       visibility: z.enum(["public", "private", "advisory"]).optional(),
       reporter_git_sha: z.string().optional(),

--- a/tests/unit/submit_issue_dx.test.ts
+++ b/tests/unit/submit_issue_dx.test.ts
@@ -1,10 +1,11 @@
 /**
- * DX tests for submit_issue improvements (issues #181, #182, #183, #191, #206).
+ * DX tests for submit_issue improvements (issues #181, #182, #183, #191, #206, #1484).
  *
- * #181 — store tool description must rank high in tool_search for common verbs
- * #182 — reporter_app_version auto-populate logic in the server layer
+ * #181  — store tool description must rank high in tool_search for common verbs
+ * #182  — reporter_app_version auto-populate logic in the server layer
  * #183/#206 — AUTH_REQUIRED errors surface an actionable hint instead of a raw JSON blob
- * #191 — tool deregistration documented in mcp/instructions.md (doc-only, no code test)
+ * #191  — tool deregistration documented in mcp/instructions.md (doc-only, no code test)
+ * #1484 — body with literal \n sequences normalised to real newlines at parse time
  */
 
 import { describe, it, expect } from "vitest";
@@ -76,6 +77,43 @@ describe("AUTH_REQUIRED error shaping (#183, #206)", () => {
   it("handles string error gracefully", () => {
     const msg = formatRemoteSubmitError("something went wrong");
     expect(msg).toContain("something went wrong");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #1484 — body literal \n normalisation
+// ---------------------------------------------------------------------------
+
+/** Mirrors the unescapeBody helper in handleSubmitIssue */
+function unescapeBody(s: string): string {
+  return s.replace(/\\n/g, "\n").replace(/\\t/g, "\t");
+}
+
+describe("submit_issue body literal \\n normalisation (#1484)", () => {
+  it("converts literal backslash-n to real newlines", () => {
+    const input = "## Summary\\n\\nSome text.\\n\\n## Steps\\n\\n1. First";
+    const result = unescapeBody(input);
+    expect(result).toBe("## Summary\n\nSome text.\n\n## Steps\n\n1. First");
+    expect(result).not.toContain("\\n");
+  });
+
+  it("converts literal backslash-t to real tabs", () => {
+    const input = "col1\\tcol2\\tcol3";
+    expect(unescapeBody(input)).toBe("col1\tcol2\tcol3");
+  });
+
+  it("leaves strings with real newlines unchanged", () => {
+    const input = "## Summary\n\nSome text.";
+    expect(unescapeBody(input)).toBe(input);
+  });
+
+  it("handles body with no escape sequences unchanged", () => {
+    const input = "Plain body with no special chars.";
+    expect(unescapeBody(input)).toBe(input);
+  });
+
+  it("handles empty string", () => {
+    expect(unescapeBody("")).toBe("");
   });
 });
 


### PR DESCRIPTION
## Summary

- MCP clients sometimes send the `body` argument with literal `\n` two-character sequences instead of real newlines, causing GitHub issues to render as a single run-on block (root cause of #356 formatting issues)
- Adds a Zod `.transform()` on the `body` field in `handleSubmitIssue` that decodes `\n` → newline and `\t` → tab at parse time
- Adds 5 regression tests to `tests/unit/submit_issue_dx.test.ts` covering the normalisation path (#1484)

## Test plan

- [x] `npm run type-check` passes
- [x] `npx vitest run tests/unit/submit_issue_dx.test.ts` — all 19 tests pass (14 pre-existing + 5 new)
- [x] Pre-existing failing test files (`cursor_hook_stop_backfill`, `hook_failure_hint`, `cli_smoke`, `graph_neighborhood_pagination`, `cli_api_commands`, `cli_doctor_setup`) are integration/CLI tests requiring a live server; unrelated to this change

Closes #1484

🤖 Generated with [Claude Code](https://claude.com/claude-code)