### PR TITLE
docs(infra): decouple deployment-topology doc from a specific session

### DIFF
--- a/docs/infrastructure/multi_tenant_deployment_topology.md
+++ b/docs/infrastructure/multi_tenant_deployment_topology.md
@@ -135,10 +135,11 @@ This sequences risk correctly: ship on what exists (A), harden the known sharp e
 (`busy_timeout`), and earn the larger storage investment (B) against real load rather
 than a hypothetical.
 
-## Open questions for the working session
+## Open questions for a deployment decision
 
-These are the operator-specific inputs that move the recommendation, and the agenda for
-a deployment conversation:
+These are the operator-specific inputs that move the recommendation. A team choosing a
+topology should answer them against its real workload; they also form a natural agenda
+for a deployment review:
 
 - **Tenant count and growth curve** — tens, hundreds, thousands? This is the main fork
   between Topology A and Topology B.


### PR DESCRIPTION
Follow-up to #1511. The deployment-topology doc's open-questions section was headed "for the working session" — coupling a permanent substrate-documentation artifact to a specific engagement. The questions themselves (tenant count, write concurrency, isolation requirements, self-host appetite, system-of-record relationship) are generic deployment-decision inputs, so this reframes the heading and lead-in to stand on their own.

Rationale: the doc belongs in the repo as reusable reference for any multi-tenant adopter; any session/conversation framing belongs in correspondence, not in the doc itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)