### PR TITLE
fix(launchd): build + watch Inspector SPA in watch-build agent

### DIFF
--- a/scripts/run_watch_build_launchd.sh
+++ b/scripts/run_watch_build_launchd.sh
@@ -41,12 +41,43 @@ ensure_global_cli_linked
 
 # Full build once at startup (tsc + copy_pdf_worker_wrapper) so dist/ is complete before watch runs.
 if run_npm run build:server; then
-  echo "[$(timestamp)] Initial build completed."
+  echo "[$(timestamp)] Initial server build completed."
 else
-  echo "[$(timestamp)] Initial build failed; continuing with watch mode." >&2
+  echo "[$(timestamp)] Initial server build failed; continuing with watch mode." >&2
+fi
+
+# Build the bundled Inspector SPA into dist/inspector so the prod server serves
+# the latest UI. The watch loop below keeps it current on subsequent edits.
+# Without this the server hot-reloads but the SPA bundle goes stale (the cause
+# of the marketing-home-not-deploying issue on 2026-06-03).
+if run_npm run build:inspector:prod-target; then
+  echo "[$(timestamp)] Initial inspector build completed."
+else
+  echo "[$(timestamp)] Initial inspector build failed; continuing with watch mode." >&2
 fi
 
 RESTART_DELAY=5
+
+# Inspector watcher: vite build --watch into dist/inspector so SPA source edits
+# rebuild the served bundle, mirroring how dev:types keeps server types current.
+inspector_watch_loop() {
+  while true; do
+    run_npm run watch:inspector:prod || true
+    echo "[$(timestamp)] watch:inspector:prod exited, restarting in ${RESTART_DELAY}s..." >&2
+    sleep "$RESTART_DELAY"
+  done
+}
+inspector_watch_loop &
+INSPECTOR_WATCH_PID=$!
+
+# Stop the inspector watcher if this script is terminated by launchd.
+cleanup() {
+  if [[ -n "${INSPECTOR_WATCH_PID:-}" ]]; then
+    kill "${INSPECTOR_WATCH_PID}" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT INT TERM
+
 while true; do
   run_npm run dev:types || true
   echo "[$(timestamp)] dev:types exited, restarting in ${RESTART_DELAY}s..."

--- a/src/shared/openapi_types.ts
+++ b/src/shared/openapi_types.ts
@@ -3154,9 +3154,13 @@ export interface components {
        */
       store_warnings?: {
         /**
-         * @description Schema-defined warning code (declared in the schema's
-         *     `store_warnings[].code`). Stable identifier callers can
-         *     switch on.
+         * @description Stable warning code callers can switch on. Two sources:
+         *     (1) schema-defined rules declared in the schema's
+         *     `store_warnings[].code`; (2) schema-declaration-driven
+         *     codes emitted by the store path itself — currently
+         *     `MISSING_CONTENT_FIELD` (fired when a schema declares
+         *     `content_field` and the stored observation omits or
+         *     empties that field).
          */
         code: string;
         /** @description Human-readable description from the schema rule. */


### PR DESCRIPTION
## Problems
- The `com.neotoma.watch-build` LaunchAgent (`scripts/run_watch_build_launchd.sh`) ran `build:server` once at startup, then watched only server types via `dev:types`. It never built or watched the bundled Inspector SPA.
- Result: `dist/inspector/` goes stale. The prod server hot-reloads server code but keeps serving an old SPA bundle.
- Surfaced 2026-06-03: after #327 merged and the prod checkout moved to `main` (`0.15.0`), the server reported `0.15.0` but the Inspector home was still the pre-merge bundle (no marketing home), because nothing rebuilt `dist/inspector`.

## Solutions
- Build the Inspector once at startup via `build:inspector:prod-target`, alongside `build:server`, so `dist/inspector` is fresh at login / after reboot.
- Run `watch:inspector:prod` (vite `build --watch` → `dist/inspector`) as a background loop, mirroring how `dev:types` keeps server types current, so SPA source edits rebuild the served bundle automatically.
- Add an `EXIT`/`INT`/`TERM` trap to stop the inspector watcher when launchd terminates the agent (no orphaned vite watcher).

## UX improvements
No user-visible change to the app. Operational: future Inspector changes deploy automatically on the self-hosted prod instance instead of silently serving a stale bundle.

## Documentation
No functional API/MCP/CLI change; no user-facing docs required. The script's behavior change is documented inline in `run_watch_build_launchd.sh` comments, including the dated root-cause note.

## Test plan
- [x] `bash -n scripts/run_watch_build_launchd.sh` — syntax OK
- [x] Referenced npm scripts exist: `build:server`, `build:inspector:prod-target`, `watch:inspector:prod`, `dev:types`
- [x] Verified the one-time `build:inspector:prod-target` produces `dist/inspector/assets/home-*.js` containing the new marketing-home copy, and the running prod server serves it (HTTP 200)
- [ ] Manual: reload the LaunchAgent (`launchctl unload/load com.neotoma.watch-build`) and confirm both server and inspector rebuild at startup, and that editing an inspector source file triggers a `dist/inspector` rebuild

## Breaking changes
No breaking changes.

## Related
- Follow-up to #327 (inspector consolidation + bundling), which introduced the bundled `dist/inspector` the prod server serves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
