### PR TITLE
feat(inspector): cap sidebar pins at 8 with 'Show all' link

### DIFF
--- a/inspector/src/components/layout/pinned_primitives_sidebar.tsx
+++ b/inspector/src/components/layout/pinned_primitives_sidebar.tsx
@@ -169,6 +169,8 @@ function PinnedNavItem({
   );
 }
 
+const SIDEBAR_PIN_LIMIT = 8;
+
 export function PinnedPrimitivesSidebar({ collapsed }: { collapsed: boolean }) {
   const location = useLocation();
   const { pins, replacePins } = usePinnedPrimitives();
@@ -177,6 +179,8 @@ export function PinnedPrimitivesSidebar({ collapsed }: { collapsed: boolean }) {
   const [dragIndex, setDragIndex] = useState<number | null>(null);
   const [dropIndex, setDropIndex] = useState<number | null>(null);
 
+  const visiblePins = pins.slice(0, SIDEBAR_PIN_LIMIT);
+  const hiddenCount = Math.max(0, pins.length - SIDEBAR_PIN_LIMIT);
   const reorderable = !collapsed && pins.length > 1;
 
   const handleDragEnd = useCallback(() => {
@@ -235,7 +239,7 @@ export function PinnedPrimitivesSidebar({ collapsed }: { collapsed: boolean }) {
           }
         }}
       >
-        {pins.map((pin, index) => (
+        {visiblePins.map((pin, index) => (
           <PinnedNavItem
             key={pin.href}
             pin={pin}
@@ -254,6 +258,18 @@ export function PinnedPrimitivesSidebar({ collapsed }: { collapsed: boolean }) {
             onDrop={handleDrop}
           />
         ))}
+        {hiddenCount > 0 && (
+          <Link
+            to="/"
+            className={cn(
+              "flex items-center gap-3 rounded-md py-2 text-xs font-medium text-muted-foreground transition-colors hover:text-sidebar-foreground",
+              collapsed ? "justify-center px-0" : "px-3"
+            )}
+          >
+            {!collapsed && <span>Show all ({pins.length})</span>}
+            {collapsed && <span className="text-[10px]">+{hiddenCount}</span>}
+          </Link>
+        )}
       </div>
     </>
   );


### PR DESCRIPTION
## Summary

- Caps the pinned-primitives sidebar at **8 visible pins** (`SIDEBAR_PIN_LIMIT`), with a **"Show all (N)"** link (or `+N` when collapsed) routing to home for the overflow.
- Extracted from session UI work in the `neotoma-inspector` checkout during the frontend-consolidation pass; the rest of that work already landed on `main`. The accompanying `skeleton.tsx` `bg-skeleton`→`bg-muted` edit was intentionally **dropped** (it would undo the `--skeleton` skinning token).

## Test plan

- [ ] CI `frontend` + `baseline` lanes green (type-check passes locally against inspector tsconfig)
- [ ] Sidebar shows at most 8 pins; "Show all (N)" appears only when pins exceed 8