### PR TITLE
chore: regenerate openapi_types.ts to fix stale CI baseline gate on main

### DIFF
--- a/src/shared/openapi_types.ts
+++ b/src/shared/openapi_types.ts
@@ -3154,9 +3154,13 @@ export interface components {
        */
       store_warnings?: {
         /**
-         * @description Schema-defined warning code (declared in the schema's
-         *     `store_warnings[].code`). Stable identifier callers can
-         *     switch on.
+         * @description Stable warning code callers can switch on. Two sources:
+         *     (1) schema-defined rules declared in the schema's
+         *     `store_warnings[].code`; (2) schema-declaration-driven
+         *     codes emitted by the store path itself — currently
+         *     `MISSING_CONTENT_FIELD` (fired when a schema declares
+         *     `content_field` and the stored observation omits or
+         *     empties that field).
          */
         code: string;
         /** @description Human-readable description from the schema rule. */


### PR DESCRIPTION
## Problem

`main` is red on the **"OpenAPI types are in sync with openapi.yaml"** step of the `baseline` CI job. This blocks the gate on every open PR (e.g. #1544, #1545 fail `baseline` despite touching only docs).

## Root cause

`openapi.yaml`'s `store_warnings[].code` description was updated (documenting the `MISSING_CONTENT_FIELD` code emitted by the `content_field` store path) but `src/shared/openapi_types.ts` was not regenerated when that change merged. `npm run openapi:generate` on a clean `origin/main` produces a 7-line diff, so the in-sync check fails.

## Fix

Regenerate `src/shared/openapi_types.ts` from `openapi.yaml` (`npm run openapi:generate`). Generated-file-only; the change is a description comment on the `store_warnings.code` field. No behavior change, no `openapi.yaml` edit.

## Verification

- `npm run openapi:generate` now produces no further diff (in sync).
- Single file changed: `src/shared/openapi_types.ts` (+7/-3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)