### PR TITLE
ci(preview): make docs preview deploy non-blocking on missing/expired token

### DIFF
--- a/.github/workflows/docs_pr_preview.yml
+++ b/.github/workflows/docs_pr_preview.yml
@@ -76,7 +76,28 @@ jobs:
             -e "s|/android-chrome-512x512\.png|/pr-${PR_NUMBER}/android-chrome-512x512.png|g" \
             -e "s|/site\.webmanifest|/pr-${PR_NUMBER}/site.webmanifest|g"
 
+      # The preview deploy pushes to the external markmhendrickson/neotoma-dev-site
+      # repo using DEV_PAGES_DEPLOY_TOKEN. When that token is missing or expired the
+      # deploy cannot succeed — but a docs preview is a convenience, not a gate, so a
+      # bad/absent token must NOT paint every docs PR's checks red. We therefore gate
+      # the deploy on token presence and mark it continue-on-error; the build/validation
+      # steps above still run and still fail the check on real content problems.
+      - name: Check deploy token presence
+        id: deploy_token
+        env:
+          DEV_PAGES_DEPLOY_TOKEN: ${{ secrets.DEV_PAGES_DEPLOY_TOKEN }}
+        run: |
+          if [ -n "$DEV_PAGES_DEPLOY_TOKEN" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "::warning title=Docs preview not deployed::DEV_PAGES_DEPLOY_TOKEN is not set; skipping the preview deploy. The static site still built and validated above. See the preview-deploy rotation runbook to restore deploys."
+          fi
+
       - name: Deploy PR preview
+        id: deploy
+        if: steps.deploy_token.outputs.present == 'true'
+        continue-on-error: true
         uses: peaceiris/actions-gh-pages@v4
         with:
           personal_token: ${{ secrets.DEV_PAGES_DEPLOY_TOKEN }}
@@ -87,7 +108,13 @@ jobs:
           keep_files: true
           commit_message: "PR #${{ github.event.pull_request.number }} preview from ${{ github.sha }}"
 
+      - name: Warn if preview deploy failed
+        if: steps.deploy.outcome == 'failure'
+        run: |
+          echo "::warning title=Docs preview deploy failed::The static site built and validated, but pushing the preview to neotoma-dev-site failed (likely an expired DEV_PAGES_DEPLOY_TOKEN). This does not block the PR. See the preview-deploy rotation runbook to restore deploys."
+
       - name: Post preview URL as PR comment
+        if: steps.deploy.outcome == 'success'
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
## Summary

Stops the `preview` check from failing on every docs PR when `DEV_PAGES_DEPLOY_TOKEN` is missing or expired. A docs preview is a convenience, not a gate — an expired deploy token should not paint unrelated PRs red.

Part 2 of #1599. (Part 1 — rotating the actual PAT — is an owner action and is tracked in that issue.)

## What changed

`.github/workflows/docs_pr_preview.yml`, "Deploy PR preview" step:

- **Token-presence gate** (`Check deploy token presence`): if `DEV_PAGES_DEPLOY_TOKEN` is empty, skip the deploy and emit a `::warning::` annotation instead of attempting an auth that will fail.
- **`continue-on-error: true`** on the deploy: an auth/push failure (expired token) no longer fails the whole `preview` check.
- **Failure warning step**: surfaces a clear annotation when the deploy step fails.
- **Gate the preview-URL comment on `steps.deploy.outcome == 'success'`**: never advertise a `https://dev.neotoma.io/pr-N/` link that would 404.

The build + validation steps (`validate:routes`, `build:ui`, `build:site:pages`, `validate:locales`, `validate:site-export`) are **unchanged** and still fail the check on real content/build problems. Only the external-deploy push is made non-fatal.

## Context

The token expired ~2026-06-03 (last successful push to `neotoma-dev-site` was 2026-06-02); since then `docs_pr_preview.yml` has failed identically on every docs PR (#284, #1577, #1578, release/v0.16.0, …). The same token also powers `docs_pr_preview_cleanup.yml` and the production `deploy-pages-dev-site.yml` — see #1599 for the rotation runbook and full blast radius.

## Verification

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — workflow YAML parses.
- [x] Change is confined to `.github/workflows/docs_pr_preview.yml` (+27 lines); no code/test files touched.
- [ ] After merge: a docs PR shows `preview` as passing (with a deploy-skipped/failed warning annotation) while the token is still unrotated; once the token is rotated (#1599), the deploy + preview comment resume.

Closes #1599 once the token is also rotated — leaving #1599 open until Part 1 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)