### PR TITLE
docs: schema-compatibility policy (#1 In place) + exit-rebuild protocol (#6)

### DIFF
--- a/docs/architecture/schema_compatibility_policy.md
+++ b/docs/architecture/schema_compatibility_policy.md
@@ -1,0 +1,118 @@
+# Schema Compatibility Policy
+
+## Scope
+
+This document is the **stated compatibility guarantee** for registered
+entity-type schemas: what kinds of schema change are safe for an adopter
+building on Neotoma, what counts as breaking, and how a breaking change is
+versioned and migrated so a schema in use never changes shape under a consumer
+without an explicit version bump and a migration path.
+
+It is the policy half of schema stability. The _mechanism_ it relies on —
+`schema_version`, additive expansion, the registry, deterministic reducers —
+is documented in [`schema_expansion.md`](schema_expansion.md),
+[`schema_registry.md`](../subsystems/schema_registry.md), and
+[`schema_handling.md`](schema_handling.md). This document states the guarantee
+those mechanisms back; it does not restate the mechanism.
+
+It satisfies commitment **#1 (Schema stability and versioned evolution)** in
+[`../foundation/adopter_dependency_commitments.md`](../foundation/adopter_dependency_commitments.md)
+and is the policy referenced by tracking issue #1520.
+
+## The guarantee, in one sentence
+
+A registered schema that an adopter depends on will not change shape under them:
+**additive changes are always safe, breaking changes require an explicit
+`schema_version` bump and a migration path, and a schema in active use is never
+silently mutated.**
+
+## What is a safe (additive, non-breaking) change
+
+These changes preserve compatibility and do **not** require a version bump.
+Existing observations remain valid and readable; existing consumers keep working
+unchanged.
+
+- **Adding a new optional field** to a schema.
+- **Adding a new entity type** to the registry.
+- **Adding a new converter** for an existing field that does not change already
+  stored values.
+- **Adding `aliases`** to an entity type (duplicate-type equivalence hints).
+- **Widening a field's accepted input** (e.g. accepting an additional
+  representation that canonicalizes to the same stored value).
+- **Relaxing a constraint** (making a previously required field optional).
+- **Adding `temporal_fields`, `reference_fields`, or `canonical_name_fields`
+  declarations** that derive from data already present, where the derivation is
+  deterministic and does not retroactively change existing snapshots' identity.
+
+Schema expansion (the automatic detection of recurring `unknown_fields`) only
+ever produces additive changes, and only under explicit user opt-in — see
+[`schema_expansion.md`](schema_expansion.md).
+
+## What is a breaking change
+
+These changes can invalidate or reshape data an adopter already relies on. Each
+**requires an explicit `schema_version` bump and a stated migration path**; none
+may be applied silently to a schema in use.
+
+- **Removing or renaming a field.**
+- **Changing a field's type** in a way that is not a pure widening (e.g.
+  `string` → `number`, or narrowing an enum by removing a value).
+- **Adding a new required field** without a default (existing observations would
+  fail validation).
+- **Changing `canonical_name_fields`** in a way that alters how existing entities
+  resolve to identity (this can re-bucket already-stored entities and is treated
+  as the most sensitive breaking change).
+- **Changing a field's declared `merge_policy`** in a way that changes the
+  reduced snapshot for existing observations.
+- **Removing an entity type, alias, or converter** that stored data depends on.
+
+## How a breaking change is handled
+
+When a breaking change is genuinely required, the obligations are:
+
+1. **Version bump.** The new schema is registered under an incremented
+   `schema_version`. The prior version is not mutated; existing observations stay
+   bound to the version they were written under.
+2. **Migration path.** A documented, deterministic migration describes how data
+   under the old version is reinterpreted under the new one. Per the immutability
+   invariant, migration creates **new** observations (reinterpretations); it does
+   not edit existing observations or source in place
+   ([`../subsystems/observation_architecture.md`](../subsystems/observation_architecture.md)).
+3. **Coexistence.** Old-version and new-version observations coexist; the reducer
+   resolves each under its own version. An adopter is never forced to migrate
+   instantaneously.
+4. **Announcement.** The breaking change is named in the release supplement's
+   "Breaking changes" section, consistent with the contract-stability discipline
+   (see [`openapi_contract_flow.md`](openapi_contract_flow.md) and commitment #2).
+
+## What an adopter can rely on
+
+- A schema you build against today will not start rejecting or reshaping your
+  existing data because of a Neotoma upgrade, unless that upgrade carries an
+  explicit `schema_version` bump for that type and a migration path you can read.
+- Additive evolution (new fields, new types) will not break your existing reads
+  or writes.
+- Identity stability: an entity's `canonical_name`/`entity_id` derivation will
+  not change under you without a versioned, migrated, announced change — because
+  identity churn is the most disruptive thing a substrate can do to an adopter.
+- You can pin to a `schema_version` and know its shape is frozen.
+
+## Relationship to the support window
+
+How _long_ a prior `schema_version` remains readable and reducible after a newer
+version ships is governed by the **backward-compatibility support window**
+(commitment #3,
+[`../foundation/adopter_dependency_commitments.md`](../foundation/adopter_dependency_commitments.md),
+tracking #1522). This document states _what_ compatibility means; the support
+window states _for how long_ old versions are guaranteed. The two are
+complementary: this policy guarantees old-version data is never silently
+reshaped, and the support window guarantees how long it stays first-class.
+
+## Related documents
+
+- [`schema_expansion.md`](schema_expansion.md) — the additive auto-expansion mechanism.
+- [`schema_registry.md`](../subsystems/schema_registry.md) — how schemas and versions are stored.
+- [`schema_handling.md`](schema_handling.md) — runtime schema resolution.
+- [`../subsystems/observation_architecture.md`](../subsystems/observation_architecture.md) — immutability; reinterpretation creates new observations.
+- [`determinism.md`](determinism.md) — deterministic extraction across versions (commitment #4).
+- [`../foundation/adopter_dependency_commitments.md`](../foundation/adopter_dependency_commitments.md) — the dependency-stability scorecard this policy satisfies (#1).

--- a/docs/developer/exit_rebuild_test.md
+++ b/docs/developer/exit_rebuild_test.md
@@ -1,0 +1,139 @@
+# Exit / Rebuild Test Protocol
+
+## Purpose
+
+This is the protocol for the **leave-and-rebuild test** that proves an adopter's
+dependence on Neotoma is reversible in practice, not just by promise. It is the
+documented, repeatable procedure behind commitment **#6 (Portability and exit
+proven)** in
+[`../foundation/adopter_dependency_commitments.md`](../foundation/adopter_dependency_commitments.md)
+(tracking #1524).
+
+The test answers one question with a number: **starting from a realistic dataset
+held in an external system of record, how long does it take to stand up a fresh
+Neotoma instance, populate it, tear it down, and stand it up again — end to
+end?** The pass bar is **"weeks, not migration"** — i.e., the rebuild is an
+operational task measured in hours-to-a-day of wall-clock work, not a
+multi-week data-migration project.
+
+Commitment #6 flips from _Partial_ to _In place_ when this protocol has been
+**executed against a realistic dataset and the result recorded** — not when this
+document merely exists. The document is the procedure; the recorded run is the
+evidence.
+
+## The posture this validates
+
+The portability guarantee rests on a specific architecture: the adopter keeps
+their **own** system of record (e.g. Postgres), and Neotoma is a **rebuildable
+derived layer** populated from it. A breaking Neotoma change, or a decision to
+leave entirely, costs an index rebuild — not customer data. This test measures
+the real cost of that rebuild so the "reversible by construction" claim is
+backed by a timed, reproducible run rather than an assertion.
+
+## What the test exercises
+
+1. **Export** — getting a complete, structured snapshot of the data out of
+   Neotoma (or, for the rebuild-from-source-of-record case, having it available
+   in the adopter's own store).
+2. **Rebuild** — populating a fresh Neotoma instance from that data via the
+   bulk-import path.
+3. **Teardown** — destroying the instance.
+4. **Rebuild again** — repeating the populate step to confirm it is repeatable
+   and idempotent, not a one-time success.
+5. **Verification** — confirming the rebuilt instance is equivalent to the
+   original (entity counts, snapshot equivalence, relationship integrity).
+
+## Commands
+
+The bulk-import path is the load-bearing mechanism and is already shipped:
+
+- **`neotoma entities import <file>`** — bulk-import entities from a JSONL file
+  (one entity JSON object per line), chunked into batched transactional
+  `POST /store` calls. Idempotent per chunk via `--idempotency-prefix`, so a
+  re-run with the same prefix and file is a safe no-op — which is what makes the
+  "rebuild again" step cheap and replay-safe. Runs in dry-run/plan mode without
+  `--commit`. See [`cli_reference.md`](cli_reference.md).
+
+The export side has more than one candidate and **the protocol must confirm
+which produces import-compatible JSONL** rather than assume it (see Known gaps):
+
+- `neotoma entities list` (with `--type`, `--limit`, `--offset`) — enumerates
+  entities; the run must confirm its output is, or can be trivially shaped into,
+  the JSONL `entities import` consumes.
+- `neotoma snapshots export` — fleet-neutral snapshot JSON with per-field
+  provenance; a different shape than the import format, useful for verification
+  rather than as a direct import source.
+- For the rebuild-from-source-of-record case, the JSONL is generated from the
+  adopter's own Postgres export, not from Neotoma at all — this is the primary
+  path the posture above describes.
+
+## Procedure
+
+Run against a **realistic dataset** — representative entity counts, relationship
+fan-out, and entity-type mix for the adopter's workload. A toy dataset does not
+exercise the cost that matters.
+
+1. **Prepare the source dataset.** Either (a) a Postgres export shaped into
+   import JSONL (the source-of-record path), or (b) an export from an existing
+   Neotoma instance. Record dataset size: entity count, relationship count,
+   entity-type histogram.
+2. **Stand up a fresh instance.** `neotoma init` a clean data directory. Record
+   wall-clock from here.
+3. **Dry-run the import.** `neotoma entities import <file>` (no `--commit`) and
+   confirm the plan matches the dataset (no resolution errors).
+4. **Commit the import.** `neotoma entities import <file> --commit
+--idempotency-prefix <prefix>`. Record wall-clock and any errors.
+5. **Verify equivalence.** Compare against the source: entity count
+   (`neotoma stats`), spot-check snapshots (`neotoma snapshots export` diff
+   against the original where applicable), confirm relationships resolved
+   (`neotoma relationships list <id>` on a sample). Record discrepancies.
+6. **Tear down.** Destroy the instance / data directory.
+7. **Rebuild again.** Repeat steps 2–5 with the **same** file and
+   `--idempotency-prefix`. Confirm the second run is idempotent (same end state,
+   no duplicate data) and record wall-clock.
+8. **Record the result.** Total wall-clock per rebuild, dataset size, any manual
+   steps required, and any gaps hit. This recording is the #6 evidence.
+
+## Pass / fail
+
+- **Pass:** both rebuilds complete, the rebuilt instance is equivalent to the
+  source, the second rebuild is idempotent, and total wall-clock is
+  "weeks, not migration" (operational, not a project). #6 flips to In place and
+  this run is cited as its evidence.
+- **Fail / partial:** if a step requires undocumented manual work, the rebuild is
+  not equivalent, or the time is migration-scale, the test has done its job — it
+  surfaced that reversibility is thinner than advertised **before** anyone
+  depended on it. File the specific gap and treat it as blocking for #6.
+
+## Known gaps to confirm during the run
+
+These are open questions the first execution should resolve and record, rather
+than assume away:
+
+- **Export → import format pairing.** Confirm which export command emits JSONL
+  that `entities import` consumes directly, or document the (deterministic)
+  shaping step between them. If no single command round-trips today, that is a
+  finding, and closing it is part of flipping #6.
+- **Relationships and observations.** Confirm whether `entities import` rebuilds
+  relationships and full observation history, or only current-entity snapshots —
+  and if the latter, what additional step restores edges and provenance.
+- **Idempotency across a full dataset.** Confirm the per-chunk idempotency holds
+  for the entire realistic dataset on the "rebuild again" pass, not just a small
+  sample.
+
+## Running it as a joint exercise
+
+For an adopter (e.g. during a Phase 0 evaluation), the highest-value form of this
+test is **joint**: the adopter brings a realistic dataset shaped from their own
+system of record, and both parties run the protocol together and agree the
+success bar up front. That removes "trust us" from the reversibility claim — the
+adopter watches the rebuild happen and times it themselves — and the recorded run
+becomes the #6 evidence for everyone, not just for that adopter.
+
+## Related documents
+
+- [`../foundation/adopter_dependency_commitments.md`](../foundation/adopter_dependency_commitments.md) — commitment #6 and the dependency-stability scorecard.
+- [`cli_reference.md`](cli_reference.md) — `entities import`, `snapshots export`, `entities list`, `stats`.
+- [`../architecture/idempotence_pattern.md`](../architecture/idempotence_pattern.md) — why re-import is replay-safe.
+- [`../subsystems/observation_architecture.md`](../subsystems/observation_architecture.md) — immutability; what a faithful rebuild must reproduce.
+- [`../infrastructure/multi_tenant_deployment_topology.md`](../infrastructure/multi_tenant_deployment_topology.md) — instance-per-tenant, the topology a clean lift-out depends on.

--- a/docs/developer/pr_review_reading_list.md
+++ b/docs/developer/pr_review_reading_list.md
@@ -27,7 +27,7 @@ Load only when the diff touches the listed files or directories.
 | `src/services/observation*`, `src/services/sources*` | `docs/subsystems/sources.md`, `docs/subsystems/observation_architecture.md` |
 | `src/services/interpretation*` | `docs/subsystems/interpretations.md` |
 | `src/services/relationships*` | `docs/subsystems/relationships.md` |
-| `src/services/entity*`, `src/services/schema_registry*` | `docs/foundation/entity_resolution.md`, `docs/subsystems/schema_registry.md`, `docs/subsystems/schema.md` |
+| `src/services/entity*`, `src/services/schema_registry*` | `docs/foundation/entity_resolution.md`, `docs/subsystems/schema_registry.md`, `docs/subsystems/schema.md`, `docs/architecture/schema_compatibility_policy.md` |
 | `src/services/entity_merge*` | `docs/subsystems/entity_merge.md` |
 | `src/services/timeline*`, `src/services/events*` | `docs/foundation/timeline_events.md`, `docs/subsystems/timeline_events.md`, `docs/subsystems/events.md` |
 | `src/services/deletion*` | `docs/subsystems/deletion.md` |

--- a/docs/foundation/adopter_dependency_commitments.md
+++ b/docs/foundation/adopter_dependency_commitments.md
@@ -86,12 +86,12 @@ work behind each move is open and itemized.
 
 | #   | Commitment                                 | Status   | What exists / what's missing                                                                                                                         | Tracking                                                         |
 | --- | ------------------------------------------ | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
-| 1   | Schema stability + versioned evolution     | Partial  | `schema_version` and additive expansion exist (`docs/architecture/schema_expansion.md`); a single stated compatibility policy is not yet written.    | [#1520](https://github.com/markmhendrickson/neotoma/issues/1520) |
+| 1   | Schema stability + versioned evolution     | In place | `schema_version` and additive expansion exist (`docs/architecture/schema_expansion.md`); the stated compatibility policy is now written (`docs/architecture/schema_compatibility_policy.md`).  | —                                                                |
 | 2   | Contract stability                         | Partial  | OpenAPI-first flow, legacy-payload corpus, and BC-diff gate exist; a stated **deprecation window** does not.                                         | [#1521](https://github.com/markmhendrickson/neotoma/issues/1521) |
 | 3   | Backward compatibility + replay            | Partial  | Immutability of observations/source is enforced (`docs/subsystems/observation_architecture.md`); a stated **support window** is not yet set.         | [#1522](https://github.com/markmhendrickson/neotoma/issues/1522) |
 | 4   | Deterministic extraction across versions   | In place | Content-derived IDs, stable ordering, deterministic reducers are enforced invariants (`docs/architecture/determinism.md`).                           | —                                                                |
 | 5   | Redlines demonstrated, not just stated     | Partial  | `redlines.md` is in force; MIT + open core are real and verifiable; a recurring demonstration record is still being built.                           | [#1523](https://github.com/markmhendrickson/neotoma/issues/1523) |
-| 6   | Portability + exit proven                  | Partial  | Export (`memory-export`, `snapshots export`), bulk import, and deletion commands exist; a tested end-to-end leave-and-rebuild is not yet documented. | [#1524](https://github.com/markmhendrickson/neotoma/issues/1524) |
+| 6   | Portability + exit proven                  | Partial  | Export (`memory-export`, `snapshots export`), bulk import, and deletion commands exist; the leave-and-rebuild protocol is now written (`docs/developer/exit_rebuild_test.md`), but a recorded run against a realistic dataset is still pending. | [#1524](https://github.com/markmhendrickson/neotoma/issues/1524) |
 | 7   | Change governance published                | Partial  | Breaking-change discipline (release supplements, BC gate) exists; the deprecation window and decision process are not yet written down.              | [#1525](https://github.com/markmhendrickson/neotoma/issues/1525) |
 | 8   | Supported multi-tenant deployment topology | Partial  | The topology decision aid exists (`docs/infrastructure/multi_tenant_deployment_topology.md`); a _tested_ production topology is not yet established. | [#1526](https://github.com/markmhendrickson/neotoma/issues/1526) |
 | 9   | Security review cadence                    | In place | Pre-release security gates (diff classifier, protected-routes manifest, security review) run on sensitive releases.                                  | —                                                                |
@@ -102,11 +102,14 @@ The detail for each follows.
 
 ### Stability
 
-1. **Schema stability and versioned evolution.** _(Partial)_ Registered entity-type schemas
+1. **Schema stability and versioned evolution.** _(In place)_ Registered entity-type schemas
    evolve under a documented compatibility policy: additive changes are safe,
    breaking changes are versioned and migrated, and a schema in use does not
    change shape under a consumer without an explicit version bump and migration
-   path.
+   path. The policy is stated in
+   [`../architecture/schema_compatibility_policy.md`](../architecture/schema_compatibility_policy.md);
+   the additive-expansion mechanism it relies on is in
+   [`../architecture/schema_expansion.md`](../architecture/schema_expansion.md).
 2. **Contract stability.** _(Partial)_ The HTTP/MCP/CLI contract surface is governed by the
    OpenAPI-first flow and the breaking-change discipline already in place
    (breaking changes named in release supplements, legacy-payload corpus, BC
@@ -130,9 +133,13 @@ The detail for each follows.
    capture or quiet license/policy drift (R12), no category drift into the
    vertical applications built on the substrate (R13).
 6. **Portability and exit are proven.** _(Partial)_ Export, deletion, and rebuild-from-source-
-   of-record are documented and tested end-to-end, so an adopter can leave with
+   of-record are documented end-to-end, so an adopter can leave with
    their data at any time. Dependence on Neotoma is reversible by construction,
-   not by promise.
+   not by promise. The repeatable leave-and-rebuild **protocol** is now written
+   ([`../developer/exit_rebuild_test.md`](../developer/exit_rebuild_test.md)); the
+   row flips to In place once that protocol has been **executed against a
+   realistic dataset and the timed result recorded** (the recorded run is the
+   evidence, not the protocol's existence).
 7. **Change governance is published.** _(Partial)_ How breaking changes are decided,
    announced, and supported — including the deprecation window above — is written
    down, so an adopter can predict the cost of staying current.


### PR DESCRIPTION
Two adopter-safety documentation artifacts. **No governance amendment** — this is the half of the original combined PR that needs no constitutional process. Split out so the `redlines.md` change (adding a redline R17) can be handled separately as a proper amendment rather than a single-party merge.

## Schema-compatibility policy (#1: Partial → In place)
`docs/architecture/schema_compatibility_policy.md` — the stated guarantee for registered-schema evolution: additive changes always safe, breaking changes require an explicit `schema_version` bump + migration path, a schema in use is never silently reshaped, identity (`canonical_name`/`entity_id`) is stable across upgrades. The mechanism already existed; this is the policy that turns it into an adopter guarantee. Flips dependency-scorecard row #1 to **In place**. Registered in `pr_review_reading_list.md` per review advisory.

## Exit-rebuild test protocol (#6: stays Partial)
`docs/developer/exit_rebuild_test.md` — the repeatable leave-and-rebuild procedure: export → `neotoma entities import` → teardown → rebuild → verify, timed against a *"weeks, not migration"* bar. **#6 deliberately stays Partial** — it flips only once the protocol is executed against a realistic dataset and the run recorded; the doc is the procedure, not the evidence. The protocol is explicit that the export→import-JSONL pairing is a gap the first run must confirm rather than assume.

## Not in this PR (intentionally)
The R17 non-compete redline and the R13→R17 citation corrections are held back as a **proposed governance amendment** — adding a numbered redline must route through the amendment process in `redlines.md` (written rationale, reflection period, no single-party ratification per R12), not a quiet merge. Tracked separately.

Docs only. PII-clean, doc-dependency validator passes, links verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)