### PR TITLE
fix: cursor-hooks entities shape, relationship-service tiebreaker, copy:env path typo

### DIFF
--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,8 +61,8 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **403**
-- Backend and repo Vitest files: **370**
+- Total automated test files: **404**
+- Backend and repo Vitest files: **371**
 - Frontend Vitest files: **9**
 - Playwright spec files: **24**
 
@@ -72,7 +72,7 @@ flowchart TD
 | Vitest unit tests | 99 |
 | Vitest service tests | 33 |
 | Source-adjacent tests | 47 |
-| Vitest integration tests | 110 |
+| Vitest integration tests | 111 |
 | Vitest CLI tests | 59 |
 | Vitest contract tests | 12 |
 | Vitest security tests | 2 |
@@ -307,7 +307,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm run test:integration` or `npx vitest run tests/integration`
 **Requirements:** Database configured; remote-dependent subsets additionally need `RUN_REMOTE_TESTS=1`.
-**Files (110):**
+**Files (111):**
 - `tests/integration/aauth_attribution_stamping.test.ts`
 - `tests/integration/aauth_resource_metadata.test.ts`
 - `tests/integration/aauth_revocation_e2e.test.ts`
@@ -395,6 +395,7 @@ flowchart TD
 - `tests/integration/record_activity_attribution.test.ts`
 - `tests/integration/relationship_agent_attribution_api.test.ts`
 - `tests/integration/relationship_pagination_determinism.test.ts`
+- `tests/integration/relationship_query_determinism.test.ts`
 - `tests/integration/relationship_snapshots.test.ts`
 - `tests/integration/retrieval_transport_reliability.test.ts`
 - `tests/integration/root_landing.test.ts`

--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
     "setup:launchd-issues-sync": "node scripts/install_launchd_issues_sync.js",
     "reload:launchd-neotoma": "bash scripts/reload_neotoma_launchagents.sh",
     "shutdown:launchd-neotoma": "bash scripts/shutdown_neotoma_launchagents.sh",
-    "copy:env": "node scripts/colpy-env-to-worktree.js",
+    "copy:env": "node scripts/copy-env-to-worktree.js",
     "tunnel:https": "bash scripts/setup-https-tunnel.sh",
     "setup:worktree": "bash scripts/cursor-worktree-init.sh",
     "setup:data": "node scripts/setup-data-symlink.js",

--- a/packages/cursor-hooks/hooks/_common.ts
+++ b/packages/cursor-hooks/hooks/_common.ts
@@ -42,6 +42,44 @@ export function log(level: string, message: string): void {
   }
 }
 
+/**
+ * Reference to a stored entity as returned by a `store` call.
+ */
+interface StoredEntityRefLike {
+  entity_id?: string;
+}
+
+/**
+ * Tolerantly read the stored-entity list from a `store` response.
+ *
+ * The `/store` transport returns the entity refs at the TOP level
+ * (`result.entities`), but older typings and some code paths expect them
+ * nested under `result.structured.entities`. Prefer the top-level list and
+ * fall back to the nested shape so entity ids are never silently dropped.
+ * Mirrors `extractStoredEntities` in `@neotoma/client`; kept inline here so
+ * cursor-hooks does not depend on an unreleased client export.
+ */
+export function extractStoredEntities(result: unknown): StoredEntityRefLike[] {
+  if (!result || typeof result !== "object") return [];
+  const r = result as {
+    entities?: StoredEntityRefLike[];
+    structured?: { entities?: StoredEntityRefLike[] };
+  };
+  if (Array.isArray(r.entities)) return r.entities;
+  if (Array.isArray(r.structured?.entities)) return r.structured.entities;
+  return [];
+}
+
+/**
+ * Convenience wrapper over {@link extractStoredEntities} returning the
+ * `entity_id` of the stored entity at `index` (default first), or undefined.
+ */
+export function pickStoredEntityId(result: unknown, index = 0): string | undefined {
+  const entity = extractStoredEntities(result)[index];
+  if (entity && typeof entity.entity_id === "string") return entity.entity_id;
+  return undefined;
+}
+
 export async function readHookInput<T = Record<string, unknown>>(): Promise<T> {
   return new Promise((resolve) => {
     let data = "";
@@ -406,13 +444,11 @@ export async function recordConversationTurn(
   const idempotencyKey =
     input.idempotencyKey ?? makeIdempotencyKey(input.sessionId, input.turnId, "turn");
   try {
-    const result = (await client.store({
+    const result = await client.store({
       entities: [entity],
       idempotency_key: idempotencyKey,
-    })) as {
-      structured?: { entities?: Array<{ entity_id?: string }> };
-    };
-    return { entityId: result.structured?.entities?.[0]?.entity_id };
+    });
+    return { entityId: pickStoredEntityId(result) };
   } catch (err) {
     log("debug", `recordConversationTurn store failed: ${(err as Error).message}`);
     return null;

--- a/packages/cursor-hooks/hooks/after_tool_use.ts
+++ b/packages/cursor-hooks/hooks/after_tool_use.ts
@@ -32,6 +32,7 @@ import {
   looksLikeRetrieveInvocation,
   looksLikeStoreStructured,
   makeIdempotencyKey,
+  pickStoredEntityId,
   readFailureHint,
   recordConversationTurn,
   runHook,
@@ -141,15 +142,15 @@ async function handle(
       ...harnessProvenance({ hook_event: hookEventName }),
     };
     try {
-      const result = (await client.store({
+      const result = await client.store({
         entities: [entity],
         idempotency_key: makeIdempotencyKey(
           sessionId,
           turnId,
           `tool-${toolName}-${Date.now()}`
         ),
-      })) as { structured?: { entities?: Array<{ entity_id?: string }> } };
-      const id = result.structured?.entities?.[0]?.entity_id;
+      });
+      const id = pickStoredEntityId(result);
       if (typeof id === "string") toolEntityId = id;
     } catch (err) {
       log("debug", `${hookEventName} store failed: ${(err as Error).message}`);

--- a/packages/cursor-hooks/hooks/before_submit_prompt.ts
+++ b/packages/cursor-hooks/hooks/before_submit_prompt.ts
@@ -30,6 +30,7 @@ import {
   isExpectedNetworkError,
   log,
   makeIdempotencyKey,
+  pickStoredEntityId,
   recordConversationTurn,
   runHook,
   turnContextFields,
@@ -49,13 +50,7 @@ function extractIdentifiers(prompt: string): string[] {
   return [...found];
 }
 
-function extractEntityId(result: unknown, index = 0): string | undefined {
-  if (!result || typeof result !== "object") return undefined;
-  const r = result as { structured?: { entities?: Array<{ entity_id?: string }> } };
-  const entity = r.structured?.entities?.[index];
-  if (entity && typeof entity.entity_id === "string") return entity.entity_id;
-  return undefined;
-}
+const extractEntityId = pickStoredEntityId;
 
 async function handle(
   input: Record<string, unknown>

--- a/packages/cursor-hooks/hooks/post_tool_use_failure.ts
+++ b/packages/cursor-hooks/hooks/post_tool_use_failure.ts
@@ -25,6 +25,7 @@ import {
   isNeotomaRelevantTool,
   log,
   makeIdempotencyKey,
+  pickStoredEntityId,
   recordConversationTurn,
   runHook,
   turnContextFields,
@@ -136,15 +137,15 @@ async function handle(
   };
   let failureEntityId: string | undefined;
   try {
-    const result = (await client.store({
+    const result = await client.store({
       entities: [entity],
       idempotency_key: makeIdempotencyKey(
         sessionId,
         turnId,
         `tool-failure-${toolName}-${errorClass}-${Date.now()}`
       ),
-    })) as { structured?: { entities?: Array<{ entity_id?: string }> } };
-    const id = result.structured?.entities?.[0]?.entity_id;
+    });
+    const id = pickStoredEntityId(result);
     if (typeof id === "string") failureEntityId = id;
   } catch (err) {
     log("debug", `${hookEventName} store failed: ${(err as Error).message}`);

--- a/packages/cursor-hooks/hooks/stop.ts
+++ b/packages/cursor-hooks/hooks/stop.ts
@@ -33,6 +33,7 @@ import {
   isHookComplianceFollowupEnabled,
   log,
   makeIdempotencyKey,
+  pickStoredEntityId,
   readTurnState,
   recordConversationTurn,
   runHook,
@@ -41,13 +42,7 @@ import {
   type SkippedStoreDiagnosis,
 } from "./_common.js";
 
-function pickEntityId(result: unknown): string | undefined {
-  if (!result || typeof result !== "object") return undefined;
-  const r = result as { structured?: { entities?: Array<{ entity_id?: string }> } };
-  const first = r.structured?.entities?.[0];
-  if (first && typeof first.entity_id === "string") return first.entity_id;
-  return undefined;
-}
+const pickEntityId = pickStoredEntityId;
 
 function followupMessage(
   diagnosis: SkippedStoreDiagnosis | undefined

--- a/src/services/relationships.ts
+++ b/src/services/relationships.ts
@@ -271,9 +271,12 @@ export class RelationshipsService {
         .or(`source_entity_id.eq.${entityId},target_entity_id.eq.${entityId}`);
     }
 
-    const { data, error } = await query.order("last_observation_at", {
-      ascending: false,
-    });
+    // Order by recency, then by relationship_key (the relationship_snapshots
+    // PRIMARY KEY) as a stable secondary sort so ties on last_observation_at
+    // are deterministic. See docs/architecture/determinism.md.
+    const { data, error } = await query
+      .order("last_observation_at", { ascending: false })
+      .order("relationship_key", { ascending: true });
 
     if (error) {
       throw new Error(`Failed to get relationships: ${error.message}`);
@@ -337,11 +340,15 @@ export class RelationshipsService {
     type: RelationshipType,
     includeDeleted: boolean = false
   ): Promise<RelationshipSnapshot[]> {
+    // Order by recency, then by relationship_key (the relationship_snapshots
+    // PRIMARY KEY) as a stable secondary sort so ties on last_observation_at
+    // are deterministic. See docs/architecture/determinism.md.
     const { data, error } = await db
       .from("relationship_snapshots")
       .select("*")
       .eq("relationship_type", type)
-      .order("last_observation_at", { ascending: false });
+      .order("last_observation_at", { ascending: false })
+      .order("relationship_key", { ascending: true });
 
     if (error) {
       throw new Error(`Failed to get relationships by type: ${error.message}`);

--- a/tests/integration/relationship_query_determinism.test.ts
+++ b/tests/integration/relationship_query_determinism.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Determinism tests for the non-paginated relationship query methods on
+ * RelationshipsService.
+ *
+ * `getRelationshipsForEntity` and `getRelationshipsByType` order results by
+ * `last_observation_at DESC`. When two relationships share the same
+ * `last_observation_at`, that ordering alone is nondeterministic. These tests
+ * assert the stable secondary sort on `relationship_key ASC` (the
+ * relationship_snapshots PRIMARY KEY) so ties resolve deterministically.
+ *
+ * See docs/architecture/determinism.md ("Sorting MUST use deterministic
+ * tiebreakers").
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { db } from "../../src/db.js";
+import { relationshipsService } from "../../src/services/relationships.js";
+
+describe("RelationshipsService query determinism", () => {
+  const userId = "00000000-0000-0000-0000-000000000000";
+  const sourceEntityId = "det_source_entity";
+  // Shared timestamp forces a tie on last_observation_at so only the
+  // secondary sort distinguishes the two rows.
+  const tiedTimestamp = "2026-01-01T00:00:00.000Z";
+
+  // relationship_keys chosen so insertion order (b before a) differs from
+  // the expected sorted order (a before b). This makes the test fail if the
+  // secondary sort is dropped and the DB falls back to insertion/rowid order.
+  const keyA = "REFERS_TO:det_source_entity:det_target_a";
+  const keyB = "REFERS_TO:det_source_entity:det_target_b";
+
+  async function insertSnapshot(relationshipKey: string, targetEntityId: string): Promise<void> {
+    const { error } = await db.from("relationship_snapshots").insert({
+      relationship_key: relationshipKey,
+      relationship_type: "REFERS_TO",
+      source_entity_id: sourceEntityId,
+      target_entity_id: targetEntityId,
+      schema_version: "1.0",
+      snapshot: {},
+      computed_at: tiedTimestamp,
+      observation_count: 1,
+      last_observation_at: tiedTimestamp,
+      provenance: {},
+      user_id: userId,
+    });
+    if (error) {
+      throw new Error(`Failed to seed snapshot ${relationshipKey}: ${error.message}`);
+    }
+  }
+
+  beforeEach(async () => {
+    await db.from("relationship_snapshots").delete().eq("source_entity_id", sourceEntityId);
+
+    // Insert B first, then A: insertion order is the reverse of expected order.
+    await insertSnapshot(keyB, "det_target_b");
+    await insertSnapshot(keyA, "det_target_a");
+  });
+
+  it("getRelationshipsForEntity orders ties by relationship_key ASC", async () => {
+    const rels = await relationshipsService.getRelationshipsForEntity(sourceEntityId, "outgoing");
+
+    const keys = rels.map((r) => r.relationship_key);
+    expect(keys).toEqual([keyA, keyB]);
+  });
+
+  it("getRelationshipsByType orders ties by relationship_key ASC", async () => {
+    const rels = await relationshipsService.getRelationshipsByType("REFERS_TO");
+
+    const seeded = rels.filter((r) => r.source_entity_id === sourceEntityId);
+    const keys = seeded.map((r) => r.relationship_key);
+    expect(keys).toEqual([keyA, keyB]);
+  });
+
+  it("repeated queries return a stable order", async () => {
+    const first = (
+      await relationshipsService.getRelationshipsForEntity(sourceEntityId, "outgoing")
+    ).map((r) => r.relationship_key);
+    const second = (
+      await relationshipsService.getRelationshipsForEntity(sourceEntityId, "outgoing")
+    ).map((r) => r.relationship_key);
+
+    expect(first).toEqual(second);
+    expect(first).toEqual([keyA, keyB]);
+  });
+});


### PR DESCRIPTION
Three small out-of-scope sibling cleanups found during PR work. Each addresses a *sibling surface* of an existing issue whose primary fix is owned by another PR, so these are referenced as **related** (not `Fixes`).

## FIX 1 — cursor-hooks share the #316 `structured.entities` bug

The `stop`, `_common`, `post_tool_use_failure`, `before_submit_prompt`, and `after_tool_use` hooks in `packages/cursor-hooks/hooks/` read `storeResult.structured?.entities`, but the `/store` transport returns `entities` at the **top level**, so entity ids were silently dropped.

- Added a tolerant `extractStoredEntities(result)` / `pickStoredEntityId(result, index)` helper in `packages/cursor-hooks/hooks/_common.ts` that prefers `result.entities` and falls back to `result.structured.entities`.
- Routed all five hooks through the helper (the two local `pickEntityId` / `extractEntityId` copies now delegate to it).
- The canonical fix (PR #1487) adds an exported `extractStoredEntities` to `@neotoma/client`, but that export is **not yet on `main`**, so the tolerant read is replicated inline here rather than importing an unmerged export. cursor-hooks does depend on `@neotoma/client` (`file:../client`), so it can switch to the shared export once #1487 lands.
- cursor-hooks has no test harness, so the change is kept minimal and type-safe (`tsc -p packages/cursor-hooks/tsconfig.json` passes with the client built + linked).

## FIX 2 — non-paginated relationship methods share the #368 tiebreaker gap

`RelationshipsService.getRelationshipsForEntity` and `getRelationshipsByType` in `src/services/relationships.ts` ordered by `last_observation_at DESC` with no stable secondary key, so ties were nondeterministic.

- Added `relationship_key ASC` (the `relationship_snapshots` PRIMARY KEY) as the stable secondary sort in both methods, per `docs/architecture/determinism.md` ("Sorting MUST use deterministic tiebreakers").
- Added `tests/integration/relationship_query_determinism.test.ts`: seeds two snapshots sharing `last_observation_at` in reverse insertion order and asserts both methods return them in `relationship_key ASC` order. Verified the test **fails** when the tiebreaker is removed (negative control) and passes with it.
- Did **not** touch the paginated `/list_relationships`, `/retrieve_graph_neighborhood`, `GET /relationships` paths in `src/actions.ts` — those are owned by PR #1491 (avoids conflict).

## FIX 3 — `copy:env` script path typo

`package.json`'s `copy:env` script referenced `scripts/colpy-env-to-worktree.js`; the actual file is `scripts/copy-env-to-worktree.js`. Fixed the typo. The corrected path resolves, and `.claude/rules/worktree_env.md` / `scripts/setup-env-copy-hook.sh` already referenced the correct name.

## Related issues

- Related to #316 (the `@neotoma/client` helper fix is PR #1487; this PR covers the cursor-hooks consumers).
- Related to #368 (the paginated-endpoint fix is PR #1491; this PR covers the non-paginated `relationships.ts` service methods).

## Tests

- `npm run type-check`: pass.
- `npm run lint`: pass (0 errors).
- `npm run format:check`: pass.
- New + adjacent relationship tests (`relationship_query_determinism`, `relationship_reducer`, `relationship_agent_attribution_api`, `cli_relationship_commands`): 35 passing.
- `docs/testing/automated_test_catalog.md` regenerated (`npm run generate:test-catalog`) and validated.
- Pre-existing worktree-environment failures (absent `inspector/` directory and unbuilt cursor-hooks package) are identical with and without this change; this PR introduces no new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)