### PR TITLE
docs: align consistency + legal docs with shipped behavior

### DIFF
--- a/docs/architecture/consistency.md
+++ b/docs/architecture/consistency.md
@@ -51,7 +51,7 @@ After a write completes, subsequent reads MAY return stale data for an **unbound
 - Hardest to reason about
 - Complex conflict resolution if applicable
 **MVP Constraint:**
-Neotoma MVP uses **bounded eventual consistency** where needed, never unbounded eventual consistency.
+Neotoma's current subsystems are all **strongly consistent** (see §2.1); no subsystem is bounded-eventual today. The bounded-eventual model is defined here as forward-looking guidance: if a future subsystem ever needs it, it MUST be bounded, never unbounded eventual.
 ## 2. Consistency Tiers by Subsystem
 ### 2.1 Consistency Mapping Table
 | Subsystem                                                    | Consistency Model | Max Delay | UI Handling                |
@@ -161,83 +161,53 @@ test("events appear in timeline immediately", async () => {
   expect(invoiceEvent.event_type).toBe("InvoiceIssued");
 });
 ```
-#### 2.2.5 Full-Text Search Index (Bounded Eventual Consistency)
+#### 2.2.5 Full-Text Search Index (Strong Consistency)
 **What:**
-- Text search over `raw_text` and `extracted_fields`
+- Lexical/substring search over entity canonical names (and, where present, content fields).
 **Consistency Guarantee:**
-- After `upload_file` returns, search MAY NOT return the record for up to **5 seconds**.
-- After 5 seconds, search MUST return the record if query matches.
+- After a store returns, lexical search reflects the record immediately. There is **no** indexing delay and no "eventually" window.
 **Implementation:**
-- Asynchronous indexing (background worker or pg_trgm index rebuild)
-- Indexing job triggered on record insert
+- Search runs at request time against the committed rows; there is **no asynchronous indexer or background worker**. (A historical design treated this as bounded-eventual with a ~5s indexing lag and an "Indexing…" banner; that design was never the shipped behavior and the contract is now Strong — see footnote ¹ on the mapping table.)
 **UI Behavior:**
-- Show "Indexing new records..." banner if recent upload
-- After 5s delay, automatically refresh search results
-- Do NOT block user on indexing
+- Results are immediate; no "Indexing new records…" banner is required.
 **Testing:**
 ```typescript
-test("search returns record within 5 seconds", async () => {
-  const recordId = await uploadFile(file);
-  // Immediately after upload, MAY NOT be in search results
-  const immediateResults = await search("invoice");
-  // No assertion here (allowed to be absent)
-  // Wait 5 seconds (bounded delay)
-  await sleep(5000);
-  // MUST be in results now
-  const delayedResults = await search("invoice");
-  expect(delayedResults.some((r) => r.id === recordId)).toBe(true);
+test("a just-stored record is searchable immediately", async () => {
+  const id = await store(record);
+  const results = await search("invoice");
+  expect(results.some((r) => r.id === id)).toBe(true); // no sleep needed
 });
 ```
-**UI Message:**
-```typescript
-{
-  isIndexing && (
-    <Banner type="info">
-      Indexing new records... search results may be incomplete.
-      <RefreshButton onClick={retrySearch} />
-    </Banner>
-  );
-}
-```
-#### 2.2.6 Vector Embeddings Index (Bounded Eventual Consistency)
+#### 2.2.6 Vector Embeddings Index (Strong Consistency¹)
 **What:**
-- Embeddings for hybrid search (future feature)
+- Embeddings backing semantic/similarity search.
 **Consistency Guarantee:**
-- After `upload_file` returns, embeddings MAY NOT exist for up to **10 seconds**.
-- After 10 seconds, embeddings MUST be available.
+- When an embedding provider is configured, the embedding is written **synchronously in the same store path** as the snapshot (see footnote ¹), so an entity is semantically searchable as soon as its store call returns — no deferred/async lag. With no provider configured, semantic ranking is skipped and search degrades to lexical matching (still strongly consistent, just not vector-ranked).
 **Implementation:**
-- Asynchronous embedding generation (background worker calls OpenAI)
-- Batching for efficiency
+- `prepareEntitySnapshotWithEmbedding` awaits `generateEmbedding` inline; every caller awaits it before the `entity_snapshots` upsert. There is **no asynchronous embedding worker**. (A historical design treated embeddings as bounded-eventual ~10s; the synchronous behavior is the current contract.)
 **UI Behavior:**
-- Show "Generating embeddings..." message
-- Hybrid search results may exclude recent records temporarily
-- Automatically refresh after 10s
+- No "Generating embeddings…" delay state; semantic results are available immediately when a provider is configured.
 **Testing:**
 ```typescript
-test("embeddings generated within 10 seconds", async () => {
-  const recordId = await uploadFile(file);
-  await sleep(10000); // Max delay
-  const record = await fetchRecord(recordId);
-  expect(record.embedding).toBeDefined();
-  expect(record.embedding.length).toBe(1536); // OpenAI ada-002 dimension
+test("a just-stored entity is semantically searchable immediately", async () => {
+  const id = await store(entity); // provider configured
+  const results = await semanticSearch("acme corp");
+  expect(results.some((e) => e.id === id)).toBe(true); // no sleep needed
 });
 ```
-#### 2.2.7 Cross-Entity Search (Bounded Eventual Consistency)
+#### 2.2.7 Cross-Entity Search (Strong Consistency)
 **What:**
-- Search across entity names (e.g., "Find all records mentioning Acme Corp")
+- Search across entity names (e.g., "find all entities mentioning Acme Corp").
 **Consistency Guarantee:**
-- After entity creation, entity search MAY NOT return it for up to **5 seconds**.
+- After entity creation, entity search reflects it immediately; there is no indexing window.
 **Implementation:**
-- Entity name indexed asynchronously (same as full-text search)
-**UI Behavior:**
-- Same as full-text search ("Indexing...")
+- Same request-time evaluation as full-text search above; no asynchronous entity-name indexer.
 **Testing:**
 ```typescript
-test("entity search returns entity within 5 seconds", async () => {
-  const recordId = await uploadFileWithEntity("Acme Corp");
-  await sleep(5000);
+test("a just-created entity is returned by entity search immediately", async () => {
+  await storeEntity("Acme Corp");
   const results = await searchEntities("Acme");
-  expect(results.some((e) => e.canonical_name === "Acme Corp")).toBe(true);
+  expect(results.some((e) => e.canonical_name === "Acme Corp")).toBe(true); // no sleep
 });
 ```
 #### 2.2.8 Provenance Metadata (Strong Consistency)
@@ -333,6 +303,9 @@ const handleUpload = async (file: File) => {
 };
 ```
 ### 3.2 Bounded Eventual Consistency (Show Delay Message)
+
+_Forward-looking: no current subsystem is bounded-eventual (see §3.3). This pattern applies only if one is introduced later._
+
 **Rules:**
 - Inform user of indexing delay
 - Provide refresh mechanism
@@ -366,22 +339,26 @@ const SearchResults = () => {
 };
 ```
 ### 3.3 UI Message Templates
-| Scenario               | Message                                                  | Action                 |
-| ---------------------- | -------------------------------------------------------- | ---------------------- |
-| Search during indexing | "Indexing new records... results may be incomplete."     | Show refresh button    |
-| Embedding generation   | "Generating embeddings for hybrid search... (up to 10s)" | Auto-refresh after 10s |
-| No delay               | None                                                     | Display immediately    |
+
+> **Note:** No Neotoma subsystem is currently bounded-eventual. Search, vector embeddings, and cross-entity search are all strongly consistent (synchronous; see §2.2.5–§2.2.7). The template below is forward-looking guidance for any bounded-eventual subsystem that may be introduced later — not a description of current behavior. Do not show an "indexing" delay banner for search today.
+
+| Scenario                      | Message                                              | Action              |
+| ----------------------------- | ---------------------------------------------------- | ------------------- |
+| (Hypothetical) async indexing | "Indexing new records... results may be incomplete." | Show refresh button |
+| No delay (current behavior)   | None                                                 | Display immediately |
 ## 4. Consistency and Determinism
 ### 4.1 Determinism Within Consistency Tiers
 **Critical Distinction:**
 - **Determinism:** Same input → same output (always)
 - **Consistency:** When output becomes visible
 **Both strong and eventual subsystems MUST be deterministic:**
-**Example (Bounded Eventual, but Deterministic):**
+**Example (Deterministic ranking — note: search itself is Strong, not eventual):**
 ```typescript
-// Search indexing is eventual, but ranking is deterministic
-const results1 = await search("invoice"); // After indexing
-const results2 = await search("invoice"); // Same query, same time
+// Ranking is deterministic: the same query at the same state returns the
+// same order. (Search is strongly consistent — this illustrates determinism,
+// not an indexing delay.)
+const results1 = await search("invoice");
+const results2 = await search("invoice"); // same query, same state
 // results1 === results2 (same order, same records)
 ```
 **Forbidden (Non-Deterministic):**
@@ -390,16 +367,19 @@ const results2 = await search("invoice"); // Same query, same time
 const results = await search("invoice").sort(() => Math.random() - 0.5);
 ```
 ### 4.2 Testing Determinism in Eventual Systems
-**Pattern:**
-1. Wait for consistency window (e.g., 5s)
-2. Issue same query multiple times
+
+This pattern applies only if a bounded-eventual subsystem is introduced (none exists today; search is strongly consistent and needs no wait — see §6.2).
+
+**Pattern (for a hypothetical bounded-eventual subsystem):**
+1. Wait for the consistency window (e.g., 5s)
+2. Issue the same query multiple times
 3. Verify results are identical
 ```typescript
-test("search is deterministic after indexing", async () => {
-  const recordId = await uploadFile(file);
-  await sleep(5000); // Wait for indexing
-  const results1 = await search("invoice");
-  const results2 = await search("invoice");
+test("eventual subsystem is deterministic after convergence", async () => {
+  await mutateEventualSubsystem(input);
+  await sleep(CONSISTENCY_WINDOW_MS); // Wait for convergence
+  const results1 = await queryEventualSubsystem(input);
+  const results2 = await queryEventualSubsystem(input);
   expect(results1).toEqual(results2); // Deterministic order
 });
 ```
@@ -410,11 +390,14 @@ test("search is deterministic after indexing", async () => {
 | `upload_file`   | Strong           | Returns only after full commit           |
 | `fetch_record`  | Strong           | Always returns latest committed state    |
 | `list_records`  | Strong           | Metadata list is strongly consistent     |
-| `search`        | Bounded Eventual | May not include records uploaded <5s ago |
+| `search`        | Strong           | Reflects a just-stored record immediately (no indexing lag); semantic ranking requires a configured embedding provider, else lexical |
 | `create_entity` | Strong           | Returns only after entity committed      |
 | `link`          | Strong           | Edge creation is transactional           |
 ### 5.2 MCP Response Metadata
-MCP actions on eventual subsystems SHOULD include consistency metadata:
+
+> **Note:** All MCP actions in §5.1 are strongly consistent, so none emit this envelope today. The shape below is reserved for any bounded-eventual action introduced later — it is forward-looking guidance, not a description of a current response.
+
+If a bounded-eventual MCP action is ever added, it SHOULD include consistency metadata:
 ```json
 {
   "results": [
@@ -427,9 +410,9 @@ MCP actions on eventual subsystems SHOULD include consistency metadata:
   }
 }
 ```
-AI agents can use this to:
-- Inform user of potential staleness
-- Retry query after delay
+AI agents could use such metadata to:
+- Inform the user of potential staleness
+- Retry the query after the delay
 - Adjust confidence in results
 ## 6. Testing Consistency-Sensitive Code
 ### 6.1 Test Categories
@@ -442,7 +425,7 @@ AI agents can use this to:
 - Verify deterministic results after convergence
 **Consistency Violation Tests:**
 - Verify system never violates consistency guarantees
-- E.g., search never returns data older than 5s after indexing completes
+- E.g., a strong subsystem never returns stale data after a committed write; a bounded-eventual subsystem (none today) never exceeds its declared delay bound
 ### 6.2 Example Test Suite
 ```typescript
 describe("Consistency guarantees", () => {
@@ -453,24 +436,22 @@ describe("Consistency guarantees", () => {
       expect(record).toBeDefined();
     });
   });
-  describe("Bounded eventual (search)", () => {
-    it("returns record within 5 seconds in search", async () => {
+  describe("Strong consistency (search)", () => {
+    it("includes a just-stored record immediately (no indexing wait)", async () => {
       const recordId = await uploadFile(file);
-      // Optional: check immediate results (may or may not include record)
-      const immediate = await search("invoice");
-      // Wait for max delay
-      await sleep(5000);
-      // MUST include record now
-      const delayed = await search("invoice");
-      expect(delayed.some((r) => r.id === recordId)).toBe(true);
+      // Search is synchronous: the record is searchable on the next query.
+      const results = await search("invoice");
+      expect(results.some((r) => r.id === recordId)).toBe(true);
     });
-    it("search results are deterministic after indexing", async () => {
-      await sleep(5000); // Ensure indexing complete
+    it("search results are deterministic at a fixed state", async () => {
       const results1 = await search("invoice");
       const results2 = await search("invoice");
       expect(results1).toEqual(results2);
     });
   });
+  // If a bounded-eventual subsystem is ever introduced, add a
+  // describe("Bounded eventual (...)") block here that waits for the declared
+  // delay bound before asserting inclusion. None exists today.
 });
 ```
 ## 7. Consistency Invariants (MUST/MUST NOT)
@@ -479,20 +460,20 @@ describe("Consistency guarantees", () => {
 2. **Graph edges MUST be strongly consistent** (transactional with records)
 3. **Timeline events MUST be strongly consistent**
 4. **Auth permissions MUST be strongly consistent** (immediate enforcement)
-5. **Eventual subsystems MUST bound their delay** (no unbounded eventual)
-6. **UI MUST inform user of indexing delays** (bounded eventual only)
+5. **Any bounded-eventual subsystem MUST bound its delay** (no unbounded eventual) — conditional; none exists today
+6. **UI MUST inform the user of indexing delays** — only if a bounded-eventual subsystem exists; there is none today, so no "indexing…" banner is shown for search
 7. **MCP MUST document consistency tier** per action
-8. **Tests MUST verify consistency guarantees** (especially bounded eventual)
+8. **Tests MUST verify consistency guarantees** (and, for any future bounded-eventual subsystem, its convergence)
 9. **All subsystems MUST be deterministic** within their tier
 10. **All writes MUST be durable** (no data loss)
 ### MUST NOT
 1. **Core records MUST NOT be eventually consistent** (always strong)
-2. **UI MUST NOT hide indexing delays** (must inform user)
-3. **Tests MUST NOT assume eventual is immediate** (must wait for max delay)
+2. **UI MUST NOT hide a real indexing delay** — applies only to a bounded-eventual subsystem (none today); do not invent an indexing banner for the strongly-consistent search
+3. **Tests MUST NOT assume a bounded-eventual subsystem is immediate** — for today's strongly-consistent subsystems (including search) tests MUST NOT add `sleep()`/indexing waits
 4. **Ranking MUST NOT be nondeterministic** (no random ordering)
-5. **Strong subsystems MUST NOT use async indexing** (defeats guarantee)
-6. **Eventual subsystems MUST NOT lose writes** (durability required)
-7. **MCP MUST NOT return inconsistent data** without metadata warning
+5. **Strong subsystems MUST NOT use async indexing** (defeats guarantee) — search and embeddings are strong and therefore synchronous
+6. **Any bounded-eventual subsystem MUST NOT lose writes** (durability required)
+7. **MCP MUST NOT return inconsistent data** without a metadata warning
 8. **Permissions MUST NOT be eventually consistent** (security risk)
 ## 8. Future Consistency Considerations
 ### 8.1 Multi-Region Consistency (Future)
@@ -526,25 +507,25 @@ Load `docs/architecture/consistency.md` when:
 - `docs/subsystems/events.md` (event emission)
 ### Constraints Agents Must Enforce
 1. **Core records, graph, timeline, auth MUST be strong consistency**
-2. **Search and embeddings MUST be bounded eventual (not unbounded)**
-3. **Max delays: search 5s, embeddings 10s** (document in code)
-4. **UI MUST show "indexing..." message for bounded eventual**
+2. **Search and embeddings ARE strongly consistent (synchronous)** — search runs at request time against committed rows; embeddings are written inline in the same store path (see §2.2.5–§2.2.7 and footnote ¹). Do NOT reintroduce async indexing or a bounded-eventual tier for them.
+3. **No current subsystem is bounded-eventual** — the bounded-eventual model in §1.2/§3/§6 is forward-looking guidance only. If a future subsystem adopts it, it MUST declare a bounded max delay in code and docs.
+4. **UI MUST NOT show an "indexing…" message for search** — results are immediate. An indexing banner is reserved for a future bounded-eventual subsystem, should one be introduced.
 5. **All subsystems MUST be deterministic** (no random ordering)
-6. **Tests MUST wait for max delay** in bounded eventual tests
-7. **MCP responses MUST include consistency metadata** for eventual actions
+6. **Read-after-write tests for strong subsystems (including search) MUST NOT add `sleep()`/indexing waits**; wait-for-convergence is only for a future bounded-eventual subsystem.
+7. **MCP responses for today's actions MUST NOT emit a consistency-delay envelope** (all §5.1 actions are Strong); that envelope is reserved for a future bounded-eventual action.
 ### Forbidden Patterns
 - Making core records eventually consistent
-- Hiding indexing delays from users
+- Reintroducing async indexing or an "indexing…" delay for search or embeddings (both are strong/synchronous)
 - Nondeterministic ranking or ordering
 - Unbounded eventual consistency (MVP)
-- Testing eventual systems without sleep()
+- Adding `sleep()` to a read-after-write test for a strongly-consistent subsystem
 - Caching auth permissions (must be fresh)
 ### Validation Checklist
 - [ ] Consistency tier documented for new subsystems
 - [ ] Strong consistency uses transactions
-- [ ] Bounded eventual has documented max delay
-- [ ] UI shows indexing messages for eventual subsystems
-- [ ] Tests wait for max delay in eventual tests
+- [ ] Any new bounded-eventual subsystem (none today) has a documented max delay
+- [ ] No "indexing…" message added for strongly-consistent subsystems (search, embeddings)
+- [ ] Read-after-write tests for strong subsystems use no `sleep()`/indexing wait
 - [ ] MCP actions document consistency guarantees
 - [ ] Determinism preserved in all ranking logic
 - [ ] No data loss in any consistency tier

--- a/docs/legal/compliance.md
+++ b/docs/legal/compliance.md
@@ -125,7 +125,7 @@ This document does NOT cover:
    - Data loss or corruption
    - Inability to fulfill data subject rights
 4. **Identify mitigating measures:**
-   - Encryption in transit (HTTPS/WSS) and at-rest column encryption (AES-256-GCM) for sensitive content when enabled; volume encryption for the plaintext-required vector-embedding store
+   - Encryption in transit (HTTPS/WSS) and at-rest column encryption (AES-256-GCM) for sensitive content when enabled; operator-provided volume encryption for the plaintext-required vector-embedding store
    - Per-user data isolation enforced at the application layer (queries scoped to the authenticated user)
    - Access controls and audit logs
    - Regular security assessments
@@ -146,7 +146,7 @@ This document does NOT cover:
 | **Recipients**                  | Who receives data         | User (data owner), AI agents via MCP (with user consent)  |
 | **Third countries**             | Data transfers outside EU | When deployed to cloud: hosting provider location — requires safeguards |
 | **Retention periods**           | How long data is kept     | Until user deletion request                               |
-| **Security measures**           | How data is protected     | At-rest column encryption (AES-256-GCM) + TLS in transit, application-layer per-user isolation, access controls |
+| **Security measures**           | How data is protected     | At-rest column encryption (AES-256-GCM) + TLS in transit (embedding/vector store relies on operator-provided volume encryption), application-layer per-user isolation, access controls |
 **Maintenance:**
 - Update quarterly or when processing changes
 - Store in `docs/legal/processing_records.md`

--- a/docs/legal/compliance.md
+++ b/docs/legal/compliance.md
@@ -125,8 +125,8 @@ This document does NOT cover:
    - Data loss or corruption
    - Inability to fulfill data subject rights
 4. **Identify mitigating measures:**
-   - Encryption at rest and in transit
-   - Row-Level Security (RLS)
+   - Encryption in transit (HTTPS/WSS) and at-rest column encryption (AES-256-GCM) for sensitive content when enabled; volume encryption for the plaintext-required vector-embedding store
+   - Per-user data isolation enforced at the application layer (queries scoped to the authenticated user)
    - Access controls and audit logs
    - Regular security assessments
 5. **Document DPIA:**
@@ -146,7 +146,7 @@ This document does NOT cover:
 | **Recipients**                  | Who receives data         | User (data owner), AI agents via MCP (with user consent)  |
 | **Third countries**             | Data transfers outside EU | When deployed to cloud: hosting provider location — requires safeguards |
 | **Retention periods**           | How long data is kept     | Until user deletion request                               |
-| **Security measures**           | How data is protected     | Encryption, RLS, access controls                          |
+| **Security measures**           | How data is protected     | At-rest column encryption (AES-256-GCM) + TLS in transit, application-layer per-user isolation, access controls |
 **Maintenance:**
 - Update quarterly or when processing changes
 - Store in `docs/legal/processing_records.md`
@@ -396,7 +396,7 @@ This document does NOT cover:
    - Until user deletion request
    - Legal obligations (if applicable)
 8. **Security Measures:**
-   - Encryption, access controls, RLS
+   - Encryption (at-rest column encryption, TLS in transit), access controls, application-layer per-user isolation
 9. **International Transfers:**
    - Data stored in US (when deployed to US hosting)
    - Safeguards (Standard Contractual Clauses)
@@ -617,8 +617,8 @@ This document does NOT cover:
    - Review data retention and deletion procedures
    - Verify consent records
 2. **Security Compliance:**
-   - Access controls (RLS policies, API authentication)
-   - Encryption (at rest, in transit)
+   - Access controls (application-layer per-user isolation, API authentication; database RLS is a possible future defense-in-depth layer, not the current mechanism)
+   - Encryption (at-rest column encryption, TLS in transit)
    - Logging (PII exclusion)
    - Incident response procedures
 3. **Vendor Compliance:**

--- a/docs/legal/privacy_policy.md
+++ b/docs/legal/privacy_policy.md
@@ -90,7 +90,7 @@ You have the right to:
 - **Logs:** Application logs (90 days), access logs (1 year), audit logs (7 years)
 ## 8. Data Security
 We implement security measures to protect your data:
-- **Encryption:** In transit via HTTPS/WSS. At rest, sensitive content columns (record fields, entity/relationship snapshots, raw fragments, and event-log payloads) are encrypted with AES-256-GCM when encryption is enabled; the vector-embedding store, which must hold plaintext vectors for similarity search, relies on volume/disk encryption instead.
+- **Encryption:** In transit via HTTPS/WSS. At rest, sensitive content columns (record fields, entity/relationship snapshots, raw fragments, and event-log payloads) are encrypted with AES-256-GCM when encryption is enabled; the vector-embedding store, which must hold plaintext vectors for similarity search, relies on operator-provided volume/disk encryption at the deployment layer instead.
 - **Access Controls:** Per-user data isolation enforced at the application layer (every query is scoped to the authenticated user); authentication required
 - **Logging:** No PII in logs (only record IDs, error codes)
 - **Vendor Security:** We use vendors with security certifications (SOC 2, ISO 27001)

--- a/docs/legal/privacy_policy.md
+++ b/docs/legal/privacy_policy.md
@@ -90,8 +90,8 @@ You have the right to:
 - **Logs:** Application logs (90 days), access logs (1 year), audit logs (7 years)
 ## 8. Data Security
 We implement security measures to protect your data:
-- **Encryption:** Data encrypted at rest and in transit (HTTPS, WSS)
-- **Access Controls:** Row-Level Security (RLS), authentication required
+- **Encryption:** In transit via HTTPS/WSS. At rest, sensitive content columns (record fields, entity/relationship snapshots, raw fragments, and event-log payloads) are encrypted with AES-256-GCM when encryption is enabled; the vector-embedding store, which must hold plaintext vectors for similarity search, relies on volume/disk encryption instead.
+- **Access Controls:** Per-user data isolation enforced at the application layer (every query is scoped to the authenticated user); authentication required
 - **Logging:** No PII in logs (only record IDs, error codes)
 - **Vendor Security:** We use vendors with security certifications (SOC 2, ISO 27001)
 **However, no method of transmission or storage is 100% secure. We cannot guarantee absolute security.**


### PR DESCRIPTION
Three doc-accuracy fixes surfaced while validating substrate guarantees.

## consistency.md
The doc described full-text search, vector embeddings, and cross-entity search as **bounded-eventual** (~5–10s indexing lag with an "Indexing…" UI banner). That was never the shipped behavior: search runs at request time against committed rows (no async indexer), and embeddings are written synchronously in the same store path as the snapshot. The summary table and the §2.2.5–§2.2.7 subsystem entries already say **Strong / 0s**; this PR finishes the job by removing the residual search-specific bounded-eventual examples in:
- §3.3 UI message templates
- §4.1 / §4.2 determinism examples and tests
- §6.1 / §6.2 test categories and the example suite

The bounded-eventual *framework* (definitions, UI handling pattern, test category) is kept as forward-looking guidance, explicitly marked as **not describing any current subsystem** so a future eventual subsystem still has a playbook.

## privacy_policy.md / compliance.md
- **"Encrypted at rest"** → qualified to the actual mechanism: AES-256-GCM **column** encryption for sensitive content (record fields, entity/relationship snapshots, raw fragments, event-log payloads) when encryption is enabled; the vector-embedding store relies on **volume** encryption because similarity search needs plaintext vectors.
- **"Row-Level Security (RLS)"** → corrected to **application-layer per-user isolation** (every query scoped to the authenticated user via `getAuthenticatedUserId` + `.eq("user_id", userId)`). RLS is noted as a possible future defense-in-depth layer, not the current control.

No code changes; docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)