### PR TITLE
ci(review): make Claude PR reviewer submit a formal review with state

### DIFF
--- a/.github/workflows/claude_pr_review.yml
+++ b/.github/workflows/claude_pr_review.yml
@@ -33,6 +33,13 @@ permissions:
 
 concurrency:
   group: pr-review-${{ github.event.pull_request.number || github.event.issue.number }}
+  # Cancel an in-flight review when the PR is force-pushed again, so we don't burn
+  # a full review on a soon-superseded commit. The trade-off: a cancelled run can
+  # leave a stale "review in progress" checklist comment with no verdict. The
+  # review step mitigates this by submitting a FORMAL review (with state) keyed to
+  # a `Reviewed commit: <sha>` line on completion — so a completed review is always
+  # distinguishable from a cancelled stub, and GitHub associates the review state
+  # with the commit it actually ran against.
   cancel-in-progress: true
 
 jobs:
@@ -108,9 +115,9 @@ jobs:
 
           gh pr comment $PR_NUMBER --repo $REPO --body "**Claude review skipped** — diff is below the automatic-review threshold (${FILES} file(s), ${LINES} line(s) changed).
 
-Thresholds that trigger a review: >5 files, >150 lines, any \`packages/\` change, any auth-related path, or a simultaneous \`src/\` + \`openapi.yaml\` change.
+          Thresholds that trigger a review: >5 files, >150 lines, any \`packages/\` change, any auth-related path, or a simultaneous \`src/\` + \`openapi.yaml\` change.
 
-To request a review anyway, comment \`@claude review\` on this PR."
+          To request a review anyway, comment \`@claude review\` on this PR."
 
       - uses: anthropics/claude-code-action@beta
         if: steps.diff_check.outputs.substantial == 'true'
@@ -121,7 +128,7 @@ To request a review anyway, comment \`@claude review\` on this PR."
           timeout_minutes: 60
           max_turns: 60
           trigger_phrase: "@claude review"
-          allowed_tools: "Edit,MultiEdit,Glob,Grep,LS,Read,Write,mcp__github_comment__update_claude_comment,Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git rm:*),Bash(git fetch:*)"
+          allowed_tools: "Edit,MultiEdit,Glob,Grep,LS,Read,Write,mcp__github_comment__update_claude_comment,Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git rm:*),Bash(git fetch:*),Bash(gh pr review:*),Bash(gh pr view:*),Bash(gh pr diff:*)"
           direct_prompt: |
             Invoke the `/review` skill (`.claude/skills/review/SKILL.md`) against this pull request.
 
@@ -136,4 +143,20 @@ To request a review anyway, comment \`@claude review\` on this PR."
             - Phase 5b: product/UX and principles alignment — product principles (explicit over implicit, no silent behavior, provenance), silent behavior changes, agent instruction coherence (verify referenced tools/entities/preferences actually exist), error/hint quality, API naming and semantic consistency, discoverability, supplement accuracy
             - Phase 6: emit findings in the structured `[BLOCKING|ADVISORY|NIT] <category>` format the skill defines, then a summary block with the verdict (APPROVED / APPROVED-WITH-NOTES / NEEDS-CHANGES)
 
-            Post the review as a single PR comment. Be direct and specific — cite file and line numbers; skip praise. Verdict rules are non-negotiable: any BLOCKING finding requires NEEDS-CHANGES.
+            Be direct and specific — cite file and line numbers; skip praise. Verdict rules are non-negotiable: any BLOCKING finding requires NEEDS-CHANGES.
+
+            Submit the review as a FORMAL GitHub review, not a plain PR comment, so the
+            verdict carries a trackable review state that GitHub displays and that a
+            reader can tell is complete. Write the full structured review (findings +
+            summary + verdict) to a file, then submit it with `gh pr review` mapped from
+            the verdict:
+              - APPROVED            -> `gh pr review <PR> --approve --body-file <file>`
+              - APPROVED-WITH-NOTES -> `gh pr review <PR> --comment --body-file <file>`
+              - NEEDS-CHANGES       -> `gh pr review <PR> --request-changes --body-file <file>`
+            Resolve `<PR>` as `${{ github.event.pull_request.number || github.event.issue.number }}`.
+            Include the line `Reviewed commit: <full head SHA>` (from `gh pr view --json headRefOid`)
+            at the top of the body, so a later force-push makes it plainly visible that the
+            review predates the current head. A formal review with an explicit state is the
+            required deliverable: do NOT finish by leaving only an in-progress checklist
+            comment — if you cannot complete the review, say so explicitly with a
+            `--request-changes` review stating it is incomplete.


### PR DESCRIPTION
## Problem

The automated Claude PR reviewer posts its verdict as a **plain PR comment**, which carries no trackable review state. Two consequences:

1. A reader can't tell from GitHub whether a review *completed* — the verdict (APPROVED / NEEDS-CHANGES) is buried in comment text, with no review-state badge.
2. A run cancelled by a force-push (under `cancel-in-progress: true`) leaves behind a stale **"review in progress"** checklist comment with every phase unchecked and **no verdict** — indistinguishable at a glance from a finished review. (This is exactly what happened on #1479: its review comments are perpetual in-progress stubs because rapid force-pushes cancelled each run before Phase 6.)

## Fix

- The reviewer now submits a **formal GitHub review** via `gh pr review`, mapping its verdict to the review state: APPROVED → `--approve`, APPROVED-WITH-NOTES → `--comment`, NEEDS-CHANGES → `--request-changes`. The verdict now has trackable state GitHub displays.
- It stamps `Reviewed commit: <head SHA>` at the top of the body, so a later force-push makes review staleness visible.
- A formal review with explicit state is now the **required deliverable** — finishing with only an in-progress checklist is explicitly disallowed; an incomplete review must say so via `--request-changes`.
- Adds the `gh pr review/view/diff` Bash permissions.
- Documents the `cancel-in-progress` trade-off in the concurrency block.
- Fixes a latent block-scalar indentation issue in the skipped-review comment so the workflow parses cleanly under strict YAML / actionlint (GitHub tolerated it; strict parsers did not).

🤖 Generated with [Claude Code](https://claude.com/claude-code)