### PR TITLE
docs(relationships): document pagination ordering invariant (#368 follow-up)

### DIFF
--- a/docs/subsystems/relationships.md
+++ b/docs/subsystems/relationships.md
@@ -247,6 +247,25 @@ async function getRelatedEntities(
 }
 ```
 
+### 5.3 Pagination Ordering
+
+Relationship list and graph endpoints MUST order results by `last_observation_at DESC, relationship_key ASC`.
+
+- **Primary sort:** `last_observation_at DESC` (most recently observed relationships first) — the business-meaningful field.
+- **Tiebreaker:** `relationship_key ASC`. `relationship_key` is the `relationship_snapshots` PRIMARY KEY (stable and unique), so it is a deterministic tiebreaker. Two relationships sharing the same `last_observation_at` always paginate in the same order across executions.
+
+Without a unique tiebreaker, rows with equal `last_observation_at` order arbitrarily, which makes pagination nondeterministic (a row can repeat or be skipped across pages). This follows the tiebreaker rule in [`docs/architecture/determinism.md`](../architecture/determinism.md) (§3.2 Deterministic Sorting): primary sort on a business-meaningful field, secondary sort on a unique stable field.
+
+**Applies to:**
+- `/list_relationships` (MCP)
+- `/retrieve_graph_neighborhood` (MCP)
+- `GET /relationships` (HTTP)
+- `relationships.ts` service methods `getRelationshipsForEntity` and `getRelationshipsByType` (per PR #1500)
+
+Any new paginated relationship query MUST use this ordering rather than reintroducing an order that lacks a unique tiebreaker.
+
+**Origin:** issue #368 / PR #1491, which fixed nondeterministic relationship pagination.
+
 ## 6. Relationship Observations and Snapshots
 
 ### 6.1 Creating Relationship Observations


### PR DESCRIPTION
## Summary

Documents the relationship pagination ordering invariant established by merged PR #1491 (which fixed issue #368). This is the documentation follow-up requested in that PR's review: the next contributor adding a paginated relationship query should mimic the invariant instead of reintroducing the nondeterminism.

Adds a "Pagination ordering" subsection (§5.3) to `docs/subsystems/relationships.md` stating:

- Relationship list/graph endpoints MUST order by `last_observation_at DESC, relationship_key ASC`.
- `relationship_key` is the `relationship_snapshots` PRIMARY KEY (stable, unique), so it is the deterministic tiebreaker.
- This follows the tiebreaker rule in `docs/architecture/determinism.md` §3.2 (primary sort on a business-meaningful field, secondary sort on a unique stable field).
- Endpoints/methods this applies to: `/list_relationships`, `/retrieve_graph_neighborhood`, `GET /relationships`, and the `relationships.ts` service methods `getRelationshipsForEntity` / `getRelationshipsByType` (per PR #1500).

## Scope

Docs-only. No code changes.

## Checks

- `npm run validate:doc-deps` — no downstream dependency issues.
- `npm run lint:site-copy` — OK.
- Pre-commit `format:check`, site-copy lint, and doc-deps all passed. Tests were skipped via `SKIP_TESTS=1` (not `--no-verify`); a docs change does not exercise the test suite, and the unrelated env/inspector failures are a known worktree artifact.

## Origin

Review follow-up from merged PR #1491 / issue #368.

🤖 Generated with [Claude Code](https://claude.com/claude-code)