### PR TITLE
refactor(search): share query normalizer + drop fixture-tuned stop-tokens (#1572, #1573)

### DIFF
--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,15 +61,15 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **439**
-- Backend and repo Vitest files: **406**
+- Total automated test files: **440**
+- Backend and repo Vitest files: **407**
 - Frontend Vitest files: **9**
 - Playwright spec files: **24**
 
 ### Suite counts
 | Suite | Files |
 |---|---:|
-| Vitest unit tests | 112 |
+| Vitest unit tests | 113 |
 | Vitest service tests | 34 |
 | Source-adjacent tests | 50 |
 | Vitest integration tests | 123 |
@@ -108,7 +108,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/unit`
 **Requirements:** Basic `.env` if required by the module under test.
-**Files (112):**
+**Files (113):**
 - `tests/unit/aauth_admission.test.ts`
 - `tests/unit/aauth_attestation_apple_se.test.ts`
 - `tests/unit/aauth_attestation_revocation.test.ts`
@@ -206,6 +206,7 @@ flowchart TD
 - `tests/unit/schema_agent_instructions.test.ts`
 - `tests/unit/schema_inference.test.ts`
 - `tests/unit/schema_projection_lag.test.ts`
+- `tests/unit/search_normalization.test.ts`
 - `tests/unit/security_hardening.test.ts`
 - `tests/unit/seo_metadata.test.ts`
 - `tests/unit/session_info.test.ts`

--- a/src/services/schema_registry.ts
+++ b/src/services/schema_registry.ts
@@ -5,6 +5,7 @@
  */
 
 import { db } from "../db.js";
+import { normalizeSearchText } from "../shared/search_normalization.js";
 import {
   checkPluralEntityType,
   enforceEntityTypeGuards,
@@ -522,22 +523,6 @@ export async function deriveRequiredIdentityFields(
 }
 
 /**
- * Normalize a concept phrase the same way lexical search normalizes query
- * tokens (lowercase, hyphen/underscore → space, strip non-word, collapse
- * whitespace). Kept here so `query_synonyms` declarations are compared on the
- * same footing as the incoming query without importing the search module
- * (which would create a cycle).
- */
-function normalizeConceptPhrase(text: string): string {
-  return text
-    .toLowerCase()
-    .replace(/[-_]/g, " ")
-    .replace(/[^\w\s]/g, "")
-    .replace(/\s+/g, " ")
-    .trim();
-}
-
-/**
  * Build the concept-phrase → entity_type map from `query_synonyms`
  * declarations across all active schemas (global + user-scoped). Replaces the
  * hardcoded CONCEPT_TYPE_SYNONYMS map per docs/foundation/
@@ -597,7 +582,7 @@ export async function loadConceptTypeSynonyms(
   const sorted = declarations.sort((a, b) => a.entity_type.localeCompare(b.entity_type));
   for (const { entity_type, query_synonyms } of sorted) {
     for (const raw of query_synonyms) {
-      const phrase = normalizeConceptPhrase(raw);
+      const phrase = normalizeSearchText(raw);
       if (!phrase) continue;
       if (synonyms.has(phrase)) {
         if (synonyms.get(phrase) !== entity_type) {

--- a/src/shared/action_handlers/entity_handlers.ts
+++ b/src/shared/action_handlers/entity_handlers.ts
@@ -7,6 +7,11 @@ import { semanticSearchEntities } from "../../services/entity_semantic_search.js
 import { loadConceptTypeSynonyms } from "../../services/schema_registry.js";
 import type { EntityWithProvenance } from "../../services/entity_queries.js";
 
+// Shared, dependency-free normalizer (#1572). Imported (and re-exported below
+// for back-compat) so the schema registry can use the same function without an
+// import cycle. See src/shared/search_normalization.ts.
+import { normalizeSearchText } from "../search_normalization.js";
+
 export interface SnapshotFilter {
   op: "eq" | "in" | "gt" | "lt" | "gte" | "lte" | "contains";
   value?: unknown;
@@ -50,9 +55,13 @@ const MAX_LEXICAL_CANDIDATES = 5000;
 export const ENTITY_TYPE_KEYWORD_BOOST = 280;
 
 /**
- * Tokens that carry no identity signal in a descriptive multi-term query.
- * Used only by the partial-token fallback (#1551) to avoid letting filler
- * words inflate overlap scores. Strict all-token matching is unaffected.
+ * Generic English stopwords that carry no identity signal in a descriptive
+ * multi-term query. Used only by the partial-token fallback (#1551) to avoid
+ * letting filler words inflate overlap scores; strict all-token matching is
+ * unaffected. Intentionally limited to domain-agnostic function words — no
+ * site- or fixture-specific noise tokens (#1573): precision on descriptive
+ * queries is the job of PARTIAL_MATCH_MIN_OVERLAP_RATIO, not an ad-hoc
+ * denylist that would accrete a new entry every time a query trips the gate.
  */
 const PARTIAL_MATCH_STOP_TOKENS = new Set([
   "a",
@@ -64,9 +73,6 @@ const PARTIAL_MATCH_STOP_TOKENS = new Set([
   "of",
   "for",
   "with",
-  "now",
-  "try",
-  "site",
 ]);
 
 /**
@@ -136,14 +142,9 @@ type LexicalMatch = {
   score: number;
 };
 
-export function normalizeSearchText(text: string): string {
-  return text
-    .toLowerCase()
-    .replace(/[-_]/g, " ")
-    .replace(/[^\w\s]/g, "")
-    .replace(/\s+/g, " ")
-    .trim();
-}
+// Re-export the shared normalizer (imported above) so existing references to
+// `normalizeSearchText` from this module keep resolving (#1572).
+export { normalizeSearchText };
 
 export function matchesSearchTokens(searchableText: string, searchTokens: string[]): boolean {
   if (searchTokens.length === 0) return false;

--- a/src/shared/search_normalization.ts
+++ b/src/shared/search_normalization.ts
@@ -1,0 +1,25 @@
+/**
+ * Shared search-text normalization (#1572).
+ *
+ * Dependency-free so it can be imported by both the lexical-search module
+ * (`src/shared/action_handlers/entity_handlers.ts`) and the schema registry
+ * (`src/services/schema_registry.ts`) without creating an import cycle —
+ * entity_handlers already imports schema_registry, so schema_registry cannot
+ * import entity_handlers. Previously this normalizer was duplicated in both
+ * files (the registry copy was `normalizeConceptPhrase`); a future change to
+ * tokenization (e.g. Unicode folding, stemming) would have had to be mirrored
+ * in two places or the concept→type synonym bridge would silently stop
+ * matching. Keeping it here is the single source of truth.
+ *
+ * Lowercases, maps hyphen/underscore to space, strips non-word characters,
+ * and collapses whitespace, so a query string and a stored `query_synonyms`
+ * phrase compare on the same footing.
+ */
+export function normalizeSearchText(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[-_]/g, " ")
+    .replace(/[^\w\s]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}

--- a/tests/unit/search_normalization.test.ts
+++ b/tests/unit/search_normalization.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Unit tests for the shared search-text normalizer (#1572).
+ *
+ * This module is the single source of truth for query/synonym normalization,
+ * imported by both the lexical-search handler and the schema registry (which
+ * previously each held a byte-identical copy). These tests pin the
+ * normalization contract so the two consumers stay in lock-step.
+ */
+
+import { describe, expect, it } from "vitest";
+import { normalizeSearchText } from "../../src/shared/search_normalization.js";
+// Re-exported from entity_handlers for back-compat — must resolve to the same fn.
+import { normalizeSearchText as normalizeViaHandlers } from "../../src/shared/action_handlers/entity_handlers.js";
+
+describe("normalizeSearchText (#1572 shared normalizer)", () => {
+  it("lowercases", () => {
+    expect(normalizeSearchText("Bank ACCOUNT")).toBe("bank account");
+  });
+
+  it("maps hyphen and underscore to space", () => {
+    expect(normalizeSearchText("bank-account_balance")).toBe("bank account balance");
+  });
+
+  it("strips non-word punctuation", () => {
+    expect(normalizeSearchText("bank, account! (savings)")).toBe("bank account savings");
+  });
+
+  it("collapses whitespace and trims", () => {
+    expect(normalizeSearchText("  bank   account \n savings  ")).toBe("bank account savings");
+  });
+
+  it("returns empty string for all-punctuation input", () => {
+    expect(normalizeSearchText("!!! ,. ()")).toBe("");
+  });
+
+  it("is re-exported from entity_handlers as the same implementation", () => {
+    // Both import paths must resolve to one function — the duplication #1572
+    // removed would otherwise let them drift.
+    expect(normalizeViaHandlers).toBe(normalizeSearchText);
+  });
+});


### PR DESCRIPTION
Closes #1572. Closes #1573.

## #1572 — extract a shared, cycle-free query normalizer

`normalizeSearchText` lived in `src/shared/action_handlers/entity_handlers.ts` and was **duplicated byte-for-byte** as `normalizeConceptPhrase` in `src/services/schema_registry.ts`. The registry kept a private copy because `entity_handlers` already imports `schema_registry`, so importing back would create a cycle. The hazard: a future tokenization change (Unicode folding, stemming) would have to be mirrored in both, or the `query_synonyms` concept→type bridge would silently stop matching the normalized query.

Fix: extract a **dependency-free** `src/shared/search_normalization.ts` and import it from both. `entity_handlers` re-exports the name for back-compat, so no caller changes.

## #1573 — drop fixture-tuned stop-tokens from a generic module

`PARTIAL_MATCH_STOP_TOKENS` mixed generic English function words (`a/an/the/of`…) with **site-/fixture-specific noise tokens** (`now`, `try`, `site`) that were tuned to suppress one decoy in the #1551 test. That is hardcoded query-domain knowledge leaking into a generic search module — the same class of smell #1563 otherwise removed.

Fix: drop the three noise tokens. Precision on descriptive queries is the job of `PARTIAL_MATCH_MIN_OVERLAP_RATIO` (0.5), not an ad-hoc denylist that would grow an entry every time a query trips the gate. Verified no test depended on the removed tokens — the `lexical_search` #1551 precision cases still pass via the overlap threshold.

## Key problems solved
- Duplicated normalizer that could silently drift between the search handler and the schema registry.
- Domain-/fixture-specific noise tokens in a generic stopword set.

## Key solutions implemented
- Single `search_normalization.ts` module imported by both consumers (re-exported for back-compat).
- Stop-token set reduced to domain-agnostic function words.

## Automated tests
- New `tests/unit/search_normalization.test.ts` (6 tests), including an assertion that the `entity_handlers` re-export **is the same function** as the shared module — so the two consumers cannot drift again.
- `lexical_search`, `entity_search_mode`, and schema-registry suites green. `type-check` / `lint` / `format` clean.

## Documentation update needs
- None. No API or behavior change (pure refactor + dead-token removal); `openapi.yaml` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)