### PR TITLE
feat(skills): add user-level /end and /status session skills

### DIFF
--- a/skills/end/SKILL.md
+++ b/skills/end/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: end
+description: Session-end audit. Files remaining work as task entities and lists them as bullets, verifies all data intended for Neotoma storage from this session is actually stored, and persists what's missing. Invoke at the natural close of a working session, before context is lost.
+triggers:
+  - /end
+  - end session
+  - wrap up session
+  - close out session
+  - finish session
+user_invocable: true
+supported_harnesses:
+  - claude-code
+  - cursor
+entity_id: ent_af748d985b7bfa4f636eea70
+---
+
+# end
+
+## Purpose
+
+Run a session-close audit so nothing intended for follow-up or for Neotoma storage falls through the cracks. Distinct from `store-data` (single per-record persistence) and `store-neotoma` (full chat-transcript persistence): `/end` is the meta-step that decides which of those to invoke, files trackable work as task entities, and verifies storage.
+
+This skill is **user-level** (`~/.claude/skills/end/`), so it is available in every repo automatically.
+
+## Scope
+
+Applies once per session, at user request. Does not modify code. Files Neotoma entities (tasks, sources, plan updates), persists missing entities, and delegates to `store-neotoma` for chat persistence.
+
+## Execution policy (no confirmation gate)
+
+`/end` runs end-to-end without asking for approval:
+
+- It **files task entities first**, stores missing entities, and invokes `store-neotoma` as needed — **then** reports what it did.
+- It does **not** request confirmation before filing tasks, storing entities, or invoking `store-neotoma`.
+- The only thing it never auto-executes is `do-now` code work unless the user explicitly asked for it in-session; those are filed as tasks like any other `track` item.
+- PII MUST still be stripped from any filed issues per the `feedback_issue_pii` memory, and standing constraints (Neotoma prod, never mark yoga/therapy done, etc.) still apply.
+
+## Phase 1: Remaining-work audit
+
+Scan the current conversation and identify every follow-up under these headings:
+
+1. **Open work** — TODOs the assistant introduced, partial implementations, files modified but not verified, tests not run, lint/type-check skipped, PRs/commits not made.
+2. **Decisions or proposals not acted on** — recommendations the user accepted that have not been executed; designs sketched but not implemented.
+3. **Trackable follow-ups** — bugs noticed in passing, refactors deferred, documentation drift spotted, dependencies needing updates.
+4. **External obligations** — anything waiting on CI, a remote agent, a scheduled task, or a third party.
+5. **User feedback or preferences expressed this session** — candidates for memory (`feedback`/`user`/`project`/`reference`).
+
+For each item, classify: `do-now` (trivially finishable inline only if the user asked), `track` (file as a task entity), or `drop` (acknowledged, no action — give a one-line reason).
+
+## Phase 2: Neotoma storage audit
+
+Determine what should be in Neotoma from this session and what already is.
+
+1. **Per-turn lifecycle compliance** — confirm each turn this session followed the Neotoma turn lifecycle (user message + assistant message stored, PART_OF + REFERS_TO edges). If any turn was skipped (which is forbidden), note it for repair.
+2. **Substantive entities surfaced** — list every concrete entity discussed or produced this session: plans, decisions, skills, rules, bugs, contacts, transactions, events, code artifacts, etc. For each, check via `retrieve_entity_by_identifier` or `retrieve_entities` whether it is already stored.
+3. **Files or attachments** — any files the user pasted, screenshots, transcripts, or external URLs fetched. Check whether each has a corresponding `source_id` / content-addressed source row.
+4. **Memory-worthy facts** — items that should be written to the auto-memory directory (`~/.claude/projects/.../memory/`) per the auto-memory protocol.
+
+## Phase 3: Execute (file tasks first, then everything else)
+
+Run in this order, without confirmation:
+
+1. **File `task` entities for every `track` item from Phase 1.** Create them via the `store` MCP tool (Neotoma prod) with `REFERS_TO` edges to the relevant entities, and `PART_OF` the active plan when one applies (e.g. the Ateles plan `ent_99ace4dd6673aa36ed08b1fe`). Follow the `update-tasks` skill for field values and priority mapping. Capture the returned task entity IDs.
+2. **Store missing entities or sources flagged in Phase 2** via the `store` MCP tool.
+3. **If the conversation itself has not been persisted** as a `conversation` + dual `conversation_message` shape end-to-end, invoke `store-neotoma` to do the full transcript sweep — **without confirmation** (pass through the no-confirm intent).
+4. **Write any memory files** per the auto-memory protocol and update the `MEMORY.md` index.
+5. **Repair any skipped-turn lifecycle gaps** found in Phase 2.1.
+
+## Phase 4: Final report (bullets reflect what was actually stored)
+
+Because tasks are filed **before** reporting, the bulleted list reflects committed state, not intentions.
+
+Render two sections:
+
+### Remaining work (now tracked)
+
+A bullet list of every `track` item, each as: `- <one-line description> — task [<entity_id>](<origin>/inspector/entities/<entity_id>)`. Then a short `do-now` list (done inline or filed) and a `dropped` list with one-line reasons.
+
+### Storage
+
+- Entities/sources stored this turn (with entity IDs).
+- Memory files written.
+- Whether `store-neotoma` was invoked, and its affected-records summary.
+
+Then render the mandatory `🧠 Neotoma` turn report covering all entities created across Phases 3–4 (Created / Updated / Retrieved groups with linked entity IDs).
+
+## Affected-records output (shared with store-neotoma)
+
+Both `/end` and `store-neotoma` MUST emit a **succinct affected-records list** in the Neotoma-MCP turn-report style — the same Created (N) / Updated (N) / Retrieved (N) grouping the live-chat instructions dictate for per-turn operations. One bullet per record: emoji + label + linked `entity_type` text pointing to `<origin>/inspector/entities/<entity_id>`. Do not dump full snapshots; a one-line labeled link per record is the contract.
+
+## Relationship to other skills
+
+- **`store-data`** — per-entity/per-file store primitive. `/end` calls the underlying `store` MCP tool for each gap in Phase 2.
+- **`store-neotoma`** — full chat-transcript persistence. `/end` delegates to it when the conversation is not yet fully persisted, and (per user preference) invokes it **without a confirmation gate**, expecting it to emit the succinct affected-records list above.
+- **`update-tasks`** — field/priority guidance for the task entities `/end` files in Phase 3.1.
+
+## Constraints
+
+- MUST file `track` items as task entities **before** rendering the remaining-work bullets, so the bullets reflect stored state.
+- MUST NOT request confirmation before filing tasks, storing entities, or invoking `store-neotoma`.
+- MUST NOT skip the storage audit even if the user only asks about remaining work, and vice versa.
+- MUST classify every surfaced item; no unclassified entries.
+- MUST check existing Neotoma state via retrieval before declaring an item "not stored."
+- MUST defer chat-transcript storage to `store-neotoma`, not re-implement it.
+- MUST strip PII from any filed issues per the `feedback_issue_pii` memory; use `visibility: private` for session-derived issues.
+- MUST use Neotoma prod, never the dev instance.

--- a/skills/status/SKILL.md
+++ b/skills/status/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: status
+description: Mid-session status report. Summarizes what's been achieved so far this session and what work remains, in succinct qualitative prose and bullets with only light technical detail. Read-only — stores nothing, files nothing. Invoke any time to take stock without closing the session.
+triggers:
+  - /status
+  - session status
+  - where are we
+  - what's done so far
+  - status report
+user_invocable: true
+supported_harnesses:
+  - claude-code
+  - cursor
+---
+
+# status
+
+## Purpose
+
+Give the user a quick, readable read-out of the session so far: what's been accomplished and what's still outstanding. This is a **stock-taking** skill, not a closing skill. It is the lightweight counterpart to `/end`.
+
+This skill is **user-level** (`~/.claude/skills/status/`), so it is available in every repo automatically.
+
+## How it differs from `/end`
+
+- **`/status` is read-only.** It does NOT store entities, file tasks, write memory, invoke `store-neotoma`, or render the `🧠 Neotoma` turn report. It just reports. (Read-only retrieval of an existing plan is allowed — see Project-aware mode — but it never writes.)
+- **`/end` is the closing audit** — it files and persists. Reach for `/end` at the natural close of a session; reach for `/status` any time mid-session to check in.
+
+## Modes
+
+`/status` has one default behavior and two optional modifiers, which compose:
+
+- **`/status`** — the default: a quick, session-only read-out (the lightweight version below).
+- **`/status verbose`** (also `--full`, `full`, `detailed`) — a longer read-out with more detail per item. See *Verbose variant*.
+- **`/status project`** (also `plan`) — fold in the active plan's remaining work. See *Project-aware mode*. This is also applied automatically when an active plan is obvious from context (see that section), unless the user passed `session` / `--session-only`.
+
+Modifiers stack: `/status verbose project` gives the detailed, plan-aware read-out.
+
+## What to report
+
+Scan the conversation so far and produce a tight report with two parts.
+
+### Achieved this session
+
+A short qualitative summary of what's actually been completed and verified — framed in plain outcomes, not a tool-by-tool log. Lead with a one- or two-sentence prose overview of the session's arc, then a bullet list of concrete wins. Each bullet is one outcome in plain language (e.g. "Made `/end` a user-level skill available in every repo"), with at most a light technical anchor (a file path, entity ID, or PR number) where it genuinely helps the user locate the work. Only count things that are done — not things attempted or in flight.
+
+### Remaining
+
+What's still open, as the user would think about it — not an exhaustive TODO dump. Bullet list, each item phrased as the outstanding outcome, optionally tagged with where it stands:
+
+- **In progress** — started but not finished this session.
+- **Next up** — agreed/obvious next steps not yet begun.
+- **Blocked / waiting** — anything depending on CI, a remote agent, a scheduled task, the operator, or a third party (name the blocker in a few words).
+
+If something was explicitly dropped or deferred, note it in one line so the user knows it wasn't forgotten.
+
+## Format and tone rules
+
+- **Succinct.** Aim for something scannable in well under a minute. Prefer fewer, higher-signal bullets over completeness.
+- **Qualitative prose and/or bullets.** A short lead paragraph per section is welcome; long nested checklists are not.
+- **Light technical detail only.** Include a file path, entity ID, or PR number only when it helps the user *find* the work — never raw tool output, diffs, command logs, or schema chatter.
+- **Outcomes, not mechanics.** Describe what changed for the user, not which tools were called to do it.
+- **No new work.** Do not start tasks, store data, or propose a long plan; if the user wants to close out and persist, point them at `/end`.
+
+## Suggested shape
+
+```
+**Session so far**
+
+<1–2 sentence overview of what this session has been about.>
+
+Achieved
+- <outcome> (<optional light anchor>)
+- <outcome>
+
+Remaining
+- <outcome> — in progress
+- <outcome> — next up
+- <outcome> — blocked on <thing>
+```
+
+Adapt freely: if the session has achieved a lot and has little remaining (or vice versa), let the sections breathe accordingly. If almost nothing has happened yet, say so in a sentence rather than padding.
+
+## Project-aware mode
+
+When the session is tied to a tracked plan, `/status` can cross-reference it so "Remaining" reflects not just this session but where the broader project stands.
+
+**When to engage it:**
+
+- The user passed `project` / `plan`, OR
+- An active plan is obvious from context — e.g. CLAUDE.md names a plan entity (the Ateles plan is `ent_99ace4dd6673aa36ed08b1fe`), or the session has been working against one. When obvious, engage it by default; skip if the user passed `session` / `--session-only`.
+
+**How (read-only):**
+
+1. Retrieve the plan entity via `retrieve_entity_by_identifier` / `retrieve_entity_snapshot` (Neotoma prod). Read its `todos`, `next_steps`, `decisions`, and `body`. **Never correct or write the plan** — that's `/update-plan`'s job; `/status` only reads.
+2. In **Achieved**, mark any session outcomes that close a plan todo, e.g. "Made `/end` user-level — closes plan todo *distribute end skill*."
+3. In **Remaining**, add a short **Plan** sub-group: the plan's still-open todos and `next_steps` not touched this session, each one line. Surface current `next_steps` blockers verbatim-ish but trimmed.
+4. Keep it light: summarize the plan's open items, don't dump the whole todo array. If the plan has many open todos, show the top few by priority and note the count of the rest (e.g. "+6 more open todos").
+
+If no plan is found, silently fall back to the session-only report — do not announce the absence unless the user explicitly asked for `project` mode.
+
+## Verbose variant
+
+`/status verbose` produces a fuller read-out while keeping the same structure and the same read-only, outcomes-first discipline. Relative to the default:
+
+- Each **Achieved** bullet may carry a second clause of context — *why* it mattered or what it unblocks — and may include the navigation anchor inline.
+- **Remaining** items may note the dependency or the reason they're still open, not just the tag.
+- Add a brief **Decisions made this session** sub-section (one line each) when the session settled anything worth recording — so the user can eyeball what might warrant `/end` persistence.
+- Still no raw logs, diffs, or tool-by-tool narration. "Verbose" means more *context*, not more *mechanics*. Target a comfortable read in a couple of minutes, not an exhaustive audit.
+
+## Constraints
+
+- MUST be read-only: no `store`, no task filing, no memory writes, no `store-neotoma`, no `🧠 Neotoma` turn report. Project-aware mode may *read* a plan but MUST NOT correct or write it (that's `/update-plan`).
+- MUST keep technical detail light — anchors for navigation only, never logs or diffs — in both default and verbose modes.
+- MUST separate genuinely-completed work from outstanding/in-progress work; do not report attempts as achievements.
+- Default `/status` MUST stay succinct; resist turning the report into a full audit (that's `/end`). `verbose` adds context, never mechanics.
+- Project-aware mode MUST summarize the plan's open items, not dump the full todo array.


### PR DESCRIPTION
Tracks two user-level Claude/Cursor skills here so they are version-controlled and portable across machines, rather than living only as untracked files in `~/.claude/skills/`.

## What
- **`skills/end/SKILL.md`** — `/end`: session-close audit. Files remaining work as task entities (tasks first, then lists them), verifies all intended session data is stored in Neotoma, and persists what's missing. No confirmation gate.
- **`skills/status/SKILL.md`** — `/status`: read-only mid-session read-out of work achieved vs. remaining, succinct and qualitative. Composable `verbose` and `project` (plan cross-reference) modifiers.

## Why here
`~/.claude/skills/{end,status}` are symlinked to these paths, matching how every other user-level skill in `skills/` is already tracked. Canonical skill bodies live in Neotoma; these files mirror them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)