### PR TITLE
feat(sse): encrypt substrate_events durable-log payload at rest

### DIFF
--- a/src/repositories/sqlite/local_db_adapter.ts
+++ b/src/repositories/sqlite/local_db_adapter.ts
@@ -69,9 +69,11 @@ let cachedDataKey: Uint8Array | null = null;
 
 /**
  * Load the data encryption key from config (key file or mnemonic).
- * Returns null if encryption is not enabled.
+ * Returns null if encryption is not enabled. Exported so other at-rest write
+ * paths that bypass this adapter (e.g. the durable substrate-event log) can
+ * reuse the same derived key rather than duplicating key-loading logic.
  */
-function getDataKey(): Uint8Array | null {
+export function getDataKey(): Uint8Array | null {
   if (!config.encryption.enabled) {
     return null;
   }

--- a/src/services/subscriptions/event_log.ts
+++ b/src/services/subscriptions/event_log.ts
@@ -13,8 +13,38 @@
  */
 
 import { getSqliteDb } from "../../repositories/sqlite/sqlite_client.js";
+import { getDataKey } from "../../repositories/sqlite/local_db_adapter.js";
+import { encryptColumn, decryptColumn, isEncryptedColumn } from "../../crypto/column_encryption.js";
 import { logger } from "../../utils/logger.js";
 import type { SubstrateEvent } from "../../events/types.js";
+
+/**
+ * Encryption-at-rest for the durable-event-log payload.
+ *
+ * The `substrate_events.payload` column persists the full event JSON to disk.
+ * Unlike the entity tables, this table is written through the raw SQLite client
+ * (not the column-encrypting `local_db_adapter`), so it would otherwise be
+ * plaintext even when encryption is enabled. These helpers close that gap by
+ * encrypting the payload with the same AES-256-GCM data key when encryption is
+ * configured, and transparently reading both encrypted and legacy-plaintext
+ * rows so enabling encryption never breaks resume of pre-existing events.
+ */
+function maybeEncryptPayload(plaintext: string): string {
+  const key = getDataKey();
+  return key ? encryptColumn(plaintext, key) : plaintext;
+}
+
+function maybeDecryptPayload(stored: string): string {
+  if (!isEncryptedColumn(stored)) {
+    return stored; // legacy plaintext row, or encryption disabled at write time
+  }
+  const key = getDataKey();
+  if (!key) {
+    // Row is encrypted but no key is configured now — cannot recover it.
+    throw new Error("durable event payload is encrypted but no data key is configured");
+  }
+  return decryptColumn(stored, key);
+}
 
 export const EVENT_RETENTION_DAYS = Math.max(
   1,
@@ -62,7 +92,7 @@ export function persistSubstrateEvent(
       event.event_type,
       event.user_id ?? null,
       event.entity_id ?? null,
-      JSON.stringify(event),
+      maybeEncryptPayload(JSON.stringify(event)),
       createdAt
     );
   return Number(info.lastInsertRowid);
@@ -113,10 +143,13 @@ export function getEventsAfterSeq(
   const out: DurableEvent[] = [];
   for (const row of rows) {
     try {
-      out.push({ seq: row.seq, event: JSON.parse(row.payload) as SubstrateEvent });
+      out.push({
+        seq: row.seq,
+        event: JSON.parse(maybeDecryptPayload(row.payload)) as SubstrateEvent,
+      });
     } catch {
-      // Skip a corrupt payload rather than fail the whole resume.
-      logger.warn("[event_log] skipping unparseable durable event", { seq: row.seq });
+      // Skip a corrupt or undecryptable payload rather than fail the whole resume.
+      logger.warn("[event_log] skipping unreadable durable event", { seq: row.seq });
     }
   }
   return out;

--- a/tests/subscriptions/durable_event_log.test.ts
+++ b/tests/subscriptions/durable_event_log.test.ts
@@ -16,6 +16,9 @@ import {
   hasDurableCursor,
   pruneEventLog,
 } from "../../src/services/subscriptions/event_log.js";
+import { clearCachedDataKey } from "../../src/repositories/sqlite/local_db_adapter.js";
+import { isEncryptedColumn } from "../../src/crypto/column_encryption.js";
+import { config } from "../../src/config.js";
 import type { SubstrateEvent, SubstrateEventType } from "../../src/events/types.js";
 
 const USER = "00000000-0000-0000-0000-000000000000";
@@ -130,9 +133,7 @@ describe("durable substrate-event log (#1464 Tier 2)", () => {
     persistSubstrateEvent(ev("b", { eventType: "entity.created" }), null);
     persistSubstrateEvent(ev("b", { eventType: "entity.updated" }), null);
 
-    expect(
-      getEventsAfterSeq(USER, 0, 1000, { entityIds: ["b"] }).length
-    ).toBe(2);
+    expect(getEventsAfterSeq(USER, 0, 1000, { entityIds: ["b"] }).length).toBe(2);
     const combined = getEventsAfterSeq(USER, 0, 1000, {
       entityIds: ["b"],
       eventTypes: ["entity.updated"],
@@ -172,5 +173,81 @@ describe("durable substrate-event log (#1464 Tier 2)", () => {
     expect(hasDurableCursor(USER, seq - 1)).toBe(true);
     // Two below the oldest means an event was pruned between cursor and window.
     expect(hasDurableCursor(USER, seq - 2)).toBe(false);
+  });
+});
+
+// --- Encryption at rest for the durable-log payload ---
+
+describe("durable substrate-event log: payload encryption at rest", () => {
+  // A 24-word BIP39 mnemonic (test-only) to drive the data key.
+  const TEST_MNEMONIC =
+    "test test test test test test test test test test test test " +
+    "test test test test test test test test test test test junk";
+
+  beforeEach(() => {
+    getSqliteDb().prepare("DELETE FROM substrate_events").run();
+  });
+  afterEach(() => {
+    getSqliteDb().prepare("DELETE FROM substrate_events").run();
+    config.encryption.enabled = false;
+    config.encryption.mnemonic = "";
+    clearCachedDataKey();
+  });
+
+  function enableEncryption(): void {
+    config.encryption.enabled = true;
+    config.encryption.mnemonic = TEST_MNEMONIC;
+    config.encryption.mnemonicPassphrase = "";
+    config.encryption.keyFilePath = "";
+    clearCachedDataKey();
+  }
+
+  function rawPayload(seq: number): string {
+    const row = getSqliteDb()
+      .prepare("SELECT payload FROM substrate_events WHERE seq = ?")
+      .get(seq) as { payload: string } | undefined;
+    return row?.payload ?? "";
+  }
+
+  it("writes the payload as ciphertext on disk when encryption is enabled", () => {
+    enableEncryption();
+    const seq = persistSubstrateEvent(ev("secret-entity"), null);
+
+    const stored = rawPayload(seq);
+    // Stored value is the iv:authTag:ciphertext format, not the plaintext JSON.
+    expect(isEncryptedColumn(stored)).toBe(true);
+    expect(stored).not.toContain("secret-entity");
+    expect(stored).not.toContain("entity.created");
+  });
+
+  it("round-trips an encrypted payload back to the original event on read", () => {
+    enableEncryption();
+    const seq = persistSubstrateEvent(ev("rt"), null);
+
+    const recovered = getEventsAfterSeq(USER, seq - 1);
+    expect(recovered).toHaveLength(1);
+    expect(recovered[0]!.event.entity_id).toBe("rt");
+    expect(recovered[0]!.event.event_type).toBe("entity.created");
+  });
+
+  it("reads legacy plaintext rows written before encryption was enabled", () => {
+    // Write a plaintext row (encryption disabled), then enable encryption.
+    const plainSeq = persistSubstrateEvent(ev("legacy"), null);
+    expect(isEncryptedColumn(rawPayload(plainSeq))).toBe(false);
+
+    enableEncryption();
+    const encSeq = persistSubstrateEvent(ev("modern"), null);
+    expect(isEncryptedColumn(rawPayload(encSeq))).toBe(true);
+
+    // Both the legacy-plaintext and the newly-encrypted row read back correctly.
+    const recovered = getEventsAfterSeq(USER, plainSeq - 1);
+    expect(recovered.map((d) => d.event.entity_id)).toEqual(["legacy", "modern"]);
+  });
+
+  it("still writes plaintext when encryption is disabled (no key)", () => {
+    const seq = persistSubstrateEvent(ev("plain"), null);
+    expect(isEncryptedColumn(rawPayload(seq))).toBe(false);
+    const recovered = getEventsAfterSeq(USER, seq - 1);
+    expect(recovered[0]!.event.entity_id).toBe("plain");
   });
 });


### PR DESCRIPTION
Closes one of the two at-rest encryption gaps flagged by an adopter with a data-sovereignty requirement.

## Problem

Neotoma encrypts the entity tables' sensitive content/metadata columns (AES-256-GCM, via `local_db_adapter`). But the durable substrate-event log (#1482) persists full event payloads to `substrate_events.payload` through the **raw** SQLite client, bypassing that adapter — so the payload was **plaintext on disk even when encryption was enabled**.

## Fix

- `persistSubstrateEvent` encrypts the payload with the same AES-256-GCM data key (exported `getDataKey` from `local_db_adapter` as the single key source); `getEventsAfterSeq` decrypts transparently.
- `isEncryptedColumn` gates decryption, so **legacy plaintext rows and the encryption-disabled case read back unchanged** — enabling encryption never breaks resume of pre-existing events.
- The `event_type` / `entity_id` columns stay plaintext, so the SQL-side subscription narrowing from the #1482 review still works.
- 4 regression tests: ciphertext-on-disk, encrypted round-trip, mixed legacy+encrypted read, plaintext-when-disabled. Full subscriptions suite (59) green.

## The other gap (not fixable the same way)

The vector embedding tables are the other raw-client writer, but they **cannot** be column-encrypted: `sqlite-vec` computes similarity over the raw vectors in the index, so encrypting them breaks semantic search. Those rely on an **encrypted volume** rather than column encryption — an architectural constraint, not unfinished work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)