### PR TITLE
docs: correct overstated 'encryption at rest' for the SQLite backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Neotoma stores user data and requires secure configuration.
 
 - **Authentication:** Local auth (dev stub or key-based when encryption is enabled).
 - **Authorization:** Local data isolation and explicit operation-level access controls.
-- **Data protection:** User-controlled data with full export and deletion control. Never used for training. Optional encryption at rest.
+- **Data protection:** User-controlled data with full export and deletion control. Never used for training. At-rest encryption of the SQLite database is provided at the deployment layer (encrypted volume) — the database file is plaintext on disk by default; the key-based settings gate auth and optional log encryption, not database-file encryption.
 - **Verify your setup:** Run `npm run doctor` for environment, database, and security checks. See [Auth](docs/subsystems/auth.md), [Privacy](docs/subsystems/privacy.md), [Compliance](docs/legal/compliance.md).
 
 ## Development

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -658,8 +658,9 @@ Application layer MUST distinguish and signal retry eligibility.
 - Database-level row-level security (RLS) is a possible future defense-in-depth layer, not the current line of defense — see [`docs/subsystems/auth.md`](../subsystems/auth.md#authorization) for the enforced contract and the two multi-tenant models
 ### 7.2 Data Security
 **At Rest:**
-- Database encryption at rest
-- File storage encryption (S3 server-side encryption)
+- The default SQLite backend (`better-sqlite3`) writes a **plaintext database file** on disk. Encryption at rest is **not provided by the database layer today** and must be supplied by the deployment: an encrypted volume/disk (LUKS, cloud-provider volume encryption), or a SQLCipher-style encrypted SQLite build (not yet a shipped/tested Neotoma configuration). The `NEOTOMA_ENCRYPTION_ENABLED` / key-file / mnemonic settings gate **key-based auth and optional log encryption**, not database-file encryption — do not rely on them for at-rest data protection.
+- File storage encryption (S3 server-side encryption) when an S3-compatible backend is configured.
+- The planned local-first E2EE architecture (v2.x, browser SQLite WASM + OPFS, server stores only ciphertext) is the eventual native at-rest story; it is aspirational, not current.
 **In Transit:**
 - HTTPS for all HTTP API calls
 - WSS (WebSocket Secure) for MCP connections

--- a/docs/foundation/quality_requirements.md
+++ b/docs/foundation/quality_requirements.md
@@ -63,6 +63,6 @@ All operations MUST emit:
 - MVP: All authenticated users see all records (single-user)
 - Future: Per-user isolation via `user_id` column + RLS policies
 **Data Protection:**
-- Database encryption at rest (optional, key file or mnemonic)
+- At-rest encryption of the SQLite database file is **not provided by the database layer today** — the file is plaintext on disk. Provide it at the deployment layer (encrypted volume) or via a SQLCipher-style build (not yet a shipped/tested configuration). The key-file / mnemonic settings gate key-based auth and optional log encryption, not database-file encryption.
 - HTTPS for all API calls
 - WSS (WebSocket Secure) for MCP connections

--- a/docs/security/threat_model.md
+++ b/docs/security/threat_model.md
@@ -74,7 +74,7 @@ The attribution contract (`docs/subsystems/agent_attribution_integration.md`) tr
 ## What the gates do **not** cover
 
 - **Operational-layer secret rotation** (e.g. forcing operators to rotate the bearer token after a regression). Track 2 will wire this through subscriptions / peer / guest with an explicit `remediation_task` entity.
-- **Cryptographic correctness.** AAuth signatures, OAuth PKCE, and the encryption-at-rest path are reviewed against `docs/subsystems/aauth.md` and `docs/subsystems/encryption.md`; the gates here check *usage*, not *primitive correctness*.
+- **Cryptographic correctness.** AAuth signatures and OAuth PKCE are reviewed against `docs/subsystems/aauth.md`; the gates here check *usage*, not *primitive correctness*. Note: there is no database-at-rest encryption in the current SQLite backend — the file is plaintext on disk, and at-rest protection is a deployment-layer concern (encrypted volume) rather than a Neotoma cryptographic primitive (see `docs/architecture/architecture.md` § 7.2).
 - **Supply-chain attacks.** `npm audit`, Socket.dev, and the package lockfile policy stay the canonical defense (see `docs/developer/pre_release_checklist.md` § 1.8).
 - **Social engineering and phishing.** Out of scope; covered by the operator runbook.
 


### PR DESCRIPTION
A partner evaluating Neotoma for a data-sovereignty-critical deployment flagged that the foundations docs list **'encryption at rest'** as a property — but the default `better-sqlite3` backend writes a **plaintext database file** on disk. The docs also conflated the `NEOTOMA_ENCRYPTION_ENABLED` / key-file / mnemonic settings (which gate key-based auth and optional **log** encryption) with database-file encryption.

## Corrects four sites

- `docs/architecture/architecture.md` § 7.2, `README.md`, `docs/foundation/quality_requirements.md`, `docs/security/threat_model.md`: state the honest posture — at-rest protection is a **deployment-layer** concern (encrypted volume) or a **not-yet-shipped SQLCipher** build, not a database primitive. The v2.x E2EE architecture (browser SQLite WASM + OPFS) is the aspirational native story.

## Deliberately left alone

- The legitimate **token/secret** at-rest encryption claims (AES-256-GCM refresh tokens via `MCP_TOKEN_ENCRYPTION_KEY`, secrets manager) are real and untouched.
- `docs/security/threat_model.md` also referenced a non-existent `docs/subsystems/encryption.md`; that dangling reference is removed.

## Flagged separately

The same overstatement appears in `docs/legal/privacy_policy.md` and `docs/legal/compliance.md` ('data encrypted at rest'). Those are user-facing legal commitments and are flagged for separate legal review, not edited here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)