### PR TITLE
feat(sqlite): set busy_timeout so lock contention waits, not SQLITE_BUSY

### DIFF
--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,8 +61,8 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **411**
-- Backend and repo Vitest files: **378**
+- Total automated test files: **412**
+- Backend and repo Vitest files: **379**
 - Frontend Vitest files: **9**
 - Playwright spec files: **24**
 

--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,15 +61,15 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **410**
-- Backend and repo Vitest files: **377**
+- Total automated test files: **411**
+- Backend and repo Vitest files: **378**
 - Frontend Vitest files: **9**
 - Playwright spec files: **24**
 
 ### Suite counts
 | Suite | Files |
 |---|---:|
-| Vitest unit tests | 101 |
+| Vitest unit tests | 102 |
 | Vitest service tests | 33 |
 | Source-adjacent tests | 47 |
 | Vitest integration tests | 112 |
@@ -108,7 +108,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/unit`
 **Requirements:** Basic `.env` if required by the module under test.
-**Files (101):**
+**Files (102):**
 - `tests/unit/aauth_admission.test.ts`
 - `tests/unit/aauth_attestation_apple_se.test.ts`
 - `tests/unit/aauth_attestation_revocation.test.ts`
@@ -203,6 +203,7 @@ flowchart TD
 - `tests/unit/session_info.test.ts`
 - `tests/unit/site_page_markdown.test.ts`
 - `tests/unit/spa_path.test.ts`
+- `tests/unit/sqlite_connection_pragmas.test.ts`
 - `tests/unit/store_alias_dispatch.test.ts`
 - `tests/unit/submit_issue_dx.test.ts`
 - `tests/unit/subscription_types.test.ts`

--- a/src/repositories/sqlite/sqlite_client.ts
+++ b/src/repositories/sqlite/sqlite_client.ts
@@ -3,6 +3,31 @@ import path from "path";
 import { config } from "../../config.js";
 import Database, { type SqliteDatabase } from "./sqlite_driver.js";
 
+/**
+ * Milliseconds a SQLite connection waits for a contended lock before failing
+ * with SQLITE_BUSY. better-sqlite3 defaults to 0 (fail immediately), which
+ * surfaces as a hard error the moment a second process (a backup job, a
+ * migration, an instance-per-tenant host running an out-of-band task) touches
+ * the write lock. A non-zero busy_timeout makes that case degrade to a short
+ * wait-and-retry instead. Override via NEOTOMA_SQLITE_BUSY_TIMEOUT_MS; default
+ * 5000ms. See docs/infrastructure/multi_tenant_deployment_topology.md.
+ */
+export const SQLITE_BUSY_TIMEOUT_MS = Math.max(
+  0,
+  Number.parseInt(process.env.NEOTOMA_SQLITE_BUSY_TIMEOUT_MS || "", 10) || 5000
+);
+
+/**
+ * Apply the connection PRAGMAs every Neotoma SQLite handle needs: WAL for
+ * concurrent readers alongside a single writer, foreign-key enforcement, and a
+ * busy_timeout so lock contention waits rather than throwing immediately.
+ */
+function applyConnectionPragmas(db: SqliteDatabase): void {
+  db.pragma("journal_mode = WAL");
+  db.pragma("foreign_keys = ON");
+  db.pragma(`busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS}`);
+}
+
 let cachedDb: SqliteDatabase | null = null;
 
 const SCHEMA_STATEMENTS = [
@@ -468,8 +493,7 @@ export function getSqliteDb(): SqliteDatabase {
   mkdirSync(dir, { recursive: true });
 
   const db = new Database(dbPath);
-  db.pragma("journal_mode = WAL");
-  db.pragma("foreign_keys = ON");
+  applyConnectionPragmas(db);
 
   ensureSchema(db);
   cachedDb = db;
@@ -485,8 +509,7 @@ export function ensureSqliteDbInitialized(dbPath: string): void {
   mkdirSync(dir, { recursive: true });
   const db = new Database(dbPath);
   try {
-    db.pragma("journal_mode = WAL");
-    db.pragma("foreign_keys = ON");
+    applyConnectionPragmas(db);
     ensureSchema(db);
   } finally {
     db.close();

--- a/tests/unit/sqlite_connection_pragmas.test.ts
+++ b/tests/unit/sqlite_connection_pragmas.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Connection-PRAGMA tests for the SQLite client.
+ *
+ * Asserts the durability/concurrency PRAGMAs every Neotoma SQLite handle needs
+ * are applied on open: WAL journal mode and a non-zero busy_timeout so
+ * cross-process lock contention waits rather than failing immediately with
+ * SQLITE_BUSY. See docs/infrastructure/multi_tenant_deployment_topology.md.
+ *
+ * The driver wrapper (`sqlite_driver.ts`) returns `pragma()` results as an
+ * array of row objects on better-sqlite3, e.g. `[{ busy_timeout: 5000 }]`. On
+ * the node:sqlite fallback (Node 22+, no `.pragma()` method) the wrapper runs
+ * the PRAGMA via `exec` and returns `[]` — the value is still applied, just not
+ * readable back through this path — so a readback returning no rows is treated
+ * as "driver does not expose pragma readback", not a failure.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  getSqliteDb,
+  SQLITE_BUSY_TIMEOUT_MS,
+} from "../../src/repositories/sqlite/sqlite_client.js";
+
+/** Read a single-value PRAGMA back through the driver wrapper, or null if the
+ *  active driver does not expose pragma readback (returns no rows). */
+function readPragma(command: string): number | string | null {
+  const db = getSqliteDb();
+  const rows = db.pragma(command) as Array<Record<string, unknown>>;
+  if (!Array.isArray(rows) || rows.length === 0) return null;
+  const first = rows[0];
+  const values = Object.values(first);
+  return (values.length > 0 ? (values[0] as number | string) : null) ?? null;
+}
+
+describe("SQLite connection PRAGMAs", () => {
+  it("applies WAL journal mode on open", () => {
+    const mode = readPragma("journal_mode");
+    if (mode === null) return; // driver without pragma readback
+    expect(String(mode).toLowerCase()).toBe("wal");
+  });
+
+  it("applies a non-zero busy_timeout on open (not the better-sqlite3 default of 0)", () => {
+    const timeout = readPragma("busy_timeout");
+    if (timeout === null) return; // driver without pragma readback
+    expect(Number(timeout)).toBeGreaterThan(0);
+    expect(Number(timeout)).toBe(SQLITE_BUSY_TIMEOUT_MS);
+  });
+
+  it("enforces foreign keys on open", () => {
+    const fk = readPragma("foreign_keys");
+    if (fk === null) return; // driver without pragma readback
+    expect(Number(fk)).toBe(1);
+  });
+
+  it("resolves busy_timeout to a non-negative integer, defaulting to 5000ms", () => {
+    expect(Number.isInteger(SQLITE_BUSY_TIMEOUT_MS)).toBe(true);
+    expect(SQLITE_BUSY_TIMEOUT_MS).toBeGreaterThanOrEqual(0);
+    if (!process.env.NEOTOMA_SQLITE_BUSY_TIMEOUT_MS) {
+      expect(SQLITE_BUSY_TIMEOUT_MS).toBe(5000);
+    }
+  });
+});


### PR DESCRIPTION
Implements recommendation #2 of the [deployment-topology decision aid](https://github.com/markmhendrickson/neotoma/pull/1511): set a non-zero SQLite `busy_timeout`.

## Problem

`better-sqlite3` defaults `busy_timeout` to 0, so the moment a second process touches the write lock — a backup job, a migration, an instance-per-tenant host running an out-of-band task — it fails immediately with `SQLITE_BUSY` instead of waiting. This is the single sharpest edge in the current single-writer deployment model.

## Change

- Apply `busy_timeout` on connection open (both `getSqliteDb` and `ensureSqliteDbInitialized`), env-overridable via `NEOTOMA_SQLITE_BUSY_TIMEOUT_MS` (default 5000ms).
- Consolidate the connection PRAGMAs (WAL, foreign_keys, busy_timeout) into one `applyConnectionPragmas()` helper so both open paths stay in sync.
- Add a unit test asserting the PRAGMAs are applied, robust to the `node:sqlite` fallback driver (Node 22+) that does not expose pragma readback.

No behavior change for the common single-process case; this only affects how cross-process contention degrades (wait-and-retry vs. immediate throw).

🤖 Generated with [Claude Code](https://claude.com/claude-code)