### PR TITLE
docs: address exit-rebuild protocol review nits

### DIFF
--- a/docs/developer/exit_rebuild_test.md
+++ b/docs/developer/exit_rebuild_test.md
@@ -120,6 +120,19 @@ than assume away:
 - **Idempotency across a full dataset.** Confirm the per-chunk idempotency holds
   for the entire realistic dataset on the "rebuild again" pass, not just a small
   sample.
+- **Idempotency prefix across a teardown.** The "rebuild again" step (7) reuses
+  the same `--idempotency-prefix` as the first build, but against a _fresh_
+  instance whose idempotency ledger was destroyed at teardown (step 6). Confirm
+  whether the prefix's no-op safety is per-instance (so a post-teardown rebuild
+  re-writes from scratch as intended) or whether any cross-instance state would
+  cause the second build to skip writes it should perform. Record which.
+- **Snapshot-equivalence semantics.** "Equivalent to the source" (steps 5, 8)
+  needs a stated definition before the run, not after. Decide what equivalence
+  means: exact `snapshots export` byte-equality, equality modulo timestamps and
+  instance-local ids, or equality of the reduced field values per entity. Record
+  the chosen definition and the comparison method, since a too-strict definition
+  fails on benign id/timestamp differences and a too-loose one misses real
+  rebuild gaps.
 
 ## Running it as a joint exercise
 

--- a/docs/developer/pr_review_reading_list.md
+++ b/docs/developer/pr_review_reading_list.md
@@ -41,6 +41,7 @@ Load only when the diff touches the listed files or directories.
 | `openapi.yaml`, `src/shared/contract*`, `src/shared/openapi*` | `docs/architecture/openapi_contract_flow.md` |
 | `src/tool_definitions.ts`, `src/server.ts`, `docs/developer/mcp/` | `docs/developer/mcp/instructions.md`, `docs/developer/agent_instructions_sync_rules.mdc` |
 | `src/cli/` | `docs/developer/cli_reference.md` |
+| `src/cli/entities*` (import/export), bulk-import or export-path changes | `docs/developer/exit_rebuild_test.md` |
 | Error response shapes | `docs/reference/error_codes.md` |
 
 ### Auth and security


### PR DESCRIPTION
Folds in the 3 non-blocking nits from the #1608 review (all in the exit-rebuild protocol doc).

- Register `exit_rebuild_test.md` on a CLI source-path row in `pr_review_reading_list.md` so import/export-path diffs auto-load it.
- Name the **cross-teardown `--idempotency-prefix`** behavior as a Known gap — the rebuild-again step reuses the prefix against a fresh instance whose idempotency ledger was destroyed at teardown.
- Name **snapshot-equivalence semantics** as a Known gap — define what "equivalent to the source" means (byte-equality vs. modulo timestamps/ids vs. reduced-field equality) before the run, not after.

Docs only. PII-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)