### PR TITLE
fix(entities): retrieve_entities lightweight projection crashes on SQLite (no such column: status)

### DIFF
--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,18 +61,18 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **461**
-- Backend and repo Vitest files: **428**
+- Total automated test files: **463**
+- Backend and repo Vitest files: **430**
 - Frontend Vitest files: **9**
 - Playwright spec files: **24**
 
 ### Suite counts
 | Suite | Files |
 |---|---:|
-| Vitest unit tests | 118 |
+| Vitest unit tests | 119 |
 | Vitest service tests | 34 |
 | Source-adjacent tests | 53 |
-| Vitest integration tests | 133 |
+| Vitest integration tests | 134 |
 | Vitest CLI tests | 63 |
 | Vitest contract tests | 13 |
 | Vitest security tests | 3 |
@@ -109,7 +109,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/unit`
 **Requirements:** Basic `.env` if required by the module under test.
-**Files (118):**
+**Files (119):**
 - `tests/unit/aauth_admission.test.ts`
 - `tests/unit/aauth_attestation_apple_se.test.ts`
 - `tests/unit/aauth_attestation_revocation.test.ts`
@@ -336,7 +336,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm run test:integration` or `npx vitest run tests/integration`
 **Requirements:** Database configured; remote-dependent subsets additionally need `RUN_REMOTE_TESTS=1`.
-**Files (133):**
+**Files (134):**
 - `tests/integration/aauth_attribution_stamping.test.ts`
 - `tests/integration/aauth_resource_metadata.test.ts`
 - `tests/integration/aauth_revocation_e2e.test.ts`
@@ -368,6 +368,7 @@ flowchart TD
 - `tests/integration/describe_entity_type.test.ts`
 - `tests/integration/docs_route.test.ts`
 - `tests/integration/entity_identifier_handler.test.ts`
+- `tests/integration/entity_queries_status_column.test.ts`
 - `tests/integration/entity_queries.test.ts`
 - `tests/integration/entity_search_mode.test.ts`
 - `tests/integration/events_stream.test.ts`

--- a/src/services/entity_queries.ts
+++ b/src/services/entity_queries.ts
@@ -445,9 +445,17 @@ export async function queryEntities(
 
   const entityIds = entities.map((e: any) => e.id);
   const filteredEntityIds = entityIds;
+  // For the lightweight (no-snapshot) projection we still need the `status`
+  // field that callers expect on the returned row. We cannot project it with a
+  // PostgREST `snapshot->>status` JSON operator here: that syntax is only
+  // translated by the SQLite adapter inside filter clauses (normalizeColumnName),
+  // not inside the raw SELECT list, so SQLite resolves `status` as a literal
+  // column and throws `no such column: status`. Instead, select the `snapshot`
+  // JSON column itself and derive `status` from it in JS below. This keeps the
+  // returned row shape identical across the Postgres and SQLite backends.
   const snapshotSelect = includeSnapshots
     ? "*"
-    : "entity_id, schema_version, observation_count, last_observation_at, computed_at, snapshot->>status";
+    : "entity_id, schema_version, observation_count, last_observation_at, computed_at, snapshot";
   const { data: snapshots, error: snapshotsError } = await db
     .from("entity_snapshots")
     .select(snapshotSelect)
@@ -623,6 +631,8 @@ export async function queryEntities(
   return entities.map((entity: any) => {
     const snapshot = snapshotMap.get(entity.id);
     const rawFragments = rawFragmentsByEntity.get(entity.id);
+    const snapshotData = (snapshot?.snapshot ?? {}) as Record<string, unknown>;
+    const lightweightStatus = snapshotData["status"];
     return {
       entity_id: entity.id,
       entity_type: entity.entity_type,
@@ -630,8 +640,8 @@ export async function queryEntities(
       schema_version: snapshot?.schema_version,
       snapshot: includeSnapshots
         ? snapshot?.snapshot || {}
-        : snapshot?.["status"] != null
-          ? { status: snapshot["status"] }
+        : lightweightStatus != null
+          ? { status: lightweightStatus }
           : {},
       raw_fragments:
         includeSnapshots && rawFragments && Object.keys(rawFragments).length > 0

--- a/tests/integration/entity_queries_status_column.test.ts
+++ b/tests/integration/entity_queries_status_column.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Regression tests for the lightweight (include_snapshots=false) projection on
+ * the local SQLite backend (issues #1627 and #1625).
+ *
+ * The lightweight projection used to select `snapshot->>status`. That PostgREST
+ * JSON-operator syntax is only translated by the SQLite adapter inside filter
+ * clauses (normalizeColumnName), NOT inside the raw SELECT list, so SQLite
+ * resolved `status` as a literal column and threw:
+ *
+ *   Failed to query snapshots: no such column: status
+ *
+ * This failed for EVERY entity type (#1627), and reading any type whose snapshot
+ * lacks a `status` field — e.g. `activity_log` (#1625) — hit the same error.
+ *
+ * Unlike `tests/integration/entity_queries.test.ts` (excluded from the default
+ * lane and only run against Postgres with RUN_REMOTE_TESTS=1), this suite runs
+ * on the default local SQLite lane so the adapter-specific bug is actually
+ * exercised.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { db, getServiceRoleClient } from "../../src/db.js";
+import { queryEntities } from "../../src/services/entity_queries.js";
+
+const serviceRoleClient = getServiceRoleClient();
+
+describe("queryEntities lightweight projection on SQLite (#1627, #1625)", () => {
+  const testUserId = "status-column-regression-user";
+  const testEntityIds: string[] = [];
+
+  async function cleanupEntities() {
+    if (testEntityIds.length === 0) return;
+    await db.from("entity_snapshots").delete().in("entity_id", testEntityIds);
+    await db.from("entities").delete().in("id", testEntityIds);
+    testEntityIds.length = 0;
+  }
+
+  async function createEntityWithSnapshot(
+    id: string,
+    entityType: string,
+    canonicalName: string,
+    snapshot: Record<string, unknown>
+  ) {
+    const now = new Date().toISOString();
+    await serviceRoleClient.from("entities").insert({
+      id,
+      user_id: testUserId,
+      entity_type: entityType,
+      canonical_name: canonicalName,
+    });
+    testEntityIds.push(id);
+    await serviceRoleClient.from("entity_snapshots").upsert({
+      entity_id: id,
+      user_id: testUserId,
+      entity_type: entityType,
+      schema_version: "1.0",
+      canonical_name: canonicalName,
+      snapshot,
+      provenance: {},
+      observation_count: 1,
+      last_observation_at: now,
+      computed_at: now,
+    });
+  }
+
+  beforeEach(async () => {
+    await cleanupEntities();
+  });
+
+  afterEach(async () => {
+    await cleanupEntities();
+  });
+
+  it("returns rows (no error) for a type WITH a status field and carries status", async () => {
+    await createEntityWithSnapshot(
+      "ent_status_txn",
+      "transaction",
+      "Coffee purchase",
+      { amount: 4.5, status: "cleared" }
+    );
+
+    const results = await queryEntities({
+      userId: testUserId,
+      entityType: "transaction",
+      includeSnapshots: false,
+      limit: 100,
+      offset: 0,
+    });
+
+    const found = results.find((e) => e.entity_id === "ent_status_txn");
+    expect(found).toBeDefined();
+    // The lightweight row must still carry status derived from the snapshot.
+    expect(found!.snapshot).toEqual({ status: "cleared" });
+  });
+
+  it("returns rows (no error) for a type WITHOUT a status field (#1625)", async () => {
+    await createEntityWithSnapshot(
+      "ent_no_status_log",
+      "activity_log",
+      "User signed in",
+      { action: "login", actor: "system" }
+    );
+
+    // The core regression: this used to throw
+    //   "Failed to query snapshots: no such column: status"
+    const results = await queryEntities({
+      userId: testUserId,
+      entityType: "activity_log",
+      includeSnapshots: false,
+      limit: 100,
+      offset: 0,
+    });
+
+    const found = results.find((e) => e.entity_id === "ent_no_status_log");
+    expect(found).toBeDefined();
+    // No status field on the snapshot → empty lightweight snapshot, not an error.
+    expect(found!.snapshot).toEqual({});
+  });
+
+  it("returns mixed types in one lightweight scan without throwing", async () => {
+    await createEntityWithSnapshot("ent_mix_txn", "transaction", "Refund", {
+      amount: 12,
+      status: "pending",
+    });
+    await createEntityWithSnapshot("ent_mix_log", "activity_log", "Logout event", {
+      action: "logout",
+    });
+
+    const results = await queryEntities({
+      userId: testUserId,
+      includeSnapshots: false,
+      limit: 100,
+      offset: 0,
+    });
+
+    const txn = results.find((e) => e.entity_id === "ent_mix_txn");
+    const log = results.find((e) => e.entity_id === "ent_mix_log");
+    expect(txn).toBeDefined();
+    expect(log).toBeDefined();
+    expect(txn!.snapshot).toEqual({ status: "pending" });
+    expect(log!.snapshot).toEqual({});
+  });
+});

--- a/tests/unit/entity_queries_status_projection.test.ts
+++ b/tests/unit/entity_queries_status_projection.test.ts
@@ -69,8 +69,10 @@ describe("entity_queries — status projection (#1586)", () => {
       observation_count: 1,
       last_observation_at: "2025-01-01T00:00:00Z",
       computed_at: "2025-01-01T00:00:00Z",
-      // PostgREST returns the extracted text value under the key "status"
-      status: "active",
+      // The lightweight projection selects the `snapshot` JSON column and the
+      // query layer derives `status` from it in JS (the `snapshot->>status`
+      // PostgREST operator is not translated inside the SQLite SELECT list).
+      snapshot: { status: "active" },
     };
 
     // deletionObservations (getDeletedEntityIds) — observations query
@@ -118,7 +120,7 @@ describe("entity_queries — status projection (#1586)", () => {
       observation_count: 1,
       last_observation_at: "2025-01-01T00:00:00Z",
       computed_at: "2025-01-01T00:00:00Z",
-      status: null, // no status
+      snapshot: {}, // no status field
     };
 
     const deletionQuery = buildQuery([]);
@@ -171,7 +173,7 @@ describe("entity_queries — status projection (#1586)", () => {
       observation_count: 1,
       last_observation_at: "2025-01-01T00:00:00Z",
       computed_at: "2025-01-01T00:00:00Z",
-      status: "active",
+      snapshot: { status: "active" },
     };
     const snapshotInactive = {
       entity_id: "ent_inactive",
@@ -179,7 +181,7 @@ describe("entity_queries — status projection (#1586)", () => {
       observation_count: 1,
       last_observation_at: "2025-01-02T00:00:00Z",
       computed_at: "2025-01-02T00:00:00Z",
-      status: "inactive",
+      snapshot: { status: "inactive" },
     };
 
     const deletionQuery = buildQuery([]);
@@ -233,7 +235,7 @@ describe("entity_queries — status projection (#1586)", () => {
       observation_count: 1,
       last_observation_at: "2025-01-01T00:00:00Z",
       computed_at: "2025-01-01T00:00:00Z",
-      status: "active",
+      snapshot: { status: "active" },
     };
 
     // snapshot-driven scan: entity_snapshots for id candidates


### PR DESCRIPTION
## Summary

`retrieve_entities` with `include_snapshots: false` failed on the local SQLite backend with:

```
MCP error -32603: Failed to query snapshots: no such column: status
```

for **every** entity type. Reading any type whose snapshot lacks a `status` field (e.g. `activity_log`) hit the same error.

### Root cause

The lightweight projection in `src/services/entity_queries.ts` selected `snapshot->>status`. That PostgREST JSON-operator syntax is only translated by the SQLite adapter inside *filter* clauses (`normalizeColumnName`), **not** inside the raw `SELECT` list (which is interpolated verbatim into the SQL). SQLite therefore parsed `status` as a literal column and threw `no such column: status`. The full-snapshot branch selects `*`, so it never hit this.

### Fix (low risk, no contract change)

Select the real `snapshot` JSON column instead of `snapshot->>status`, and derive `status` from the snapshot object in JS. The returned lightweight row shape is identical (status still present when set, `{}` otherwise) and consistent across the Postgres and SQLite backends. No OpenAPI change — `status` was already part of the lightweight row.

### Why it wasn't caught

`tests/integration/entity_queries.test.ts` is excluded from the default local lane (`vitest.config.ts`) and only runs against Postgres with `RUN_REMOTE_TESTS=1`, where the `->>` operator works. The added regression test runs on the **default SQLite lane** so the adapter-specific bug is actually exercised.

## Changes

- `src/services/entity_queries.ts` — lightweight projection selects `snapshot` JSON and derives `status` in JS.
- `tests/integration/entity_queries_status_column.test.ts` — new SQLite-lane regression test: a type **with** a status field (`transaction`) and a type **without** one (`activity_log`) both return rows without error.
- `tests/unit/entity_queries_status_projection.test.ts` — updated mocks to reflect the snapshot-JSON projection.

## Test plan

- [x] New regression test fails on the unpatched code with the exact `no such column: status` error, passes with the fix.
- [x] `npx vitest run tests/integration/entity_queries_status_column.test.ts tests/unit/entity_queries_status_projection.test.ts tests/integration/entity_search_mode.test.ts src/repositories/sqlite/__tests__/local_db_adapter.test.ts` → 29 passed.

Fixes #1627
Fixes #1625