### PR TITLE
fix(issues): write github_number back via per-field correct() (#1610) [RC backport]

### DIFF
--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -1,48 +1,38 @@
 # Automated test catalog
-
 ## Scope
-
 This document summarizes repo-wide automated test coverage and inventories every automated test file in the repository. It does not define test-writing standards, fixture rules, or route coverage policy.
 
 ## Purpose
-
 Provide one canonical markdown source for what automated tests exist, how the major suites are run, and which validation commands keep the catalog current.
 
 ## Scope
-
 This document covers:
-
 - Repo-wide automated test inventory
 - High-level suite and runner breakdowns
 - Primary local and CI validation commands
 - Catalog maintenance workflow
 
 This document does not cover:
-
 - Test quality policy
 - Fixture design standards
 - Feature-specific testing strategy
 - Historical audit narratives
 
 ## Invariants
-
 1. Every automated test file in the repo must appear in this catalog.
 2. This catalog is generated from the repository tree, not maintained by hand.
 3. When test files, suite directories, or validation lanes change, the catalog must be regenerated in the same change.
 4. Policy changes belong in `docs/testing/testing_standard.md`; inventory changes belong here.
 
 ## Definitions
-
 - **Automated test file**: A repo test source matched by this catalog's scanner (`tests/**`, `src/**`, `frontend/src/**`, `playwright/tests/**`).
 - **Catalog generator**: `scripts/generate-automated-test-catalog.ts`, the only source allowed to rewrite this file.
 - **Catalog validator**: `npm run validate:test-catalog`, which fails when this file drifts from the repo tree.
 
 ## Data models or schemas
-
 None.
 
 ## Flows or sequences
-
 1. Change or add tests.
 2. Run `npm run generate:test-catalog`.
 3. Review the generated markdown diff.
@@ -56,53 +46,47 @@ flowchart TD
 ```
 
 ## Examples
-
 - Add `tests/integration/new_feature.test.ts` -> regenerate the catalog so the new file appears under the integration suite.
 - Rename `tests/cli/old_name.test.ts` -> regenerate the catalog so the old path disappears and the new path appears.
 - Add a new CI lane for tests -> update this document's command summary and run the validator.
 
 ## Testing requirements
-
 - `npm run generate:test-catalog` must be run when automated test inventory changes.
 - `npm run validate:test-catalog` must pass before merge.
 - CI runs `npm run validate:test-catalog` in the baseline lane.
 
 ## Maintenance
-
 - Canonical policy doc: `docs/testing/testing_standard.md`.
 - Historical audit doc: `docs/testing/test_coverage_audit_summary.md`.
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-
 - Total automated test files: **401**
 - Backend and repo Vitest files: **368**
 - Frontend Vitest files: **9**
 - Playwright spec files: **24**
 
 ### Suite counts
-
-| Suite                           | Files |
-| ------------------------------- | ----: |
-| Vitest unit tests               |    99 |
-| Vitest service tests            |    33 |
-| Source-adjacent tests           |    47 |
-| Vitest integration tests        |   109 |
-| Vitest CLI tests                |    59 |
-| Vitest contract tests           |    11 |
-| Vitest security tests           |     2 |
-| Vitest subscription tests       |     3 |
-| Vitest agent tests              |     1 |
-| Vitest fixture tests            |     1 |
-| Vitest helper tests             |     1 |
-| Vitest shared-environment tests |     1 |
-| Frontend Vitest tests           |     9 |
-| Playwright E2E tests            |    22 |
-| Playwright Inspector E2E tests  |     2 |
-| Tests Scripts                   |     1 |
+| Suite | Files |
+|---|---:|
+| Vitest unit tests | 99 |
+| Vitest service tests | 33 |
+| Source-adjacent tests | 47 |
+| Vitest integration tests | 109 |
+| Vitest CLI tests | 59 |
+| Vitest contract tests | 11 |
+| Vitest security tests | 2 |
+| Vitest subscription tests | 3 |
+| Vitest agent tests | 1 |
+| Vitest fixture tests | 1 |
+| Vitest helper tests | 1 |
+| Vitest shared-environment tests | 1 |
+| Frontend Vitest tests | 9 |
+| Playwright E2E tests | 22 |
+| Playwright Inspector E2E tests | 2 |
+| Tests Scripts | 1 |
 
 ## Primary validation commands
-
 - `npm test`
 - `npm run test:frontend`
 - `npm run test:remote:critical`
@@ -112,22 +96,18 @@ flowchart TD
 - `npm run validate:doc-deps`
 
 ## CI lanes
-
 - Baseline CI runs `type-check`, `lint`, `lint:site-copy`, `npm test`, `validate:coverage`, `validate:test-catalog`, and `validate:doc-deps`.
 - Frontend CI runs `npm run test:frontend`.
 - Site/export CI runs route, locale, and export validation tasks.
 - Remote integration nightly runs `npm run test:remote:critical` when enabled.
 
 ## Automated test suites
-
 ### Vitest unit tests
-
 **Directory:** `tests/unit/`
 **Runner:** `vitest`
 **Command:** `npm test -- tests/unit`
 **Requirements:** Basic `.env` if required by the module under test.
 **Files (99):**
-
 - `tests/unit/aauth_admission.test.ts`
 - `tests/unit/aauth_attestation_apple_se.test.ts`
 - `tests/unit/aauth_attestation_revocation.test.ts`
@@ -229,13 +209,11 @@ flowchart TD
 - `tests/unit/workout_session_schema.test.ts`
 
 ### Vitest service tests
-
 **Directory:** `tests/services/`
 **Runner:** `vitest`
 **Command:** `npm test -- tests/services`
 **Requirements:** Basic `.env` if required by the module under test.
 **Files (33):**
-
 - `tests/services/auto_enhancement_converter_detection.test.ts`
 - `tests/services/auto_enhancement_processor.test.ts`
 - `tests/services/capability_registry.test.ts`
@@ -271,13 +249,11 @@ flowchart TD
 - `tests/services/sync_webhook_outbound.test.ts`
 
 ### Source-adjacent tests
-
 **Directory:** `src/**/__tests__/` and `src/**/*.test.ts(x)`
 **Runner:** `vitest`
 **Command:** `npm test -- src`
 **Requirements:** Basic `.env` if required by the module under test.
 **Files (47):**
-
 - `src/cli/parse_cli_corrected_value.test.ts`
 - `src/crypto/crypto.test.ts`
 - `src/record_types.test.ts`
@@ -327,13 +303,11 @@ flowchart TD
 - `src/version_check.test.ts`
 
 ### Vitest integration tests
-
 **Directory:** `tests/integration/`
 **Runner:** `vitest`
 **Command:** `npm run test:integration` or `npx vitest run tests/integration`
 **Requirements:** Database configured; remote-dependent subsets additionally need `RUN_REMOTE_TESTS=1`.
 **Files (109):**
-
 - `tests/integration/aauth_attribution_stamping.test.ts`
 - `tests/integration/aauth_resource_metadata.test.ts`
 - `tests/integration/aauth_revocation_e2e.test.ts`
@@ -445,13 +419,11 @@ flowchart TD
 - `tests/integration/v0.2.0_ingestion.test.ts`
 
 ### Vitest CLI tests
-
 **Directory:** `tests/cli/`
 **Runner:** `vitest`
 **Command:** `npm test -- tests/cli`
 **Requirements:** Basic `.env`; some tests provision temp config homes automatically.
 **Files (59):**
-
 - `tests/cli/api_client_offline_fallback.test.ts`
 - `tests/cli/backup_verify.test.ts`
 - `tests/cli/cli_access_commands.test.ts`
@@ -513,13 +485,11 @@ flowchart TD
 - `tests/cli/transcript_parser.test.ts`
 
 ### Vitest contract tests
-
 **Directory:** `tests/contract/`
 **Runner:** `vitest`
 **Command:** `npm test -- tests/contract`
 **Requirements:** Generated contract artifacts present when the suite expects them.
 **Files (11):**
-
 - `tests/contract/cli_handler_dist_smoke.test.ts`
 - `tests/contract/contract_mapping.test.ts`
 - `tests/contract/contract_mcp_cli_parity.test.ts`
@@ -533,76 +503,62 @@ flowchart TD
 - `tests/contract/vite_config.test.ts`
 
 ### Vitest security tests
-
 **Directory:** `tests/security/`
 **Runner:** `vitest`
 **Command:** `npx vitest run tests/security`
 **Requirements:** Use alongside the dedicated security validation scripts when changing auth or route protection.
 **Files (2):**
-
 - `tests/security/auth_topology_matrix.test.ts`
 - `tests/security/tenant_isolation_matrix.test.ts`
 
 ### Vitest subscription tests
-
 **Directory:** `tests/subscriptions/`
 **Runner:** `vitest`
 **Command:** `npx vitest run tests/subscriptions`
 **Requirements:** Basic `.env`; some tests start an in-process HTTP server.
 **Files (3):**
-
 - `tests/subscriptions/guest_write_rate_limit_routing.test.ts`
 - `tests/subscriptions/subscription_guest_auth.test.ts`
 - `tests/subscriptions/subscription_loop_prevention.test.ts`
 
 ### Vitest agent tests
-
 **Directory:** `tests/agent/`
 **Runner:** `vitest`
 **Command:** `npm run test:agent-mcp`
 **Requirements:** Agent/provider-specific environment may be required for non-skipped cases.
 **Files (1):**
-
 - `tests/agent/mcp_instruction_behavior.test.ts`
 
 ### Vitest fixture tests
-
 **Directory:** `tests/fixtures/`
 **Runner:** `vitest`
 **Command:** `npx vitest run tests/fixtures`
 **Requirements:** Fixture files present in the repo checkout.
 **Files (1):**
-
 - `tests/fixtures/replay_graph.test.ts`
 
 ### Vitest helper tests
-
 **Directory:** `tests/helpers/`
 **Runner:** `vitest`
 **Command:** `npx vitest run tests/helpers`
 **Requirements:** Helper-specific fixtures present in the repo checkout.
 **Files (1):**
-
 - `tests/helpers/redact_for_test_report.test.ts`
 
 ### Vitest shared-environment tests
-
 **Directory:** `tests/shared/`
 **Runner:** `vitest`
 **Command:** `npx vitest run tests/shared`
 **Requirements:** Basic `.env`.
 **Files (1):**
-
 - `tests/shared/local_transport_env.test.ts`
 
 ### Frontend Vitest tests
-
 **Directory:** `frontend/src/`
 **Runner:** `vitest` with `jsdom`
 **Command:** `npm run test:frontend`
 **Requirements:** Run with `RUN_FRONTEND_TESTS=1` or the dedicated script.
 **Files (9):**
-
 - `frontend/src/bridge/websocket.test.ts`
 - `frontend/src/lib/idempotency.test.ts`
 - `frontend/src/site/mdx_site_registry.test.ts`
@@ -614,13 +570,11 @@ flowchart TD
 - `frontend/src/utils/vite_chunk_recovery.test.ts`
 
 ### Playwright E2E tests
-
 **Directory:** `playwright/tests/`
 **Runner:** `playwright`
 **Command:** `npm run test:e2e`
 **Requirements:** Playwright browsers installed; mock or real API configured per suite.
 **Files (22):**
-
 - `playwright/tests/auto-enhancement.spec.ts`
 - `playwright/tests/design-system.spec.ts`
 - `playwright/tests/entity-detail.spec.ts`
@@ -645,45 +599,36 @@ flowchart TD
 - `playwright/tests/upload-flow.spec.ts`
 
 ### Playwright Inspector E2E tests
-
 **Directory:** `playwright/tests/inspector/`
 **Runner:** `playwright`
 **Command:** `npm run test:e2e:inspector`
 **Requirements:** Inspector bundle built before execution.
 **Files (2):**
-
 - `playwright/tests/inspector/inspector-entity-detail.spec.ts`
 - `playwright/tests/inspector/inspector-issues.spec.ts`
 
 ### Tests Scripts
-
 **Directory:** `tests/scripts/`
 **Runner:** `vitest`
 **Command:** `npx vitest run tests/scripts`
 **Requirements:** Basic `.env` if required by the module under test.
 **Files (1):**
-
 - `tests/scripts/launchd_cli_sync_tooling.test.ts`
 
 ## Agent instructions
-
 ### When to load this document
-
 Load this document when adding, removing, moving, or renaming automated tests, or when changing test commands or CI lanes.
 
 ### Required co-loaded documents
-
 - `docs/testing/testing_standard.md`
 - `docs/conventions/documentation_standards.md`
 
 ### Constraints agents must enforce
-
 1. Regenerate this document when automated test inventory changes.
 2. Validate this document before completing test-related changes.
 3. Keep policy changes in `testing_standard.md`, not in the generated inventory sections here.
 
 ### Validation checklist
-
 - [ ] Test inventory regenerated after test-file changes
 - [ ] `npm run validate:test-catalog` passed
 - [ ] Related policy docs updated if commands or CI lanes changed

--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -1,38 +1,48 @@
 # Automated test catalog
+
 ## Scope
+
 This document summarizes repo-wide automated test coverage and inventories every automated test file in the repository. It does not define test-writing standards, fixture rules, or route coverage policy.
 
 ## Purpose
+
 Provide one canonical markdown source for what automated tests exist, how the major suites are run, and which validation commands keep the catalog current.
 
 ## Scope
+
 This document covers:
+
 - Repo-wide automated test inventory
 - High-level suite and runner breakdowns
 - Primary local and CI validation commands
 - Catalog maintenance workflow
 
 This document does not cover:
+
 - Test quality policy
 - Fixture design standards
 - Feature-specific testing strategy
 - Historical audit narratives
 
 ## Invariants
+
 1. Every automated test file in the repo must appear in this catalog.
 2. This catalog is generated from the repository tree, not maintained by hand.
 3. When test files, suite directories, or validation lanes change, the catalog must be regenerated in the same change.
 4. Policy changes belong in `docs/testing/testing_standard.md`; inventory changes belong here.
 
 ## Definitions
+
 - **Automated test file**: A repo test source matched by this catalog's scanner (`tests/**`, `src/**`, `frontend/src/**`, `playwright/tests/**`).
 - **Catalog generator**: `scripts/generate-automated-test-catalog.ts`, the only source allowed to rewrite this file.
 - **Catalog validator**: `npm run validate:test-catalog`, which fails when this file drifts from the repo tree.
 
 ## Data models or schemas
+
 None.
 
 ## Flows or sequences
+
 1. Change or add tests.
 2. Run `npm run generate:test-catalog`.
 3. Review the generated markdown diff.
@@ -46,47 +56,53 @@ flowchart TD
 ```
 
 ## Examples
+
 - Add `tests/integration/new_feature.test.ts` -> regenerate the catalog so the new file appears under the integration suite.
 - Rename `tests/cli/old_name.test.ts` -> regenerate the catalog so the old path disappears and the new path appears.
 - Add a new CI lane for tests -> update this document's command summary and run the validator.
 
 ## Testing requirements
+
 - `npm run generate:test-catalog` must be run when automated test inventory changes.
 - `npm run validate:test-catalog` must pass before merge.
 - CI runs `npm run validate:test-catalog` in the baseline lane.
 
 ## Maintenance
+
 - Canonical policy doc: `docs/testing/testing_standard.md`.
 - Historical audit doc: `docs/testing/test_coverage_audit_summary.md`.
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **400**
-- Backend and repo Vitest files: **367**
+
+- Total automated test files: **401**
+- Backend and repo Vitest files: **368**
 - Frontend Vitest files: **9**
 - Playwright spec files: **24**
 
 ### Suite counts
-| Suite | Files |
-|---|---:|
-| Vitest unit tests | 99 |
-| Vitest service tests | 33 |
-| Source-adjacent tests | 46 |
-| Vitest integration tests | 109 |
-| Vitest CLI tests | 59 |
-| Vitest contract tests | 11 |
-| Vitest security tests | 2 |
-| Vitest subscription tests | 3 |
-| Vitest agent tests | 1 |
-| Vitest fixture tests | 1 |
-| Vitest helper tests | 1 |
-| Vitest shared-environment tests | 1 |
-| Frontend Vitest tests | 9 |
-| Playwright E2E tests | 22 |
-| Playwright Inspector E2E tests | 2 |
-| Tests Scripts | 1 |
+
+| Suite                           | Files |
+| ------------------------------- | ----: |
+| Vitest unit tests               |    99 |
+| Vitest service tests            |    33 |
+| Source-adjacent tests           |    47 |
+| Vitest integration tests        |   109 |
+| Vitest CLI tests                |    59 |
+| Vitest contract tests           |    11 |
+| Vitest security tests           |     2 |
+| Vitest subscription tests       |     3 |
+| Vitest agent tests              |     1 |
+| Vitest fixture tests            |     1 |
+| Vitest helper tests             |     1 |
+| Vitest shared-environment tests |     1 |
+| Frontend Vitest tests           |     9 |
+| Playwright E2E tests            |    22 |
+| Playwright Inspector E2E tests  |     2 |
+| Tests Scripts                   |     1 |
 
 ## Primary validation commands
+
 - `npm test`
 - `npm run test:frontend`
 - `npm run test:remote:critical`
@@ -96,18 +112,22 @@ flowchart TD
 - `npm run validate:doc-deps`
 
 ## CI lanes
+
 - Baseline CI runs `type-check`, `lint`, `lint:site-copy`, `npm test`, `validate:coverage`, `validate:test-catalog`, and `validate:doc-deps`.
 - Frontend CI runs `npm run test:frontend`.
 - Site/export CI runs route, locale, and export validation tasks.
 - Remote integration nightly runs `npm run test:remote:critical` when enabled.
 
 ## Automated test suites
+
 ### Vitest unit tests
+
 **Directory:** `tests/unit/`
 **Runner:** `vitest`
 **Command:** `npm test -- tests/unit`
 **Requirements:** Basic `.env` if required by the module under test.
 **Files (99):**
+
 - `tests/unit/aauth_admission.test.ts`
 - `tests/unit/aauth_attestation_apple_se.test.ts`
 - `tests/unit/aauth_attestation_revocation.test.ts`
@@ -209,11 +229,13 @@ flowchart TD
 - `tests/unit/workout_session_schema.test.ts`
 
 ### Vitest service tests
+
 **Directory:** `tests/services/`
 **Runner:** `vitest`
 **Command:** `npm test -- tests/services`
 **Requirements:** Basic `.env` if required by the module under test.
 **Files (33):**
+
 - `tests/services/auto_enhancement_converter_detection.test.ts`
 - `tests/services/auto_enhancement_processor.test.ts`
 - `tests/services/capability_registry.test.ts`
@@ -249,11 +271,13 @@ flowchart TD
 - `tests/services/sync_webhook_outbound.test.ts`
 
 ### Source-adjacent tests
+
 **Directory:** `src/**/__tests__/` and `src/**/*.test.ts(x)`
 **Runner:** `vitest`
 **Command:** `npm test -- src`
 **Requirements:** Basic `.env` if required by the module under test.
-**Files (46):**
+**Files (47):**
+
 - `src/cli/parse_cli_corrected_value.test.ts`
 - `src/crypto/crypto.test.ts`
 - `src/record_types.test.ts`
@@ -286,6 +310,7 @@ flowchart TD
 - `src/services/issues/neotoma_client.test.ts`
 - `src/services/issues/redaction_guard.test.ts`
 - `src/services/issues/seed_schema.test.ts`
+- `src/services/issues/sync_issues_push_writeback.test.ts`
 - `src/services/memory_export.test.ts`
 - `src/services/plans/capture_harness_plan.test.ts`
 - `src/services/plans/seed_schema.test.ts`
@@ -302,11 +327,13 @@ flowchart TD
 - `src/version_check.test.ts`
 
 ### Vitest integration tests
+
 **Directory:** `tests/integration/`
 **Runner:** `vitest`
 **Command:** `npm run test:integration` or `npx vitest run tests/integration`
 **Requirements:** Database configured; remote-dependent subsets additionally need `RUN_REMOTE_TESTS=1`.
 **Files (109):**
+
 - `tests/integration/aauth_attribution_stamping.test.ts`
 - `tests/integration/aauth_resource_metadata.test.ts`
 - `tests/integration/aauth_revocation_e2e.test.ts`
@@ -418,11 +445,13 @@ flowchart TD
 - `tests/integration/v0.2.0_ingestion.test.ts`
 
 ### Vitest CLI tests
+
 **Directory:** `tests/cli/`
 **Runner:** `vitest`
 **Command:** `npm test -- tests/cli`
 **Requirements:** Basic `.env`; some tests provision temp config homes automatically.
 **Files (59):**
+
 - `tests/cli/api_client_offline_fallback.test.ts`
 - `tests/cli/backup_verify.test.ts`
 - `tests/cli/cli_access_commands.test.ts`
@@ -484,11 +513,13 @@ flowchart TD
 - `tests/cli/transcript_parser.test.ts`
 
 ### Vitest contract tests
+
 **Directory:** `tests/contract/`
 **Runner:** `vitest`
 **Command:** `npm test -- tests/contract`
 **Requirements:** Generated contract artifacts present when the suite expects them.
 **Files (11):**
+
 - `tests/contract/cli_handler_dist_smoke.test.ts`
 - `tests/contract/contract_mapping.test.ts`
 - `tests/contract/contract_mcp_cli_parity.test.ts`
@@ -502,62 +533,76 @@ flowchart TD
 - `tests/contract/vite_config.test.ts`
 
 ### Vitest security tests
+
 **Directory:** `tests/security/`
 **Runner:** `vitest`
 **Command:** `npx vitest run tests/security`
 **Requirements:** Use alongside the dedicated security validation scripts when changing auth or route protection.
 **Files (2):**
+
 - `tests/security/auth_topology_matrix.test.ts`
 - `tests/security/tenant_isolation_matrix.test.ts`
 
 ### Vitest subscription tests
+
 **Directory:** `tests/subscriptions/`
 **Runner:** `vitest`
 **Command:** `npx vitest run tests/subscriptions`
 **Requirements:** Basic `.env`; some tests start an in-process HTTP server.
 **Files (3):**
+
 - `tests/subscriptions/guest_write_rate_limit_routing.test.ts`
 - `tests/subscriptions/subscription_guest_auth.test.ts`
 - `tests/subscriptions/subscription_loop_prevention.test.ts`
 
 ### Vitest agent tests
+
 **Directory:** `tests/agent/`
 **Runner:** `vitest`
 **Command:** `npm run test:agent-mcp`
 **Requirements:** Agent/provider-specific environment may be required for non-skipped cases.
 **Files (1):**
+
 - `tests/agent/mcp_instruction_behavior.test.ts`
 
 ### Vitest fixture tests
+
 **Directory:** `tests/fixtures/`
 **Runner:** `vitest`
 **Command:** `npx vitest run tests/fixtures`
 **Requirements:** Fixture files present in the repo checkout.
 **Files (1):**
+
 - `tests/fixtures/replay_graph.test.ts`
 
 ### Vitest helper tests
+
 **Directory:** `tests/helpers/`
 **Runner:** `vitest`
 **Command:** `npx vitest run tests/helpers`
 **Requirements:** Helper-specific fixtures present in the repo checkout.
 **Files (1):**
+
 - `tests/helpers/redact_for_test_report.test.ts`
 
 ### Vitest shared-environment tests
+
 **Directory:** `tests/shared/`
 **Runner:** `vitest`
 **Command:** `npx vitest run tests/shared`
 **Requirements:** Basic `.env`.
 **Files (1):**
+
 - `tests/shared/local_transport_env.test.ts`
 
 ### Frontend Vitest tests
+
 **Directory:** `frontend/src/`
 **Runner:** `vitest` with `jsdom`
 **Command:** `npm run test:frontend`
 **Requirements:** Run with `RUN_FRONTEND_TESTS=1` or the dedicated script.
 **Files (9):**
+
 - `frontend/src/bridge/websocket.test.ts`
 - `frontend/src/lib/idempotency.test.ts`
 - `frontend/src/site/mdx_site_registry.test.ts`
@@ -569,11 +614,13 @@ flowchart TD
 - `frontend/src/utils/vite_chunk_recovery.test.ts`
 
 ### Playwright E2E tests
+
 **Directory:** `playwright/tests/`
 **Runner:** `playwright`
 **Command:** `npm run test:e2e`
 **Requirements:** Playwright browsers installed; mock or real API configured per suite.
 **Files (22):**
+
 - `playwright/tests/auto-enhancement.spec.ts`
 - `playwright/tests/design-system.spec.ts`
 - `playwright/tests/entity-detail.spec.ts`
@@ -598,36 +645,45 @@ flowchart TD
 - `playwright/tests/upload-flow.spec.ts`
 
 ### Playwright Inspector E2E tests
+
 **Directory:** `playwright/tests/inspector/`
 **Runner:** `playwright`
 **Command:** `npm run test:e2e:inspector`
 **Requirements:** Inspector bundle built before execution.
 **Files (2):**
+
 - `playwright/tests/inspector/inspector-entity-detail.spec.ts`
 - `playwright/tests/inspector/inspector-issues.spec.ts`
 
 ### Tests Scripts
+
 **Directory:** `tests/scripts/`
 **Runner:** `vitest`
 **Command:** `npx vitest run tests/scripts`
 **Requirements:** Basic `.env` if required by the module under test.
 **Files (1):**
+
 - `tests/scripts/launchd_cli_sync_tooling.test.ts`
 
 ## Agent instructions
+
 ### When to load this document
+
 Load this document when adding, removing, moving, or renaming automated tests, or when changing test commands or CI lanes.
 
 ### Required co-loaded documents
+
 - `docs/testing/testing_standard.md`
 - `docs/conventions/documentation_standards.md`
 
 ### Constraints agents must enforce
+
 1. Regenerate this document when automated test inventory changes.
 2. Validate this document before completing test-related changes.
 3. Keep policy changes in `testing_standard.md`, not in the generated inventory sections here.
 
 ### Validation checklist
+
 - [ ] Test inventory regenerated after test-file changes
 - [ ] `npm run validate:test-catalog` passed
 - [ ] Related policy docs updated if commands or CI lanes changed

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -144,8 +144,21 @@ export interface Operations {
   /** Create multiple relationships between existing entities. */
   createRelationships(input: CreateRelationshipsInput): Promise<unknown>;
 
-  /** Correct an observation (creates a new observation that supersedes the prior). */
-  correct(input: { entity_id: string; corrections: Record<string, unknown> }): Promise<unknown>;
+  /**
+   * Correct a single field on an entity (creates a high-priority observation that
+   * supersedes the prior value). The underlying `correct` tool applies ONE field
+   * per call and requires `field`, `value`, and a unique `idempotency_key`
+   * (see CorrectEntityRequestSchema). It does NOT accept a `corrections` map —
+   * passing one fails Zod validation silently at the tool boundary (#1610).
+   */
+  correct(input: {
+    entity_id: string;
+    entity_type?: string;
+    field: string;
+    value: unknown;
+    idempotency_key: string;
+    user_id?: string;
+  }): Promise<unknown>;
 
   /** List registered entity types (schema-level discovery). */
   listEntityTypes(input?: { search?: string }): Promise<unknown>;

--- a/src/services/issues/sync_issues_from_github.ts
+++ b/src/services/issues/sync_issues_from_github.ts
@@ -163,22 +163,42 @@ async function pushUnsyncedIssues(
     }
 
     // Write github_number/url back and clear sync_pending.
-    try {
-      await ops.correct({
-        entity_id: entityId,
-        corrections: {
-          github_number: created.number,
-          github_url: created.html_url,
-          sync_pending: false,
-          last_synced_at: new Date().toISOString(),
-        },
-      });
-    } catch (err) {
-      // Push succeeded but local update failed — not fatal, but notable.
-      result.push_errors.push(
-        `GitHub issue #${created.number} created but local update failed for ${entityId}: ${(err as Error).message}`
-      );
-      // Still count as pushed since the GitHub issue exists.
+    //
+    // The `correct` tool applies ONE field per call and requires an explicit
+    // `field` + `value` + unique `idempotency_key` (see CorrectEntityRequestSchema).
+    // Passing a `corrections` map silently failed Zod validation, so the
+    // github_number was never persisted and the next sync re-pushed the same
+    // entity — creating duplicate GitHub issues on every run (#1610).
+    //
+    // Idempotency keys are deterministic per (entity, field, github number) so a
+    // replayed sync re-applies the identical correction instead of erroring.
+    const writeBacks: Array<{ field: string; value: unknown }> = [
+      { field: "github_number", value: created.number },
+      { field: "github_url", value: created.html_url },
+      { field: "sync_pending", value: false },
+      // Derive from the GitHub issue's creation timestamp (not wall-clock) so a
+      // replayed sync re-applies the identical value under the same idempotency
+      // key rather than tripping ERR_IDEMPOTENCY_MISMATCH.
+      { field: "last_synced_at", value: created.created_at },
+    ];
+
+    for (const { field, value } of writeBacks) {
+      try {
+        await ops.correct({
+          entity_id: entityId,
+          entity_type: "issue",
+          field,
+          value,
+          idempotency_key: `issue-push-writeback-${entityId}-${field}-gh${created.number}`,
+        });
+      } catch (err) {
+        // Push succeeded but local update failed — not fatal, but notable.
+        // Record once per failing field so the cause is visible.
+        result.push_errors.push(
+          `GitHub issue #${created.number} created but local ${field} write-back failed for ${entityId}: ${(err as Error).message}`
+        );
+        // Still count as pushed since the GitHub issue exists.
+      }
     }
 
     result.issues_pushed++;

--- a/src/services/issues/sync_issues_push_writeback.test.ts
+++ b/src/services/issues/sync_issues_push_writeback.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Regression coverage for #1610: the push leg must write github_number/url back
+// onto the local issue entity using per-field `correct` calls (field + value +
+// idempotency_key). The previous implementation passed a `corrections` map,
+// which failed Zod validation at the tool boundary, so the local entity never
+// recorded its github_number and every subsequent sync re-pushed it — creating
+// duplicate GitHub issues.
+
+const mockCreateIssue = vi.fn();
+const mockListIssues = vi.fn();
+const mockListIssueComments = vi.fn();
+
+const { mockLoadIssuesConfig } = vi.hoisted(() => ({
+  mockLoadIssuesConfig: vi.fn(),
+}));
+
+const defaultIssuesConfig = {
+  target_url: "https://neotoma.example.com",
+  repo: "test/repo",
+  github_auth: "gh_cli" as const,
+  reporting_mode: "consent" as const,
+  sync_staleness_ms: 300000,
+  configured_at: "2026-01-01T00:00:00Z",
+  author_alias: null,
+};
+
+vi.mock("./github_client.js", () => ({
+  createIssue: (...args: unknown[]) => mockCreateIssue(...args),
+  listIssues: (...args: unknown[]) => mockListIssues(...args),
+  listIssueComments: (...args: unknown[]) => mockListIssueComments(...args),
+  addIssueComment: vi.fn(),
+  mergeNeotomaToolingIssueLabels: (labels?: string[]) => [
+    "neotoma",
+    ...(labels ?? []).filter((label) => label !== "neotoma"),
+  ],
+}));
+
+vi.mock("./config.js", () => ({
+  loadIssuesConfig: (...args: unknown[]) => mockLoadIssuesConfig(...args),
+}));
+
+// Redaction guard passes title/body through in tests.
+vi.mock("./redaction_guard.js", () => ({
+  runRedactionGuard: ({ title, body }: { title: string; body: string }) => ({ title, body }),
+}));
+
+import { syncIssuesFromGitHub } from "./sync_issues_from_github.js";
+import type { Operations } from "../../core/operations.js";
+
+function makeOps(correctImpl?: (input: unknown) => Promise<unknown>): {
+  ops: Operations;
+  correct: ReturnType<typeof vi.fn>;
+} {
+  const correct = vi.fn(correctImpl ?? (async () => ({ ok: true })));
+  const ops = {
+    correct,
+    // Return one unsynced public issue with no github_number.
+    retrieveEntities: vi.fn(async () => ({
+      entities: [
+        {
+          entity_id: "ent_test_issue_1",
+          snapshot: {
+            visibility: "public",
+            github_number: "",
+            title: "Test issue title",
+            body: "Test issue body",
+            labels: ["bug"],
+          },
+        },
+      ],
+    })),
+    executeTool: vi.fn(async () => ({})),
+  } as unknown as Operations;
+  return { ops, correct };
+}
+
+describe("sync_issues push leg write-back (#1610)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLoadIssuesConfig.mockResolvedValue(defaultIssuesConfig);
+    mockCreateIssue.mockResolvedValue({
+      number: 4242,
+      html_url: "https://github.com/test/repo/issues/4242",
+      created_at: "2026-06-09T00:00:00Z",
+      title: "Test issue title",
+      body: "Test issue body",
+      state: "open",
+      labels: [{ name: "bug" }],
+      user: null,
+      closed_at: null,
+      updated_at: "2026-06-09T00:00:00Z",
+    });
+    // Pull leg returns nothing — we only exercise the push leg here.
+    mockListIssues.mockResolvedValue([]);
+    mockListIssueComments.mockResolvedValue([]);
+  });
+
+  it("writes github_number/url back via per-field correct() with idempotency keys", async () => {
+    const { ops, correct } = makeOps();
+
+    const result = await syncIssuesFromGitHub(ops, { push: true });
+
+    expect(result.issues_pushed).toBe(1);
+    expect(result.push_errors).toEqual([]);
+
+    // One correct() call per write-back field — never a `corrections` map.
+    const fields = correct.mock.calls.map((c) => (c[0] as { field: string }).field);
+    expect(fields).toEqual(["github_number", "github_url", "sync_pending", "last_synced_at"]);
+
+    for (const call of correct.mock.calls) {
+      const arg = call[0] as Record<string, unknown>;
+      expect(arg).not.toHaveProperty("corrections");
+      expect(arg.entity_id).toBe("ent_test_issue_1");
+      expect(arg.entity_type).toBe("issue");
+      expect(typeof arg.field).toBe("string");
+      expect(arg).toHaveProperty("value");
+      // idempotency_key is required and unique per field.
+      expect(typeof arg.idempotency_key).toBe("string");
+      expect((arg.idempotency_key as string).length).toBeGreaterThan(0);
+    }
+
+    const githubNumberCall = correct.mock.calls.find(
+      (c) => (c[0] as { field: string }).field === "github_number"
+    )?.[0] as Record<string, unknown>;
+    expect(githubNumberCall.value).toBe(4242);
+
+    // last_synced_at is derived from the GitHub created_at (deterministic),
+    // not wall-clock, so replays stay idempotent.
+    const lastSyncedCall = correct.mock.calls.find(
+      (c) => (c[0] as { field: string }).field === "last_synced_at"
+    )?.[0] as Record<string, unknown>;
+    expect(lastSyncedCall.value).toBe("2026-06-09T00:00:00Z");
+
+    // Idempotency keys are unique across the four fields.
+    const keys = correct.mock.calls.map(
+      (c) => (c[0] as { idempotency_key: string }).idempotency_key
+    );
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it("still counts the issue as pushed and records a per-field error when write-back fails", async () => {
+    const { ops } = makeOps(async () => {
+      throw new Error("simulated correct failure");
+    });
+
+    const result = await syncIssuesFromGitHub(ops, { push: true });
+
+    // GitHub issue exists, so it counts as pushed despite the local failure.
+    expect(result.issues_pushed).toBe(1);
+    // One push_error per failing field (4 fields).
+    expect(result.push_errors.length).toBe(4);
+    expect(result.push_errors[0]).toContain("write-back failed");
+  });
+});

--- a/tests/services/sync_issues_from_github.test.ts
+++ b/tests/services/sync_issues_from_github.test.ts
@@ -116,7 +116,11 @@ describe("syncIssuesFromGitHub", () => {
       .mockResolvedValueOnce([comment(101), comment(102)])
       .mockResolvedValueOnce([comment(201)]);
 
-    const result = await syncIssuesFromGitHub(ops, { state: "all", labels: ["bug"], since: "2026-05-01T00:00:00Z" });
+    const result = await syncIssuesFromGitHub(ops, {
+      state: "all",
+      labels: ["bug"],
+      since: "2026-05-01T00:00:00Z",
+    });
 
     expect(mockListIssues).toHaveBeenCalledWith({
       state: "all",
@@ -164,16 +168,13 @@ describe("syncIssuesFromGitHub", () => {
 
     expect(store).toHaveBeenCalledTimes(4);
     expect(seenIdempotencyKeys).toEqual(
-      new Set([
-        "issue-sync-test/repo-1",
-        "issue-comment-sync-test/repo-1-101",
-      ]),
+      new Set(["issue-sync-test/repo-1", "issue-comment-sync-test/repo-1-101"])
     );
   });
 
   describe("push leg — local public issues without github_number", () => {
     function makeEntityList(
-      entities: Array<{ entity_id: string; snapshot: Record<string, unknown> }>,
+      entities: Array<{ entity_id: string; snapshot: Record<string, unknown> }>
     ) {
       return { entities };
     }
@@ -183,6 +184,7 @@ describe("syncIssuesFromGitHub", () => {
       mockCreateIssue.mockResolvedValue({
         number: 42,
         html_url: "https://github.com/test/repo/issues/42",
+        created_at: "2026-06-09T00:00:00Z",
       });
     });
 
@@ -200,7 +202,7 @@ describe("syncIssuesFromGitHub", () => {
               labels: ["bug"],
             },
           },
-        ]),
+        ])
       );
 
       const result = await syncIssuesFromGitHub(ops);
@@ -209,18 +211,28 @@ describe("syncIssuesFromGitHub", () => {
         expect.objectContaining({
           title: "[redacted] Public bug",
           body: "[redacted] Details here",
-        }),
+        })
       );
-      expect(ops.correct).toHaveBeenCalledWith(
-        expect.objectContaining({
-          entity_id: "ent-public-1",
-          corrections: expect.objectContaining({
-            github_number: 42,
-            github_url: "https://github.com/test/repo/issues/42",
-            sync_pending: false,
-          }),
-        }),
+      // #1610: write-back uses per-field correct() calls (field + value +
+      // idempotency_key), NOT a `corrections` map (which fails Zod validation
+      // and caused duplicate GitHub issues on every sync).
+      const correctCalls = (ops.correct as ReturnType<typeof vi.fn>).mock.calls.map(
+        (c) => c[0] as Record<string, unknown>
       );
+      for (const arg of correctCalls) {
+        expect(arg).not.toHaveProperty("corrections");
+        expect(arg.entity_id).toBe("ent-public-1");
+        expect(arg.entity_type).toBe("issue");
+        expect(typeof arg.field).toBe("string");
+        expect(typeof arg.idempotency_key).toBe("string");
+        expect((arg.idempotency_key as string).length).toBeGreaterThan(0);
+      }
+      const byField = Object.fromEntries(correctCalls.map((a) => [a.field, a.value]));
+      expect(byField.github_number).toBe(42);
+      expect(byField.github_url).toBe("https://github.com/test/repo/issues/42");
+      expect(byField.sync_pending).toBe(false);
+      expect(byField.last_synced_at).toBe("2026-06-09T00:00:00Z");
+
       expect(result.issues_pushed).toBe(1);
       expect(result.push_errors).toEqual([]);
     });
@@ -239,7 +251,7 @@ describe("syncIssuesFromGitHub", () => {
               labels: [],
             },
           },
-        ]),
+        ])
       );
 
       const result = await syncIssuesFromGitHub(ops);
@@ -262,7 +274,7 @@ describe("syncIssuesFromGitHub", () => {
               labels: [],
             },
           },
-        ]),
+        ])
       );
 
       const result = await syncIssuesFromGitHub(ops);
@@ -285,7 +297,7 @@ describe("syncIssuesFromGitHub", () => {
               labels: [],
             },
           },
-        ]),
+        ])
       );
 
       const result = await syncIssuesFromGitHub(ops);
@@ -308,7 +320,7 @@ describe("syncIssuesFromGitHub", () => {
               labels: [],
             },
           },
-        ]),
+        ])
       );
       mockCreateIssue.mockRejectedValue(new Error("GitHub 422 Unprocessable"));
 
@@ -335,7 +347,7 @@ describe("syncIssuesFromGitHub", () => {
               labels: [],
             },
           },
-        ]),
+        ])
       );
 
       const result = await syncIssuesFromGitHub(ops, { push: false });
@@ -359,7 +371,7 @@ describe("syncIssuesFromGitHub", () => {
               labels: [],
             },
           },
-        ]),
+        ])
       );
 
       await syncIssuesFromGitHub(ops);
@@ -369,7 +381,7 @@ describe("syncIssuesFromGitHub", () => {
         expect.objectContaining({
           title: "[redacted] Issue with PII name",
           body: "[redacted] Contact me at private@example.com",
-        }),
+        })
       );
     });
   });


### PR DESCRIPTION
Backports the #1610 fix to the **release/v0.15.0** RC branch.

Cherry-pick of `aa8bcc71` (squash-merge of #1613 on `main`). The RC branch was 146 commits behind main and did not yet contain this fix.

## What it fixes

The `sync_issues` push leg wrote `github_number`/`github_url` back via `correct({ entity_id, corrections: {…} })`, but the `correct` tool requires one field per call (`field` + `value` + `idempotency_key`); the map failed Zod validation, so the local issue entity never recorded its `github_number` and every sync re-pushed it — creating duplicate GitHub issues on every run.

The fix issues per-field `correct()` calls with deterministic idempotency keys, derives `last_synced_at` from the GitHub `created_at` for replay-idempotency, corrects the misleading `Operations.correct` interface type, and adds regression coverage.

## Backport notes

- Source-code changes (`sync_issues_from_github.ts`, `operations.ts`, both test files) cherry-picked cleanly.
- Only conflict was the generated `docs/testing/automated_test_catalog.md`; resolved by regenerating from the RC tree (`npm run generate:test-catalog`) and prettier-formatting.

## Verification on the RC tree

- `npm run build:server` → clean
- Issues tests (`tests/services/sync_issues_from_github.test.ts` + `src/services/issues/`) → 69 passed
- `tsc --noEmit` → 0 errors; prettier → clean; test catalog → valid

The 3 `test:unit` failures on this branch (`package_scripts`, `external_actor_badge`, `agent_badge_tier_icon`) are **pre-existing on release/v0.15.0** — verified failing on the pristine branch before this cherry-pick, unrelated to this change (likely fixed by main commits the RC hasn't received yet).

Original PR: #1613 · Fixes #1610

🤖 Generated with [Claude Code](https://claude.com/claude-code)