### PR TITLE
Release v0.16.0

### DIFF
--- a/.claude/skills/advisory/SKILL.md
+++ b/.claude/skills/advisory/SKILL.md
@@ -1,0 +1,314 @@
+---
+name: advisory
+description: File, maintain, and close security advisories. Keeps docs/security/advisories/, docs/security/practices.md, and GitHub Security Advisories (GHSA) in sync. Two modes — new (file advisory) and close (mark fixed).
+triggers:
+  - /advisory
+  - file advisory
+  - create advisory
+  - close advisory
+  - mark advisory fixed
+---
+
+# Advisory
+
+Use this skill to manage the full security advisory lifecycle. It enforces atomicity — advisory files, the README index, practices.md, GitHub issues, and the GHSA are updated together so nothing drifts.
+
+Two modes:
+
+- **`/advisory new`** — File a new advisory for a discovered vulnerability
+- **`/advisory close <slug> <version>`** — Mark an existing open advisory fixed in a release
+
+---
+
+## When to Use
+
+- A vulnerability has been identified and needs a disclosure record
+- A fix has shipped for an open advisory and the record needs to be closed out
+- `practices.md` is out of date with the current advisory set
+
+Invoke with `/advisory new` or `/advisory close <slug> <version>`.
+
+---
+
+## Constraints (apply throughout)
+
+- **MUST NOT** include attack vector specifics, exploit steps, or payload details in any repo markdown file (`docs/security/advisories/`, `practices.md`, GitHub issues). Those belong in the GHSA, which is private until coordinated disclosure.
+- Sanitized content describes: what category of bug, what prerequisites, what data is accessible, what the severity is, and what the fix entails — without explaining *how* to perform the access.
+- **MUST** commit advisory files, README update, and practices.md update atomically in a single commit.
+- **MUST** use `SKIP_TESTS=1` on commit if pre-existing test failures on the branch would block the hook.
+
+---
+
+## Mode: `/advisory new`
+
+### Step 1: Gather inputs
+
+Collect the following before writing anything:
+
+| Field | Notes |
+|-------|-------|
+| Slug | `<YYYY-MM-DD>-<short-kebab-description>` — date is discovery date |
+| CVE class | Category of vulnerability (e.g., tenant isolation bypass, auth middleware gap) |
+| Affected version(s) | Which released tag(s) contain the bug |
+| Prerequisites | What the attacker needs — be specific but sanitized |
+| Impact | What data/functionality is exposed — no exploit steps |
+| Severity | Low / Medium / High with reasoning |
+| Remediation approach | What the fix entails — high level |
+| Tracking issues | GitHub issue numbers for fix and gate gaps (create if they don't exist) |
+| Gate gap | Which security gate(s) failed to catch this and why |
+
+If any field is unclear, ask before proceeding.
+
+### Step 2: Draft the advisory file
+
+Create `docs/security/advisories/<slug>.md` using this structure:
+
+```markdown
+# Advisory: <Title>
+
+**Advisory ID:** <slug>
+**Date:** <YYYY-MM-DD>
+**Severity:** <Low|Medium|High> (<brief rationale>)
+**Status:** <Fixed in vX.Y.Z | Open — fix tracked in #N, #M>
+
+---
+
+## CVE Class
+
+<One paragraph: vulnerability category, what makes it exploitable, regression class if known.>
+
+---
+
+## Affected Versions
+
+- vX.Y.Z
+
+<Fixed in / Not yet fixed.>
+
+---
+
+## Prerequisites
+
+<Numbered list of what an attacker needs. Sanitized — no exploit steps.>
+
+---
+
+## Impact
+
+<What data or functionality is exposed. Sanitized — no exploit steps.>
+
+---
+
+## Severity
+
+**<Low|Medium|High>** <reasoning paragraph>
+
+<Escalation condition if applicable.>
+
+---
+
+## Remediation
+
+<Fix approach. Reference tracking issues. No exploit details.>
+
+---
+
+## Disclosure Timeline
+
+| Date | Event |
+|------|-------|
+| <date> | Vulnerability identified |
+| <date> | Advisory filed |
+| TBD | Fix released |
+
+---
+
+## Tracking Issues
+
+- **#N** — <description>
+
+---
+
+## Gate Gap
+
+<Which gate(s) did not catch this. Why. What the extension entails. Reference tracking issue for gate fix.>
+```
+
+### Step 3: Update the advisories README index
+
+Add a row to the index table in `docs/security/advisories/README.md`:
+
+```markdown
+| [<slug>](./<slug>.md) | <Short title> | vX.Y.Z | <Severity> (<rationale>) | <Open — fix tracked in #N | Fixed in vX.Y.Z> |
+```
+
+### Step 4: Update practices.md
+
+Open `docs/security/practices.md` and make the following updates:
+
+1. **For each gate the advisory reveals a gap in:** add a row to that gate's "Known gaps" section describing the gap and referencing the advisory slug.
+
+2. **For each gate extension the advisory motivates:** add a row to that gate's "History" table with the date, change description, and advisory slug.
+
+3. **In the "Advisory → hardening linkage" section:** add a bullet for the new advisory linking it to the specific gate work it motivated (or a waiver if no gate change is needed).
+
+4. **If the advisory introduces an escalation condition** (e.g., single-tenant assumption): update the "Cross-cutting practices" section to document it.
+
+The practices.md update must reflect the *current* state — pending gate work is noted as "Pending, tracked in #N", not omitted.
+
+### Step 5: File sanitized GitHub issues
+
+For each required fix and gate gap that doesn't already have a tracking issue:
+
+```bash
+gh issue create \
+  --title "<sanitized title>" \
+  --body "<sanitized description — no attack vector details>" \
+  --label "security"
+```
+
+Issues describe *what* to fix (add per-user scoping, extend gate coverage) without explaining *how the vulnerability works*.
+
+### Step 6: Commit atomically
+
+Stage all changed files and commit:
+
+```bash
+git add docs/security/advisories/<slug>.md \
+        docs/security/advisories/README.md \
+        docs/security/practices.md
+
+SKIP_TESTS=1 git commit -m "docs(security): file advisory <slug>
+
+<one-line summary of what the vulnerability is>
+
+Advisory covers: <CVE class>. Affected: <version>. Severity: <level>.
+Fix tracked in #N. Gate gap tracked in #M.
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+### Step 7: Open a GitHub Security Advisory (GHSA)
+
+This is where full technical details can go — the GHSA is private until coordinated disclosure.
+
+```bash
+gh api repos/{owner}/{repo}/security-advisories --method POST \
+  --field summary="<title>" \
+  --field description="<full technical description including prerequisites and exploit details>" \
+  --field severity="<low|medium|high|critical>" \
+  --field vulnerabilities='[{"package":{"ecosystem":"npm","name":"neotoma"},"vulnerable_version_range":"= X.Y.Z"}]'
+```
+
+If the API call fails due to token scope, instruct the user to open manually at:
+`https://github.com/<owner>/<repo>/security/advisories/new`
+
+and provide the full content to paste.
+
+Record the GHSA URL in the advisory file's Disclosure Timeline once it's created.
+
+### Step 8: Push and open a PR
+
+```bash
+git push origin <branch>
+gh pr create \
+  --title "docs(security): file advisory <slug>" \
+  --base dev \
+  --body "..."
+```
+
+The PR description must not expose attack vector details either — treat it as public.
+
+---
+
+## Mode: `/advisory close <slug> <version>`
+
+Use when a fix has shipped in a release and the advisory record needs to be closed.
+
+### Step 1: Verify the fix is released
+
+```bash
+gh release view <version>
+```
+
+Confirm the release tag exists and the fix commits are included.
+
+### Step 2: Update the advisory file
+
+In `docs/security/advisories/<slug>.md`:
+
+- Change `**Status:** Open — fix tracked in #N` to `**Status:** Fixed in <version>`
+- Fill in the Remediation section with what was actually done (commits, approach)
+- Add the fix release date to the Disclosure Timeline table
+
+### Step 3: Update the README index
+
+Change the Status cell for the advisory row from `Open — fix tracked in #N` to `Fixed in <version>`.
+
+### Step 4: Update practices.md
+
+For each gate extension that was implemented as part of the fix:
+
+1. Move pending items from "Known gaps" to the "History" table with the date they landed
+2. Update the "Advisory → hardening linkage" bullet to show the gate work as completed
+
+### Step 5: Close tracking issues
+
+```bash
+gh issue close <fix-issue-number> --reason completed
+gh issue close <gate-gap-issue-number> --reason completed
+```
+
+Add a closure comment on each:
+
+```bash
+gh issue comment <number> --body "Fixed in <version>. Advisory: docs/security/advisories/<slug>.md"
+```
+
+### Step 6: Update the GHSA
+
+If the GHSA is open, update it to reflect the fix and set it to published if disclosure is appropriate:
+
+```bash
+gh api repos/{owner}/{repo}/security-advisories/<ghsa-id> --method PATCH \
+  --field state="published"
+```
+
+### Step 7: Commit and push
+
+```bash
+git add docs/security/advisories/<slug>.md \
+        docs/security/advisories/README.md \
+        docs/security/practices.md
+
+SKIP_TESTS=1 git commit -m "docs(security): close advisory <slug> — fixed in <version>
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+
+git push origin <branch>
+gh pr create --title "docs(security): close advisory <slug>" --base dev
+```
+
+---
+
+## File and gate reference
+
+| File | Purpose | Updated by this skill |
+|------|---------|----------------------|
+| `docs/security/advisories/README.md` | Index of all advisories | Every invocation |
+| `docs/security/advisories/<slug>.md` | Per-vulnerability record | `new` and `close` |
+| `docs/security/practices.md` | Living gate posture and hardening history | Every invocation |
+| `scripts/security/protected_routes_manifest.json` | Route auth manifest | Only if fix touches manifest |
+| `tests/security/auth_topology_matrix.test.ts` | Auth-topology test | Only if gate gap fix lands |
+
+---
+
+## Checklist before committing
+
+- [ ] Advisory file has no attack vector details (prerequisites and impact are sanitized)
+- [ ] README index row added/updated
+- [ ] practices.md updated: gate gaps noted, history rows added, hardening linkage bullet present
+- [ ] GitHub issues filed for fix and gate gap (if not pre-existing)
+- [ ] All three docs staged in the same commit
+- [ ] GHSA opened or queued for manual creation
+- [ ] PR description is sanitized (public-safe)

--- a/docs/security/practices.md
+++ b/docs/security/practices.md
@@ -1,0 +1,165 @@
+# Security Practices
+
+Living reference for Neotoma's security posture. Documents the current state of each security gate, checklist, and tooling artifact, along with the advisory or finding that motivated it. Append-only at the section level — when a gate is extended, update its section in place and add the motivating advisory to its history table.
+
+This document is paired with `docs/security/advisories/` (per-vulnerability records). Read advisories to learn *what happened*; read this document to understand *what we now do because of it*.
+
+---
+
+## Layered defense overview
+
+Neotoma's pre-release security posture is structured as five gates, two of which are advisory and three of which are blocking. Each gate covers a distinct failure mode. The composition is intentional: no single gate catches every regression class, and each gate's scope is documented so that gaps are surfaced rather than implicit.
+
+| Gate | Lane | Scope | Blocks release? |
+|------|------|-------|-----------------|
+| G1 — Diff classifier | Pre-release | Labels diffs `sensitive=true/false` to trigger downstream gates | No (gating signal only) |
+| G2 — Static lint (`security:lint`) | PR + release | Static analysis of auth-sensitive code patterns | Yes, on errors |
+| G3a — Manifest check | PR + release | Registered routes match `protected_routes_manifest.json` | Yes |
+| G3b — Auth-topology matrix | PR + release | Runtime test that protected routes reject unauthenticated callers across all reachable paths | Yes |
+| G4 — AI security review | Release only | LLM-driven adversarial walkthrough of the release diff | Manual sign-off |
+| G5 — Deployed probes | Release only | Live HTTP probes against the deployed environment | Yes |
+
+The pre-PR adversarial checklist is a sixth layer (human-driven), tracked separately in `.cursor/skills/release/SKILL.md` § Step 3.5.
+
+---
+
+## G2 — Static lint (`security:lint`)
+
+**Command:** `npm run security:lint`  
+**Implementation:** `scripts/security/lint.js`  
+**Blocks on:** Errors only. Warnings are advisory.
+
+### Current rules
+
+| Rule | What it catches | Motivating advisory |
+|------|-----------------|---------------------|
+| `forwarded-for-trust` | Direct reads of `req.socket.remoteAddress`, `X-Forwarded-For`, or `Host` headers outside the canonical helpers in `src/actions.ts` and `src/services/root_landing/**` | 2026-05-11-inspector-auth-bypass |
+| `local-dev-user-id-scope` | References to `LOCAL_DEV_USER_ID` outside `src/cli/**`, `src/services/local_auth.ts`, and `tests/**` | 2026-05-11-inspector-auth-bypass |
+| `alternate-path-auth-bypass` | Route handlers reachable through a proxy or alternate path that do not re-apply `requireUser` middleware | 2026-05-11-inspector-auth-bypass |
+
+### Known gaps
+
+The linter operates on source-text patterns. It does **not** analyze:
+
+- Database query filter clauses (`.eq("user_id", userId)`) — see G3b gap for `2026-05-21-relationship-endpoint-tenant-isolation`
+- Per-handler authorization scope after authentication
+- Cross-file data-flow
+
+Gate gap tracked in **#372**.
+
+---
+
+## G3a — Protected routes manifest
+
+**Command:** `npm run security:manifest:check` (verify) / `npm run security:manifest:write` (regenerate)  
+**Manifest:** `scripts/security/protected_routes_manifest.json`  
+**Blocks on:** Drift between registered Express routes and the manifest.
+
+### Current behavior
+
+Every public Express route MUST appear in one of two lists in the manifest:
+
+1. **`auth_required`** — Routes that require `requireUser()` or `assertGuestWriteAllowed()` middleware
+2. **`unauth_allowed`** — Routes intentionally accessible without authentication, each with a stated `reason`
+
+The check rejects PRs that add a new route without updating the manifest. Silent additions are blocked.
+
+### History
+
+| Date | Change | Motivating advisory |
+|------|--------|---------------------|
+| 2026-05-11 | Manifest instantiated and gate added to CI | 2026-05-11-inspector-auth-bypass |
+| 2026-05-11 | Inspector proxy path added with proper middleware annotation | 2026-05-11-inspector-auth-bypass |
+
+### Known gaps
+
+- The manifest verifies that auth middleware is registered. It does **not** verify that the middleware correctly resolves to the authenticated user, nor that downstream queries scope to that user. The v0.13.0 tenant isolation gap (`2026-05-21-relationship-endpoint-tenant-isolation`) shipped despite both `/list_relationships` and `/retrieve_graph_neighborhood` being correctly listed in the manifest as `auth_required`. Authentication was present; authorization scope was not.
+
+Gate gap tracked in **#372**.
+
+---
+
+## G3b — Auth-topology matrix test
+
+**Command:** `npm run test:security:auth-matrix`  
+**Test file:** `tests/security/auth_topology_matrix.test.ts`  
+**Blocks on:** Test failure.
+
+### Current behavior
+
+Runtime test that walks every route surface (direct, via Inspector proxy, via CLI tunnel) and confirms that protected routes reject unauthenticated requests with the expected error. Covers the auth-middleware layer, not the per-query authorization layer.
+
+### History
+
+| Date | Change | Motivating advisory |
+|------|--------|---------------------|
+| 2026-05-11 | Test added with coverage for direct + Inspector proxy paths | 2026-05-11-inspector-auth-bypass |
+| Pending | Extend to assert per-user query scoping on read endpoints (see #372) | 2026-05-21-relationship-endpoint-tenant-isolation |
+
+### Known gaps
+
+The matrix asserts that an unauthenticated caller is rejected. It does **not** assert that an authenticated caller cannot access another user's data. This is the gap that allowed the v0.13.0 tenant isolation issue to ship; the extension to cover cross-user read access is tracked in **#372**.
+
+---
+
+## Pre-release adversarial checklist
+
+**Location:** `.cursor/skills/release/SKILL.md` § Step 3.5  
+**Owner:** Release driver (human, with AI assistance)
+
+### Current categories
+
+The checklist enumerates known regression classes that must be walked through against the release diff before tagging:
+
+| Category | Motivating advisory |
+|----------|---------------------|
+| Alternate-path auth bypass (proxies, CLI tunnels, new middleware stacks) | 2026-05-11-inspector-auth-bypass |
+| Proxy trust / `X-Forwarded-For` / `Host` header reads | 2026-05-11-inspector-auth-bypass |
+| Local-dev shortcut widening (`LOCAL_DEV_USER_ID`, `isLocalRequest` fallbacks) | 2026-05-11-inspector-auth-bypass |
+| New unauthenticated public route | 2026-05-11-inspector-auth-bypass |
+| Guest-access widening | 2026-05-11-inspector-auth-bypass |
+| Pending: Cross-tenant data access on read endpoints (per-user query scope) | 2026-05-21-relationship-endpoint-tenant-isolation (see #372) |
+
+### Known gaps
+
+The v0.13.0 release shipped with a tenant isolation gap because **the cross-user data access category did not exist in the checklist**. The release driver walked through the alternate-path and proxy-trust categories (motivated by v0.11.1) but had no prompt to verify per-user query scoping. The checklist extension is tracked in **#372**.
+
+This is the failure mode the checklist is designed against: a regression class that isn't in the list won't be checked. New categories must be added whenever an advisory reveals a class the previous gates didn't cover.
+
+---
+
+## Cross-cutting practices
+
+### Advisory → hardening linkage
+
+Every advisory in `docs/security/advisories/` MUST result in one of:
+
+1. A new gate, rule, or checklist category (documented in this file under the relevant section)
+2. An explicit waiver with a written reason (documented in the advisory's Gate Gap section)
+
+The two advisories filed to date have both produced gate or checklist work:
+
+- `2026-05-11-inspector-auth-bypass` → G2 rules, G3a manifest, G3b matrix test, checklist categories 1–5 (all landed in v0.11.1)
+- `2026-05-21-relationship-endpoint-tenant-isolation` → G3b extension, checklist category 6 (pending, tracked in #372)
+
+### Single-tenant assumption
+
+All current gates assume single-tenant deployment. The v0.13.0 tenant isolation gap had no real-world impact because no multi-tenant deployments exist. Before any multi-tenant deployment lands:
+
+- #365 (per-user scoping on `/list_relationships`) must be fixed
+- #366 (per-user scoping on `/retrieve_graph_neighborhood`) must be fixed
+- #372 (gate coverage for cross-user data access) must be closed
+
+The escalation condition is documented in the advisory itself.
+
+### Source of truth
+
+| Surface | Canonical doc |
+|---------|---------------|
+| Per-vulnerability records | `docs/security/advisories/` |
+| Current posture and gate history | `docs/security/practices.md` (this file) |
+| Threat model | `docs/security/threat_model.md` |
+| Release-time gate execution | `.cursor/skills/release/SKILL.md` § Step 3.5 |
+| Change-time guardrails | `.claude/rules/change_guardrails_rules.md` |
+
+When a new advisory is filed, update this document in the same change — the linkage from advisory to gate change is the artifact that proves the security posture is actually evolving.


### PR DESCRIPTION
## Release v0.16.0 — candidate (notes pending)

**Base:** `main` as-is (= current production behavior; prod runs unreleased source 127 commits past the `v0.15.0` tag). This release publishes that real state as `0.16.0` so the production install stops being a 126-commit-stale `npm link` symlink and can install the actual artifact.

**This RC adds, on top of main, only 2 salvaged additive files** (no code paths, no auth surface):
- `.claude/skills/advisory/SKILL.md` — `/advisory` security-advisory lifecycle skill
- `docs/security/practices.md` — security hardening journal

These were the only genuinely-new artifacts on the stale `dev` branch. Dev's tenant-isolation code/tests were a **superseded** parallel implementation (PR #351) of the fix already shipped in **v0.14.0** (PR #379, in prod) and were intentionally dropped to avoid regressing the live read-path auth scoping.

### Status: PAUSED before release prep
Curated release notes (supplement + Highlights across the 127-commit range), the security review lane (`security_review.md`), the `/review` coverage lane, and execute (tag / npm publish / sandbox deploy) are **not yet run**. This PR is open as the public review window; release prep resumes on operator go-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)