### PR TITLE
feat(launchd): rc-autodeploy LaunchAgent — rolling main → RC → prod

### DIFF
--- a/docs/developer/launchd_dev_servers.md
+++ b/docs/developer/launchd_dev_servers.md
@@ -73,6 +73,16 @@ rm ~/Library/LaunchAgents/com.neotoma.dev-server.plist
 
 For a separate always-on **built** API in production mode (build + default prod port + `start:server`), see [`docs/developer/launchd_prod_server.md`](launchd_prod_server.md) and `npm run setup:launchd-prod-server`.
 
+## RC auto-deploy ("rolling main = RC")
+
+`npm run setup:launchd-rc-autodeploy` installs `com.neotoma.rc-autodeploy`, which keeps the running prod server current with `origin/main` unattended. Every 120s it runs `scripts/redeploy_rc_from_main.sh`, which:
+
+1. `git fetch` + **fast-forward-only** pull of `origin/main` into the RC checkout, preserving the uncommitted RC version bump (e.g. `0.16.0-rc.1`) via stash/pop; it refuses to proceed on a non-fast-forward divergence.
+2. Rebuilds `dist` (`npm run build:server`).
+3. **Hard**-restarts `com.neotoma.prod-server` (`launchctl kickstart -k`) so the process re-imports fresh modules — a soft reload was observed to miss reducer changes.
+
+It is idempotent (no-op when the RC already equals `origin/main`) and single-flight (atomic `mkdir` lock). This is **mechanical deploy only** — it makes no release judgment. Cutting tagged releases remains a separate, gated step (e.g. the Ateles `Struthio` release agent). Override `HEALTH_URL` / poll interval via the plist if needed.
+
 ## Scope
 
 - **macOS only.** LaunchAgents are a macOS feature. On Linux, use a systemd user service or similar.

--- a/package.json
+++ b/package.json
@@ -166,6 +166,7 @@
     "setup:launchd-dev": "node scripts/install_launchd_dev_server.js",
     "setup:launchd-dev-server": "npm run setup:launchd-dev",
     "setup:launchd-prod-server": "node scripts/install_launchd_prod_server.js",
+    "setup:launchd-rc-autodeploy": "node scripts/install_launchd_rc_autodeploy.js",
     "setup:launchd-cli-sync": "node scripts/install_launchd_watch_build.js",
     "setup:launchd-watch-build": "npm run setup:launchd-cli-sync",
     "setup:launchd-issues-sync": "node scripts/install_launchd_issues_sync.js",

--- a/scripts/com.neotoma.rc-autodeploy.plist.template
+++ b/scripts/com.neotoma.rc-autodeploy.plist.template
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  com.neotoma.rc-autodeploy — "rolling main = RC" auto-deploy LaunchAgent.
+
+  Polls origin/main and, when the RC checkout is behind, fast-forwards it
+  (preserving the uncommitted RC version bump), rebuilds dist, and HARD-restarts
+  the prod-server LaunchAgent so merged-to-main changes reach the running server
+  unattended within one poll interval. Mechanical only (no release judgment) —
+  Struthio still owns cutting tagged releases.
+
+  Install via: node scripts/install_launchd_rc_autodeploy.js
+  Placeholders (REPO_ROOT_PLACEHOLDER etc.) are substituted by the installer.
+-->
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.neotoma.rc-autodeploy</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>REPO_ROOT_PLACEHOLDER/scripts/redeploy_rc_from_main.sh</string>
+  </array>
+  <key>WorkingDirectory</key>
+  <string>REPO_ROOT_PLACEHOLDER</string>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>StartInterval</key>
+  <integer>120</integer>
+  <key>StandardOutPath</key>
+  <string>REPO_ROOT_PLACEHOLDER/data/logs/launchd-rc-autodeploy.log</string>
+  <key>StandardErrorPath</key>
+  <string>REPO_ROOT_PLACEHOLDER/data/logs/launchd-rc-autodeploy.error.log</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/usr/sbin:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:NODE_BIN_DIR_PLACEHOLDER</string>
+    <key>RC_DIR</key>
+    <string>REPO_ROOT_PLACEHOLDER</string>
+    <key>PROD_LABEL</key>
+    <string>com.neotoma.prod-server</string>
+    <key>HEALTH_URL</key>
+    <string>HEALTH_URL_PLACEHOLDER</string>
+    <key>BRANCH</key>
+    <string>main</string>
+  </dict>
+</dict>
+</plist>

--- a/scripts/install_launchd_rc_autodeploy.js
+++ b/scripts/install_launchd_rc_autodeploy.js
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+/**
+ * Install the rc-autodeploy LaunchAgent: "rolling main = RC" auto-deploy.
+ *
+ * Polls origin/main every StartInterval seconds; when the RC checkout (this
+ * repo) is behind, fast-forwards it (preserving the uncommitted RC version
+ * bump), rebuilds dist, and HARD-restarts com.neotoma.prod-server so
+ * merged-to-main changes reach the running server unattended. Mechanical deploy
+ * only — Struthio still owns cutting tagged releases.
+ *
+ * Writes com.neotoma.rc-autodeploy.plist to ~/Library/LaunchAgents.
+ *
+ * Usage: node scripts/install_launchd_rc_autodeploy.js
+ * Env overrides: HEALTH_URL (default https://neotoma.markmhendrickson.com/health)
+ */
+import { chmodSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { homedir, platform } from "os";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+import { execSync } from "child_process";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, "..");
+const isMac = platform() === "darwin";
+
+if (!isMac) {
+  console.error("LaunchAgent is macOS only. Use systemd/cron or another scheduler on Linux.");
+  process.exit(1);
+}
+
+const launchAgentsDir = join(homedir(), "Library", "LaunchAgents");
+const plistName = "com.neotoma.rc-autodeploy.plist";
+const templatePath = join(__dirname, "com.neotoma.rc-autodeploy.plist.template");
+const plistPath = join(launchAgentsDir, plistName);
+const logDir = join(repoRoot, "data", "logs");
+
+// The deploy script needs node/npm on PATH under a GUI-less launchd session;
+// add the running node's bin dir so `npm run build:server` resolves.
+const nodeBinDir = dirname(process.execPath);
+const healthUrl = process.env.HEALTH_URL || "https://neotoma.markmhendrickson.com/health";
+
+const template = readFileSync(templatePath, "utf-8");
+const plistContent = template
+  .replace(/REPO_ROOT_PLACEHOLDER/g, repoRoot)
+  .replace(/NODE_BIN_DIR_PLACEHOLDER/g, nodeBinDir)
+  .replace(/HEALTH_URL_PLACEHOLDER/g, healthUrl);
+
+const runScript = join(__dirname, "redeploy_rc_from_main.sh");
+chmodSync(runScript, 0o755);
+mkdirSync(logDir, { recursive: true });
+mkdirSync(launchAgentsDir, { recursive: true });
+writeFileSync(plistPath, plistContent);
+
+console.log("Installed:", plistPath);
+console.log("Logs:      ", join(logDir, "launchd-rc-autodeploy.{log,error.log}"));
+console.log("Health URL:", healthUrl);
+console.log("");
+console.log("This agent polls origin/main every 120s and, when behind, fast-forwards the RC,");
+console.log("rebuilds dist, and hard-restarts com.neotoma.prod-server. Mechanical deploy only.");
+console.log("");
+
+try {
+  const uid = execSync("id -u", { encoding: "utf-8" }).trim();
+  try {
+    execSync(`launchctl bootout "gui/${uid}/com.neotoma.rc-autodeploy"`, { stdio: "ignore" });
+  } catch {
+    /* not loaded */
+  }
+  execSync(`launchctl bootstrap "gui/${uid}" "${plistPath}"`, { stdio: "inherit" });
+  console.log("Loaded. rc-autodeploy is active (runs once now, then every 120s).");
+} catch {
+  console.log("Run manually to start now:");
+  console.log(`  launchctl bootstrap "gui/$(id -u)" "${plistPath}"`);
+}

--- a/scripts/redeploy_rc_from_main.sh
+++ b/scripts/redeploy_rc_from_main.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+#
+# redeploy_rc_from_main.sh — "rolling main = RC" auto-deploy.
+#
+# Brings the running prod server up to the latest origin/main by:
+#   1. fast-forwarding the RC checkout (this repo) to origin/main,
+#      preserving the uncommitted RC version bump (e.g. 0.16.0-rc.1),
+#   2. rebuilding dist (so the global CLI + any dist consumers are current),
+#   3. HARD-restarting the prod-server launchagent (kill + relaunch) so tsx /
+#      node --watch re-imports fresh modules — a soft reload was observed to
+#      miss reducer changes (see the #1595 deploy session).
+#
+# Idempotent: if the RC is already at origin/main, it exits early without
+# touching the server. Intended to be invoked by the com.neotoma.rc-autodeploy
+# LaunchAgent on a StartInterval (poll), and safe to run by hand.
+#
+# Exit codes: 0 = up-to-date or successfully deployed; non-zero = error (the
+# server is left running on its prior build; nothing destructive on failure).
+
+set -uo pipefail
+
+RC_DIR="${RC_DIR:-/Users/markmhendrickson/neotoma-rc-src}"
+PROD_LABEL="${PROD_LABEL:-com.neotoma.prod-server}"
+HEALTH_URL="${HEALTH_URL:-https://neotoma.markmhendrickson.com/health}"
+BRANCH="${BRANCH:-main}"
+LOCK_DIR="${LOCK_DIR:-/tmp/neotoma-rc-autodeploy.lock.d}"
+
+ts() { date '+%Y-%m-%d %H:%M:%S'; }
+log() { echo "[$(ts)] $*"; }
+
+# Single-flight via atomic mkdir (portable; flock is unavailable on macOS).
+# A stale lock older than 30 min is reclaimed so a crashed run cannot wedge the
+# loop forever.
+if [ -d "$LOCK_DIR" ]; then
+  if [ -n "$(find "$LOCK_DIR" -prune -mmin +30 2>/dev/null)" ]; then
+    log "reclaiming stale lock (>30m old)"
+    rmdir "$LOCK_DIR" 2>/dev/null || true
+  fi
+fi
+if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+  log "another redeploy is in progress; skipping."
+  exit 0
+fi
+trap 'rmdir "$LOCK_DIR" 2>/dev/null || true' EXIT
+
+cd "$RC_DIR" || { log "ERROR: RC_DIR $RC_DIR missing"; exit 1; }
+
+git fetch origin "$BRANCH" --quiet || { log "ERROR: git fetch failed"; exit 1; }
+
+LOCAL="$(git rev-parse HEAD)"
+REMOTE="$(git rev-parse "origin/$BRANCH")"
+
+if [ "$LOCAL" = "$REMOTE" ]; then
+  log "RC already at origin/$BRANCH ($(git rev-parse --short HEAD)); nothing to do."
+  exit 0
+fi
+
+# Refuse to deploy if HEAD has diverged from origin/main (not a fast-forward).
+# Rolling-main model assumes the RC only ever fast-forwards; a divergence means
+# someone committed on the RC checkout and a human must reconcile.
+if ! git merge-base --is-ancestor "$LOCAL" "$REMOTE"; then
+  log "ERROR: RC HEAD has diverged from origin/$BRANCH (not a fast-forward). Aborting; needs manual reconcile."
+  exit 1
+fi
+
+log "Updating RC $(git rev-parse --short HEAD) -> $(git rev-parse --short "origin/$BRANCH")"
+
+# Preserve the uncommitted RC version bump (and any other local tweaks) across
+# the pull. Stash only if there is something to stash.
+STASHED=0
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  if git stash push --quiet --include-untracked -m "rc-autodeploy: preserve local RC tweaks"; then
+    STASHED=1
+    log "stashed local RC changes (incl. version bump)"
+  else
+    log "ERROR: failed to stash local changes; aborting before pull"
+    exit 1
+  fi
+fi
+
+if ! git merge --ff-only "origin/$BRANCH" --quiet; then
+  log "ERROR: fast-forward merge failed"
+  [ "$STASHED" -eq 1 ] && git stash pop --quiet || true
+  exit 1
+fi
+
+if [ "$STASHED" -eq 1 ]; then
+  if ! git stash pop --quiet; then
+    log "WARNING: stash pop conflicted (likely main changed package.json vs the RC version bump)."
+    log "         Resolve manually in $RC_DIR; server NOT restarted to avoid shipping a conflicted tree."
+    exit 1
+  fi
+  log "restored local RC changes after fast-forward"
+fi
+
+log "RC now at $(git rev-parse --short HEAD); rebuilding dist…"
+if ! npm run build:server >/dev/null 2>&1; then
+  log "ERROR: build:server failed; server left on prior build."
+  exit 1
+fi
+log "build:server complete."
+
+# HARD restart: kickstart -k kills the existing job instance and relaunches it,
+# forcing tsx/node --watch to re-import modules from the updated source.
+log "hard-restarting $PROD_LABEL…"
+if ! launchctl kickstart -k "gui/$(id -u)/$PROD_LABEL" 2>/dev/null; then
+  launchctl kickstart -k "user/$(id -u)/$PROD_LABEL" 2>/dev/null || {
+    log "ERROR: failed to kickstart $PROD_LABEL"; exit 1; }
+fi
+
+# Wait for health to come back (best-effort; the server does its own build on
+# launch, so allow generous time).
+log "waiting for $HEALTH_URL to report healthy…"
+for i in $(seq 1 30); do
+  if curl -s -m 5 "$HEALTH_URL" 2>/dev/null | grep -q '"ok":true'; then
+    log "DEPLOYED: server healthy at $(git rev-parse --short HEAD) ($(curl -s -m 5 "$HEALTH_URL" | sed 's/.*\"version\":\"//;s/\".*//'))."
+    exit 0
+  fi
+  sleep 5
+done
+
+log "WARNING: deployed code + restarted, but health did not confirm within ~150s. Check the prod-server log."
+exit 0


### PR DESCRIPTION
## What

Adds a LaunchAgent that keeps the running prod server current with `origin/main` unattended, closing the gap where merged-to-main fixes required a manual pull + rebuild + restart of the RC checkout (the serving source behind `~/neotoma-active → neotoma-rc-src`).

This was prompted by a real incident: two merged reducer fixes (#1541, #1595) did not reach the running server because nothing automatically advances the RC checkout.

## Design (rolling main = RC)

Per operator decision, there is effectively always one RC that tracks `main`; every merge flows in. No cherry-pick. Release **judgment** (cutting a tagged `vX.Y.Z`) stays a separate, gated step — the Struthio release agent — so this is **mechanical deploy only**.

`scripts/redeploy_rc_from_main.sh` (every 120s via the agent):
1. `git fetch` + **fast-forward-only** pull of `origin/main` into the RC, preserving the uncommitted RC version bump (e.g. `0.16.0-rc.1`) via stash/pop; refuses a non-FF divergence.
2. `npm run build:server`.
3. **Hard**-restart `com.neotoma.prod-server` (`launchctl kickstart -k`) — a soft reload was observed to miss reducer module changes under `node --watch`/tsx.
4. Wait on the health endpoint.

Idempotent (no-op when already at `origin/main`), single-flight (atomic `mkdir` lock, macOS-safe; `flock` is unavailable on macOS).

## Files

- `scripts/redeploy_rc_from_main.sh` — the deploy script
- `scripts/com.neotoma.rc-autodeploy.plist.template` + `scripts/install_launchd_rc_autodeploy.js` — install/load the agent, mirroring the existing prod-server launchd convention
- `package.json` — `setup:launchd-rc-autodeploy` script
- `docs/developer/launchd_dev_servers.md` — documents the loop

## Validation

Installed and running on the operator's machine: a real run deployed the RC `c2ed28bd0 → b371c0896`, preserved the rc bump, rebuilt, hard-restarted, server healthy at `0.16.0-rc.1`; the idempotent no-op path also confirmed (polls "nothing to do" every 2 min). Installer JS, deploy-script bash syntax, and plist template all validate.

## Known follow-up (not in this PR)

Prod currently serves via `dev:server` (tsx-from-source). Running from built `dist` (`node dist/actions.js`) would remove the stale-module class entirely; it runs cleanly standalone but crash-looped under this launchd wrapper and needs a separate careful pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)