### PR TITLE
fix(gha): guard concurrency.group expression against empty on push events

### DIFF
--- a/.github/workflows/claude_pr_review.yml
+++ b/.github/workflows/claude_pr_review.yml
@@ -32,7 +32,7 @@ permissions:
   issues: write
 
 concurrency:
-  group: pr-review-${{ github.event.pull_request.number || github.event.issue.number }}
+  group: pr-review-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
   # Cancel an in-flight review when the PR is force-pushed again, so we don't burn
   # a full review on a soon-superseded commit. The trade-off: a cancelled run can
   # leave a stale "review in progress" checklist comment with no verdict. The


### PR DESCRIPTION
## Summary

- `concurrency.group` expression `pr-review-${{ github.event.pull_request.number || github.event.issue.number }}` resolves to an empty string on `push` events (both context variables are undefined)
- GitHub validates workflow files on every push, and the empty concurrency group causes validation to fail — producing phantom failed runs named by file path with zero jobs
- Fix: add `|| github.run_id` as a fallback so push events get a unique, non-empty group string

## Test plan

- [ ] Verify next push to any branch produces no `claude_pr_review.yml` failure run
- [ ] Verify PR open/sync events still trigger the review job normally
- [ ] Verify `issue_comment` `@claude review` events still trigger normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)