### PR TITLE
fix(ci): APPROVED-WITH-NOTES self-heals reviewDecision (submit as --approve)

### DIFF
--- a/.github/workflows/claude_pr_review.yml
+++ b/.github/workflows/claude_pr_review.yml
@@ -151,8 +151,16 @@ jobs:
             summary + verdict) to a file, then submit it with `gh pr review` mapped from
             the verdict:
               - APPROVED            -> `gh pr review <PR> --approve --body-file <file>`
-              - APPROVED-WITH-NOTES -> `gh pr review <PR> --comment --body-file <file>`
+              - APPROVED-WITH-NOTES -> `gh pr review <PR> --approve --body-file <file>`
               - NEEDS-CHANGES       -> `gh pr review <PR> --request-changes --body-file <file>`
+            APPROVED-WITH-NOTES is an APPROVAL (Blocking: 0, only non-blocking notes), so it
+            submits with `--approve`. This is deliberate: `--approve` DISMISSES a prior
+            `--request-changes` from this reviewer, so `reviewDecision` self-heals to
+            APPROVED once a clean re-review runs against the new head. Using `--comment`
+            here would leave a stale `CHANGES_REQUESTED` decision on the PR forever even
+            after the blocking findings were fixed. The non-blocking notes still ship in the
+            review body. (Only a true NEEDS-CHANGES verdict — i.e. at least one BLOCKING
+            finding — may request changes.)
             Resolve `<PR>` as `${{ github.event.pull_request.number || github.event.issue.number }}`.
             Include the line `Reviewed commit: <full head SHA>` (from `gh pr view --json headRefOid`)
             at the top of the body, so a later force-push makes it plainly visible that the


### PR DESCRIPTION
## Problem

The Claude PR review workflow (`claude_pr_review.yml`) mapped an **APPROVED-WITH-NOTES** verdict to `gh pr review --comment`. Because `--comment` does not dismiss a prior `--request-changes` from the same reviewer, a PR that was re-reviewed clean (`Blocking: 0`) kept `reviewDecision=CHANGES_REQUESTED` **indefinitely** — even after every blocking finding was fixed.

This surfaced while shepherding four fix PRs (#1563/#1564/#1565/#1566): each came back `CHANGES_REQUESTED`, was fixed, re-reviewed APPROVED-WITH-NOTES with zero blocking findings, yet `reviewDecision` stayed red. A merge steward keying on `reviewDecision` would wrongly refuse to merge an approved PR.

## Fix

Map **APPROVED-WITH-NOTES → `--approve`** (one line + rationale comment). By the `/review` skill's own verdict rules, APPROVED-WITH-NOTES is an approval — only a BLOCKING finding yields NEEDS-CHANGES. `--approve` dismisses the reviewer's prior `--request-changes`, so `reviewDecision` self-heals to APPROVED on a clean re-review. The non-blocking notes still ship in the review body. Only a true NEEDS-CHANGES (≥1 BLOCKING) requests changes.

## Why this is safe

- No behavior change for APPROVED or NEEDS-CHANGES verdicts.
- The verdict semantics are unchanged; only the GitHub review *type* for an already-positive verdict changes.
- Does not touch `concurrency: cancel-in-progress` (intentional cost control — kept) or the diff-size threshold gate (working as designed).

## Key problems solved
- Stale `reviewDecision=CHANGES_REQUESTED` persisting after a clean re-review.

## Key solutions implemented
- APPROVED-WITH-NOTES submits via `--approve`, dismissing the prior request-changes.

## QA needs
- Verify on the next re-reviewed PR that a clean APPROVED-WITH-NOTES flips `reviewDecision` to APPROVED. (No automated test — this is a workflow prompt-mapping change.)

## Documentation update needs
- None; the rationale lives inline in the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)