### PR TITLE
fix(inspector): serve SPA at / via early content-negotiation

### DIFF
--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,8 +61,8 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **415**
-- Backend and repo Vitest files: **382**
+- Total automated test files: **416**
+- Backend and repo Vitest files: **383**
 - Frontend Vitest files: **9**
 - Playwright spec files: **24**
 

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -120,9 +120,10 @@ import {
 } from "./services/root_landing/index.js";
 import { mountDocsRoutes } from "./services/docs/index.js";
 import {
-  installInspectorMount,
+  installInspectorLegacyRedirect,
   installInspectorRootStaticAssets,
   installInspectorSpaFallback,
+  installInspectorSpaShellEarly,
   resolveBundledInspectorDir,
 } from "./services/inspector_mount.js";
 import { getSandboxTermsResponse } from "./services/sandbox/terms.js";
@@ -293,23 +294,27 @@ if (isSandboxMode()) {
   );
 }
 
-// Inspector SPA mount. Deliberately registered before all auth / rate-limit
-// middleware so the SPA shell + assets are reachable without a bearer — the
-// API calls the Inspector makes still flow through the normal auth stack below.
+// Inspector SPA mount at the server root `/` (content-negotiation
+// unification, plan ent_1f176dbbe9a39e6bbad27f1f). Deliberately registered
+// before all auth / rate-limit middleware so the SPA shell + assets are
+// reachable without a bearer — the API calls the SPA makes still flow through
+// the normal auth stack below.
 //
-// Two parallel mounts run today (content-negotiation unification, plan
-// ent_1f176dbbe9a39e6bbad27f1f):
 //   - installInspectorRootStaticAssets: serves /assets/*, /favicon.svg from
-//     dist/inspector at the server root. Inspector built with
-//     VITE_PUBLIC_BASE_PATH=/ resolves its asset URLs here.
-//   - installInspectorMount: legacy /inspector/* mount for back-compat with
-//     any existing links (MCP instructions, conversation summary, etc.).
-//     Will be removed once all links migrate to the unprefixed form.
+//     dist/inspector at the server root. The SPA is built with
+//     VITE_PUBLIC_BASE_PATH=/ so its asset + router base resolve here.
+//   - installInspectorLegacyRedirect: 308 /inspector/* → /* so stale links
+//     (MCP instructions, conversation summary URLs) keep working without a
+//     second SPA mount.
 //
-// The SPA shell itself is served by installInspectorSpaFallback (registered
-// at the END of route registration) for any HTML request to a non-API path.
+// The SPA shell is served by the content-negotiation handler in two places:
+//   - installInspectorSpaShellEarly (registered just before the auth gate):
+//     browser HTML requests to SPA client routes (/sources, /entities/:id, …)
+//     get the shell BEFORE the JSON data routes can intercept them.
+//   - installInspectorSpaFallback (registered at the END): catches any
+//     remaining unmatched HTML request. Both reuse the same handler.
 installInspectorRootStaticAssets(app, process.env, logger);
-installInspectorMount(app, process.env, logger);
+installInspectorLegacyRedirect(app, logger);
 
 // ── Sandbox session endpoints ───────────────────────────────────────────
 // Registered before general auth so the session handshake works for
@@ -3027,6 +3032,16 @@ async function resolveGuestScopedEntityAccess(
 
   return { userId: entity.user_id, entityType: entity.entity_type };
 }
+
+// Inspector SPA shell — early content-negotiation handler. Registered BEFORE
+// the auth gate and the JSON data routes (/sources, /entities/:id, /schemas, …)
+// so that a browser navigating to a SPA client route (Accept: text/html) gets
+// the SPA shell instead of a 401/JSON from the data route. API / agent / curl
+// clients (Accept: application/json | */* | absent) fall through to the real
+// data route. Excludes API-only paths and entity rendered-page surfaces
+// (/entities/:id/html|markdown). Registered after GET / (so the hosted_sandbox
+// funnel still wins), mountDocsRoutes, /me, and /server-info.
+installInspectorSpaShellEarly(app, process.env, logger);
 
 // Public key-based authentication middleware
 // MCP-style auth (same patterns as /mcp): encryption off = no auth or dev token; encryption on = key-derived token

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -3038,9 +3038,12 @@ async function resolveGuestScopedEntityAccess(
 // so that a browser navigating to a SPA client route (Accept: text/html) gets
 // the SPA shell instead of a 401/JSON from the data route. API / agent / curl
 // clients (Accept: application/json | */* | absent) fall through to the real
-// data route. Excludes API-only paths and entity rendered-page surfaces
-// (/entities/:id/html|markdown). Registered after GET / (so the hosted_sandbox
-// funnel still wins), mountDocsRoutes, /me, and /server-info.
+// data route. Excludes API-only paths (isApiOnlyPath, incl. /openapi*.yaml and
+// /me) and entity rendered-page surfaces (/entities/:id/html|markdown).
+// Registered after GET / and mountDocsRoutes (so the hosted_sandbox funnel and
+// docs HTML still win). Routes that register LATER (e.g. /me at ~3306,
+// /openapi.yaml at ~9960) are NOT shadowed because their paths are in the
+// API-only deny-list, so this handler next()s them through.
 installInspectorSpaShellEarly(app, process.env, logger);
 
 // Public key-based authentication middleware

--- a/src/services/inspector_mount.ts
+++ b/src/services/inspector_mount.ts
@@ -234,12 +234,15 @@ export function installInspectorMount(
   let { staticDir } = cfg;
   if (!staticDir) return;
 
-  // NOTE: We intentionally do NOT mount Inspector assets at `/` here. The API
-  // route namespace (e.g. `/entities/:id`, `/relationships`, `/schemas`,
-  // `/sources`) overlaps with Inspector client routes by design — the
-  // `/inspector/*` prefix is load-bearing to keep them separated. A future
-  // feature unit will migrate the API to `/api/*` and unify the Inspector at
-  // `/`; see plan ent_c1d65039242aa2a920d805c7.
+  // NOTE: This legacy `/inspector/*` mount is retained only as an asset/shell
+  // surface for back-compat. The SPA is now served at `/` via content
+  // negotiation: `installInspectorRootStaticAssets` serves `/assets/*`, and
+  // `installInspectorSpaShellEarly` serves the shell to browsers
+  // (Accept: text/html) on SPA client routes (`/sources`, `/entities/:id`, …)
+  // BEFORE the data routes return JSON. The API route namespace overlap is
+  // resolved by Accept-based dispatch, not by a path prefix — no `/api/*`
+  // migration is required. Callers preferring a hard cutover replace this
+  // mount with `installInspectorLegacyRedirect` (308 `/inspector → /`).
   if (inspectorLiveBuild) {
     staticDir = resolveLiveInspectorStaticDir(staticDir);
   }
@@ -442,11 +445,9 @@ export function installInspectorRootStaticAssets(
  * to `/` so legacy links continue to work. Deep paths like
  * `/inspector/entities/foo` are also redirected, preserving query and hash.
  *
- * Not currently invoked from `src/actions.ts` — the legacy `/inspector/*`
- * mount is intentionally kept active for back-compat with stale links
- * (MCP instructions, conversation summary URLs, third-party docs). Call
- * this helper instead of `installInspectorMount` once all known link
- * sources have migrated to the unprefixed form.
+ * Invoked from `src/actions.ts` in place of `installInspectorMount` to retire
+ * the `/inspector` prefix: the SPA is served at `/` via content negotiation,
+ * and legacy `/inspector/*` links 308-redirect to their unprefixed form.
  */
 export function installInspectorLegacyRedirect(
   app: express.Application,
@@ -505,6 +506,21 @@ export function isApiOnlyPath(pathname: string): boolean {
     }
   }
   return false;
+}
+
+/**
+ * Entity rendered-page surfaces: `GET /entities/:id/html` and
+ * `GET /entities/:id/markdown` serve a server-rendered published page (the
+ * HTML variant supports `?access_token=` guest reads) directly to browsers
+ * with `Accept: text/html`. These are NOT Inspector SPA client routes, so the
+ * content-negotiation SPA-shell handler MUST exclude them — otherwise a
+ * browser navigating to a published page would get the blank SPA shell
+ * instead of the rendered page. Suffix-matched (not prefix), so it cannot be
+ * expressed via {@link API_ONLY_PREFIXES}.
+ */
+export function isEntityRenderedSurfacePath(pathname: string): boolean {
+  const normalized = normalizeInspectorUrlPathname(pathname);
+  return /^\/entities\/[^/]+\/(html|markdown)$/.test(normalized);
 }
 
 /**
@@ -574,6 +590,61 @@ export function acceptPrefersHtml(accept: string | undefined): boolean {
  * The `Vary: Accept` header is set on every HTML response so caches do not
  * cross-contaminate JSON and HTML clients.
  */
+/**
+ * Build the content-negotiation SPA-shell middleware shared by the early
+ * mount (registered before the data routes so browser navigations to SPA
+ * client routes like `/sources` get the shell instead of JSON) and the late
+ * fallback (catches genuinely-unmatched paths). A request is served the shell
+ * only when ALL hold: GET/HEAD, Accept prefers HTML (q-aware), the path is not
+ * API-only, and the path is not an entity rendered-page surface.
+ */
+function makeInspectorSpaShellMiddleware(bundledDir: string): express.RequestHandler {
+  return (req, res, next) => {
+    if (req.method !== "GET" && req.method !== "HEAD") return next();
+    if (!acceptPrefersHtml(req.headers.accept)) return next();
+    if (isApiOnlyPath(req.path)) return next();
+    if (isEntityRenderedSurfacePath(req.path)) return next();
+    const shell = readInspectorIndexHtml(bundledDir);
+    if (!shell) return next();
+    const proto = req.protocol;
+    const host = req.get("host") || "localhost";
+    const origin = `${proto}://${host}`;
+    const html = injectInspectorApiBaseMeta(shell, origin);
+    res.setHeader("Vary", "Accept");
+    res.setHeader("Cache-Control", "no-store");
+    res.type("text/html; charset=utf-8").send(html);
+  };
+}
+
+/**
+ * Install the SPA-shell content-negotiation handler EARLY — before the global
+ * auth gate and the data routes (`/sources`, `/entities/:id`, `/schemas`, …)
+ * in `src/actions.ts`. Those routes return JSON unconditionally and 401
+ * unauthenticated browsers, so without this early handler a browser navigating
+ * to a SPA client route would never reach the late fallback. Browsers
+ * (Accept: text/html) get the shell here; API/agent/curl clients (json,
+ * wildcard, or absent Accept) fall through to the real data route and get JSON.
+ *
+ * MUST be registered AFTER `GET /` (so the hosted_sandbox funnel HTML still
+ * wins), `mountDocsRoutes`, and the `/me` / `/server-info` routes, and BEFORE
+ * the auth gate. Reuses the same handler as the late fallback.
+ */
+export function installInspectorSpaShellEarly(
+  app: express.Application,
+  _env: NodeJS.ProcessEnv = process.env,
+  logger: { info: (msg: string) => void; warn: (msg: string) => void }
+): void {
+  const bundledDir = resolveBundledInspectorDir();
+  if (!bundledDir) {
+    logger.info("[Inspector] No bundled SPA found; early SPA-shell handler NOT installed.");
+    return;
+  }
+  app.use(makeInspectorSpaShellMiddleware(bundledDir));
+  logger.info(
+    "[Inspector] Early SPA-shell handler installed (browser HTML requests to SPA client routes serve shell before data routes)."
+  );
+}
+
 export function installInspectorSpaFallback(
   app: express.Application,
   _env: NodeJS.ProcessEnv = process.env,
@@ -586,20 +657,7 @@ export function installInspectorSpaFallback(
     );
     return;
   }
-  app.use((req, res, next) => {
-    if (req.method !== "GET" && req.method !== "HEAD") return next();
-    if (!acceptPrefersHtml(req.headers.accept)) return next();
-    if (isApiOnlyPath(req.path)) return next();
-    const shell = readInspectorIndexHtml(bundledDir);
-    if (!shell) return next();
-    const proto = req.protocol;
-    const host = req.get("host") || "localhost";
-    const origin = `${proto}://${host}`;
-    const html = injectInspectorApiBaseMeta(shell, origin);
-    res.setHeader("Vary", "Accept");
-    res.setHeader("Cache-Control", "no-store");
-    res.type("text/html; charset=utf-8").send(html);
-  });
+  app.use(makeInspectorSpaShellMiddleware(bundledDir));
   logger.info(`[Inspector] SPA fallback installed (HTML requests to non-API paths serve shell).`);
 }
 

--- a/src/services/inspector_mount.ts
+++ b/src/services/inspector_mount.ts
@@ -478,6 +478,13 @@ const API_ONLY_PREFIXES: readonly string[] = [
   "/.well-known/",
   "/api/",
   "/openapi",
+  // Exact spec routes: `isApiOnlyPath` matches a prefix only at a path-segment
+  // boundary (`=== prefix` or `prefix + "/"`), so the bare `/openapi` entry
+  // above does NOT cover the `.yaml` suffixes. List them explicitly — the
+  // early SPA-shell handler runs BEFORE these routes, so without these a
+  // browser GET to /openapi.yaml would be shadowed by the SPA shell.
+  "/openapi.yaml",
+  "/openapi_actions.yaml",
   "/robots.txt",
   "/favicon.ico",
   "/server-info",

--- a/src/shared/openapi_types.ts
+++ b/src/shared/openapi_types.ts
@@ -3154,9 +3154,13 @@ export interface components {
        */
       store_warnings?: {
         /**
-         * @description Schema-defined warning code (declared in the schema's
-         *     `store_warnings[].code`). Stable identifier callers can
-         *     switch on.
+         * @description Stable warning code callers can switch on. Two sources:
+         *     (1) schema-defined rules declared in the schema's
+         *     `store_warnings[].code`; (2) schema-declaration-driven
+         *     codes emitted by the store path itself — currently
+         *     `MISSING_CONTENT_FIELD` (fired when a schema declares
+         *     `content_field` and the stored observation omits or
+         *     empties that field).
          */
         code: string;
         /** @description Human-readable description from the schema rule. */

--- a/tests/integration/inspector_content_negotiation.test.ts
+++ b/tests/integration/inspector_content_negotiation.test.ts
@@ -96,6 +96,15 @@ describe("isApiOnlyPath", () => {
     expect(isApiOnlyPath("/robots.txt")).toBe(true);
   });
 
+  it("matches the openapi spec routes (.yaml suffix, not a path-segment boundary)", () => {
+    // The bare `/openapi` prefix does NOT cover `.yaml` suffixes (isApiOnlyPath
+    // matches at segment boundaries), so the exact spec routes are listed
+    // explicitly. The early SPA-shell handler runs BEFORE these routes, so this
+    // exclusion is what keeps a browser GET /openapi.yaml from being shadowed.
+    expect(isApiOnlyPath("/openapi.yaml")).toBe(true);
+    expect(isApiOnlyPath("/openapi_actions.yaml")).toBe(true);
+  });
+
   it("matches the OAuth / MCP / sandbox-session families", () => {
     expect(isApiOnlyPath("/mcp/oauth/authorize")).toBe(true);
     expect(isApiOnlyPath("/oauth/callback")).toBe(true);
@@ -249,6 +258,19 @@ describe("installInspectorSpaShellEarly — end-to-end", () => {
     });
     expect(res.status).toBe(200);
     expect(res.headers.get("content-type")).toMatch(/text\/html/);
+  });
+
+  it("does NOT shadow /openapi.yaml for Accept: text/html (spec route reaches its handler)", async () => {
+    const { baseUrl } = await startApp((app) => {
+      app.get("/openapi.yaml", (_req, res) => res.type("text/yaml").send("openapi: 3.1.0"));
+      app.get("/openapi_actions.yaml", (_req, res) => res.type("text/yaml").send("openapi: 3.1.0"));
+    });
+    for (const p of ["/openapi.yaml", "/openapi_actions.yaml"]) {
+      const res = await fetch(`${baseUrl}${p}`, { headers: { Accept: "text/html" } });
+      expect(res.status, p).toBe(200);
+      expect(res.headers.get("content-type"), p).toMatch(/yaml/);
+      expect(await res.text()).toContain("openapi: 3.1.0");
+    }
   });
 });
 

--- a/tests/integration/inspector_content_negotiation.test.ts
+++ b/tests/integration/inspector_content_negotiation.test.ts
@@ -19,7 +19,9 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   acceptPrefersHtml,
   isApiOnlyPath,
+  isEntityRenderedSurfacePath,
   installInspectorSpaFallback,
+  installInspectorSpaShellEarly,
 } from "../../src/services/inspector_mount.js";
 
 type Server = ReturnType<express.Application["listen"]>;
@@ -123,6 +125,134 @@ describe("isApiOnlyPath", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Unit-level: isEntityRenderedSurfacePath
+// ---------------------------------------------------------------------------
+
+describe("isEntityRenderedSurfacePath", () => {
+  it("matches the entity rendered-page surfaces", () => {
+    expect(isEntityRenderedSurfacePath("/entities/abc/html")).toBe(true);
+    expect(isEntityRenderedSurfacePath("/entities/abc/markdown")).toBe(true);
+    expect(isEntityRenderedSurfacePath("/entities/ent_123/html")).toBe(true);
+  });
+
+  it("does NOT match the SPA entity routes", () => {
+    expect(isEntityRenderedSurfacePath("/entities")).toBe(false);
+    expect(isEntityRenderedSurfacePath("/entities/abc")).toBe(false);
+    expect(isEntityRenderedSurfacePath("/entities/abc/timeline")).toBe(false);
+    expect(isEntityRenderedSurfacePath("/entities/abc/history")).toBe(false);
+    // Nested segment beyond :id/html is not the rendered surface.
+    expect(isEntityRenderedSurfacePath("/entities/abc/html/extra")).toBe(false);
+  });
+
+  it("is trailing-slash / double-slash safe", () => {
+    expect(isEntityRenderedSurfacePath("/entities//abc/html")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end: early SPA-shell handler (registered BEFORE data routes)
+// ---------------------------------------------------------------------------
+
+describe("installInspectorSpaShellEarly — end-to-end", () => {
+  let server: Server | null = null;
+
+  afterEach(() => {
+    if (server) {
+      server.close();
+      server = null;
+    }
+  });
+
+  function startApp(
+    registerDataRoutes: (app: express.Application) => void
+  ): Promise<{ baseUrl: string }> {
+    return new Promise((resolve) => {
+      const app = express();
+      // Early shell handler runs BEFORE the data routes — this is the
+      // inversion vs the late fallback: browser HTML requests to SPA client
+      // routes get the shell before the JSON data route can answer.
+      installInspectorSpaShellEarly(app, process.env, noopLogger());
+      registerDataRoutes(app);
+      app.use((_req, res) => {
+        res.status(404).json({ error: "not_found_fallthrough" });
+      });
+      server = app.listen(0, () => {
+        const addr = server!.address() as AddressInfo;
+        resolve({ baseUrl: `http://127.0.0.1:${addr.port}` });
+      });
+    });
+  }
+
+  // A data route that always returns JSON, like the real /sources, /schemas, etc.
+  function jsonDataRoutes(app: express.Application) {
+    app.get("/sources", (_req, res) => res.json({ sources: [], total: 0 }));
+    app.get("/entities/:id", (_req, res) => res.json({ entity_id: "stub" }));
+    app.get("/entities/:id/html", (_req, res) =>
+      res.type("text/html").send("<!DOCTYPE html><title>Published</title>PUBLISHED_PAGE")
+    );
+    app.get("/entities/:id/markdown", (_req, res) =>
+      res.type("text/markdown").send("# Published markdown")
+    );
+  }
+
+  it("serves the SPA shell to a browser navigating to /sources (before the JSON data route)", async () => {
+    const { baseUrl } = await startApp(jsonDataRoutes);
+    const res = await fetch(`${baseUrl}/sources`, {
+      headers: { Accept: "text/html,application/xhtml+xml;q=0.9,*/*;q=0.8" },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toMatch(/text\/html/);
+    expect(res.headers.get("vary")).toBe("Accept");
+    expect(await res.text()).toMatch(/<html/i);
+  });
+
+  it("returns JSON from the data route for an API client (Accept: application/json)", async () => {
+    const { baseUrl } = await startApp(jsonDataRoutes);
+    const res = await fetch(`${baseUrl}/sources`, {
+      headers: { Accept: "application/json" },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toMatch(/application\/json/);
+    expect(await res.json()).toEqual({ sources: [], total: 0 });
+  });
+
+  it("returns JSON for wildcard-only Accept (agent / curl default)", async () => {
+    const { baseUrl } = await startApp(jsonDataRoutes);
+    const res = await fetch(`${baseUrl}/sources`, { headers: { Accept: "*/*" } });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toMatch(/application\/json/);
+  });
+
+  it("does NOT shadow /entities/:id/html — published page reaches its handler even for Accept: text/html", async () => {
+    const { baseUrl } = await startApp(jsonDataRoutes);
+    const res = await fetch(`${baseUrl}/entities/abc/html`, {
+      headers: { Accept: "text/html" },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain("PUBLISHED_PAGE");
+  });
+
+  it("does NOT shadow /entities/:id/markdown for Accept: text/html", async () => {
+    const { baseUrl } = await startApp(jsonDataRoutes);
+    const res = await fetch(`${baseUrl}/entities/abc/markdown`, {
+      headers: { Accept: "text/html" },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toMatch(/text\/markdown/);
+  });
+
+  it("serves the SPA shell for a browser GET to /entities/:id (the SPA detail route)", async () => {
+    const { baseUrl } = await startApp(jsonDataRoutes);
+    const res = await fetch(`${baseUrl}/entities/abc`, {
+      headers: { Accept: "text/html" },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toMatch(/text\/html/);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // End-to-end: SPA fallback over HTTP
 // ---------------------------------------------------------------------------
 
@@ -152,7 +282,10 @@ describe("installInspectorSpaFallback — end-to-end", () => {
       installInspectorSpaFallback(
         app,
         opts.overrideBundledDir
-          ? ({ ...process.env, NEOTOMA_INSPECTOR_STATIC_DIR: opts.overrideBundledDir } as NodeJS.ProcessEnv)
+          ? ({
+              ...process.env,
+              NEOTOMA_INSPECTOR_STATIC_DIR: opts.overrideBundledDir,
+            } as NodeJS.ProcessEnv)
           : process.env,
         noopLogger()
       );


### PR DESCRIPTION
## Problems
- After #327, the inspector SPA shell was served at `/`, but browser navigations to data routes (`/sources`, `/entities/:id`, `/schemas`, `/relationships`, `/timeline`, …) hit the JSON data routes first — those routes are registered before the late SPA fallback and return JSON / 401 to browsers, so the SPA never rendered its own pages. Visiting `/` rendered only because of the late fallback; visiting a deep route showed JSON or an auth error.
- The SPA bakes its Router `basename` from `import.meta.env.BASE_URL`. When a stale `dist/inspector` was built with `VITE_PUBLIC_BASE_PATH=/inspector/` but served at `/`, the router refused to render → blank page (the symptom that prompted this).

## Solutions
- Register the SPA-shell content-negotiation handler **early**, before the auth gate and the data routes (`src/actions.ts`, just before the auth `app.use` at the public-key middleware). New `installInspectorSpaShellEarly` shares one handler with the late `installInspectorSpaFallback`. It serves the shell only when: `GET`/`HEAD` + Accept prefers HTML (q-aware `acceptPrefersHtml`) + not an API-only path + not an entity rendered-page surface. Browsers get the SPA; API / agent / curl clients (`application/json` / `*/*` / absent Accept) fall through to the real data route and get JSON.
- New `isEntityRenderedSurfacePath` predicate excludes `/entities/:id/html` and `/entities/:id/markdown` — server-rendered published pages (the html variant supports `?access_token=` guest reads, restored in `44a4a657`). Without it, the early handler would shadow a published page with the blank shell. **This is the highest-risk regression; it is guarded and tested.**
- Retire the `/inspector` prefix: swap `installInspectorMount` → `installInspectorLegacyRedirect` (308 `/inspector/* → /*`, query/hash preserved). The SPA already builds at base `/` (`VITE_PUBLIC_BASE_PATH=/`), so basename + assets resolve at root.
- Updated stale comments claiming serving at `/` requires migrating the API to `/api/*` — content negotiation makes that migration unnecessary.

## UX improvements
- Browser navigation to any SPA route (`/sources`, `/entities/x`, `/schemas`, …) renders the SPA. `/inspector/*` 308-redirects to `/*`. No user-visible change for API clients.

## Documentation
No functional API / MCP / CLI change and no OpenAPI shape change (no new routes, no field changes). Behavior is documented inline in `inspector_mount.ts` / `actions.ts` comments. No `docs/site/site_doc_manifest.yaml` entry required.

## Test plan
- [x] `npm run type-check`
- [x] `npm run lint` (0 errors)
- [x] `npm test -- tests/integration/inspector_content_negotiation.test.ts` (29/29)
- [x] `npm test -- tests/integration/inspector_bundled_mount.test.ts tests/integration/root_landing.test.ts` (98 total across the 3 files)
- [x] `npm test -- tests/contract/` (130/130)
- [x] `npm run build`
- [x] Manual against `node dist/actions.js`: browser `/sources` → `text/html` shell; API `/sources` → `application/json`; `/inspector` → 308 `/`; `/inspector/entities/abc?q=1` → 308 `/entities/abc?q=1`; `/` shell refs `/assets/*`; `/me` → JSON; `/entities/<id>/html` → handler JSON error (not shell).

## Breaking changes
No breaking changes. `/inspector/*` now 308-redirects to `/*` instead of serving the SPA directly; all paths and query/hash are preserved, so existing links keep working.

## Related
- Follows up #327 (inspector consolidation + root serving) and the unification plan `ent_1f176dbbe9a39e6bbad27f1f`.
- Fixes the blank-page issue tracked at `ent_f8acf218794512f12517dcf3`.
- Note: retiring the *term* "inspector" repo-wide is a separate follow-up, not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
