### PR TITLE
docs(foundation): publish adopter dependency-stability commitments

### DIFF
--- a/docs/developer/developer_preview_launch_checklist.md
+++ b/docs/developer/developer_preview_launch_checklist.md
@@ -10,11 +10,11 @@ This document does not cover marketing, positioning, or post-preview roadmap; se
 
 ## 1. Contract surface (MVP scope)
 
-| Criterion | Status | Evidence |
-|-----------|--------|----------|
-| OpenAPI as single source of truth | Done | `openapi.yaml` at repo root; `src/shared/contract_mappings.ts` defines `OPENAPI_OPERATION_MAPPINGS` with operationId, path, mcpTool, cliCommand per operation. |
-| CLI + MCP as adapters to same contract | Done | Mappings in `contract_mappings.ts`; CLI in `src/cli/index.ts`; MCP tool handling in `src/server.ts` (CallToolRequestSchema). |
-| No web app in scope for announced preview | Done | README and this checklist frame preview as CLI + MCP + OpenAPI only; frontend exists for development/future use. |
+| Criterion                                 | Status | Evidence                                                                                                                                                       |
+| ----------------------------------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| OpenAPI as single source of truth         | Done   | `openapi.yaml` at repo root; `src/shared/contract_mappings.ts` defines `OPENAPI_OPERATION_MAPPINGS` with operationId, path, mcpTool, cliCommand per operation. |
+| CLI + MCP as adapters to same contract    | Done   | Mappings in `contract_mappings.ts`; CLI in `src/cli/index.ts`; MCP tool handling in `src/server.ts` (CallToolRequestSchema).                                   |
+| No web app in scope for announced preview | Done   | README and this checklist frame preview as CLI + MCP + OpenAPI only; frontend exists for development/future use.                                               |
 
 **Verdict:** Contract surface is in place.
 
@@ -22,11 +22,11 @@ This document does not cover marketing, positioning, or post-preview roadmap; se
 
 ## 2. Guarantees and disclaimers (in repo)
 
-| Criterion | Status | Evidence |
-|-----------|--------|----------|
-| Four guarantees documented in repo | Done | [README – Developer preview](../../README.md#developer-preview): no silent data loss; explicit, inspectable state mutations; auditable operations; CLI and MCP map to same underlying contract. |
-| "What is not guaranteed yet" documented | Done | README: stable schemas, deterministic extraction across versions, long-term replay compatibility, backward compatibility; breaking changes expected. |
-| Who this is for / not for | Done | README: "Who this is for" and "Who this is not for (yet)" under Developer preview. |
+| Criterion                               | Status | Evidence                                                                                                                                                                                        |
+| --------------------------------------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Four guarantees documented in repo      | Done   | [README – Developer preview](../../README.md#developer-preview): no silent data loss; explicit, inspectable state mutations; auditable operations; CLI and MCP map to same underlying contract. |
+| "What is not guaranteed yet" documented | Done   | README: stable schemas, deterministic extraction across versions, long-term replay compatibility, backward compatibility; breaking changes expected.                                            |
+| Who this is for / not for               | Done   | README: "Who this is for" and "Who this is not for (yet)" under Developer preview.                                                                                                              |
 
 **Verdict:** Guarantees and disclaimers are in the Neotoma repo.
 
@@ -34,10 +34,10 @@ This document does not cover marketing, positioning, or post-preview roadmap; se
 
 ## 3. MCP ↔ CLI audit trail
 
-| Criterion | Status | Evidence |
-|-----------|--------|----------|
-| Every MCP tool call logs equivalent CLI invocation | Done | `src/server.ts` (CallToolRequestSchema handler): `buildCliEquivalentInvocation(name, args)` then `logger.info(\`[MCP Server] CLI equivalent: ${cliEquivalent}\`)`. |
-| Redaction-aware logging | Done | `contract_mappings.ts`: `sanitizeCliArgs()`, `SAFE_ARG_FIELDS`; only safe fields (e.g. type, limit) logged; others `<redacted>`. |
+| Criterion                                          | Status | Evidence                                                                                                                                                           |
+| -------------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Every MCP tool call logs equivalent CLI invocation | Done   | `src/server.ts` (CallToolRequestSchema handler): `buildCliEquivalentInvocation(name, args)` then `logger.info(\`[MCP Server] CLI equivalent: ${cliEquivalent}\`)`. |
+| Redaction-aware logging                            | Done   | `contract_mappings.ts`: `sanitizeCliArgs()`, `SAFE_ARG_FIELDS`; only safe fields (e.g. type, limit) logged; others `<redacted>`.                                   |
 
 **Verdict:** MCP ↔ CLI audit trail is implemented.
 
@@ -45,11 +45,11 @@ This document does not cover marketing, positioning, or post-preview roadmap; se
 
 ## 4. CLI output contract
 
-| Criterion | Status | Evidence |
-|-----------|--------|----------|
-| CLI has stable `--json` | Done | `src/cli/index.ts`: `.option("--json", "Output machine-readable JSON")`; documented in `cli_reference.md`, `cli_overview.md`. |
-| CLI has `--pretty` for humans | Done | `src/cli/index.ts`: `.option("--pretty", "Output formatted JSON for humans")`; mutual exclusivity with `--json` enforced. |
-| MCP never parses human output | Done | MCP uses `executeTool()` and returns structured responses; does not invoke CLI and parse stdout. See `docs/proposals/mcp-cli-action-items.md` and related reports. |
+| Criterion                     | Status | Evidence                                                                                                                                                           |
+| ----------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| CLI has stable `--json`       | Done   | `src/cli/index.ts`: `.option("--json", "Output machine-readable JSON")`; documented in `cli_reference.md`, `cli_overview.md`.                                      |
+| CLI has `--pretty` for humans | Done   | `src/cli/index.ts`: `.option("--pretty", "Output formatted JSON for humans")`; mutual exclusivity with `--json` enforced.                                          |
+| MCP never parses human output | Done   | MCP uses `executeTool()` and returns structured responses; does not invoke CLI and parse stdout. See `docs/proposals/mcp-cli-action-items.md` and related reports. |
 
 **Verdict:** CLI output contract is satisfied.
 
@@ -57,10 +57,10 @@ This document does not cover marketing, positioning, or post-preview roadmap; se
 
 ## 5. Fixtures and failure gallery
 
-| Criterion | Status | Evidence |
-|-----------|--------|----------|
-| Fixtures and expected outputs | Done | `tests/fixtures/` with README; `expected/` (e.g. contact_snapshot.json, transaction_snapshot.json); replay_graph and other fixture tests. |
-| Failure gallery | Done | `docs/reports/failure_gallery.md`: failure cases (auth, idempotency conflict, invalid schema, not found, etc.), error envelopes, testing requirements. |
+| Criterion                     | Status | Evidence                                                                                                                                               |
+| ----------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Fixtures and expected outputs | Done   | `tests/fixtures/` with README; `expected/` (e.g. contact_snapshot.json, transaction_snapshot.json); replay_graph and other fixture tests.              |
+| Failure gallery               | Done   | `docs/reports/failure_gallery.md`: failure cases (auth, idempotency conflict, invalid schema, not found, etc.), error envelopes, testing requirements. |
 
 **Verdict:** Fixtures and failure gallery are in place.
 
@@ -68,11 +68,11 @@ This document does not cover marketing, positioning, or post-preview roadmap; se
 
 ## 6. Developer preview storage stance
 
-| Criterion | Status | Evidence |
-|-----------|--------|----------|
-| Local-only stance documented | Done | [Developer preview storage](developer_preview_storage.md): preview supports local storage only (SQLite + local file storage); Remote backends not supported in preview. |
-| When to use local vs remote (future) | Done | Same doc: quick reference table; "when remote storage is reintroduced" and use cases (multi-user, hosted, etc.). |
-| README and getting started aligned | Done | README Developer preview section and [Getting started](getting_started.md) reference local-only for preview. |
+| Criterion                            | Status | Evidence                                                                                                                                                                |
+| ------------------------------------ | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Local-only stance documented         | Done   | [Developer preview storage](developer_preview_storage.md): preview supports local storage only (SQLite + local file storage); Remote backends not supported in preview. |
+| When to use local vs remote (future) | Done   | Same doc: quick reference table; "when remote storage is reintroduced" and use cases (multi-user, hosted, etc.).                                                        |
+| README and getting started aligned   | Done   | README Developer preview section and [Getting started](getting_started.md) reference local-only for preview.                                                            |
 
 **Verdict:** Developer preview storage stance is documented.
 
@@ -80,14 +80,14 @@ This document does not cover marketing, positioning, or post-preview roadmap; se
 
 ## 7. Summary: checklist status
 
-| Area | Fulfilled | Outstanding |
-|------|-----------|-------------|
-| Contract surface (OpenAPI, CLI, MCP) | Yes | — |
-| Four guarantees + "not guaranteed yet" in repo | Yes | — |
-| MCP logs CLI equivalent (redaction-aware) | Yes | — |
-| CLI `--json` / `--pretty`; MCP does not parse human output | Yes | — |
-| Fixtures + expected outputs + failure gallery | Yes | — |
-| Local-only default; storage stance documented | Yes | — |
+| Area                                                       | Fulfilled | Outstanding |
+| ---------------------------------------------------------- | --------- | ----------- |
+| Contract surface (OpenAPI, CLI, MCP)                       | Yes       | —           |
+| Four guarantees + "not guaranteed yet" in repo             | Yes       | —           |
+| MCP logs CLI equivalent (redaction-aware)                  | Yes       | —           |
+| CLI `--json` / `--pretty`; MCP does not parse human output | Yes       | —           |
+| Fixtures + expected outputs + failure gallery              | Yes       | —           |
+| Local-only default; storage stance documented              | Yes       | —           |
 
 All criteria from the ateles developer-preview assessment are currently satisfied in this repo.
 
@@ -97,12 +97,31 @@ All criteria from the ateles developer-preview assessment are currently satisfie
 
 These are not criteria for "preview readiness" but should be done before promoting the preview publicly. They reflect current README "Next steps" and pre-release validation.
 
-| Item | Status | Notes |
-|------|--------|-------|
-| Uncommitted changes reviewed | Outstanding | README: "Review uncommitted changes (262 files)". Resolve or document before announcement. |
-| Pending migrations applied | Outstanding | Apply any pending migrations; run `npm run migrate` and verify. |
-| Test suite audited | Outstanding | Run full test suite; address flakiness or failures. See [Pre-release validation](pre_release_validation_rules.mdc). |
-| Version / release wording | Outstanding | Decide whether to tag a release (e.g. v0.4.0) or announce "current main" as preview; update README "Current Status" and "Developer preview" line accordingly. |
+| Item                         | Status      | Notes                                                                                                                                                         |
+| ---------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Uncommitted changes reviewed | Outstanding | README: "Review uncommitted changes (262 files)". Resolve or document before announcement.                                                                    |
+| Pending migrations applied   | Outstanding | Apply any pending migrations; run `npm run migrate` and verify.                                                                                               |
+| Test suite audited           | Outstanding | Run full test suite; address flakiness or failures. See [Pre-release validation](pre_release_validation_rules.mdc).                                           |
+| Version / release wording    | Outstanding | Decide whether to tag a release (e.g. v0.4.0) or announce "current main" as preview; update README "Current Status" and "Developer preview" line accordingly. |
+
+---
+
+## Beyond preview: dependency-stability and general-release readiness
+
+This checklist is backward-looking — it records what the developer-preview stage
+committed to. Two forward-looking bars are documented separately:
+
+- **Dependency-stability** — the stability/governance/operability commitments an
+  application building on Neotoma can hold us to:
+  [`adopter_dependency_commitments.md`](../foundation/adopter_dependency_commitments.md).
+  Criteria-gated, not date-gated; the README's "not guaranteed yet" list is, in
+  effect, its agenda.
+- **General-release readiness** — the go-to-market gates for sustaining
+  unassisted adoption at scale:
+  [`general_release_criteria.md`](../icp/general_release_criteria.md).
+
+The two are orthogonal: one is whether it is safe to depend on, the other is
+whether it is ready to broadly distribute.
 
 ---
 

--- a/docs/foundation/adopter_dependency_commitments.md
+++ b/docs/foundation/adopter_dependency_commitments.md
@@ -1,0 +1,147 @@
+# Adopter Dependency Commitments
+
+## Scope
+
+This document states the **stability, governance, and operability commitments**
+an application building on Neotoma can hold us to — the conditions that determine
+whether it is safe to depend on the substrate and trust that the ground will not
+move under you. It exists so that "when is this safe to depend on, and who
+decides?" has a public, checkable answer rather than resting on a version number
+or a verbal assurance.
+
+These commitments are deliberately **not technical feature checklists** and **not
+go-to-market readiness gates** — the substrate's capabilities already exist and
+are documented elsewhere, and adoption readiness is tracked separately. They are
+the maturity properties an _adopter_ cares about: that schemas and contracts do
+not shift under you, that you can always leave with your data, and that the
+governance commitments are real and enforced.
+
+### How this differs from general-release readiness
+
+Neotoma has two distinct "is it ready?" lenses, and they are intentionally
+separate documents:
+
+- **`docs/icp/general_release_criteria.md`** — _go-to-market_ readiness: whether
+  Neotoma can sustain unassisted discovery, adoption, and retention at scale
+  (adoption evidence, activation, feedback signal). That is the team's lens for
+  deciding when to broaden distribution.
+- **This document** — _dependency-safety_: whether an external product can build
+  on the substrate without the ground shifting. That is the adopter's lens for
+  deciding whether to depend.
+
+The two are orthogonal. A version can be safe to depend on (this document)
+before it is broadly market-ready (the ICP document), or vice versa. This
+document is the one an evaluator deciding whether to build on Neotoma should
+read.
+
+These commitments are **criteria-gated, not date-gated.** They are satisfied
+when the conditions below are met — not on a calendar date, not at an arbitrary
+version bump. When all are met with documented evidence, Neotoma is dependency-
+stable (and `1.0` is tagged); we will not declare it to hit a date, nor hold it
+back once met.
+
+Related:
+
+- `docs/foundation/redlines.md` — the constitutional governance commitments
+  (R1–R16) that the governance commitments below reference.
+- `docs/foundation/substrate_and_applications.md` — the substrate/application
+  boundary that defines what these commitments do and do not cover.
+- `docs/developer/developer_preview_launch_checklist.md` — what the current
+  developer-preview stage committed to (the backward-looking checklist).
+- `docs/icp/general_release_criteria.md` — the orthogonal go-to-market readiness
+  gates (see above).
+
+## Current stage
+
+Neotoma is a **developer preview** (v0.x). The preview guarantees and their
+explicit "not yet" disclaimers are documented in the README and the developer-
+preview checklist. The "not yet" list — stable schemas, deterministic extraction
+across versions, long-term replay compatibility, backward compatibility — is, in
+effect, the dependency-stability agenda. This document names those items as
+commitments and adds the governance and operability conditions that a version
+label alone cannot express.
+
+## The commitments
+
+Dependency-stability requires **all** of the following. Each is checkable, and
+each links to where its evidence lives or will live.
+
+### Stability
+
+1. **Schema stability and versioned evolution.** Registered entity-type schemas
+   evolve under a documented compatibility policy: additive changes are safe,
+   breaking changes are versioned and migrated, and a schema in use does not
+   change shape under a consumer without an explicit version bump and migration
+   path.
+2. **Contract stability.** The HTTP/MCP/CLI contract surface is governed by the
+   OpenAPI-first flow and the breaking-change discipline already in place
+   (breaking changes named in release supplements, legacy-payload corpus, BC
+   diff gate). At this bar, the contract carries a stated deprecation policy: how
+   long a deprecated field or endpoint is supported before removal.
+3. **Backward compatibility and replay.** Data written by an earlier version
+   remains readable and reducible by a later version within a stated support
+   window. Observations and source remain immutable; reinterpretation across
+   versions is additive, never destructive.
+4. **Deterministic extraction across versions.** The canonicalization that bounds
+   LLM stochasticity (content-derived IDs, stable ordering, deterministic
+   reducers) is stable across releases, so the same inputs continue to produce the
+   same stored truth.
+
+### Governance
+
+5. **The redline commitments hold and are demonstrated, not just stated.**
+   `docs/foundation/redlines.md` (R1–R16) is in force, and this bar requires
+   evidence that the load-bearing ones are real: open-source core under MIT (R6),
+   no hosted-only features that compromise local-first (R5), no unilateral
+   capture or quiet license/policy drift (R12), no category drift into the
+   vertical applications built on the substrate (R13).
+6. **Portability and exit are proven.** Export, deletion, and rebuild-from-source-
+   of-record are documented and tested end-to-end, so an adopter can leave with
+   their data at any time. Dependence on Neotoma is reversible by construction,
+   not by promise.
+7. **Change governance is published.** How breaking changes are decided,
+   announced, and supported — including the deprecation window above — is written
+   down, so an adopter can predict the cost of staying current.
+
+### Operability
+
+8. **A supported multi-tenant deployment story.** At least one documented,
+   tested production deployment topology (see
+   `docs/infrastructure/multi_tenant_deployment_topology.md`) with its concurrency
+   envelope, backup/restore, and isolation guarantees stated — not just
+   "runs on a laptop."
+9. **Security review cadence.** The pre-release security gates run on every
+   sensitive release, and this bar requires a stated ongoing cadence (review on
+   sensitive change, advisory disclosure process, a documented response path for
+   reported issues) rather than a one-time audit.
+10. **Observability and operational documentation.** The logging, metrics, and
+    event surfaces an operator needs to run Neotoma in production are documented,
+    with no PII in any observable surface.
+11. **A stated support posture.** What support, SLAs (if any), and version-support
+    windows an adopter can expect are written down — even if the answer for some
+    tiers is "self-hosted, community-supported." The point is that the posture is
+    explicit, not that it is maximal.
+
+## What this bar does not mean
+
+- **Not feature-completeness.** This is a stability and trust bar, not a claim
+  that every planned capability has shipped. New capabilities continue to land
+  under the same compatibility discipline.
+- **Not the end of the substrate/application boundary.** Reaching it does not
+  change what the substrate owns versus what the application owns
+  (`docs/foundation/substrate_and_applications.md`). Neotoma at 1.0 is still the
+  State Layer and still does not move up into vertical applications (R13).
+- **Not a managed-service commitment.** This is about the substrate's maturity,
+  not about a hosted offering. The self-hosted path is the supported path; any
+  managed offering is a separate decision.
+- **Not go-to-market readiness.** Whether Neotoma can sustain unassisted adoption
+  at scale is a separate question, tracked in `docs/icp/general_release_criteria.md`.
+
+## How to use this document
+
+- An adopter evaluating whether to depend on Neotoma can read this as the bar we
+  hold ourselves to, and hold us to it.
+- A contributor proposing a change toward dependency-stability can check it
+  against these commitments and cite the one it advances.
+- When every commitment has documented, checkable evidence, the bar is met and
+  `1.0` is tagged — at that point, not before, and not delayed past it.

--- a/docs/icp/general_release_criteria.md
+++ b/docs/icp/general_release_criteria.md
@@ -2,7 +2,9 @@
 
 Criteria for exiting the developer release and entering general release. The developer release exists to validate architecture, ICP, and activation path. General release means Neotoma can sustain unassisted discovery, adoption, and retention at scale.
 
-**Related docs:** [`primary_icp.md`](./primary_icp.md) (durable ICP definition) · [`developer_release_targeting.md`](./developer_release_targeting.md) (dev release targeting and activation risks)
+**Related docs:** [`primary_icp.md`](./primary_icp.md) (durable ICP definition) · [`developer_release_targeting.md`](./developer_release_targeting.md) (dev release targeting and activation risks) · [`adopter_dependency_commitments.md`](../foundation/adopter_dependency_commitments.md) (the orthogonal _dependency-safety_ lens — stability/governance/exit commitments an adopter holds us to, distinct from the go-to-market readiness gates here)
+
+> **Two lenses, not one.** This document is the _go-to-market_ readiness gate (can Neotoma sustain unassisted adoption at scale?). It is distinct from [`adopter_dependency_commitments.md`](../foundation/adopter_dependency_commitments.md), the _dependency-safety_ bar (is it safe for an external product to build on the substrate?). A version can satisfy one before the other; they are tracked separately on purpose.
 
 ---
 
@@ -25,6 +27,7 @@ General release readiness means sufficient evidence on all three.
 **Threshold:** 5+ genuinely active users who have reached the expansion stage of the adoption funnel.
 
 **"Active" defined as:**
+
 - Observations being stored weekly
 - 3+ entity types in use (beyond default auto-stored types)
 - No reversion to workarounds (markdown files, Notion, manual re-prompting for domains Neotoma covers)
@@ -56,6 +59,7 @@ Pre-install evaluators (those who have not completed install on their own machin
 **What this proves:** The docs, onboarding flow, error messages, and agent instructions are sufficient for self-service adoption. During the dev release, personal intervention is expected; for general release, it can't scale.
 
 **Evidence to track:**
+
 - Did they install from docs alone, on their own machine?
 - Did they hit a blocker that required human help between install and first sustained write?
 - Did they discover Priority 2+ data types without being prompted?
@@ -69,15 +73,15 @@ Pre-install evaluators (those who have not completed install on their own machin
 
 Each of the activation risk classes from [`developer_release_targeting.md`](./developer_release_targeting.md) needs minimum resolution. The first four rows are the original risk classes; the four rows below are sub-gates promoted to first-class measurement based on the round-2 evaluator corpus.
 
-| Risk class / sub-gate | Minimum status for general release | Current status |
-|---|---|---|
-| **Cognitive cold-start** (`gate4_cognitive_coldstart`) | ≤25% of evaluators report `friction` or `blocked` on cognitive cold-start; Priority 1 data auto-stores; "what to store" guide has worked examples; agent proactively suggests next entity types | Failing — 7/16 = 44% `friction\|blocked` in current corpus |
-| **UX friction** | Error messages guide recovery; successful storage is confirmed to user; duplicate entity edge cases resolved or surfaced gracefully | Pending |
-| **Trust barrier** | SBOM or dependency audit published (if proven to be a real blocker); supply chain posture surfaced in install docs | Pending |
-| **Prior bad experience** | Onboarding surface includes integrity-first framing; at least one user-facing comparison (fuzzy memory vs. Neotoma guarantees) exists | Pending |
-| **Install-path friction** (`gate4_install_path_friction`) | Cold install on evaluator's actual machine completes with ≤2 approval prompts, in ≤5 minutes, respecting version-managed Node (Mise / asdf / nvm / volta), and emits a canonical `installed at <path>` line | Failing — 0/3 round-2 fresh-install attempts met threshold |
-| **Retrieval transparency** (`gate4_retrieval_transparency`) | The harness surfaces a visible breadcrumb of which observations the agent just used during a turn (e.g. "read N observations from Neotoma"), enabling the user to verify what informed an agent response | Pending |
-| **Privacy / local-LLM compatibility** (`gate4_privacy_local_llm_compatibility`) | A documented `/local-llm` (or equivalent) surface plus a working walkthrough for at least one local-LLM topology (Ollama / LM Studio / Alaris-class), including a Neotoma-CLI-without-MCP path for harnesses that do not speak MCP | Pending |
+| Risk class / sub-gate                                                           | Minimum status for general release                                                                                                                                                                                                 | Current status                                             |
+| ------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| **Cognitive cold-start** (`gate4_cognitive_coldstart`)                          | ≤25% of evaluators report `friction` or `blocked` on cognitive cold-start; Priority 1 data auto-stores; "what to store" guide has worked examples; agent proactively suggests next entity types                                    | Failing — 7/16 = 44% `friction\|blocked` in current corpus |
+| **UX friction**                                                                 | Error messages guide recovery; successful storage is confirmed to user; duplicate entity edge cases resolved or surfaced gracefully                                                                                                | Pending                                                    |
+| **Trust barrier**                                                               | SBOM or dependency audit published (if proven to be a real blocker); supply chain posture surfaced in install docs                                                                                                                 | Pending                                                    |
+| **Prior bad experience**                                                        | Onboarding surface includes integrity-first framing; at least one user-facing comparison (fuzzy memory vs. Neotoma guarantees) exists                                                                                              | Pending                                                    |
+| **Install-path friction** (`gate4_install_path_friction`)                       | Cold install on evaluator's actual machine completes with ≤2 approval prompts, in ≤5 minutes, respecting version-managed Node (Mise / asdf / nvm / volta), and emits a canonical `installed at <path>` line                        | Failing — 0/3 round-2 fresh-install attempts met threshold |
+| **Retrieval transparency** (`gate4_retrieval_transparency`)                     | The harness surfaces a visible breadcrumb of which observations the agent just used during a turn (e.g. "read N observations from Neotoma"), enabling the user to verify what informed an agent response                           | Pending                                                    |
+| **Privacy / local-LLM compatibility** (`gate4_privacy_local_llm_compatibility`) | A documented `/local-llm` (or equivalent) surface plus a working walkthrough for at least one local-LLM topology (Ollama / LM Studio / Alaris-class), including a Neotoma-CLI-without-MCP path for harnesses that do not speak MCP | Pending                                                    |
 
 <!-- Evidence basis for sub-gates:
   - Cognitive cold-start promotion: 7/16 friction|blocked across N=16 corpus.
@@ -93,6 +97,7 @@ Each of the activation risk classes from [`developer_release_targeting.md`](./de
 **Threshold:** Zero data integrity failures observed across active users.
 
 **Specifically:**
+
 - No silent overwrites (append-only guarantee held)
 - No schema violations that slipped through validation
 - No provenance gaps (every stored observation traceable to source)
@@ -108,6 +113,7 @@ Each of the activation risk classes from [`developer_release_targeting.md`](./de
 **Threshold:** Enough observed usage data to build a general release roadmap from evidence, not speculation.
 
 **Questions that should be answerable from observed behavior:**
+
 - Which entity types do users actually store first, second, third?
 - What does the real (not hypothesized) expansion path look like?
 - Which MCP workflows are most common?


### PR DESCRIPTION
Adds `docs/foundation/adopter_dependency_commitments.md` — the stability, governance, and operability commitments an application building on Neotoma can hold us to, so "when is this safe to depend on, and who decides?" has a public, checkable answer.

## The two-lens distinction (important)

The repo already has `docs/icp/general_release_criteria.md`, which defines **go-to-market readiness** (adoption evidence, retention, unassisted activation — backed by an evaluator corpus). This new doc is the **orthogonal dependency-safety lens**: whether an external product can build on the substrate without the ground shifting. The two are deliberately separate and now cross-reference each other:

- *general_release_criteria.md* → is Neotoma ready to **broadly distribute**?
- *adopter_dependency_commitments.md* (this) → is it safe to **depend on**?

A version can satisfy one before the other.

## What it commits to (non-technical, criteria-gated not date-gated)

- **Stability:** schema + contract stability with a deprecation policy, backward-compat + replay, deterministic extraction across versions.
- **Governance:** the redline commitments (R5/R6/R12/R13) demonstrated not just stated, proven portability/exit, published change governance.
- **Operability:** a supported multi-tenant deployment topology, security-review cadence, observability docs, a stated support posture.

Cross-links the developer-preview launch checklist forward to both forward-looking bars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)