### PR TITLE
perf(graph): fan-out (high-degree hub) traversal benchmark (#1467)

### DIFF
--- a/docs/performance/graph_traversal.md
+++ b/docs/performance/graph_traversal.md
@@ -1,10 +1,11 @@
-# Graph traversal scale benchmark (#1467)
+# Graph traversal benchmark (#1467)
 
 Measures the cost of Neotoma's native breadth-first multi-hop traversal — the
-algorithm behind `retrieve_related_entities` and `retrieve_graph_neighborhood`.
-The purpose is to answer, with measured numbers rather than assumption, whether
-native traversal is fast enough for a given workload or whether a dedicated
-graph database is still warranted.
+algorithm behind `retrieve_related_entities` and `retrieve_graph_neighborhood`
+— along two dimensions: graph **scale** (total table size) and **fan-out**
+(degree of a single hub). The purpose is to answer, with measured numbers rather
+than assumption, whether native traversal is fast enough for a given workload or
+whether a dedicated graph database is still warranted.
 
 ## How to run
 
@@ -22,59 +23,95 @@ provides.
 The traversal is an **in-memory BFS over the `relationship_snapshots` table**:
 at each hop it issues point queries (`source_entity_id` / `target_entity_id`)
 for every node in the current frontier, expands to unseen neighbours, and
-repeats. There is no precomputed adjacency index — cost is dominated by the
-number of per-hop queries, which grows with both the neighbourhood size and the
-total table size.
+repeats. Composite indexes on `(source_entity_id, user_id)` and
+`(target_entity_id, user_id)` (#1467) make each per-hop lookup an indexed query
+rather than a table scan. Two dimensions drive cost, and the benchmark measures
+them separately:
 
-The benchmark seeds a breadth-first tree rooted at a hub (fan-out 8), so a
-3-hop traversal visits ≈ 8 + 64 + 512 = 585 nodes — a realistic "warm
-relationship graph" shape — while the *total* relationship count varies.
+1. **Total table size** — does traversal stay fast as the overall graph grows?
+2. **Fan-out at a node** — what happens at a single high-degree hub (the
+   "super-connector": one entity linked to thousands of others)?
 
-## Measured results
+These are different questions, and they have different answers.
 
-Local SQLite (WAL), single process. Indicative numbers; absolute values vary by
-hardware, but the **scaling shape** is the takeaway.
+### Dimension 1: scale (fixed neighbourhood, growing table)
+
+Seeds a breadth-first tree rooted at a hub (fan-out 8), so a 3-hop traversal
+visits ≈ 8 + 64 + 512 = 585 nodes — a fixed "warm relationship graph"
+neighbourhood — while the _total_ relationship count varies.
 
 | relationships | 1-hop (ms) | 2-hop (ms) | 3-hop (ms) | nodes visited @ 3 hops |
-|---|---|---|---|---|
-| 1,000  | ~5   | ~23  | ~185 | 585 |
-| 10,000 | ~7   | ~53  | ~430 | 585 |
-| 50,000 | ~12  | ~96  | ~777 | 585 |
+| ------------- | ---------- | ---------- | ---------- | ---------------------- |
+| 1,000         | ~0.3       | ~0.5       | ~2.5       | 585                    |
+| 10,000        | ~0.1       | ~0.3       | ~2.5       | 585                    |
+| 50,000        | ~0.1       | ~0.3       | ~5.8       | 585                    |
+
+With the indexes in place, a fixed-size neighbourhood traversal is **flat
+against total table size** — 3-hop over a 585-node neighbourhood costs single-
+digit milliseconds whether the table holds 1k or 50k relationships. (Before the
+indexes the same 50k/3-hop case was ~777 ms; the indexes are a ~130× reduction
+on that case.)
+
+### Dimension 2: fan-out (single high-degree hub)
+
+The scale table holds the neighbourhood fixed, so it does **not** exercise a
+wide frontier. This benchmark does: one hub with `degree` direct neighbours,
+each neighbour carrying a secondary fan-out of 4. The hub's 1-hop frontier is
+`degree` wide; its 2-hop frontier is `degree × 4` wide.
+
+| hub degree | total relationships | 1-hop (ms) | 2-hop (ms) | visited @ 1 | visited @ 2 |
+| ---------- | ------------------- | ---------- | ---------- | ----------- | ----------- |
+| 100        | 500                 | ~0.3       | ~2.7       | 101         | 501         |
+| 1,000      | 5,000               | ~1.7       | ~27.6      | 1,001       | 5,001       |
+| 5,000      | 25,000              | ~9.1       | ~142.8     | 5,001       | 25,001      |
+| 20,000     | 100,000             | ~40.7      | ~548.5     | 20,001      | 100,001     |
+
+Unlike the scale dimension, **fan-out cost grows roughly linearly with hub
+degree.** A 20,000-degree super-connector costs ~40 ms for a single hop and
+~550 ms for two hops, because the traversal must materialise and expand a
+frontier proportional to the degree. The indexes make each lookup fast; they do
+not change the fact that a wide frontier means proportionally more lookups and
+more in-memory expansion.
 
 ## Interpretation
 
-- **1-hop is cheap and roughly flat** (5–12 ms) across table sizes — a direct
-  neighbour lookup is a single indexed query regardless of total graph size.
-- **Cost grows super-linearly with hop depth**, because each hop fans out to
-  many more point queries. 3-hop over a ~585-node neighbourhood is the
-  expensive case.
-- **Total table size matters**, not just neighbourhood size: the same 585-node
-  3-hop traversal goes from ~185 ms at 1k relationships to ~777 ms at 50k. Each
-  per-hop query scans a larger table.
+- **Depth over a normal neighbourhood is cheap** — single-digit ms at 3 hops,
+  flat against table size. The indexes solve the "does it stay fast as the graph
+  grows?" question.
+- **Fan-out is the real ceiling.** Cost scales with the degree of the node you
+  start from (and of the nodes you pass through). A high-degree hub is the case
+  that gets expensive, and it does so independently of total table size.
+- The two combine: a deep traversal _through_ one or more high-degree hubs is
+  the worst case, because each such hub multiplies the frontier the next hop
+  must expand.
 
-## Practical guidance and the "do we still need Neo4j?" question
+## Practical guidance and the "do we still need a dedicated graph DB?" question
 
-- For **shallow traversals (1–2 hops)** at the table sizes a typical
-  relationship-intelligence product reaches, native traversal is comfortably
-  fast (tens of ms) and a separate graph DB is **not** justified by latency.
-- For **deep traversals (3+ hops) over large graphs (tens of thousands of
-  relationships and up)**, latency enters the hundreds-of-ms range and keeps
-  climbing. A consumer doing frequent deep traversals at scale should either
-  (a) cap hop depth, (b) cache hot neighbourhoods, or (c) project into a
-  dedicated graph index (e.g. Neo4j) — which is exactly the Phase 5 decision in
-  the Prospect CRM adoption plan, now answerable with these numbers rather than
-  a guess.
-- There is currently **no precomputed adjacency index** and no stated scale
-  ceiling in the code. If deep-traversal-at-scale becomes a hot path, an
-  adjacency materialisation (or recursive SQL CTE) is the natural next
-  optimisation before reaching for an external graph DB.
+- For **shallow-to-moderate traversals over ordinary-degree nodes**, native
+  traversal is comfortably fast (single-digit to low-tens of ms) and a separate
+  graph DB is **not** justified by latency, even at tens of thousands of
+  relationships.
+- For **traversals rooted at or passing through high-degree hubs**, latency
+  scales with degree and reaches hundreds of ms at the 2-hop / 20k-degree end. A
+  consumer with super-connector nodes and frequent multi-hop queries through
+  them should either (a) cap hop depth, (b) cache hot hub neighbourhoods, (c)
+  bound or paginate the per-hop frontier, or (d) project into a dedicated graph
+  index. Whether to reach for an external graph DB is a function of **how many
+  high-degree hubs the workload traverses and how often**, not of total graph
+  size.
+- The indexes (#1467) remove total-table-size as a cost driver. Fan-out remains
+  one. If high-degree multi-hop becomes a hot path, a bounded-frontier or
+  adjacency-materialisation optimisation is the natural next step before an
+  external graph DB.
 
 ## Caveats
 
 - Numbers are from local SQLite in a single process; a production deployment's
-  storage and concurrency profile will differ.
+  storage and concurrency profile will differ. Absolute values vary by hardware
+  — the **scaling shape** (flat vs. table size, linear vs. fan-out) is the
+  durable takeaway, not the millisecond figures.
 - The benchmark times the traversal algorithm directly against the DB, not
   through the MCP or HTTP transport, so it isolates traversal cost from request
   overhead.
-- This is a measurement artifact, not a regression gate: the test asserts only
-  loose sanity bounds so it does not become flaky.
+- This is a measurement artifact, not a regression gate: the tests assert only
+  loose sanity bounds so they do not become flaky.

--- a/tests/performance/graph_traversal.bench.test.ts
+++ b/tests/performance/graph_traversal.bench.test.ts
@@ -185,3 +185,131 @@ describe("graph traversal scale benchmark (#1467)", () => {
     }, 120_000);
   }
 });
+
+// ---------------------------------------------------------------------------
+// Fan-out (high-degree hub) benchmark (#1467)
+// ---------------------------------------------------------------------------
+//
+// The scale benchmark above grows the *total* table size while holding the
+// traversal neighbourhood fixed (fan-out 8, ~585 nodes at 3 hops). That answers
+// "does traversal stay flat as the graph grows?" but NOT "what happens at a
+// single high-degree node?" — the super-connector case (one entity linked to
+// thousands of others) where a single hop must materialise a very wide
+// frontier. This block isolates that dimension: one hub with `degree`
+// direct neighbours, each neighbour carrying a small secondary fan-out so the
+// 2-hop frontier is genuinely wide. Degree varies; everything else is held.
+
+const HUB_DEGREES = [100, 1_000, 5_000, 20_000];
+const SECONDARY_FANOUT = 4;
+
+interface FanoutRow {
+  hub_degree: number;
+  total_relationships: number;
+  hop1_ms: number;
+  hop2_ms: number;
+  visited_at_1: number;
+  visited_at_2: number;
+}
+
+/**
+ * Seed a single high-degree hub: `degree` direct neighbours off one hub node,
+ * each neighbour linked to `SECONDARY_FANOUT` second-level nodes. The hub's
+ * 1-hop frontier is `degree` wide; its 2-hop frontier is `degree *
+ * SECONDARY_FANOUT` wide — the wide-frontier shape the balanced tree never
+ * exercises.
+ */
+async function seedHub(prefix: string, degree: number): Promise<{ hub: string; keys: string[] }> {
+  const hub = `${prefix}_hub`;
+  const rows: Array<Record<string, unknown>> = [];
+  const keys: string[] = [];
+
+  for (let i = 0; i < degree; i++) {
+    const neighbour = `${prefix}_d${i}`;
+    const hubKey = `related_to:${hub}:${neighbour}`;
+    keys.push(hubKey);
+    rows.push({
+      relationship_key: hubKey,
+      relationship_type: "related_to",
+      source_entity_id: hub,
+      target_entity_id: neighbour,
+      schema_version: "1.0",
+      snapshot: {},
+      user_id: USER_ID,
+    });
+    for (let s = 0; s < SECONDARY_FANOUT; s++) {
+      const leaf = `${prefix}_d${i}_s${s}`;
+      const leafKey = `related_to:${neighbour}:${leaf}`;
+      keys.push(leafKey);
+      rows.push({
+        relationship_key: leafKey,
+        relationship_type: "related_to",
+        source_entity_id: neighbour,
+        target_entity_id: leaf,
+        schema_version: "1.0",
+        snapshot: {},
+        user_id: USER_ID,
+      });
+    }
+  }
+
+  const CHUNK = 1000;
+  for (let i = 0; i < rows.length; i += CHUNK) {
+    await db.from("relationship_snapshots").insert(rows.slice(i, i + CHUNK));
+  }
+  return { hub, keys };
+}
+
+describe("graph traversal fan-out (high-degree hub) benchmark (#1467)", () => {
+  const prefix = `fanbench_${process.hrtime.bigint()}`;
+  const results: FanoutRow[] = [];
+  const allKeys: string[] = [];
+
+  afterAll(async () => {
+    await cleanup(allKeys);
+
+    const header =
+      "| hub degree | total relationships | 1-hop (ms) | 2-hop (ms) | visited@1 | visited@2 |";
+    const sep = "|---|---|---|---|---|---|";
+    const lines = results.map(
+      (r) =>
+        `| ${r.hub_degree} | ${r.total_relationships} | ${r.hop1_ms.toFixed(1)} | ${r.hop2_ms.toFixed(
+          1
+        )} | ${r.visited_at_1} | ${r.visited_at_2} |`
+    );
+    // eslint-disable-next-line no-console
+    console.log(
+      ["", "Graph traversal fan-out benchmark (#1467)", header, sep, ...lines, ""].join("\n")
+    );
+  });
+
+  for (const degree of HUB_DEGREES) {
+    it(`traverses a hub with ${degree} direct neighbours at 1/2 hops`, async () => {
+      const degPrefix = `${prefix}_g${degree}`;
+      const { hub, keys } = await seedHub(degPrefix, degree);
+      allKeys.push(...keys);
+
+      const start1 = process.hrtime.bigint();
+      const visited1 = await traverse(hub, 1);
+      const hop1 = Number(process.hrtime.bigint() - start1) / 1_000_000;
+
+      const start2 = process.hrtime.bigint();
+      const visited2 = await traverse(hub, 2);
+      const hop2 = Number(process.hrtime.bigint() - start2) / 1_000_000;
+
+      results.push({
+        hub_degree: degree,
+        total_relationships: degree * (1 + SECONDARY_FANOUT),
+        hop1_ms: hop1,
+        hop2_ms: hop2,
+        visited_at_1: visited1,
+        visited_at_2: visited2,
+      });
+
+      // Loose sanity bounds only. The hub's 1-hop neighbourhood is exactly its
+      // degree (plus the hub itself); 2-hop adds the secondary fan-out.
+      expect(visited1).toBe(degree + 1);
+      expect(visited2).toBe(degree + 1 + degree * SECONDARY_FANOUT);
+      expect(hop1).toBeGreaterThan(0);
+    }, 180_000);
+  }
+});


### PR DESCRIPTION
Closes the remaining gap on #1467: the existing scale benchmark held the traversal neighbourhood fixed (~585 nodes) while growing total table size, so it never measured what happens at a **single high-degree hub** — the super-connector case.

## What

- Adds a fan-out benchmark: one hub with degree 100..20k, each neighbour with a secondary fan-out, measuring 1-hop and 2-hop cost as hub degree grows.
- Refreshes `docs/performance/graph_traversal.md`: corrects the stale **pre-index** scale numbers (the doc said ~777ms at 50k/3-hop; with the #1467 indexes now merged it is ~6ms — a ~130× reduction), adds the fan-out results, and removes a partner-specific reference.

## Finding (measured, local SQLite)

| dimension | result |
|---|---|
| **Scale** (fixed neighbourhood, growing table) | flat — ~6ms at 3 hops / 50k relationships, thanks to the indexes |
| **Fan-out** (single hub, growing degree) | ~linear in degree — 20k-degree hub is ~40ms at 1 hop, ~550ms at 2 hops |

The indexes remove total-table-size as a cost driver; **fan-out is the real ceiling** and scales with hub degree independently of table size. This is the honest input to a 'do we still need a dedicated graph DB?' decision — it depends on how many high-degree hubs the workload traverses and how often, not on total graph size.

Benchmark stays out of the default test lane (`RUN_BENCH=1` / `npm run test:bench`); asserts only loose sanity bounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)