### PR TITLE
fix(mcp/cli): quick mechanical wins — #401 #1504 #1505 #1550 #1506 #367 #369 #370

### DIFF
--- a/docs/reference/error_codes.md
+++ b/docs/reference/error_codes.md
@@ -109,8 +109,8 @@ handlers can pattern-match the code uniformly.
 
 | Code                              | HTTP | Retry? | Description                                                                          |
 | --------------------------------- | ---- | ------ | ------------------------------------------------------------------------------------ |
-| `ERR_NO_SCHEMA_FOR_ENTITY_TYPE`   | 400  | No     | No registered or code-defined schema exists for the given `entity_type`              |
-| `ERR_SCHEMA_MISSING_IDENTITY_CONFIG` | 400 | No     | Existing schema lacks both `canonical_name_fields` and `identity_opt_out`            |
+| `ERR_NO_SCHEMA_FOR_ENTITY_TYPE`   | 200  | No     | No registered or code-defined schema exists for the given `entity_type`              |
+| `ERR_SCHEMA_MISSING_IDENTITY_CONFIG` | 200 | No     | Existing schema lacks both `canonical_name_fields` and `identity_opt_out`            |
 
 **`ERR_NO_SCHEMA_FOR_ENTITY_TYPE`** — raised by `update_schema_incremental` when
 the target `entity_type` has no schema registered in `schema_registry` and no

--- a/docs/reference/error_codes.md
+++ b/docs/reference/error_codes.md
@@ -103,26 +103,33 @@ interface ErrorEnvelope {
 Errors raised by `update_schema_incremental` and related schema-registry tools.
 These are structured (non-throwing) responses with an actionable `hint` field
 directing the caller to the right next tool, rather than opaque internal errors.
+They use the canonical standard error envelope (`{ error: { error_code,
+message, hint, details } }`, see `docs/subsystems/errors.md`) so CLI/MCP error
+handlers can pattern-match the code uniformly.
 
 | Code                              | HTTP | Retry? | Description                                                                          |
 | --------------------------------- | ---- | ------ | ------------------------------------------------------------------------------------ |
-| `ERR_NO_SCHEMA_FOR_ENTITY_TYPE`   | 200  | No     | No registered or code-defined schema exists for the given `entity_type`              |
-| `ERR_SCHEMA_MISSING_IDENTITY_CONFIG` | 200 | No     | Existing schema lacks both `canonical_name_fields` and `identity_opt_out`            |
+| `ERR_NO_SCHEMA_FOR_ENTITY_TYPE`   | 400  | No     | No registered or code-defined schema exists for the given `entity_type`              |
+| `ERR_SCHEMA_MISSING_IDENTITY_CONFIG` | 400 | No     | Existing schema lacks both `canonical_name_fields` and `identity_opt_out`            |
 
 **`ERR_NO_SCHEMA_FOR_ENTITY_TYPE`** — raised by `update_schema_incremental` when
 the target `entity_type` has no schema registered in `schema_registry` and no
 code-defined fallback in `schema_definitions.ts`. Incremental update needs a
 baseline to extend, so the call cannot proceed.
 
-Response shape:
+Response shape (canonical envelope):
 
 ```json
 {
-  "success": false,
-  "entity_type": "<type>",
-  "error_code": "ERR_NO_SCHEMA_FOR_ENTITY_TYPE",
-  "no_schema_for_entity_type": true,
-  "hint": "Call register_schema first ... Use analyze_schema_candidates to get field suggestions before registering."
+  "error": {
+    "error_code": "ERR_NO_SCHEMA_FOR_ENTITY_TYPE",
+    "message": "No schema is registered for entity_type \"<type>\".",
+    "hint": "Call register_schema first ... Use analyze_schema_candidates to get field suggestions before registering.",
+    "details": {
+      "entity_type": "<type>",
+      "no_schema_for_entity_type": true
+    }
+  }
 }
 ```
 
@@ -136,14 +143,16 @@ the target `entity_type` lacks both `canonical_name_fields` and
 `identity_opt_out`. The baseline schema is present but cannot be safely
 extended without an identity rule in place.
 
-Response shape:
+Response shape (canonical envelope):
 
 ```json
 {
-  "success": false,
-  "entity_type": "<type>",
-  "error_code": "ERR_SCHEMA_MISSING_IDENTITY_CONFIG",
-  "hint": "Call register_schema with a full schema_definition that includes canonical_name_fields (or identity_opt_out: \"heuristic_canonical_name\") to establish a baseline, then retry update_schema_incremental."
+  "error": {
+    "error_code": "ERR_SCHEMA_MISSING_IDENTITY_CONFIG",
+    "message": "The SchemaDefinition for entity_type \"<type>\" is missing identity configuration.",
+    "hint": "Call register_schema with a full schema_definition that includes canonical_name_fields (or identity_opt_out: \"heuristic_canonical_name\") to establish a baseline, then retry update_schema_incremental.",
+    "details": { "entity_type": "<type>" }
+  }
 }
 ```
 

--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,18 +61,18 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **419**
-- Backend and repo Vitest files: **386**
+- Total automated test files: **425**
+- Backend and repo Vitest files: **392**
 - Frontend Vitest files: **9**
 - Playwright spec files: **24**
 
 ### Suite counts
 | Suite | Files |
 |---|---:|
-| Vitest unit tests | 104 |
+| Vitest unit tests | 107 |
 | Vitest service tests | 34 |
 | Source-adjacent tests | 48 |
-| Vitest integration tests | 114 |
+| Vitest integration tests | 117 |
 | Vitest CLI tests | 60 |
 | Vitest contract tests | 12 |
 | Vitest security tests | 3 |
@@ -108,7 +108,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/unit`
 **Requirements:** Basic `.env` if required by the module under test.
-**Files (104):**
+**Files (107):**
 - `tests/unit/aauth_admission.test.ts`
 - `tests/unit/aauth_attestation_apple_se.test.ts`
 - `tests/unit/aauth_attestation_revocation.test.ts`
@@ -141,6 +141,7 @@ flowchart TD
 - `tests/unit/client_turn_report.test.ts`
 - `tests/unit/compliance_scorecard.test.ts`
 - `tests/unit/config_data_dir_resolution.test.ts`
+- `tests/unit/config_sqlite_path.test.ts`
 - `tests/unit/content_field_store_warning.test.ts`
 - `tests/unit/conversation_schema_bootstrap.test.ts`
 - `tests/unit/conversation_session_uuid_bridge.test.ts`
@@ -176,6 +177,7 @@ flowchart TD
 - `tests/unit/mcp_server_card.test.ts`
 - `tests/unit/mcp_sse_keepalive.test.ts`
 - `tests/unit/mirror_profiles.test.ts`
+- `tests/unit/mirror_rebuild_auth.test.ts`
 - `tests/unit/neotoma_entity_id.test.ts`
 - `tests/unit/observation_reducer_converters.test.ts`
 - `tests/unit/observation_reducer_merge_array_correction.test.ts`
@@ -195,6 +197,7 @@ flowchart TD
 - `tests/unit/root_landing_harness_snippets.test.ts`
 - `tests/unit/root_landing_site_nav_drift.test.ts`
 - `tests/unit/safe_request_log_format.test.ts`
+- `tests/unit/sandbox_boot_banner.test.ts`
 - `tests/unit/sandbox_pack_registry.test.ts`
 - `tests/unit/sandbox_reset.test.ts`
 - `tests/unit/schema_agent_instructions.test.ts`
@@ -315,7 +318,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm run test:integration` or `npx vitest run tests/integration`
 **Requirements:** Database configured; remote-dependent subsets additionally need `RUN_REMOTE_TESTS=1`.
-**Files (114):**
+**Files (117):**
 - `tests/integration/aauth_attribution_stamping.test.ts`
 - `tests/integration/aauth_resource_metadata.test.ts`
 - `tests/integration/aauth_revocation_e2e.test.ts`
@@ -343,6 +346,7 @@ flowchart TD
 - `tests/integration/docs_route.test.ts`
 - `tests/integration/entity_identifier_handler.test.ts`
 - `tests/integration/entity_queries.test.ts`
+- `tests/integration/entity_search_mode.test.ts`
 - `tests/integration/events_stream.test.ts`
 - `tests/integration/field_converters.test.ts`
 - `tests/integration/fixture_mcp_store_replay.test.ts`
@@ -364,6 +368,7 @@ flowchart TD
 - `tests/integration/issue_207_list_timeline_events_unknown_type.test.ts`
 - `tests/integration/issue_37_event_schema_projection.test.ts`
 - `tests/integration/lexical_search.test.ts`
+- `tests/integration/list_relationships_pagination.test.ts`
 - `tests/integration/live_issues_tooling.test.ts`
 - `tests/integration/mcp_actions_matrix.test.ts`
 - `tests/integration/mcp_auto_enhancement.test.ts`
@@ -429,6 +434,7 @@ flowchart TD
 - `tests/integration/tunnel_auth.test.ts`
 - `tests/integration/tunnel_discovery.test.ts`
 - `tests/integration/update_schema_incremental_cold_start.test.ts`
+- `tests/integration/update_schema_incremental_envelope.test.ts`
 - `tests/integration/v0.2.0_ingestion.test.ts`
 
 ### Vitest CLI tests

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2592,6 +2592,18 @@ paths:
                     type: integer
                   offset:
                     type: integer
+                  search_mode:
+                    type: string
+                    enum: [none, semantic, lexical_typed, lexical_fallback]
+                    description: |
+                      Which retrieval strategy answered the query. `none` when no
+                      `search` text was supplied; `semantic` when embedding search
+                      answered; `lexical_typed` when an entity-type token was
+                      detected; `lexical_fallback` when semantic search was
+                      attempted but returned nothing usable and lexical substring
+                      matching answered instead. Lets callers detect a silent
+                      semantic→lexical degradation (e.g. embedding provider
+                      unavailable). See issue #1506.
 
   /entities/{id}:
     get:
@@ -4437,9 +4449,19 @@ paths:
                     type: array
                     items:
                       $ref: "#/components/schemas/RelationshipSnapshot"
+                  total_count:
+                    type: integer
+                    description: |
+                      Total number of matching relationships before pagination.
+                      Canonical pagination field, matching
+                      `/retrieve_graph_neighborhood`.
                   total:
                     type: integer
-                    description: Total number of matching relationships before pagination.
+                    deprecated: true
+                    description: |
+                      Deprecated alias of `total_count`, retained for back-compat
+                      with pre-existing clients. New clients SHOULD read
+                      `total_count`. See issue #369.
                   limit:
                     type: integer
                     description: Echo of the requested `limit`.

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -87,6 +87,7 @@ import {
   SANDBOX_PUBLIC_USER_ID,
 } from "./services/local_auth.js";
 import {
+  buildSandboxBootBannerLines,
   isSandboxMode,
   resolveForceMode,
   resolveRefusePolicy,
@@ -3728,7 +3729,7 @@ app.post("/entities/query", async (req, res) => {
       snapshot_filters,
       exclude_bookkeeping,
     } = parsed.data;
-    const { entities, total } = await queryEntitiesWithCount({
+    const { entities, total, search_mode } = await queryEntitiesWithCount({
       userId,
       entityType: entity_type,
       includeMerged: include_merged,
@@ -3753,6 +3754,7 @@ app.post("/entities/query", async (req, res) => {
       total,
       limit,
       offset,
+      search_mode,
     });
   } catch (error) {
     return handleApiError(
@@ -8126,7 +8128,13 @@ app.post("/list_relationships", async (req, res) => {
 
     // Flexible query supporting source_entity_id / target_entity_id in addition
     // to the legacy entity_id + direction pattern.
-    let query = db.from("relationship_snapshots").select("*").eq("user_id", userId);
+    // Pagination is pushed to the DB (`.range()` + `count: "exact"`) so memory
+    // stays O(limit) rather than loading the full result set and slicing in
+    // process. See issue #367.
+    let query = db
+      .from("relationship_snapshots")
+      .select("*", { count: "exact" })
+      .eq("user_id", userId);
 
     if (source_entity_id && target_entity_id) {
       query = query
@@ -8165,15 +8173,16 @@ app.post("/list_relationships", async (req, res) => {
     // "Sorting MUST use deterministic tiebreakers"). See issue #368.
     query = query
       .order("last_observation_at", { ascending: false })
-      .order("relationship_key", { ascending: true });
+      .order("relationship_key", { ascending: true })
+      .range(offset, offset + limit - 1);
 
-    const { data, error } = await query;
+    const { data, error, count } = await query;
     if (error) {
       throw new Error(error.message);
     }
 
-    const all = data || [];
-    const paginated = all.slice(offset, offset + limit);
+    const paginated = data || [];
+    const total = count ?? paginated.length;
 
     logDebug("Success:list_relationships", req, {
       entity_id,
@@ -8181,9 +8190,18 @@ app.post("/list_relationships", async (req, res) => {
       target_entity_id,
       relationship_type,
       count: paginated.length,
-      total: all.length,
+      total,
     });
-    return res.json({ relationships: paginated, total: all.length, limit, offset });
+    // `total_count` is the canonical field name (matches
+    // /retrieve_graph_neighborhood). `total` is retained as a deprecated alias
+    // for back-compat with pre-existing clients. See issue #369.
+    return res.json({
+      relationships: paginated,
+      total,
+      total_count: total,
+      limit,
+      offset,
+    });
   } catch (error) {
     return handleApiError(
       req,
@@ -10237,34 +10255,17 @@ function emitSandboxBootBanner(
   mode: NeotomaSandboxModeName,
   reason: string,
   shouldRefuseBoot: boolean,
-  refusePolicy: "warn" | "enforce"
+  refusePolicy: "warn" | "enforce",
+  productionEnv: boolean
 ): void {
-  const lines: string[] = [];
-  lines.push("");
-  lines.push("─────────────────────────────────────────────────────────────");
-  lines.push(`[neotoma] Sandbox mode resolved: ${mode}`);
-  lines.push(`[neotoma] Reason: ${reason}`);
-  if (mode === "refuse") {
-    lines.push(
-      `[neotoma] WARNING: this server topology matches the v0.11.1 inspector ` +
-        `auth-bypass advisory class.`
-    );
-    lines.push(
-      `[neotoma] Set NEOTOMA_REQUIRE_AUTH=1 + provision auth, OR bind to ` +
-        `loopback (NEOTOMA_HTTP_HOST=127.0.0.1), OR opt into ` +
-        `NEOTOMA_SANDBOX_MODE=1 for the hosted-sandbox profile.`
-    );
-    if (shouldRefuseBoot) {
-      lines.push(`[neotoma] NEOTOMA_REFUSE_MODE=enforce — refusing to start. ` + `Exit code 1.`);
-    } else {
-      lines.push(
-        `[neotoma] NEOTOMA_REFUSE_MODE=${refusePolicy} — boot continues; set ` +
-          `NEOTOMA_REFUSE_MODE=enforce to make this fatal.`
-      );
-    }
-  }
-  lines.push("─────────────────────────────────────────────────────────────");
-  lines.push("");
+  // Line construction lives in sandbox_mode.ts (pure, unit-tested). See #1505.
+  const lines = buildSandboxBootBannerLines({
+    mode,
+    reason,
+    shouldRefuseBoot,
+    refusePolicy,
+    productionEnv,
+  });
   process.stderr.write(lines.join("\n"));
 }
 
@@ -10460,7 +10461,13 @@ export async function startHTTPServer() {
       forceMode,
     });
     _resolvedServerMode = verdict.mode;
-    emitSandboxBootBanner(verdict.mode, verdict.reason, verdict.shouldRefuseBoot, refusePolicy);
+    emitSandboxBootBanner(
+      verdict.mode,
+      verdict.reason,
+      verdict.shouldRefuseBoot,
+      refusePolicy,
+      productionEnv
+    );
     if (verdict.shouldRefuseBoot) {
       // Refuse mode + enforce policy: hard exit. The banner above already
       // explains the why; do not start the listener.

--- a/src/config.ts
+++ b/src/config.ts
@@ -152,7 +152,9 @@ export const config = {
   projectRoot,
   storageBackend,
   dataDir,
-  sqlitePath: join(dataDir, env === "production" ? "neotoma.prod.db" : "neotoma.db"),
+  sqlitePath:
+    process.env.NEOTOMA_SQLITE_PATH ||
+    join(dataDir, env === "production" ? "neotoma.prod.db" : "neotoma.db"),
   rawStorageDir: process.env.NEOTOMA_RAW_STORAGE_DIR || join(dataDir, rawStorageSubdir),
   eventLogPath,
   logsDir,

--- a/src/server.ts
+++ b/src/server.ts
@@ -2933,7 +2933,7 @@ export class NeotomaServer {
     // Use authenticated user_id, validate if provided
     const userId = this.getAuthenticatedUserId(parsed.user_id);
 
-    const { entities, total, excluded_merged } = await queryEntitiesWithCount({
+    const { entities, total, excluded_merged, search_mode } = await queryEntitiesWithCount({
       userId,
       entityType: parsed.entity_type,
       includeMerged: parsed.include_merged,
@@ -2955,6 +2955,7 @@ export class NeotomaServer {
       entities,
       total,
       excluded_merged,
+      search_mode,
     });
   }
 
@@ -3583,18 +3584,26 @@ export class NeotomaServer {
     if (!registeredSchema) {
       const codeDefinedSchema = await loadCodeDefinedSchemaEntry(parsed.entity_type);
       if (!codeDefinedSchema) {
+        // Canonical standard error envelope (docs/subsystems/errors.md).
+        // Nested under `error` so CLI/MCP error handlers can pattern-match the
+        // code uniformly. `no_schema_for_entity_type` retained in details for
+        // back-compat with any consumer that switched on it.
         return this.buildTextResponse({
-          success: false,
-          entity_type: parsed.entity_type,
-          error_code: "ERR_NO_SCHEMA_FOR_ENTITY_TYPE",
-          no_schema_for_entity_type: true,
-          hint:
-            "No schema is registered for this entity_type. " +
-            "update_schema_incremental requires an existing SchemaDefinition to extend. " +
-            "Call register_schema first with a full schema_definition that includes " +
-            "canonical_name_fields (or identity_opt_out), then optionally call " +
-            "update_schema_incremental to add more fields. " +
-            "Use analyze_schema_candidates to get field suggestions before registering.",
+          error: {
+            error_code: "ERR_NO_SCHEMA_FOR_ENTITY_TYPE",
+            message: `No schema is registered for entity_type "${parsed.entity_type}".`,
+            hint:
+              "No schema is registered for this entity_type. " +
+              "update_schema_incremental requires an existing SchemaDefinition to extend. " +
+              "Call register_schema first with a full schema_definition that includes " +
+              "canonical_name_fields (or identity_opt_out), then optionally call " +
+              "update_schema_incremental to add more fields. " +
+              "Use analyze_schema_candidates to get field suggestions before registering.",
+            details: {
+              entity_type: parsed.entity_type,
+              no_schema_for_entity_type: true,
+            },
+          },
         });
       }
     }
@@ -3637,15 +3646,19 @@ export class NeotomaServer {
         error.message.includes("identity_opt_out");
       if (isR2Error) {
         return this.buildTextResponse({
-          success: false,
-          entity_type: parsed.entity_type,
-          error_code: "ERR_SCHEMA_MISSING_IDENTITY_CONFIG",
-          hint:
-            "The existing SchemaDefinition for this entity_type does not declare " +
-            "canonical_name_fields or identity_opt_out, which are required before fields can " +
-            "be added incrementally. Call register_schema with a full schema_definition that " +
-            'includes canonical_name_fields (or identity_opt_out: "heuristic_canonical_name") ' +
-            "to establish a baseline, then retry update_schema_incremental.",
+          error: {
+            error_code: "ERR_SCHEMA_MISSING_IDENTITY_CONFIG",
+            message: `The SchemaDefinition for entity_type "${parsed.entity_type}" is missing identity configuration.`,
+            hint:
+              "The existing SchemaDefinition for this entity_type does not declare " +
+              "canonical_name_fields or identity_opt_out, which are required before fields can " +
+              "be added incrementally. Call register_schema with a full schema_definition that " +
+              'includes canonical_name_fields (or identity_opt_out: "heuristic_canonical_name") ' +
+              "to establish a baseline, then retry update_schema_incremental.",
+            details: {
+              entity_type: parsed.entity_type,
+            },
+          },
         });
       }
       throw new McpError(

--- a/src/services/canonical_mirror.ts
+++ b/src/services/canonical_mirror.ts
@@ -1311,6 +1311,27 @@ export async function rebuildMirror(options: RebuildOptions = {}): Promise<Rebui
 }
 
 /**
+ * Detect an authentication failure in an openapi-fetch error body. Matches the
+ * canonical error envelope (`{ error: { code: "AUTH_REQUIRED" } }`), a bare
+ * `{ code: "AUTH_REQUIRED" }`, or an HTTP 401 status surfaced on the body.
+ */
+export function isAuthError(apiError: unknown): boolean {
+  if (!apiError || typeof apiError !== "object") return false;
+  const obj = apiError as Record<string, unknown>;
+  const codeFrom = (v: unknown): string | undefined => {
+    if (v && typeof v === "object") {
+      const c = (v as Record<string, unknown>).code;
+      return typeof c === "string" ? c : undefined;
+    }
+    return undefined;
+  };
+  const code = codeFrom(obj) ?? codeFrom(obj.error);
+  if (code === "AUTH_REQUIRED" || code === "ERR_UNAUTHENTICATED") return true;
+  if (obj.status === 401 || obj.statusCode === 401) return true;
+  return false;
+}
+
+/**
  * Rebuild a single profile: query all entities of the profile's type, filter
  * by the profile's filter, render with field exclusion, and write to output_path.
  * Emits git-safety warnings (or throws when opts.strict is set).
@@ -1356,6 +1377,14 @@ async function rebuildProfile(
       },
     });
     if (apiError) {
+      // Auth failures must surface as a non-zero exit, not a silent 0-file
+      // success. The CLI catches thrown errors and sets process.exitCode = 1.
+      if (isAuthError(apiError)) {
+        throw new Error(
+          `AUTH_REQUIRED: mirror rebuild for profile ${profile.id} requires authentication. ` +
+            `Provide a bearer token (run \`neotoma auth login\` or set the API token) and retry.`
+        );
+      }
       process.stderr.write(
         `[mirror profile] API fetch failed for profile ${profile.id}: ${JSON.stringify(apiError)}\n`
       );

--- a/src/services/sandbox_mode.ts
+++ b/src/services/sandbox_mode.ts
@@ -143,6 +143,62 @@ export function resolveSandboxMode(inputs: ResolveSandboxModeInputs): ResolveSan
 }
 
 /**
+ * Build the boot banner lines for a resolved sandbox mode. Pure (no IO) so the
+ * refuse-mode remediation text is unit-testable. The caller writes the joined
+ * result to stderr.
+ *
+ * Remediation under `refuse` differs by environment: resolveSandboxMode() gates
+ * the local_sandbox loopback escape on `!productionEnv` (step 4), so binding to
+ * 127.0.0.1 under NEOTOMA_ENV=production does NOT escape refuse mode. The banner
+ * therefore only advertises the loopback escape when it actually works. See
+ * issue #1505.
+ */
+export function buildSandboxBootBannerLines(inputs: {
+  mode: NeotomaSandboxModeName;
+  reason: string;
+  shouldRefuseBoot: boolean;
+  refusePolicy: "warn" | "enforce";
+  productionEnv: boolean;
+}): string[] {
+  const { mode, reason, shouldRefuseBoot, refusePolicy, productionEnv } = inputs;
+  const lines: string[] = [];
+  lines.push("");
+  lines.push("─────────────────────────────────────────────────────────────");
+  lines.push(`[neotoma] Sandbox mode resolved: ${mode}`);
+  lines.push(`[neotoma] Reason: ${reason}`);
+  if (mode === "refuse") {
+    lines.push(
+      `[neotoma] WARNING: this server topology matches the v0.11.1 inspector ` +
+        `auth-bypass advisory class.`
+    );
+    if (productionEnv) {
+      lines.push(
+        `[neotoma] Under NEOTOMA_ENV=production, loopback bind does NOT escape ` +
+          `refuse mode. Set NEOTOMA_REQUIRE_AUTH=1 + provision auth, OR opt into ` +
+          `NEOTOMA_SANDBOX_MODE=1 for the hosted-sandbox profile.`
+      );
+    } else {
+      lines.push(
+        `[neotoma] Set NEOTOMA_REQUIRE_AUTH=1 + provision auth, OR bind to ` +
+          `loopback (NEOTOMA_HTTP_HOST=127.0.0.1), OR opt into ` +
+          `NEOTOMA_SANDBOX_MODE=1 for the hosted-sandbox profile.`
+      );
+    }
+    if (shouldRefuseBoot) {
+      lines.push(`[neotoma] NEOTOMA_REFUSE_MODE=enforce — refusing to start. ` + `Exit code 1.`);
+    } else {
+      lines.push(
+        `[neotoma] NEOTOMA_REFUSE_MODE=${refusePolicy} — boot continues; set ` +
+          `NEOTOMA_REFUSE_MODE=enforce to make this fatal.`
+      );
+    }
+  }
+  lines.push("─────────────────────────────────────────────────────────────");
+  lines.push("");
+  return lines;
+}
+
+/**
  * Read NEOTOMA_REFUSE_MODE from env. Defaults to "warn" for the first cut so
  * upgrades do not regress existing self-host configs. Operators flip to
  * "enforce" once they have confirmed their topology.

--- a/src/shared/action_handlers/entity_handlers.ts
+++ b/src/shared/action_handlers/entity_handlers.ts
@@ -628,10 +628,23 @@ async function queryEntitiesFromLexicalSearch(params: {
   return { entities, total: lexicalTotal };
 }
 
+/**
+ * Which retrieval strategy actually answered a query. Exposed to callers so a
+ * silent semantic→lexical degradation (e.g. when the embedding provider is
+ * unavailable) is observable rather than invisible. See issue #1506.
+ *   - "none"            — no search text; plain listing/filter path.
+ *   - "semantic"        — semantic (embedding) search answered the query.
+ *   - "lexical_typed"   — entity-type token detected; typed lexical search.
+ *   - "lexical_fallback"— semantic was attempted but returned nothing usable,
+ *                          so lexical substring matching answered instead.
+ */
+export type EntitySearchMode = "none" | "semantic" | "lexical_typed" | "lexical_fallback";
+
 export async function queryEntitiesWithCount(params: QueryEntitiesParams): Promise<{
   entities: EntityWithProvenance[];
   total: number;
   excluded_merged: boolean;
+  search_mode: EntitySearchMode;
 }> {
   const {
     userId,
@@ -656,6 +669,7 @@ export async function queryEntitiesWithCount(params: QueryEntitiesParams): Promi
 
   let entities: EntityWithProvenance[];
   let total: number;
+  let searchMode: EntitySearchMode = "none";
 
   if (search && search.trim()) {
     const trimmedSearch = search.trim();
@@ -697,6 +711,7 @@ export async function queryEntitiesWithCount(params: QueryEntitiesParams): Promi
       const lexicalResult = await queryEntitiesFromLexicalSearch(lexicalParams);
       entities = lexicalResult.entities;
       total = lexicalResult.total;
+      searchMode = "lexical_typed";
     } else {
       logger.info(
         `[queryEntitiesWithCount] semantic search path: userId=${userId} search=${trimmedSearch.slice(0, 50)} entityType=${entityType ?? "(any)"}`
@@ -746,15 +761,18 @@ export async function queryEntitiesWithCount(params: QueryEntitiesParams): Promi
             )
           );
           total = semanticTotal;
+          searchMode = "semantic";
         } else {
           const lexicalResult = await queryEntitiesFromLexicalSearch(lexicalParams);
           entities = lexicalResult.entities;
           total = lexicalResult.total;
+          searchMode = "lexical_fallback";
         }
       } else {
         const lexicalResult = await queryEntitiesFromLexicalSearch(lexicalParams);
         entities = lexicalResult.entities;
         total = lexicalResult.total;
+        searchMode = "lexical_fallback";
       }
     }
   } else {
@@ -816,6 +834,7 @@ export async function queryEntitiesWithCount(params: QueryEntitiesParams): Promi
     entities,
     total,
     excluded_merged: !includeMerged,
+    search_mode: searchMode,
   };
 }
 

--- a/src/shared/action_handlers/entity_identifier_handler.ts
+++ b/src/shared/action_handlers/entity_identifier_handler.ts
@@ -120,6 +120,45 @@ export async function retrieveEntityByIdentifierWithFallback(
     includeObservations = false,
     observationsLimit = 20,
   } = params;
+  // Raw entity_id fast path. Identifiers shaped like `ent_<24 hex>` are entity
+  // ids, not natural-language values; canonical_name/snapshot/semantic matching
+  // never resolves them, so without this they returned empty. retrieve_entity_
+  // snapshot already accepts raw ids; this aligns retrieve_entity_by_identifier.
+  const rawId = identifier.trim();
+  if (/^ent_[0-9a-f]{24}$/i.test(rawId)) {
+    const { data: byId, error: byIdError } = await db
+      .from("entities")
+      .select("*")
+      .eq("id", rawId)
+      .eq("user_id", userId)
+      .maybeSingle();
+    if (byIdError) {
+      throw new Error(`Failed to look up entity by id: ${byIdError.message}`);
+    }
+    if (byId) {
+      const { data: snap } = await db
+        .from("entity_snapshots")
+        .select("*")
+        .eq("user_id", userId)
+        .eq("entity_id", (byId as { id: string }).id)
+        .maybeSingle();
+      const mapped: RetrievedEntity = {
+        id: (byId as { id: string }).id,
+        entity_type: (byId as { entity_type: string }).entity_type,
+        canonical_name: (byId as { canonical_name: string }).canonical_name,
+        snapshot: snap ?? null,
+      };
+      const withObs = includeObservations
+        ? await attachObservations([mapped], userId, observationsLimit)
+        : [mapped];
+      return { entities: withObs, total: withObs.length };
+    }
+    // A well-formed but unknown entity id is an explicit not-found, not a
+    // degraded natural-language search. Return an empty result with total 0;
+    // callers distinguish "no such id" from a name miss by the id-shaped input.
+    return { entities: [], total: 0 };
+  }
+
   const normalizedRaw = entityType
     ? normalizeEntityValue(entityType, identifier)
     : identifier.trim().toLowerCase();

--- a/src/shared/openapi_types.ts
+++ b/src/shared/openapi_types.ts
@@ -4006,13 +4006,17 @@ export interface operations {
             total?: number;
             limit?: number;
             offset?: number;
-            /** @description Which retrieval strategy answered the query. `none` when no
+            /**
+             * @description Which retrieval strategy answered the query. `none` when no
              *     `search` text was supplied; `semantic` when embedding search
              *     answered; `lexical_typed` when an entity-type token was
              *     detected; `lexical_fallback` when semantic search was
              *     attempted but returned nothing usable and lexical substring
-             *     matching answered instead. See issue #1506.
-             *      */
+             *     matching answered instead. Lets callers detect a silent
+             *     semantic→lexical degradation (e.g. embedding provider
+             *     unavailable). See issue #1506.
+             * @enum {string}
+             */
             search_mode?: "none" | "semantic" | "lexical_typed" | "lexical_fallback";
           };
         };
@@ -5546,15 +5550,18 @@ export interface operations {
         content: {
           "application/json": {
             relationships?: components["schemas"]["RelationshipSnapshot"][];
-            /** @description Total number of matching relationships before pagination.
+            /**
+             * @description Total number of matching relationships before pagination.
              *     Canonical pagination field, matching
              *     `/retrieve_graph_neighborhood`.
-             *      */
+             */
             total_count?: number;
-            /** @description Deprecated alias of `total_count`, retained for back-compat
+            /**
+             * @deprecated
+             * @description Deprecated alias of `total_count`, retained for back-compat
              *     with pre-existing clients. New clients SHOULD read
              *     `total_count`. See issue #369.
-             *      */
+             */
             total?: number;
             /** @description Echo of the requested `limit`. */
             limit?: number;

--- a/src/shared/openapi_types.ts
+++ b/src/shared/openapi_types.ts
@@ -4006,6 +4006,14 @@ export interface operations {
             total?: number;
             limit?: number;
             offset?: number;
+            /** @description Which retrieval strategy answered the query. `none` when no
+             *     `search` text was supplied; `semantic` when embedding search
+             *     answered; `lexical_typed` when an entity-type token was
+             *     detected; `lexical_fallback` when semantic search was
+             *     attempted but returned nothing usable and lexical substring
+             *     matching answered instead. See issue #1506.
+             *      */
+            search_mode?: "none" | "semantic" | "lexical_typed" | "lexical_fallback";
           };
         };
       };
@@ -5538,7 +5546,15 @@ export interface operations {
         content: {
           "application/json": {
             relationships?: components["schemas"]["RelationshipSnapshot"][];
-            /** @description Total number of matching relationships before pagination. */
+            /** @description Total number of matching relationships before pagination.
+             *     Canonical pagination field, matching
+             *     `/retrieve_graph_neighborhood`.
+             *      */
+            total_count?: number;
+            /** @description Deprecated alias of `total_count`, retained for back-compat
+             *     with pre-existing clients. New clients SHOULD read
+             *     `total_count`. See issue #369.
+             *      */
             total?: number;
             /** @description Echo of the requested `limit`. */
             limit?: number;

--- a/tests/integration/entity_identifier_handler.test.ts
+++ b/tests/integration/entity_identifier_handler.test.ts
@@ -90,4 +90,80 @@ describe("retrieveEntityByIdentifierWithFallback", () => {
     expect(result.entities[0]?.id).toBe(entityId);
     expect(result.entities[0]?.snapshot).toBeTruthy();
   });
+
+  // Regression: issue #1550 — a raw `ent_<hash>` id passed as the identifier
+  // resolved to empty (retrieve_entity_snapshot accepted it, this handler did
+  // not). The raw-id fast path now resolves it directly.
+  it("resolves a raw ent_ entity id directly (issue #1550)", async () => {
+    const userId = "identifier-user-rawid";
+    const entityId = "ent_0123456789abcdef01234567"; // ent_ + 24 hex chars
+    testEntityIds.push(entityId);
+    const now = new Date().toISOString();
+
+    await serviceRoleClient.from("entities").insert({
+      id: entityId,
+      user_id: userId,
+      entity_type: "contact",
+      canonical_name: "raw-id-contact@example.com",
+    });
+    await serviceRoleClient.from("entity_snapshots").upsert({
+      entity_id: entityId,
+      user_id: userId,
+      entity_type: "contact",
+      schema_version: "1.0",
+      canonical_name: "raw-id-contact@example.com",
+      snapshot: { name: "Raw Id Contact" },
+      provenance: {},
+      observation_count: 1,
+      last_observation_at: now,
+      computed_at: now,
+    });
+
+    const result = await retrieveEntityByIdentifierWithFallback({
+      identifier: entityId,
+      userId,
+      limit: 100,
+    });
+
+    expect(result.total).toBe(1);
+    expect(result.entities).toHaveLength(1);
+    expect(result.entities[0]?.id).toBe(entityId);
+    expect(result.entities[0]?.snapshot).toBeTruthy();
+  });
+
+  it("scopes a raw ent_ id lookup to the authenticated user (issue #1550)", async () => {
+    const ownerId = "identifier-user-rawid-owner";
+    const otherId = "identifier-user-rawid-other";
+    const entityId = "ent_fedcba9876543210fedcba98";
+    testEntityIds.push(entityId);
+
+    await serviceRoleClient.from("entities").insert({
+      id: entityId,
+      user_id: ownerId,
+      entity_type: "contact",
+      canonical_name: "scoped-raw-id@example.com",
+    });
+
+    // A different user must not resolve the id, and must get an explicit empty
+    // result (not a degraded natural-language search).
+    const result = await retrieveEntityByIdentifierWithFallback({
+      identifier: entityId,
+      userId: otherId,
+      limit: 100,
+    });
+
+    expect(result.total).toBe(0);
+    expect(result.entities).toHaveLength(0);
+  });
+
+  it("returns explicit empty for a well-formed but unknown ent_ id (issue #1550)", async () => {
+    const result = await retrieveEntityByIdentifierWithFallback({
+      identifier: "ent_00000000000000000000dead",
+      userId: "identifier-user-unknown-rawid",
+      limit: 100,
+    });
+
+    expect(result.total).toBe(0);
+    expect(result.entities).toHaveLength(0);
+  });
 });

--- a/tests/integration/entity_search_mode.test.ts
+++ b/tests/integration/entity_search_mode.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Regression tests for the search_mode response signal (issue #1506).
+ *
+ * queryEntitiesWithCount silently degraded semantic → lexical search when the
+ * embedding provider was unavailable, with no signal to the caller. The
+ * response now carries `search_mode` so the degradation is observable.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { db, getServiceRoleClient } from "../../src/db.js";
+
+const semanticMock = vi.hoisted(() => ({
+  semanticSearchEntities: vi.fn(async () => ({ entityIds: [] as string[], total: 0 })),
+}));
+
+vi.mock("../../src/services/entity_semantic_search.js", () => semanticMock);
+
+import { queryEntitiesWithCount } from "../../src/shared/action_handlers/entity_handlers.js";
+
+const serviceRoleClient = getServiceRoleClient();
+
+describe("queryEntitiesWithCount search_mode", () => {
+  const testUserId = "search-mode-test-user";
+  const testEntityIds: string[] = [];
+
+  async function cleanupEntities() {
+    if (testEntityIds.length === 0) return;
+    await db.from("entity_snapshots").delete().in("entity_id", testEntityIds);
+    await db.from("entities").delete().in("id", testEntityIds);
+    testEntityIds.length = 0;
+  }
+
+  async function createEntity(id: string, entityType: string, canonicalName: string) {
+    const now = new Date().toISOString();
+    await serviceRoleClient.from("entities").insert({
+      id,
+      user_id: testUserId,
+      entity_type: entityType,
+      canonical_name: canonicalName,
+    });
+    testEntityIds.push(id);
+    await serviceRoleClient.from("entity_snapshots").upsert({
+      entity_id: id,
+      user_id: testUserId,
+      entity_type: entityType,
+      schema_version: "1.0",
+      canonical_name: canonicalName,
+      snapshot: { name: canonicalName },
+      provenance: {},
+      observation_count: 1,
+      last_observation_at: now,
+      computed_at: now,
+    });
+  }
+
+  beforeEach(async () => {
+    semanticMock.semanticSearchEntities.mockReset();
+    semanticMock.semanticSearchEntities.mockResolvedValue({ entityIds: [], total: 0 });
+    await cleanupEntities();
+  });
+
+  afterEach(async () => {
+    await cleanupEntities();
+  });
+
+  it("returns search_mode 'none' when no search text is supplied", async () => {
+    const result = await queryEntitiesWithCount({ userId: testUserId, limit: 10, offset: 0 });
+    expect(result.search_mode).toBe("none");
+  });
+
+  it("returns search_mode 'lexical_fallback' when semantic search yields nothing", async () => {
+    const id = `ent_smode_fb_${Date.now()}`;
+    await createEntity(id, "research_report", "Newsletter Recipients Report");
+
+    const result = await queryEntitiesWithCount({
+      userId: testUserId,
+      search: "newsletter recipients",
+      limit: 10,
+      offset: 0,
+    });
+
+    expect(result.search_mode).toBe("lexical_fallback");
+    expect(semanticMock.semanticSearchEntities).toHaveBeenCalled();
+  });
+
+  it("returns search_mode 'lexical_typed' when a query token names an entity type", async () => {
+    const id = `ent_smode_typed_${Date.now()}`;
+    await createEntity(id, "plan", "Quarterly Roadmap Plan");
+
+    const result = await queryEntitiesWithCount({
+      userId: testUserId,
+      search: "plan roadmap",
+      limit: 10,
+      offset: 0,
+    });
+
+    expect(result.search_mode).toBe("lexical_typed");
+    // Typed lexical bypasses semantic entirely.
+    expect(semanticMock.semanticSearchEntities).not.toHaveBeenCalled();
+  });
+
+  it("returns search_mode 'semantic' when semantic search answers the query", async () => {
+    const id = `ent_smode_sem_${Date.now()}`;
+    await createEntity(id, "research_report", "Embedding Driven Match");
+
+    semanticMock.semanticSearchEntities.mockResolvedValue({ entityIds: [id], total: 1 });
+
+    const result = await queryEntitiesWithCount({
+      userId: testUserId,
+      search: "some free text query",
+      limit: 10,
+      offset: 0,
+    });
+
+    expect(result.search_mode).toBe("semantic");
+    expect(result.entities.some((e) => e.entity_id === id)).toBe(true);
+  });
+});

--- a/tests/integration/list_relationships_pagination.test.ts
+++ b/tests/integration/list_relationships_pagination.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Integration test: /list_relationships pagination (issues #367, #369).
+ *
+ * #367: pagination must be pushed to the DB (.range() + count: "exact") rather
+ *       than loading the full result set into memory and slicing.
+ * #369: the response declares `total_count` (canonical, matching
+ *       /retrieve_graph_neighborhood) alongside the deprecated `total` alias.
+ */
+import { createHash } from "node:crypto";
+import { createServer } from "node:http";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { app } from "../../src/actions.js";
+import { db } from "../../src/db.js";
+
+const TEST_USER_ID = "00000000-0000-0000-0000-000000000077";
+const API_PORT = 18127;
+const API_BASE = `http://127.0.0.1:${API_PORT}`;
+
+function makeEntityId(tag: string): string {
+  const hex = createHash("sha256").update(tag).digest("hex").slice(0, 24);
+  return `ent_${hex}`;
+}
+
+describe("/list_relationships pagination (#367, #369)", () => {
+  let httpServer: ReturnType<typeof createServer>;
+  const sourceId = makeEntityId(`lrp-source-${Date.now()}`);
+  const REL_COUNT = 6;
+  const targetIds: string[] = [];
+  const relationshipKeys: string[] = [];
+
+  beforeAll(async () => {
+    httpServer = createServer(app);
+    await new Promise<void>((resolve, reject) => {
+      httpServer.listen(API_PORT, "127.0.0.1", () => resolve());
+      httpServer.once("error", reject);
+    });
+
+    await db.from("entities").insert({
+      id: sourceId,
+      user_id: TEST_USER_ID,
+      entity_type: "note",
+      canonical_name: "lrp-source",
+    });
+
+    for (let i = 0; i < REL_COUNT; i++) {
+      const targetId = makeEntityId(`lrp-target-${i}-${Date.now()}`);
+      targetIds.push(targetId);
+      await db.from("entities").insert({
+        id: targetId,
+        user_id: TEST_USER_ID,
+        entity_type: "note",
+        canonical_name: `lrp-target-${i}`,
+      });
+
+      const relationshipType = "REFERS_TO";
+      const relationshipKey = `${relationshipType}:${sourceId}:${targetId}`;
+      relationshipKeys.push(relationshipKey);
+      // Stagger last_observation_at so ordering is deterministic and pages are
+      // stable.
+      const ts = new Date(Date.now() + i * 1000).toISOString();
+      await db.from("relationship_snapshots").upsert({
+        relationship_key: relationshipKey,
+        relationship_type: relationshipType,
+        source_entity_id: sourceId,
+        target_entity_id: targetId,
+        schema_version: "1.0",
+        snapshot: {},
+        computed_at: ts,
+        observation_count: 1,
+        last_observation_at: ts,
+        provenance: {},
+        user_id: TEST_USER_ID,
+      });
+    }
+  });
+
+  afterAll(async () => {
+    await db.from("relationship_snapshots").delete().in("relationship_key", relationshipKeys);
+    await db
+      .from("entities")
+      .delete()
+      .in("id", [sourceId, ...targetIds]);
+    await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+  });
+
+  async function listRelationships(body: Record<string, unknown>) {
+    const resp = await fetch(`${API_BASE}/list_relationships`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ user_id: TEST_USER_ID, ...body }),
+    });
+    return resp.json() as Promise<Record<string, unknown>>;
+  }
+
+  it("reports total_count equal to all relationships before pagination", async () => {
+    const body = await listRelationships({ source_entity_id: sourceId, limit: 100, offset: 0 });
+    expect(body.total_count).toBe(REL_COUNT);
+    // Deprecated alias retained for back-compat.
+    expect(body.total).toBe(REL_COUNT);
+  });
+
+  it("returns only `limit` rows per page (DB-side .range())", async () => {
+    const body = await listRelationships({ source_entity_id: sourceId, limit: 2, offset: 0 });
+    expect((body.relationships as unknown[]).length).toBe(2);
+    expect(body.total_count).toBe(REL_COUNT);
+    expect(body.limit).toBe(2);
+    expect(body.offset).toBe(0);
+  });
+
+  it("pages disjointly across the full result set", async () => {
+    const keysOf = (b: Record<string, unknown>) =>
+      (b.relationships as Array<{ relationship_key: string }>).map((r) => r.relationship_key);
+
+    const page1 = await listRelationships({ source_entity_id: sourceId, limit: 2, offset: 0 });
+    const page2 = await listRelationships({ source_entity_id: sourceId, limit: 2, offset: 2 });
+    const page3 = await listRelationships({ source_entity_id: sourceId, limit: 2, offset: 4 });
+
+    const all = [...keysOf(page1), ...keysOf(page2), ...keysOf(page3)];
+    const unique = new Set(all);
+    expect(unique.size).toBe(all.length);
+    expect(unique.size).toBe(REL_COUNT);
+  });
+
+  it("offset beyond total returns empty page but accurate total_count", async () => {
+    const body = await listRelationships({
+      source_entity_id: sourceId,
+      limit: 10,
+      offset: REL_COUNT + 5,
+    });
+    expect((body.relationships as unknown[]).length).toBe(0);
+    expect(body.total_count).toBe(REL_COUNT);
+  });
+
+  it("total_count is consistent across pages", async () => {
+    const p1 = await listRelationships({ source_entity_id: sourceId, limit: 2, offset: 0 });
+    const p2 = await listRelationships({ source_entity_id: sourceId, limit: 2, offset: 2 });
+    expect(p1.total_count).toBe(p2.total_count);
+  });
+});

--- a/tests/integration/update_schema_incremental_cold_start.test.ts
+++ b/tests/integration/update_schema_incremental_cold_start.test.ts
@@ -62,21 +62,24 @@ describe("update_schema_incremental: cold-start graceful fallback (issue #269)",
     );
 
     const body = JSON.parse(result.content[0].text) as {
-      success?: boolean;
-      error_code?: string;
-      no_schema_for_entity_type?: boolean;
-      hint?: string;
+      error?: {
+        error_code?: string;
+        message?: string;
+        hint?: string;
+        details?: { no_schema_for_entity_type?: boolean };
+      };
     };
 
-    // Must not throw — the response body carries the error.
-    expect(body.success).toBe(false);
-    expect(body.error_code).toBe("ERR_NO_SCHEMA_FOR_ENTITY_TYPE");
-    expect(body.no_schema_for_entity_type).toBe(true);
+    // Must not throw — the response body carries the canonical error envelope
+    // (issue #370): { error: { error_code, message, hint, details } }.
+    expect(body.error).toBeDefined();
+    expect(body.error?.error_code).toBe("ERR_NO_SCHEMA_FOR_ENTITY_TYPE");
+    expect(body.error?.details?.no_schema_for_entity_type).toBe(true);
 
     // Hint must point callers to register_schema and analyze_schema_candidates.
-    expect(typeof body.hint).toBe("string");
-    expect(body.hint).toContain("register_schema");
-    expect(body.hint).toContain("analyze_schema_candidates");
+    expect(typeof body.error?.hint).toBe("string");
+    expect(body.error?.hint).toContain("register_schema");
+    expect(body.error?.hint).toContain("analyze_schema_candidates");
   });
 
   it("returns a structured non-throwing response when existing schema lacks identity configuration", async () => {
@@ -113,18 +116,21 @@ describe("update_schema_incremental: cold-start graceful fallback (issue #269)",
     );
 
     const body = JSON.parse(result.content[0].text) as {
-      success?: boolean;
-      error_code?: string;
-      hint?: string;
+      error?: {
+        error_code?: string;
+        message?: string;
+        hint?: string;
+      };
     };
 
-    // Must not throw — the response body carries the error.
-    expect(body.success).toBe(false);
-    expect(body.error_code).toBe("ERR_SCHEMA_MISSING_IDENTITY_CONFIG");
+    // Must not throw — the response body carries the canonical error envelope
+    // (issue #370).
+    expect(body.error).toBeDefined();
+    expect(body.error?.error_code).toBe("ERR_SCHEMA_MISSING_IDENTITY_CONFIG");
 
     // Hint must point callers to register_schema with canonical_name_fields.
-    expect(typeof body.hint).toBe("string");
-    expect(body.hint).toContain("register_schema");
-    expect(body.hint).toContain("canonical_name_fields");
+    expect(typeof body.error?.hint).toBe("string");
+    expect(body.error?.hint).toContain("register_schema");
+    expect(body.error?.hint).toContain("canonical_name_fields");
   });
 });

--- a/tests/integration/update_schema_incremental_envelope.test.ts
+++ b/tests/integration/update_schema_incremental_envelope.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Regression tests for update_schema_incremental error envelope (issue #370).
+ *
+ * The fallback error paths previously returned a non-standard envelope
+ * (`{ success: false, error_code, hint }`) with codes that, while documented,
+ * did not match the canonical `{ error: { error_code, message, hint, details } }`
+ * shape. CLI/MCP error handlers pattern-match the canonical envelope, so these
+ * responses were effectively invisible. The handler now emits the canonical
+ * envelope.
+ */
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { db } from "../../src/db.js";
+import { NeotomaServer } from "../../src/server.js";
+
+const TEST_USER_ID = "00000000-0000-0000-0000-0000000003ee";
+
+function parseEnvelope(result: {
+  content: Array<{ type: string; text: string }>;
+}): Record<string, unknown> {
+  return JSON.parse(result.content[0]!.text) as Record<string, unknown>;
+}
+
+describe("update_schema_incremental canonical error envelope (#370)", () => {
+  let server: NeotomaServer;
+  const noSchemaType = `no_schema_type_${Date.now()}`;
+  const missingIdentityType = `missing_identity_type_${Date.now()}`;
+
+  beforeAll(async () => {
+    server = new NeotomaServer();
+  });
+
+  afterAll(async () => {
+    await db.from("schema_registry").delete().eq("entity_type", missingIdentityType);
+  });
+
+  it("emits ERR_NO_SCHEMA_FOR_ENTITY_TYPE in the canonical envelope", async () => {
+    const result = await server.executeToolForCli(
+      "update_schema_incremental",
+      {
+        entity_type: noSchemaType,
+        fields_to_add: [{ field_name: "amount", field_type: "number" }],
+      },
+      TEST_USER_ID
+    );
+
+    const body = parseEnvelope(result);
+    expect(body).toHaveProperty("error");
+    const error = body.error as Record<string, unknown>;
+    expect(error.error_code).toBe("ERR_NO_SCHEMA_FOR_ENTITY_TYPE");
+    expect(typeof error.message).toBe("string");
+    expect(typeof error.hint).toBe("string");
+    expect((error.details as Record<string, unknown>).entity_type).toBe(noSchemaType);
+    // Must NOT carry the legacy top-level shape.
+    expect(body.success).toBeUndefined();
+    expect(body.error_code).toBeUndefined();
+  });
+
+  it("emits ERR_SCHEMA_MISSING_IDENTITY_CONFIG in the canonical envelope", async () => {
+    // Insert a base schema directly (bypassing register() validation) that
+    // declares NEITHER canonical_name_fields NOR identity_opt_out. This models
+    // a legacy schema; the incremental update's internal re-register raises the
+    // R2 identity-config error, which the handler maps to the canonical
+    // ERR_SCHEMA_MISSING_IDENTITY_CONFIG envelope.
+    const { error: insertError } = await db.from("schema_registry").insert({
+      entity_type: missingIdentityType,
+      schema_version: "1.0.0",
+      schema_definition: { fields: { existing_field: { type: "string" } } },
+      reducer_config: { merge_policies: { existing_field: { strategy: "last_write" } } },
+      active: true,
+      scope: "global",
+    });
+    expect(insertError).toBeFalsy();
+
+    const result = await server.executeToolForCli(
+      "update_schema_incremental",
+      {
+        entity_type: missingIdentityType,
+        fields_to_add: [{ field_name: "new_field", field_type: "number" }],
+      },
+      TEST_USER_ID
+    );
+
+    const body = parseEnvelope(result);
+    expect(body).toHaveProperty("error");
+    const error = body.error as Record<string, unknown>;
+    expect(error.error_code).toBe("ERR_SCHEMA_MISSING_IDENTITY_CONFIG");
+    expect(typeof error.message).toBe("string");
+    expect(typeof error.hint).toBe("string");
+    expect((error.details as Record<string, unknown>).entity_type).toBe(missingIdentityType);
+    expect(body.success).toBeUndefined();
+    expect(body.error_code).toBeUndefined();
+  });
+});

--- a/tests/unit/config_sqlite_path.test.ts
+++ b/tests/unit/config_sqlite_path.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Unit tests for NEOTOMA_SQLITE_PATH override (issue #1504).
+ *
+ * The CLI help text advertises NEOTOMA_SQLITE_PATH as a supported override, but
+ * src/config.ts hard-derived sqlitePath and ignored the env var. These tests
+ * pin the honored-override behavior and the env-derived default fallback.
+ */
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+async function importFreshConfig() {
+  vi.resetModules();
+  return import("../../src/config.ts");
+}
+
+async function makeProjectRoot(prefix: string): Promise<{ homeDir: string; projectRoot: string }> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  const homeDir = path.join(root, "home");
+  const projectRoot = path.join(root, "project");
+  await fs.mkdir(homeDir, { recursive: true });
+  await fs.mkdir(projectRoot, { recursive: true });
+  await fs.writeFile(
+    path.join(projectRoot, "package.json"),
+    JSON.stringify({ name: "neotoma", version: "0.0.0-test" }, null, 2)
+  );
+  return { homeDir, projectRoot };
+}
+
+describe("config sqlitePath resolution", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it("honors NEOTOMA_SQLITE_PATH when set", async () => {
+    const { homeDir, projectRoot } = await makeProjectRoot("neotoma-sqlite-override-");
+    const customDb = path.join(os.tmpdir(), `neotoma-custom-${Date.now()}.db`);
+
+    vi.stubEnv("HOME", homeDir);
+    vi.stubEnv("USERPROFILE", homeDir);
+    vi.stubEnv("NEOTOMA_ENV", "development");
+    vi.stubEnv("NEOTOMA_PROJECT_ROOT", projectRoot);
+    vi.stubEnv("NEOTOMA_DATA_DIR", path.join(projectRoot, "data"));
+    vi.stubEnv("NEOTOMA_SQLITE_PATH", customDb);
+
+    const { config } = await importFreshConfig();
+    expect(config.sqlitePath).toBe(customDb);
+  });
+
+  it("falls back to the env-derived default when NEOTOMA_SQLITE_PATH is unset", async () => {
+    const { homeDir, projectRoot } = await makeProjectRoot("neotoma-sqlite-default-dev-");
+    const dataDir = path.join(projectRoot, "data");
+
+    vi.stubEnv("HOME", homeDir);
+    vi.stubEnv("USERPROFILE", homeDir);
+    vi.stubEnv("NEOTOMA_ENV", "development");
+    vi.stubEnv("NEOTOMA_PROJECT_ROOT", projectRoot);
+    vi.stubEnv("NEOTOMA_DATA_DIR", dataDir);
+    vi.stubEnv("NEOTOMA_SQLITE_PATH", "");
+
+    const { config } = await importFreshConfig();
+    expect(config.sqlitePath).toBe(path.join(dataDir, "neotoma.db"));
+  });
+
+  it("uses the production db name in the default when in production", async () => {
+    const { homeDir, projectRoot } = await makeProjectRoot("neotoma-sqlite-default-prod-");
+    const dataDir = path.join(projectRoot, "data");
+
+    vi.stubEnv("HOME", homeDir);
+    vi.stubEnv("USERPROFILE", homeDir);
+    vi.stubEnv("NEOTOMA_ENV", "production");
+    vi.stubEnv("NEOTOMA_PROJECT_ROOT", projectRoot);
+    vi.stubEnv("NEOTOMA_DATA_DIR", dataDir);
+    vi.stubEnv("NEOTOMA_SQLITE_PATH", "");
+
+    const { config } = await importFreshConfig();
+    expect(config.sqlitePath).toBe(path.join(dataDir, "neotoma.prod.db"));
+  });
+});

--- a/tests/unit/mirror_rebuild_auth.test.ts
+++ b/tests/unit/mirror_rebuild_auth.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Unit tests for mirror rebuild auth failure handling (issue #401).
+ *
+ * `neotoma mirror rebuild --profile <id>` previously exited 0 having written 0
+ * files when the API returned an auth error: rebuildProfile logged to stderr
+ * and returned silently. The fix makes an auth error throw, so the CLI catch
+ * block sets a non-zero exit code. These tests cover the auth-detection logic
+ * and the throwing behavior end-to-end via rebuildMirror.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { isAuthError, rebuildMirror } from "../../src/services/canonical_mirror.ts";
+
+describe("isAuthError", () => {
+  it("detects the canonical error envelope code", () => {
+    expect(isAuthError({ error: { code: "AUTH_REQUIRED" } })).toBe(true);
+  });
+
+  it("detects a bare code", () => {
+    expect(isAuthError({ code: "AUTH_REQUIRED" })).toBe(true);
+    expect(isAuthError({ code: "ERR_UNAUTHENTICATED" })).toBe(true);
+  });
+
+  it("detects HTTP 401 surfaced on the body", () => {
+    expect(isAuthError({ status: 401 })).toBe(true);
+    expect(isAuthError({ statusCode: 401 })).toBe(true);
+  });
+
+  it("returns false for non-auth errors", () => {
+    expect(isAuthError({ error: { code: "DB_QUERY_FAILED" } })).toBe(false);
+    expect(isAuthError({ status: 500 })).toBe(false);
+    expect(isAuthError(null)).toBe(false);
+    expect(isAuthError("nope")).toBe(false);
+    expect(isAuthError(undefined)).toBe(false);
+  });
+});
+
+describe("rebuildMirror profile auth failure (issue #401)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("throws (non-zero exit signal) when the API returns AUTH_REQUIRED for a profile rebuild", async () => {
+    // Drive the built-in default `neotoma-plans` profile through the apiClient
+    // path. The apiClient returns an auth error exactly as an unauthenticated
+    // server would; rebuildProfile must throw rather than return silently.
+    const apiClient = {
+      POST: vi.fn(async () => ({ error: { error: { code: "AUTH_REQUIRED" } } })),
+    } as unknown as Parameters<typeof rebuildMirror>[0] extends { apiClient?: infer A } ? A : never;
+
+    await expect(
+      rebuildMirror({ profileId: "neotoma-plans", apiClient, kind: "entities" })
+    ).rejects.toThrow(/AUTH_REQUIRED/);
+
+    // The auth failure short-circuits before any entity is rendered/written.
+    expect((apiClient as { POST: ReturnType<typeof vi.fn> }).POST).toHaveBeenCalled();
+  });
+
+  it("does not throw for a non-auth API error (logs and continues)", async () => {
+    const apiClient = {
+      POST: vi.fn(async () => ({ error: { error: { code: "DB_QUERY_FAILED" } } })),
+    } as unknown as Parameters<typeof rebuildMirror>[0] extends { apiClient?: infer A } ? A : never;
+
+    // A non-auth error returns silently (existing behavior): the rebuild
+    // resolves with a report rather than throwing.
+    await expect(
+      rebuildMirror({ profileId: "neotoma-plans", apiClient, kind: "entities" })
+    ).resolves.toBeDefined();
+  });
+});

--- a/tests/unit/sandbox_boot_banner.test.ts
+++ b/tests/unit/sandbox_boot_banner.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Unit tests for buildSandboxBootBannerLines (issue #1505).
+ *
+ * The refuse-mode banner must not promise the loopback escape under
+ * NEOTOMA_ENV=production, because resolveSandboxMode() gates the local_sandbox
+ * loopback verdict on `!productionEnv`. Pure-function tests, no IO.
+ */
+import { describe, expect, it } from "vitest";
+
+import { buildSandboxBootBannerLines } from "../../src/services/sandbox_mode.ts";
+
+describe("buildSandboxBootBannerLines", () => {
+  it("offers the loopback escape outside production", () => {
+    const lines = buildSandboxBootBannerLines({
+      mode: "refuse",
+      reason: "no auth + non-loopback",
+      shouldRefuseBoot: false,
+      refusePolicy: "warn",
+      productionEnv: false,
+    });
+    const text = lines.join("\n");
+    expect(text).toContain("NEOTOMA_HTTP_HOST=127.0.0.1");
+    expect(text).toContain("NEOTOMA_REQUIRE_AUTH=1");
+    expect(text).toContain("NEOTOMA_SANDBOX_MODE=1");
+  });
+
+  it("does NOT promise the loopback escape under production", () => {
+    const lines = buildSandboxBootBannerLines({
+      mode: "refuse",
+      reason: "production env",
+      shouldRefuseBoot: false,
+      refusePolicy: "warn",
+      productionEnv: true,
+    });
+    const text = lines.join("\n");
+    // The misleading remediation: binding loopback does not escape refuse mode
+    // in production, so the banner must not advertise it as an escape.
+    expect(text).not.toContain("bind to loopback (NEOTOMA_HTTP_HOST=127.0.0.1)");
+    expect(text).toContain("loopback bind does NOT escape");
+    // The remediations that actually work under production are still offered.
+    expect(text).toContain("NEOTOMA_REQUIRE_AUTH=1");
+    expect(text).toContain("NEOTOMA_SANDBOX_MODE=1");
+  });
+
+  it("emits no remediation block for non-refuse modes", () => {
+    const lines = buildSandboxBootBannerLines({
+      mode: "local",
+      reason: "auth configured",
+      shouldRefuseBoot: false,
+      refusePolicy: "warn",
+      productionEnv: true,
+    });
+    const text = lines.join("\n");
+    expect(text).toContain("Sandbox mode resolved: local");
+    expect(text).not.toContain("NEOTOMA_REQUIRE_AUTH=1");
+    expect(text).not.toContain("advisory class");
+  });
+
+  it("reports enforce-policy refusal with exit code 1", () => {
+    const lines = buildSandboxBootBannerLines({
+      mode: "refuse",
+      reason: "production env",
+      shouldRefuseBoot: true,
+      refusePolicy: "enforce",
+      productionEnv: true,
+    });
+    const text = lines.join("\n");
+    expect(text).toContain("refusing to start");
+    expect(text).toContain("Exit code 1");
+  });
+});


### PR DESCRIPTION
Ships the **Quick mechanical wins** cluster as one PR: eight low-complexity, mostly-independent fixes across CLI, MCP, and the HTTP contract surface. Each issue has a regression test.

## Issues fixed

### #401 — `mirror rebuild --profile` exited 0 writing 0 files when unauthenticated
- **Root cause:** `rebuildProfile()` in `src/services/canonical_mirror.ts` logged the API auth error to stderr and `return`ed silently, so the CLI exited 0 with an empty mirror.
- **Fix:** new `isAuthError()` helper detects `AUTH_REQUIRED` / HTTP 401; `rebuildProfile` throws on auth failure, and the CLI `mirror rebuild` catch block sets `process.exitCode = 1`. Non-auth API errors keep the prior log-and-continue behavior.

### #1504 — `NEOTOMA_SQLITE_PATH` advertised in CLI help but ignored
- **Root cause:** `src/config.ts` hard-derived `sqlitePath` from `dataDir`+env and never read the env var.
- **Fix:** `sqlitePath` now honors `process.env.NEOTOMA_SQLITE_PATH` when set, falling back to the env-derived default (`neotoma.db` / `neotoma.prod.db`).

### #1505 — refuse-mode boot banner promised a loopback escape under production
- **Root cause:** `resolveSandboxMode()` gates `local_sandbox` on `!productionEnv`, so binding `127.0.0.1` under `NEOTOMA_ENV=production` does NOT escape refuse mode, yet the banner advertised it.
- **Fix:** the banner now emits production-specific remediations (require-auth or sandbox-mode) and only offers the loopback escape outside production. Banner line construction extracted to `buildSandboxBootBannerLines()` in `sandbox_mode.ts` for unit testing.

### #1550 — `retrieve_entity_by_identifier` returned empty for a raw `ent_` id
- **Root cause:** the handler matched `canonical_name` / snapshot fields / semantic search but never the `entity_id` itself, so a raw id (which `retrieve_entity_snapshot` resolves) returned empty.
- **Fix:** a raw-id fast path resolves `ent_<24hex>` directly, scoped to the authenticated user. A well-formed but unknown id returns an explicit empty result rather than a degraded natural-language search.

### #1506 — `retrieve_entities` silently degraded semantic→lexical with no signal
- **Fix:** added a `search_mode` response field (declared in `openapi.yaml` first): `none` | `semantic` | `lexical_typed` | `lexical_fallback`. Threaded through both the HTTP `/entities/query` and MCP `retrieve_entities` responses so callers can detect when the embedding provider is unavailable.

### #367 — `/list_relationships` loaded the full set into memory then sliced
- **Root cause:** the handler ran an unranged query, materialized `data || []`, then `.slice(offset, offset+limit)` in process.
- **Fix:** pagination pushed to the DB via `.range(offset, offset+limit-1)` + `count: "exact"`; memory is now O(limit) instead of O(total).

### #369 — `/list_relationships` naming parity with `/retrieve_graph_neighborhood`
- The request fields and `total`/`limit`/`offset` were already declared. The remaining gap was naming: `/retrieve_graph_neighborhood` returns `total_count`.
- **Fix:** the response now returns `total_count` (canonical) alongside a **deprecated** `total` alias — additive and non-breaking. Both declared in `openapi.yaml`.

### #370 — `update_schema_incremental` fallback errors used a non-canonical envelope
- **Root cause:** the two fallback paths in `src/server.ts` returned `{ success: false, error_code, hint }`, which CLI/MCP error handlers (expecting `{ error: { … } }`) could not pattern-match.
- **Fix:** `ERR_NO_SCHEMA_FOR_ENTITY_TYPE` and `ERR_SCHEMA_MISSING_IDENTITY_CONFIG` now emit the canonical `{ error: { error_code, message, hint, details } }` envelope. `docs/reference/error_codes.md` updated to document the canonical shape (HTTP 400). The pre-existing cold-start test was updated to assert the canonical envelope.

## Contract surface

`#1506`, `#367`, and `#369` were coordinated in one `openapi.yaml` pass; types regenerated once. `npm run openapi:bc-diff` reports **no breaking changes** — both new fields (`search_mode`, `total_count`) are additive.

## Verification

- `npm run type-check` — pass
- `npm run lint` — pass (0 errors)
- `npm run format:check` — pass
- `npm run openapi:bc-diff` — no breaking changes (2 additive fields)
- `npm test -- tests/contract/` — 130 passed
- Targeted regression tests for all 8 issues — 31 passed

Pre-existing, unrelated test failures observed in this sandbox (confirmed failing on `origin/main` without these changes): `tests/cli/cli_smoke.test.ts` reset/data-dir protection tests and `tests/integration/graph_neighborhood_pagination.test.ts`. The full-suite pre-commit gate was bypassed via the hook's sanctioned `NEOTOMA_SKIP_TESTS=1` flag (type-check, lint, format, doc-deps still ran); `--no-verify` was not used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)