### PR TITLE
fix(mcp): emit SSE retry: field on stream open (#1503)

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -852,7 +852,9 @@ const mcpServerInstances = new Map<string, NeotomaServer>();
 // solely when an `eventStore` is configured (resumability opt-in). We do not
 // configure an event store, and the stream that drops is the standalone GET
 // SSE stream, which never emits a priming event. Setting `retryInterval` would
-// therefore be an inert knob with no runtime effect, so it is omitted.
+// therefore be an inert knob with no runtime effect, so it is omitted. Instead
+// we write the SSE `retry:` field ourselves as the first frame on the GET SSE
+// stream (issue #1503); see MCP_SSE_RETRY_MS / parseMcpSseRetryMs below.
 
 /** Default MCP SSE heartbeat interval in ms when the env var is unset/invalid. */
 export const MCP_SSE_KEEPALIVE_DEFAULT_MS = 25_000;
@@ -877,6 +879,43 @@ export function parseMcpSseKeepaliveMs(raw: string | undefined): number {
 
 const MCP_SSE_KEEPALIVE_MS = parseMcpSseKeepaliveMs(process.env.NEOTOMA_MCP_SSE_KEEPALIVE_MS);
 
+// ----------------------------------------------------------------------------
+// MCP SSE reconnect hint (issue #1503)
+//
+// The SSE spec defines a `retry:` field that tells the client how many
+// milliseconds to wait before reconnecting after the stream drops. Without it,
+// a client that sees an unexpected close (proxy idle reap, NAT timeout) has no
+// server-provided guidance and may not reconnect promptly — the exact silent
+// failure mode in #1503 where Claude.ai loses the Neotoma tool registry until a
+// manual disconnect/reconnect. We write the `retry:` field as the very first
+// frame on the standalone GET SSE stream (right after the SDK flushes headers),
+// so the client records it on open and honors it on the *next* disconnect.
+//
+// This is independent of the keepalive heartbeat (#1483): the retry hint is
+// emitted even when the heartbeat is disabled, because reconnect guidance is
+// useful regardless of whether we are also sending warm-keeping pings.
+
+/** Default MCP SSE `retry:` reconnect hint in ms when the env var is unset/invalid. */
+export const MCP_SSE_RETRY_DEFAULT_MS = 3_000;
+
+/**
+ * Parse the `NEOTOMA_MCP_SSE_RETRY_MS` env value into a reconnect-hint interval.
+ *
+ * Mirrors {@link parseMcpSseKeepaliveMs}: only an unset / empty / non-numeric
+ * value falls back to the default. A literal `0` (or any negative number) is a
+ * VALID "do not emit a retry frame" sentinel and MUST flow through unchanged to
+ * the `retryMs <= 0` guard in `attachMcpSseKeepalive`.
+ */
+export function parseMcpSseRetryMs(raw: string | undefined): number {
+  if (raw === undefined) return MCP_SSE_RETRY_DEFAULT_MS;
+  const trimmed = raw.trim();
+  if (trimmed === "") return MCP_SSE_RETRY_DEFAULT_MS;
+  const parsed = Number.parseInt(trimmed, 10);
+  return Number.isFinite(parsed) ? parsed : MCP_SSE_RETRY_DEFAULT_MS;
+}
+
+const MCP_SSE_RETRY_MS = parseMcpSseRetryMs(process.env.NEOTOMA_MCP_SSE_RETRY_MS);
+
 /**
  * Attach SSE keepalive behavior to a `/mcp` GET request before the transport
  * takes over the response. Safe to call on every GET `/mcp`; it is a no-op
@@ -887,9 +926,10 @@ const MCP_SSE_KEEPALIVE_MS = parseMcpSseKeepaliveMs(process.env.NEOTOMA_MCP_SSE_
 export function attachMcpSseKeepalive(
   req: express.Request,
   res: express.Response,
-  options?: { keepaliveMs?: number; logger?: { warn: (msg: string) => void } }
+  options?: { keepaliveMs?: number; retryMs?: number; logger?: { warn: (msg: string) => void } }
 ): void {
   const keepaliveMs = options?.keepaliveMs ?? MCP_SSE_KEEPALIVE_MS;
+  const retryMs = options?.retryMs ?? MCP_SSE_RETRY_MS;
   const log = options?.logger ?? logger;
 
   // Inject X-Accel-Buffering only when the SDK actually opens an SSE stream.
@@ -900,23 +940,35 @@ export function attachMcpSseKeepalive(
   // so plain JSON-RPC POST replies are unaffected.
   const originalWriteHead = res.writeHead as typeof res.writeHead;
   let writeHeadPatched = true;
+  let retryFrameWritten = false;
   (res as express.Response).writeHead = function patchedWriteHead(
     this: express.Response,
     ...args: Parameters<typeof res.writeHead>
   ): express.Response {
+    let isSseStream = false;
     try {
       const contentType = String(res.getHeader("content-type") || "").toLowerCase();
-      if (
-        writeHeadPatched &&
-        contentType.includes("text/event-stream") &&
-        !res.getHeader("x-accel-buffering")
-      ) {
+      isSseStream = contentType.includes("text/event-stream");
+      if (writeHeadPatched && isSseStream && !res.getHeader("x-accel-buffering")) {
         res.setHeader("X-Accel-Buffering", "no");
       }
     } catch {
       // Header inspection is best-effort; never block the response.
     }
-    return originalWriteHead.apply(this, args) as express.Response;
+    const result = originalWriteHead.apply(this, args) as express.Response;
+    // Once headers are flushed for an SSE stream, write the SSE `retry:` field
+    // as the first frame so the client records the reconnect delay on open and
+    // honors it on the next unexpected close (#1503). SSE comment/field frames
+    // interleave safely before the SDK's own events. Carries no PII.
+    if (writeHeadPatched && isSseStream && !retryFrameWritten && retryMs > 0) {
+      retryFrameWritten = true;
+      try {
+        res.write(`retry: ${retryMs}\n\n`);
+      } catch {
+        // Non-fatal: the heartbeat below remains the primary keepalive.
+      }
+    }
+    return result;
   } as typeof res.writeHead;
 
   // Enable OS-level TCP keepalive so the kernel probes the peer and the

--- a/tests/unit/mcp_sse_keepalive.test.ts
+++ b/tests/unit/mcp_sse_keepalive.test.ts
@@ -5,6 +5,8 @@ import {
   attachMcpSseKeepalive,
   parseMcpSseKeepaliveMs,
   MCP_SSE_KEEPALIVE_DEFAULT_MS,
+  parseMcpSseRetryMs,
+  MCP_SSE_RETRY_DEFAULT_MS,
 } from "../../src/actions.js";
 
 /**
@@ -76,7 +78,9 @@ describe("attachMcpSseKeepalive (issue #1483)", () => {
 
   it("writes periodic SSE comment heartbeat frames once the event-stream is established", () => {
     const { req, res } = makeReqRes("GET");
-    attachMcpSseKeepalive(req as never, res as never, { keepaliveMs: 1000 });
+    // retryMs: 0 isolates this test to the heartbeat sequence; the retry frame
+    // is covered by the dedicated #1503 describe block below.
+    attachMcpSseKeepalive(req as never, res as never, { keepaliveMs: 1000, retryMs: 0 });
 
     // Before headers are sent, no frame should be written.
     vi.advanceTimersByTime(3000);
@@ -136,7 +140,7 @@ describe("attachMcpSseKeepalive (issue #1483)", () => {
   it("stops the heartbeat and restores writeHead when the stream closes", () => {
     const { req, res } = makeReqRes("GET");
     const originalWriteHead = res.writeHead;
-    attachMcpSseKeepalive(req as never, res as never, { keepaliveMs: 1000 });
+    attachMcpSseKeepalive(req as never, res as never, { keepaliveMs: 1000, retryMs: 0 });
     expect(res.writeHead).not.toBe(originalWriteHead);
 
     res.setHeader("Content-Type", "text/event-stream");
@@ -153,7 +157,7 @@ describe("attachMcpSseKeepalive (issue #1483)", () => {
 
   it("stops the heartbeat when the response has already ended", () => {
     const { req, res } = makeReqRes("GET");
-    attachMcpSseKeepalive(req as never, res as never, { keepaliveMs: 1000 });
+    attachMcpSseKeepalive(req as never, res as never, { keepaliveMs: 1000, retryMs: 0 });
 
     res.setHeader("Content-Type", "text/event-stream");
     res.writeHead(200);
@@ -165,7 +169,7 @@ describe("attachMcpSseKeepalive (issue #1483)", () => {
 
   it("disables the heartbeat when keepaliveMs <= 0 but still enables a bounded TCP keepalive", () => {
     const { req, res } = makeReqRes("GET");
-    attachMcpSseKeepalive(req as never, res as never, { keepaliveMs: 0 });
+    attachMcpSseKeepalive(req as never, res as never, { keepaliveMs: 0, retryMs: 0 });
 
     res.setHeader("Content-Type", "text/event-stream");
     res.writeHead(200);
@@ -211,6 +215,90 @@ describe("attachMcpSseKeepalive (issue #1483)", () => {
 
     vi.advanceTimersByTime(10000);
     expect(warn).not.toHaveBeenCalled();
+  });
+});
+
+describe("attachMcpSseKeepalive SSE retry: field (issue #1503)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("writes the SSE retry: field as the first frame once the event-stream opens", () => {
+    const { req, res } = makeReqRes("GET");
+    attachMcpSseKeepalive(req as never, res as never, { keepaliveMs: 1000, retryMs: 3000 });
+
+    // No frame before the SDK flushes headers.
+    vi.advanceTimersByTime(5000);
+    expect(res.writes).toHaveLength(0);
+
+    // SDK opens the SSE stream: the retry hint lands immediately, ahead of any
+    // heartbeat, so the client records it on open and honors it on disconnect.
+    res.setHeader("Content-Type", "text/event-stream");
+    res.writeHead(200);
+    expect(res.writes).toEqual(["retry: 3000\n\n"]);
+
+    // Subsequent traffic is the heartbeat; the retry frame is written only once.
+    vi.advanceTimersByTime(2000);
+    expect(res.writes).toEqual(["retry: 3000\n\n", ": hb\n\n", ": hb\n\n"]);
+  });
+
+  it("emits the retry: field even when the heartbeat is disabled (independent of keepalive)", () => {
+    const { req, res } = makeReqRes("GET");
+    attachMcpSseKeepalive(req as never, res as never, { keepaliveMs: 0, retryMs: 3000 });
+
+    res.setHeader("Content-Type", "text/event-stream");
+    res.writeHead(200);
+    vi.advanceTimersByTime(60000);
+
+    // Reconnect guidance is useful regardless of warm-keeping pings: exactly one
+    // retry frame, and no heartbeat frames.
+    expect(res.writes).toEqual(["retry: 3000\n\n"]);
+  });
+
+  it("does NOT write a retry: field on non-SSE (JSON) responses", () => {
+    const { req, res } = makeReqRes("GET");
+    attachMcpSseKeepalive(req as never, res as never, { keepaliveMs: 1000, retryMs: 3000 });
+
+    res.setHeader("Content-Type", "application/json");
+    res.writeHead(200);
+    vi.advanceTimersByTime(5000);
+    expect(res.writes).toHaveLength(0);
+  });
+
+  it("suppresses the retry: field when retryMs <= 0", () => {
+    const { req, res } = makeReqRes("GET");
+    attachMcpSseKeepalive(req as never, res as never, { keepaliveMs: 0, retryMs: 0 });
+
+    res.setHeader("Content-Type", "text/event-stream");
+    res.writeHead(200);
+    vi.advanceTimersByTime(5000);
+    expect(res.writes).toHaveLength(0);
+  });
+});
+
+describe("parseMcpSseRetryMs (issue #1503)", () => {
+  it("falls back to the default for unset / empty / non-numeric values", () => {
+    expect(parseMcpSseRetryMs(undefined)).toBe(MCP_SSE_RETRY_DEFAULT_MS);
+    expect(parseMcpSseRetryMs("")).toBe(MCP_SSE_RETRY_DEFAULT_MS);
+    expect(parseMcpSseRetryMs("   ")).toBe(MCP_SSE_RETRY_DEFAULT_MS);
+    expect(parseMcpSseRetryMs("abc")).toBe(MCP_SSE_RETRY_DEFAULT_MS);
+  });
+
+  it("passes a literal 0 through as the suppress sentinel (NOT coerced to default)", () => {
+    expect(parseMcpSseRetryMs("0")).toBe(0);
+  });
+
+  it("passes negative values through (also suppress, via the <= 0 guard)", () => {
+    expect(parseMcpSseRetryMs("-1")).toBe(-1);
+  });
+
+  it("returns the parsed value for valid positive integers", () => {
+    expect(parseMcpSseRetryMs("5000")).toBe(5000);
+    expect(parseMcpSseRetryMs(" 1500 ")).toBe(1500);
   });
 });
 
@@ -261,7 +349,7 @@ describe("attachMcpSseKeepalive env-driven disable (issue #1483 review)", () => 
     expect(keepaliveMs).toBe(0);
 
     const { req, res } = makeReqRes("GET");
-    attachMcpSseKeepalive(req as never, res as never, { keepaliveMs });
+    attachMcpSseKeepalive(req as never, res as never, { keepaliveMs, retryMs: 0 });
     res.setHeader("Content-Type", "text/event-stream");
     res.writeHead(200);
     vi.advanceTimersByTime(60000);


### PR DESCRIPTION
## Summary

The Neotoma MCP server's long-lived `GET /mcp` SSE stream drops to the Claude.ai client during tool-heavy sessions while `/health` stays green and other MCP servers (Gmail) stay up — evidence the fault is in Neotoma's SSE stream, not the client (#1503).

Issue #1483 already shipped the highest-leverage parts of the recommended fix on this same stream:
- **SSE keepalive frames** — a `: hb\n\n` comment ping every **25s** (`NEOTOMA_MCP_SSE_KEEPALIVE_MS`, default `25000`).
- **`X-Accel-Buffering: no`** so buffering proxies flush each frame, plus OS-level TCP keepalive.
- The heartbeat runs on an independent `setInterval` (issue #1503 fix #2), so **tool-call processing does not block the keepalive timer**.

This PR adds the remaining recommendation from #1503 (fix #3): the **SSE `retry:` field**.

- Writes `retry: <ms>\n\n` as the **first frame** on the GET SSE stream right after the SDK flushes headers, so the client records the reconnect delay on open and honors it on the next unexpected close.
- Independent of the heartbeat: emitted even when keepalive is disabled, since reconnect guidance is useful regardless of warm-keeping pings.
- Configurable via **`NEOTOMA_MCP_SSE_RETRY_MS`** (default **`3000`**; `0`/negative suppresses the frame, mirroring the keepalive disable sentinel).
- Frames carry **no PII** (only `retry:` / `: hb`).

Why we write `retry:` directly rather than the SDK's `retryInterval` option: in SDK 1.29 `retryInterval` only emits inside the POST→SSE *priming event* and only when an `eventStore` is configured; the standalone GET SSE stream that drops never emits a priming event, so the SDK knob is inert here.

### Keepalive interval
- Heartbeat ping: **25s** (`: hb\n\n`, pre-existing from #1483).
- Reconnect hint: **`retry: 3000`** (3s), new in this PR.

## Files changed
- `src/actions.ts` — `parseMcpSseRetryMs`, `MCP_SSE_RETRY_DEFAULT_MS`, `retryMs` option on `attachMcpSseKeepalive`, retry-frame write in the `writeHead` patch.
- `tests/unit/mcp_sse_keepalive.test.ts` — new `#1503` describe block + `parseMcpSseRetryMs` tests; existing heartbeat-only tests isolated with `retryMs: 0`.

## Test plan
- [x] `npx vitest run tests/unit/mcp_sse_keepalive.test.ts` → 24 passed (fake timers assert the retry frame is emitted once on stream open, ahead of heartbeats, and suppressed when `retryMs <= 0` or on non-SSE responses).
- [x] `npx tsc --noEmit` clean.

## Load verification is a follow-up
This cannot be fully verified without a load test against the deployed endpoint. The tests here assert that the `retry:` frame (and the pre-existing keepalive pings) are emitted on the stream at the expected point/interval using fake timers. **Full load-verification against the production `neotoma.markmhendrickson.com/mcp` endpoint — reproducing a sequence of large `correct()` writes + snapshot reads and confirming the stream survives — is a follow-up.**

Fixes #1503