### PR TITLE
docs(architecture): correct stale RLS-as-current isolation framing

### DIFF
--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -29,7 +29,7 @@ All foundational architectural components described in this document are now ful
 See `docs/releases/v0.1.0/` for release details.
 ### Planned Releases
 **v0.2.0:** Sources-First [Ingestion](../vocabulary/canonical_terms.md#ingestion) Architecture — Minimal [Ingestion](../vocabulary/canonical_terms.md#ingestion) + Correction Loop
-- [Source](../vocabulary/canonical_terms.md#source) table migration (content-addressed raw storage with RLS)
+- [Source](../vocabulary/canonical_terms.md#source) table migration (content-addressed raw storage with per-owner `user_id` scoping)
 - [Interpretations](../vocabulary/canonical_terms.md#interpretation) table for versioned [interpretation](../vocabulary/canonical_terms.md#interpretation) tracking
 - [Observation](../vocabulary/canonical_terms.md#observation) and raw fragments extensions with [provenance](../vocabulary/canonical_terms.md#provenance) (`source_id`, `interpretation_id` linkage)
 - [Entity](../vocabulary/canonical_terms.md#entity) extensions with user_id and merge tracking
@@ -826,7 +826,7 @@ Load `docs/architecture/architecture.md` when:
 - [ ] Domain logic is deterministic and testable
 - [ ] Errors use ErrorEnvelope structure
 - [ ] Database writes are transactional
-- [ ] User data isolation maintained (RLS)
+- [ ] User data isolation maintained (application-layer `user_id` scoping via `getAuthenticatedUserId`)
 - [ ] MCP actions validate inputs
 - [ ] Performance targets considered
 - [ ] Security boundaries respected

--- a/docs/architecture/consistency.md
+++ b/docs/architecture/consistency.md
@@ -303,11 +303,11 @@ test("snapshot is immediately readable after computation", async () => {
 - Reducer execution is part of observation creation transaction
 #### 2.2.11 Auth Permissions (Strong Consistency)
 **What:**
-- User permissions, workspace access, RLS policies
+- User permissions, workspace access, per-owner data isolation
 **Consistency Guarantee:**
 - After permission change, subsequent API calls MUST enforce new permissions immediately.
 **Implementation:**
-- Row-level security (RLS) evaluated per query
+- Application-layer enforcement: every query resolves the caller via `getAuthenticatedUserId` and scopes by `user_id` (`.eq("user_id", userId)`) on each request. Database-level row-level security (RLS) is a possible future defense-in-depth layer, not the current mechanism — see [`docs/subsystems/auth.md`](../subsystems/auth.md#authorization).
 - No caching of permissions
 **UI Behavior:**
 - Block user immediately if permission revoked


### PR DESCRIPTION
A post-merge review of #1478 found that `consistency.md` and `architecture.md` still described tenant isolation as **'RLS / row-level security evaluated per query'** — but the actual enforced mechanism (and the one #1478's own `auth.md` correction establishes) is **application-layer `user_id` scoping via `getAuthenticatedUserId`**. The stale framing contradicted the corrected docs and the enforced contract.

Corrects four references to name application-layer scoping, with RLS noted as a *possible future* defense-in-depth layer (consistent with the already-correct `architecture.md:658`). Documentation accuracy only — no mechanism change.

This matters for adopters cross-checking the isolation claim: the dependency-commitments and security docs assert `user_id` scoping, and these two docs should not contradict them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)