### PR TITLE
fix(http): restore GET /entities/:id/html guest route for rendered pages

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -2733,7 +2733,7 @@ export function routeAcceptsGuestPrincipal(req: Pick<express.Request, "method" |
         path === "/list_subscriptions" ||
         path === "/get_subscription_status")) ||
     (req.method === "GET" &&
-      (/^\/entities\/[^/]+(?:\/(?:observations|relationships))?$/.test(path) ||
+      (/^\/entities\/[^/]+(?:\/(?:observations|relationships|html))?$/.test(path) ||
         path === "/events/stream"))
   ) {
     return true;
@@ -3654,6 +3654,68 @@ app.get("/entities/:id/markdown", async (req, res) => {
     }
     logError("APIError:entity_markdown", req, error);
     const message = error instanceof Error ? error.message : "Failed to render entity markdown";
+    return sendError(res, 500, "DB_QUERY_FAILED", message);
+  }
+});
+
+// GET /entities/:id/html - Render a `rendered_page` entity as a standalone HTML
+// page. Accepts ?access_token=<guest_token> for unauthenticated (guest) reads;
+// authenticated users may omit it. 404s for any entity_type other than
+// `rendered_page` so the publish surface stays explicit.
+app.get("/entities/:id/html", async (req, res) => {
+  try {
+    const entityId = req.params.id;
+    const principal = await resolveRoutePrincipal(req, ["user", "guest"]);
+
+    if (principal.kind === "guest") {
+      await resolveGuestScopedEntityAccess(principal, entityId);
+    } else {
+      const userId = await getAuthenticatedUserId(req, req.query.user_id as string | undefined);
+      const { data: entity, error: entityError } = await db
+        .from("entities")
+        .select("id, user_id, entity_type")
+        .eq("id", entityId)
+        .eq("user_id", userId)
+        .single();
+      if (entityError || !entity) {
+        return sendError(res, 404, "RESOURCE_NOT_FOUND", "Entity not found");
+      }
+    }
+
+    const { getEntityWithProvenance } = await import("./services/entity_queries.js");
+    const current = await getEntityWithProvenance(entityId);
+    if (!current) {
+      return sendError(res, 404, "RESOURCE_NOT_FOUND", "Entity not found");
+    }
+    if (current.entity_type !== "rendered_page") {
+      return sendError(res, 404, "RESOURCE_NOT_FOUND", "Entity is not a rendered_page");
+    }
+
+    const snap = (current.snapshot ?? {}) as Record<string, unknown>;
+    const title = typeof snap.title === "string" ? snap.title : "Untitled";
+    const htmlBody = typeof snap.html_body === "string" ? snap.html_body : "";
+    const metaDescription =
+      typeof snap.meta_description === "string" ? snap.meta_description : undefined;
+    const customCss = typeof snap.custom_css === "string" ? snap.custom_css : undefined;
+
+    const { renderRenderedPageHtml } = await import("./services/rendered_page/html_template.js");
+    const html = renderRenderedPageHtml({ title, htmlBody, metaDescription, customCss });
+
+    const etag = current.last_observation_at
+      ? `W/"${Buffer.from(current.last_observation_at).toString("base64")}"`
+      : undefined;
+    if (etag) res.setHeader("ETag", etag);
+    res.setHeader("Content-Type", "text/html; charset=utf-8");
+    return res.send(html);
+  } catch (error) {
+    if (error instanceof Error && error.message.includes("Not authenticated")) {
+      return sendError(res, 401, "AUTH_REQUIRED", "Missing Bearer token", {
+        hint: "AAuth-signed agents can authenticate without Bearer once an active agent_grant matches their identity. Create a grant via Inspector → Agents → Grants.",
+        sandbox: { available: false },
+      });
+    }
+    logError("APIError:entity_html", req, error);
+    const message = error instanceof Error ? error.message : "Failed to render entity HTML";
     return sendError(res, 500, "DB_QUERY_FAILED", message);
   }
 });

--- a/src/services/rendered_page/html_template.ts
+++ b/src/services/rendered_page/html_template.ts
@@ -1,0 +1,95 @@
+/**
+ * Minimal HTML page template for serving `rendered_page` entities via
+ * GET /entities/:id/html.
+ *
+ * Deliberately not reusing src/services/root_landing/html_template.ts —
+ * that one is the landing-page renderer and embeds landing-specific context.
+ * This is a generic shell suitable for any rendered_page.
+ *
+ * `htmlBody` is inserted verbatim (NOT escaped). `title`, `metaDescription`,
+ * and `customCss` are sanitized as described inline.
+ */
+
+export interface RenderedPageHtmlInput {
+  title: string;
+  htmlBody: string;
+  metaDescription?: string;
+  customCss?: string;
+}
+
+const DEFAULT_STYLES = `
+*, *::before, *::after { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  font-size: 17px;
+  line-height: 1.6;
+  color: #1a1a1a;
+  background: #fafafa;
+  padding: 2.5rem 1.25rem 4rem;
+}
+main { max-width: 720px; margin: 0 auto; }
+h1, h2, h3, h4 { line-height: 1.25; margin-top: 2rem; margin-bottom: 0.75rem; }
+h1 { font-size: 2.1rem; margin-top: 0; }
+h2 { font-size: 1.5rem; }
+h3 { font-size: 1.2rem; }
+p { margin: 0 0 1rem; }
+a { color: #0b66c2; text-decoration: underline; text-underline-offset: 2px; }
+a:hover { color: #064a8a; }
+code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 0.92em; background: #efeae3; padding: 0.1em 0.35em; border-radius: 3px; }
+pre { background: #1a1a1a; color: #f4f1ec; padding: 1rem 1.1rem; border-radius: 6px; overflow-x: auto; }
+pre code { background: transparent; color: inherit; padding: 0; }
+blockquote { border-left: 3px solid #d4ccc2; margin: 1rem 0; padding: 0.3rem 0 0.3rem 1rem; color: #555; }
+hr { border: none; border-top: 1px solid #e3ddd2; margin: 2rem 0; }
+ul, ol { margin: 0 0 1rem 0; padding-left: 1.5rem; }
+li { margin-bottom: 0.35rem; }
+img { max-width: 100%; height: auto; }
+table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+th, td { text-align: left; padding: 0.5rem 0.75rem; border-bottom: 1px solid #e3ddd2; }
+th { background: #f4f1ec; font-weight: 600; }
+.footer-meta { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid #e3ddd2; font-size: 0.85rem; color: #777; }
+`;
+
+function escapeHtmlAttribute(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+/**
+ * Conservative CSS sanitizer: blocks `</style>` (which would close the inline
+ * style tag and let arbitrary HTML follow) and `<` more broadly. Authors are
+ * trusted but we still strip the one escape vector that breaks the page shell.
+ */
+function sanitizeCss(css: string): string {
+  return css.replace(/<\/?\s*style/gi, "");
+}
+
+export function renderRenderedPageHtml(input: RenderedPageHtmlInput): string {
+  const title = escapeHtmlAttribute(input.title);
+  const metaDescription = input.metaDescription ? escapeHtmlAttribute(input.metaDescription) : "";
+  const customCss = input.customCss ? sanitizeCss(input.customCss) : "";
+
+  const metaTag = metaDescription ? `<meta name="description" content="${metaDescription}">` : "";
+  const customStyleTag = customCss ? `<style>${customCss}</style>` : "";
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${title}</title>
+${metaTag}
+<style>${DEFAULT_STYLES}</style>
+${customStyleTag}
+</head>
+<body>
+<main>
+${input.htmlBody}
+</main>
+</body>
+</html>`;
+}

--- a/src/services/rendered_page/seed_schema.ts
+++ b/src/services/rendered_page/seed_schema.ts
@@ -1,0 +1,155 @@
+/**
+ * Seed the `rendered_page` entity schema.
+ *
+ * A `rendered_page` carries a bespoke HTML expression of something. It is
+ * intentionally distinct from the entity (or entities) it discusses: the
+ * `rendered_page` holds presentation, and `REFERS_TO` relationships link it
+ * to the data entities it describes. Keeping presentation separate from data
+ * prevents `source` (evidence) and presentation from colliding, and prevents
+ * every entity type from growing presentation fields it does not need.
+ *
+ * Served via `GET /entities/:id/html` (paired with this schema in actions.ts).
+ * That route 404s for any entity type other than `rendered_page`, keeping the
+ * publish surface explicit.
+ *
+ * Registered as a GLOBAL schema. Idempotent boot-time registration.
+ */
+
+import type {
+  FieldDefinition,
+  ReducerConfig,
+  SchemaDefinition,
+  SchemaRegistryEntry,
+} from "../schema_registry.js";
+import { SchemaRegistryService } from "../schema_registry.js";
+
+export const RENDERED_PAGE_ENTITY_TYPE = "rendered_page";
+
+type FieldSpec = Array<{
+  name: string;
+  type: FieldDefinition["type"];
+  required?: boolean;
+  reducer?: "last_write" | "highest_priority" | "most_specific" | "merge_array";
+  description?: string;
+}>;
+
+const RENDERED_PAGE_FIELDS: FieldSpec = [
+  {
+    name: "title",
+    type: "string",
+    required: true,
+    description: "Page title; rendered into <title> and the <h1> if no html_body header overrides",
+  },
+  {
+    name: "html_body",
+    type: "string",
+    required: true,
+    description:
+      "Body HTML injected verbatim into <body>. Do not include <html>/<head>/<body> wrappers — the server wraps this in a minimal template. Not escaped on render.",
+  },
+  {
+    name: "meta_description",
+    type: "string",
+    description: "Optional <meta name=description> value; escaped on render",
+  },
+  {
+    name: "slug",
+    type: "string",
+    description: "Optional URL-safe identifier; reserved for future pretty-URL routing (/p/<slug>)",
+  },
+  {
+    name: "custom_css",
+    type: "string",
+    description: "Optional CSS injected as an inline <style> tag in <head>",
+  },
+  {
+    name: "created_at",
+    type: "date",
+    description: "Page creation timestamp",
+  },
+];
+
+function buildSchemaDefinition(): SchemaDefinition {
+  const fields: Record<string, FieldDefinition> = {
+    schema_version: { type: "string", required: true },
+  };
+  for (const spec of RENDERED_PAGE_FIELDS) {
+    fields[spec.name] = {
+      type: spec.type,
+      required: spec.required === true,
+      ...(spec.description ? { description: spec.description } : {}),
+    };
+  }
+  return {
+    fields,
+    canonical_name_fields: ["slug", "title"],
+    temporal_fields: [{ field: "created_at", event_type: "rendered_page_created" }],
+  };
+}
+
+function buildReducerConfig(): ReducerConfig {
+  const merge_policies: ReducerConfig["merge_policies"] = {
+    schema_version: { strategy: "last_write" },
+  };
+  for (const spec of RENDERED_PAGE_FIELDS) {
+    merge_policies[spec.name] = { strategy: spec.reducer ?? "last_write" };
+  }
+  return { merge_policies };
+}
+
+export async function seedRenderedPageSchema(options?: {
+  registry?: SchemaRegistryService;
+}): Promise<SchemaRegistryEntry> {
+  const registry = options?.registry ?? new SchemaRegistryService();
+  const existing = await registry.loadGlobalSchema(RENDERED_PAGE_ENTITY_TYPE);
+
+  const definition = buildSchemaDefinition();
+  const reducerConfig = buildReducerConfig();
+
+  if (!existing) {
+    return await registry.register({
+      entity_type: RENDERED_PAGE_ENTITY_TYPE,
+      schema_version: "1.0",
+      schema_definition: definition,
+      reducer_config: reducerConfig,
+      user_specific: false,
+      activate: true,
+      metadata: {
+        label: "Rendered page",
+        description:
+          "A bespoke HTML expression of something — proposal pages, public memos, shareable narratives. Distinct from the data entities it describes; uses REFERS_TO to link them. Served via GET /entities/:id/html.",
+        category: "knowledge",
+        // submitter_scoped lets a guest read a specific rendered_page when they
+        // present a guest_access_token bound to that page's entity_id. This is
+        // the standard pattern for "publish one entity at a stable URL" —
+        // matches how /entities/:id already permits guest reads of issues.
+        guest_access_policy: "submitter_scoped",
+      },
+    });
+  }
+
+  const existingFieldNames = new Set(Object.keys(existing.schema_definition.fields ?? {}));
+  const missing = RENDERED_PAGE_FIELDS.filter((spec) => !existingFieldNames.has(spec.name));
+  if (missing.length === 0) return existing;
+
+  return await registry.updateSchemaIncremental({
+    entity_type: RENDERED_PAGE_ENTITY_TYPE,
+    fields_to_add: missing.map((spec) => ({
+      field_name: spec.name,
+      field_type: spec.type,
+      required: spec.required === true,
+      reducer_strategy: spec.reducer ?? "last_write",
+    })),
+    user_specific: false,
+    activate: true,
+    migrate_existing: true,
+  });
+}
+
+export const RENDERED_PAGE_FIELD_SPECS: ReadonlyArray<{
+  name: string;
+  type: FieldDefinition["type"];
+  required?: boolean;
+  reducer?: "last_write" | "highest_priority" | "most_specific" | "merge_array";
+  description?: string;
+}> = RENDERED_PAGE_FIELDS;


### PR DESCRIPTION
## Problem

`GET /entities/:id/html?access_token=<uuid>` returns **401 AUTH_REQUIRED** on prod (v0.15.0) for `rendered_page` entities, even with a valid guest access token. The guest token is ignored and the request falls through to the Bearer/agent-grant auth wall, so shareable rendered-page links do not load for recipients.

## Root cause

The route handler and its supporting service files were implemented earlier but stranded on the stale branch `feat/inspector-bundled-mount-cursor-handoff` and **never merged to `main`**. `origin/main` is missing both:

- the `app.get("/entities/:id/html", ...)` handler, and
- the `routeAcceptsGuestPrincipal` allowlist extension that permits guest principals on the `html` sub-path, and
- the `src/services/rendered_page/` service files the handler imports.

## Fix

Cherry-picks the two stranded commits cleanly onto `main`:

- `264697c16` — adds `src/services/rendered_page/html_template.ts` + `seed_schema.ts` (net-new).
- `7405f0333` — adds the `GET /entities/:id/html` handler (resolves the guest token, enforces `entity_type === "rendered_page"`, renders via `renderRenderedPageHtml()`) and extends the guest-principal regex to `^\/entities\/[^/]+(?:\/(?:observations|relationships|html))?$`.

3 files changed, +313/-1. No conflicts on cherry-pick (actions.ts auto-merged).

## Verification

- `grep 'entities/:id/html' src/actions.ts` → handler at line 3665
- regex at line 2736 includes `html`
- `renderRenderedPageHtml` import wired via dynamic import
- both service files present

## Impact

Unblocks shareable `rendered_page` links (e.g. follow-up pages shared by access-token URL). Needs deploy to prod to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)