### PR TITLE
fix(retrieve_entities): honor entity_types (plural) filter

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2553,6 +2553,18 @@ paths:
               properties:
                 entity_type:
                   type: string
+                  description: |
+                    Single entity-type filter. Combined as a union with
+                    `entity_types` when both are supplied.
+                entity_types:
+                  type: array
+                  items:
+                    type: string
+                  description: |
+                    Multi-type filter. When non-empty, results are restricted
+                    to entities whose `entity_type` is in this list (an IN
+                    filter), OR-combined with the singular `entity_type` when
+                    both are provided. An empty array is treated as no filter.
                 search:
                   type: string
                   description: Canonical free-text query parameter for retrieval relevance.

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -3714,6 +3714,7 @@ app.post("/entities/query", async (req, res) => {
 
     const {
       entity_type,
+      entity_types,
       search,
       limit,
       offset,
@@ -3734,6 +3735,7 @@ app.post("/entities/query", async (req, res) => {
       await queryEntitiesWithCount({
         userId,
         entityType: entity_type,
+        entityTypes: entity_types,
         includeMerged: include_merged,
         includeSnapshots: include_snapshots,
         sortBy: sort_by,

--- a/src/server.ts
+++ b/src/server.ts
@@ -2965,6 +2965,7 @@ export class NeotomaServer {
       await queryEntitiesWithCount({
         userId,
         entityType: parsed.entity_type,
+        entityTypes: parsed.entity_types,
         includeMerged: parsed.include_merged,
         includeSnapshots: parsed.include_snapshots,
         sortBy: parsed.sort_by,

--- a/src/services/entity_queries.ts
+++ b/src/services/entity_queries.ts
@@ -11,6 +11,13 @@ export interface SnapshotFilter {
 export interface EntityQueryOptions {
   userId?: string;
   entityType?: string;
+  /**
+   * Multi-type filter. When non-empty, restricts results to entities whose
+   * `entity_type` is in this list (an IN filter), OR-combined with the singular
+   * `entityType` when both are provided. An empty/omitted list applies no
+   * multi-type filter. See {@link normalizeEntityTypeFilter}.
+   */
+  entityTypes?: string[];
   includeMerged?: boolean;
   includeDeleted?: boolean;
   includeSnapshots?: boolean;
@@ -94,6 +101,27 @@ interface EntitySnapshotRow {
 const ENTITY_BASE_SELECT =
   "id, entity_type, canonical_name, user_id, merged_to_entity_id, merged_at, created_at";
 
+/**
+ * Combine the singular `entityType` and plural `entityTypes` filters into a
+ * single deduplicated, deterministically-ordered list of entity types to
+ * filter on. Returns an empty array when neither is provided (no type filter).
+ * Blank/whitespace-only entries are dropped so an `entity_types: [""]` payload
+ * does not silently match nothing.
+ */
+export function normalizeEntityTypeFilter(entityType?: string, entityTypes?: string[]): string[] {
+  const types = new Set<string>();
+  if (typeof entityType === "string" && entityType.trim().length > 0) {
+    types.add(entityType);
+  }
+  for (const candidate of entityTypes ?? []) {
+    if (typeof candidate === "string" && candidate.trim().length > 0) {
+      types.add(candidate);
+    }
+  }
+  // Stable ordering keeps the generated SQL/IN clause deterministic.
+  return [...types].sort();
+}
+
 async function getDeletedEntityIds(entityIds: string[]): Promise<Set<string>> {
   const deletedEntityIds = new Set<string>();
   if (entityIds.length === 0) {
@@ -137,6 +165,7 @@ export async function queryEntities(
   const {
     userId,
     entityType,
+    entityTypes,
     includeMerged = false,
     includeDeleted = false,
     includeSnapshots = true,
@@ -153,6 +182,23 @@ export async function queryEntities(
     identityBasis,
     snapshotFilters,
   } = options;
+
+  // Union of singular + plural type filters. Empty → no type filter.
+  const typeFilter = normalizeEntityTypeFilter(entityType, entityTypes);
+  const applyTypeFilter = <
+    T extends { eq: (c: string, v: string) => T; in: (c: string, v: string[]) => T },
+  >(
+    query: T,
+    column: string
+  ): T => {
+    if (typeFilter.length === 1) {
+      return query.eq(column, typeFilter[0]);
+    }
+    if (typeFilter.length > 1) {
+      return query.in(column, typeFilter);
+    }
+    return query;
+  };
 
   // R3: when an `identity_basis` filter is set, resolve candidate entity_ids
   // from the observations table first. Distinct per entity; we only need the
@@ -199,10 +245,8 @@ export async function queryEntities(
     entityQuery = entityQuery.eq("user_id", userId);
   }
 
-  // Filter by entity type if provided
-  if (entityType) {
-    entityQuery = entityQuery.eq("entity_type", entityType);
-  }
+  // Filter by entity type(s) if provided (singular + plural union)
+  entityQuery = applyTypeFilter(entityQuery, "entity_type");
 
   // Exclude merged entities unless explicitly requested
   if (!includeMerged) {
@@ -248,9 +292,7 @@ export async function queryEntities(
     if (userId) {
       query = query.eq("user_id", userId);
     }
-    if (entityType) {
-      query = query.eq("entity_type", entityType);
-    }
+    query = applyTypeFilter(query, "entity_type");
     if (!includeMerged) {
       query = query.is("merged_to_entity_id", null);
     }
@@ -279,9 +321,7 @@ export async function queryEntities(
       if (userId) {
         snapshotQuery = snapshotQuery.eq("user_id", userId);
       }
-      if (entityType) {
-        snapshotQuery = snapshotQuery.eq("entity_type", entityType);
-      }
+      snapshotQuery = applyTypeFilter(snapshotQuery, "entity_type");
       if (effectiveEntityIds && effectiveEntityIds.length > 0) {
         snapshotQuery = snapshotQuery.in("entity_id", effectiveEntityIds);
       }

--- a/src/services/entity_semantic_search.ts
+++ b/src/services/entity_semantic_search.ts
@@ -10,6 +10,8 @@ export interface SemanticSearchEntitiesOptions {
   searchText: string;
   userId: string;
   entityType?: string;
+  /** Multi-type filter, OR-combined with `entityType` (#1562). */
+  entityTypes?: string[];
   includeMerged?: boolean;
   /** Distance threshold (0–2). Results with distance >= threshold are dropped. Only applied in local mode. */
   similarityThreshold?: number;
@@ -35,6 +37,7 @@ export async function semanticSearchEntities(
     searchText,
     userId,
     entityType,
+    entityTypes,
     includeMerged = false,
     similarityThreshold,
     limit,
@@ -51,6 +54,7 @@ export async function semanticSearchEntities(
     queryEmbedding,
     userId,
     entityType: entityType ?? null,
+    entityTypes,
     includeMerged,
     distanceThreshold: similarityThreshold,
     limit,

--- a/src/services/local_entity_embedding.ts
+++ b/src/services/local_entity_embedding.ts
@@ -102,6 +102,11 @@ export function searchLocalEntityEmbeddings(options: {
   queryEmbedding: number[];
   userId: string;
   entityType?: string | null;
+  /**
+   * Multi-type filter, OR-combined with `entityType` (#1562). When non-empty,
+   * candidates are restricted to rows whose `entity_type` is in this list.
+   */
+  entityTypes?: string[];
   includeMerged: boolean;
   /**
    * L2 distance threshold. Results with distance >= threshold are dropped.
@@ -112,8 +117,30 @@ export function searchLocalEntityEmbeddings(options: {
   limit: number;
   offset: number;
 }): { entityIds: string[]; total: number } {
-  const { queryEmbedding, userId, entityType, includeMerged, distanceThreshold, limit, offset } =
-    options;
+  const {
+    queryEmbedding,
+    userId,
+    entityType,
+    entityTypes,
+    includeMerged,
+    distanceThreshold,
+    limit,
+    offset,
+  } = options;
+
+  // Union of singular + plural type filters. Empty → no type filter.
+  const typeFilter = (() => {
+    const types = new Set<string>();
+    if (typeof entityType === "string" && entityType.trim().length > 0) {
+      types.add(entityType);
+    }
+    for (const candidate of entityTypes ?? []) {
+      if (typeof candidate === "string" && candidate.trim().length > 0) {
+        types.add(candidate);
+      }
+    }
+    return [...types].sort();
+  })();
 
   if (
     config.storageBackend !== "local" ||
@@ -156,6 +183,15 @@ export function searchLocalEntityEmbeddings(options: {
   const float32 = new Float32Array(queryEmbedding);
   const embeddingBlob = Buffer.from(float32.buffer, float32.byteOffset, float32.byteLength);
 
+  // Build the entity_type clause from the normalized union list. No filter when
+  // empty; equality for one type; an IN(...) with bound placeholders otherwise.
+  const typeClause =
+    typeFilter.length === 0
+      ? "1 = 1"
+      : typeFilter.length === 1
+        ? "r.entity_type = ?"
+        : `r.entity_type IN (${typeFilter.map(() => "?").join(", ")})`;
+
   const rows = db
     .prepare(
       `
@@ -164,7 +200,7 @@ export function searchLocalEntityEmbeddings(options: {
     INNER JOIN entity_embedding_rows r ON r.rowid = v.rowid
     WHERE v.embedding MATCH ? AND k = ?
       AND r.user_id = ?
-      AND (? IS NULL OR r.entity_type = ?)
+      AND ${typeClause}
       AND (? = 1 OR r.merged = 0)
     ORDER BY v.distance
   `
@@ -173,8 +209,7 @@ export function searchLocalEntityEmbeddings(options: {
       embeddingBlob,
       oversample,
       userId,
-      entityType ?? null,
-      entityType ?? null,
+      ...typeFilter,
       includeMerged ? 1 : 0 /* includeMerged=1: all rows; =0: only non-merged (r.merged=0) */
     ) as Array<{ entity_id: string; distance: number }>;
 

--- a/src/shared/action_handlers/entity_handlers.ts
+++ b/src/shared/action_handlers/entity_handlers.ts
@@ -1,5 +1,5 @@
 import { db } from "../../db.js";
-import { queryEntities } from "../../services/entity_queries.js";
+import { queryEntities, normalizeEntityTypeFilter } from "../../services/entity_queries.js";
 import { BOOKKEEPING_ENTITY_TYPES } from "../../services/memory_export.js";
 import { suggestSingular } from "../../services/entity_type_guard.js";
 import { logger } from "../../utils/logger.js";
@@ -15,6 +15,13 @@ export interface SnapshotFilter {
 interface QueryEntitiesParams {
   userId: string;
   entityType?: string;
+  /**
+   * Multi-type filter. When non-empty, results are restricted to entities whose
+   * `entity_type` is in this list (an IN filter), OR-combined with the singular
+   * `entityType`. Honored on the plain-listing, lexical, and semantic search
+   * paths so a non-empty value is never silently ignored (#1562).
+   */
+  entityTypes?: string[];
   includeMerged?: boolean;
   includeSnapshots?: boolean;
   sortBy?: string;
@@ -112,6 +119,8 @@ export function conceptEntityTypeHints(
 interface LexicalSearchEntityIdsParams {
   userId: string;
   entityType?: string;
+  /** Multi-type filter, OR-combined with `entityType` (#1562). */
+  entityTypes?: string[];
   includeMerged?: boolean;
   search: string;
   /** Omit chat bookkeeping rows from product search (Inspector header, /search). */
@@ -398,7 +407,15 @@ async function lexicalSearchEntityIds(params: LexicalSearchEntityIdsParams): Pro
   total: number;
   strategies: Set<SearchStrategy>;
 }> {
-  const { userId, entityType, includeMerged = false, search, excludeBookkeeping = false } = params;
+  const {
+    userId,
+    entityType,
+    entityTypes,
+    includeMerged = false,
+    search,
+    excludeBookkeeping = false,
+  } = params;
+  const typeFilter = normalizeEntityTypeFilter(entityType, entityTypes);
   const strategies = new Set<SearchStrategy>();
   const normalizedSearch = normalizeSearchText(search);
   const searchTokens = normalizedSearch.split(" ").filter(Boolean);
@@ -425,8 +442,10 @@ async function lexicalSearchEntityIds(params: LexicalSearchEntityIdsParams): Pro
     .eq("user_id", userId)
     .order("id", { ascending: true });
 
-  if (entityType) {
-    entityQuery = entityQuery.eq("entity_type", entityType);
+  if (typeFilter.length === 1) {
+    entityQuery = entityQuery.eq("entity_type", typeFilter[0]);
+  } else if (typeFilter.length > 1) {
+    entityQuery = entityQuery.in("entity_type", typeFilter);
   } else if (typeFilterTokens.size > 0) {
     const matchingTypes = await resolveEntityTypesForTypeFilters(typeFilterTokens);
     if (matchingTypes.length > 0) {
@@ -623,6 +642,7 @@ async function lexicalSearchEntityIds(params: LexicalSearchEntityIdsParams): Pro
 async function countVisibleEntities(params: {
   userId: string;
   entityType?: string;
+  entityTypes?: string[];
   includeMerged?: boolean;
   published?: boolean;
   publishedAfter?: string;
@@ -633,6 +653,7 @@ async function countVisibleEntities(params: {
   const {
     userId,
     entityType,
+    entityTypes,
     includeMerged = false,
     published,
     publishedAfter,
@@ -641,10 +662,24 @@ async function countVisibleEntities(params: {
     createdSince,
   } = params;
 
+  const typeFilter = normalizeEntityTypeFilter(entityType, entityTypes);
+  const applyTypeFilter = <
+    T extends { eq: (c: string, v: string) => T; in: (c: string, v: string[]) => T },
+  >(
+    query: T,
+    column: string
+  ): T => {
+    if (typeFilter.length === 1) {
+      return query.eq(column, typeFilter[0]);
+    }
+    if (typeFilter.length > 1) {
+      return query.in(column, typeFilter);
+    }
+    return query;
+  };
+
   let entityIdQuery = db.from("entities").select("id").eq("user_id", userId);
-  if (entityType) {
-    entityIdQuery = entityIdQuery.eq("entity_type", entityType);
-  }
+  entityIdQuery = applyTypeFilter(entityIdQuery, "entity_type");
   if (!includeMerged) {
     entityIdQuery = entityIdQuery.is("merged_to_entity_id", null);
   }
@@ -656,9 +691,7 @@ async function countVisibleEntities(params: {
   }
   if (published !== undefined || publishedAfter || publishedBefore) {
     let snapshotQuery = db.from("entity_snapshots").select("entity_id").eq("user_id", userId);
-    if (entityType) {
-      snapshotQuery = snapshotQuery.eq("entity_type", entityType);
-    }
+    snapshotQuery = applyTypeFilter(snapshotQuery, "entity_type");
     if (published !== undefined) {
       snapshotQuery = snapshotQuery.eq("snapshot->>published", published ? "true" : "false");
     }
@@ -728,6 +761,7 @@ async function countVisibleEntities(params: {
 async function queryEntitiesFromLexicalSearch(params: {
   userId: string;
   entityType?: string;
+  entityTypes?: string[];
   includeMerged?: boolean;
   includeSnapshots?: boolean;
   sortBy?: QueryEntitiesParams["sortBy"];
@@ -754,6 +788,7 @@ async function queryEntitiesFromLexicalSearch(params: {
   } = await lexicalSearchEntityIds({
     userId: params.userId,
     entityType: params.entityType,
+    entityTypes: params.entityTypes,
     includeMerged: params.includeMerged,
     search: params.search,
     excludeBookkeeping: params.excludeBookkeeping,
@@ -767,6 +802,7 @@ async function queryEntitiesFromLexicalSearch(params: {
   const entities = await queryEntities({
     userId: params.userId,
     entityType: params.entityType,
+    entityTypes: params.entityTypes,
     includeMerged: params.includeMerged,
     includeSnapshots: params.includeSnapshots,
     sortBy: params.sortBy,
@@ -819,6 +855,7 @@ export async function queryEntitiesWithCount(params: QueryEntitiesParams): Promi
   const {
     userId,
     entityType,
+    entityTypes,
     includeMerged = false,
     includeSnapshots = true,
     sortBy = "entity_id",
@@ -836,6 +873,10 @@ export async function queryEntitiesWithCount(params: QueryEntitiesParams): Promi
     snapshotFilters,
     excludeBookkeeping = false,
   } = params;
+
+  // Union of singular + plural type filters, honored across all retrieval
+  // paths (#1562). Empty when no type filter is requested.
+  const typeFilter = normalizeEntityTypeFilter(entityType, entityTypes);
 
   let entities: EntityWithProvenance[];
   let total: number;
@@ -857,11 +898,13 @@ export async function queryEntitiesWithCount(params: QueryEntitiesParams): Promi
     // §10.2 Explicit Over Implicit). If the caller explicitly filters to a bookkeeping
     // entity_type, the explicit type filter wins and excludeBookkeeping is ignored.
     const effectiveExcludeBookkeeping =
-      excludeBookkeeping && !(entityType && BOOKKEEPING_ENTITY_TYPES.has(entityType));
+      excludeBookkeeping &&
+      !(typeFilter.length > 0 && typeFilter.some((t) => BOOKKEEPING_ENTITY_TYPES.has(t)));
 
     const lexicalParams = {
       userId,
       entityType,
+      entityTypes,
       includeMerged,
       includeSnapshots,
       sortBy,
@@ -895,6 +938,7 @@ export async function queryEntitiesWithCount(params: QueryEntitiesParams): Promi
         searchText: trimmedSearch,
         userId,
         entityType,
+        entityTypes,
         includeMerged,
         similarityThreshold,
         limit,
@@ -905,6 +949,7 @@ export async function queryEntitiesWithCount(params: QueryEntitiesParams): Promi
         entities = await queryEntities({
           userId,
           entityType,
+          entityTypes,
           includeMerged,
           includeSnapshots,
           sortBy,
@@ -957,6 +1002,7 @@ export async function queryEntitiesWithCount(params: QueryEntitiesParams): Promi
     entities = await queryEntities({
       userId,
       entityType,
+      entityTypes,
       includeMerged,
       includeSnapshots,
       sortBy,
@@ -979,6 +1025,7 @@ export async function queryEntitiesWithCount(params: QueryEntitiesParams): Promi
       const allMatches = await queryEntities({
         userId,
         entityType,
+        entityTypes,
         includeMerged,
         includeSnapshots: false,
         sortBy,
@@ -998,6 +1045,7 @@ export async function queryEntitiesWithCount(params: QueryEntitiesParams): Promi
       total = await countVisibleEntities({
         userId,
         entityType,
+        entityTypes,
         includeMerged,
         published,
         publishedAfter,

--- a/src/shared/action_schemas.ts
+++ b/src/shared/action_schemas.ts
@@ -259,6 +259,12 @@ const SnapshotFieldNameSchema = z
 const EntitiesQueryRequestBaseSchema = z
   .object({
     entity_type: z.string().optional(),
+    /**
+     * Multi-type filter. When non-empty, results are restricted to entities
+     * whose `entity_type` is in this list (an IN filter), OR-combined with the
+     * singular `entity_type`. An empty array is treated as no filter (#1562).
+     */
+    entity_types: z.array(z.string()).optional(),
     search: z.string().optional(),
     limit: z.number().int().positive().optional().default(100),
     offset: z.number().int().nonnegative().optional().default(0),
@@ -316,6 +322,15 @@ const RetrieveEntitiesRequestBaseSchema = z
   .object({
     user_id: z.string().optional(),
     entity_type: z.string().optional(),
+    /**
+     * Multi-type filter. When non-empty, results are restricted to entities
+     * whose `entity_type` is in this list (an IN filter), OR-combined with the
+     * singular `entity_type` when both are provided. An empty array is treated
+     * as no filter. Honored on both the plain listing and search paths so a
+     * caller passing `entity_types` is never silently given an unfiltered
+     * result set (#1562).
+     */
+    entity_types: z.array(z.string()).optional(),
     search: z.string().optional(),
     /**
      * Distance threshold for semantic search (L2, range ~0.9–1.5 in practice).

--- a/src/shared/openapi_types.ts
+++ b/src/shared/openapi_types.ts
@@ -4008,7 +4008,18 @@ export interface operations {
     requestBody: {
       content: {
         "application/json": {
+          /**
+           * @description Single entity-type filter. Combined as a union with
+           *     `entity_types` when both are supplied.
+           */
           entity_type?: string;
+          /**
+           * @description Multi-type filter. When non-empty, results are restricted
+           *     to entities whose `entity_type` is in this list (an IN
+           *     filter), OR-combined with the singular `entity_type` when
+           *     both are provided. An empty array is treated as no filter.
+           */
+          entity_types?: string[];
           /** @description Canonical free-text query parameter for retrieval relevance. */
           search?: string;
           /** @description Compatibility alias for `search`. */

--- a/src/tool_definitions.ts
+++ b/src/tool_definitions.ts
@@ -128,7 +128,14 @@ export function buildToolDefinitions(
         properties: {
           entity_type: {
             type: "string",
-            description: "Optional entity type filter (for example: post, task, contact).",
+            description:
+              "Optional single entity type filter (for example: post, task, contact). Combined as a union with `entity_types` when both are supplied.",
+          },
+          entity_types: {
+            type: "array",
+            items: { type: "string" },
+            description:
+              "Optional multi-type filter. When non-empty, results are restricted to entities whose type is in this list (IN filter), OR-combined with `entity_type`. An empty array is treated as no filter.",
           },
           search: {
             type: "string",

--- a/tests/integration/mcp_entity_variations.test.ts
+++ b/tests/integration/mcp_entity_variations.test.ts
@@ -309,6 +309,120 @@ describe("MCP entity actions - parameter variations", () => {
     });
   });
 
+  // Regression: retrieve_entities must honor the plural `entity_types` filter
+  // (an IN-filter OR-combined with singular `entity_type`) rather than silently
+  // running an unfiltered query. See issue #1562.
+  describe("retrieve_entities entity_types (plural) filter (#1562)", () => {
+    const typesUserId = `test-user-entity-types-${Date.now()}`;
+    const planIds: string[] = [];
+    const noteIds: string[] = [];
+    const taskIds: string[] = [];
+
+    beforeAll(async () => {
+      const sourceId = `src_entity_types_${Date.now()}`;
+      const { error: sourceError } = await db.from("sources").insert({
+        id: sourceId,
+        user_id: typesUserId,
+        content_hash: `entity_types_${Date.now()}`,
+        storage_url: "file:///test/minimal.txt",
+        mime_type: "text/plain",
+        file_size: 0,
+      });
+      expect(sourceError).toBeNull();
+      tracker.trackSource(sourceId);
+
+      const seed = async (
+        bucket: string[],
+        entityType: string,
+        count: number
+      ): Promise<void> => {
+        for (let i = 0; i < count; i++) {
+          const entityId = `ent_${entityType}_${Date.now()}_${i}`;
+          bucket.push(entityId);
+          tracker.trackEntity(entityId);
+          const { error } = await db.from("observations").insert({
+            entity_id: entityId,
+            entity_type: entityType,
+            source_id: sourceId,
+            fields: {
+              title: `${entityType} ${i}`,
+              canonical_name: `${entityType} ${i}`,
+            },
+            user_id: typesUserId,
+            schema_version: "1.0",
+            observed_at: new Date().toISOString(),
+          });
+          expect(error).toBeNull();
+          await computeEntitySnapshot(entityId);
+        }
+      };
+
+      // Distinct counts per type so a filter leak is observable in `total`.
+      await seed(planIds, "plan", 3);
+      await seed(noteIds, "note", 2);
+      await seed(taskIds, "task", 4);
+    });
+
+    it("returns a deterministic, type-filtered list for entity_types: [plan]", async () => {
+      const result = await queryEntitiesWithCount({
+        userId: typesUserId,
+        entityTypes: ["plan"],
+        includeMerged: false,
+        limit: 100,
+        offset: 0,
+      });
+
+      expect(result.total).toBe(planIds.length);
+      expect(result.entities).toHaveLength(planIds.length);
+      expect(result.entities.every((e) => e.entity_type === "plan")).toBe(true);
+      expect(result.search_mode).toBe("none");
+    });
+
+    it("filters across both types for a multi-type entity_types array", async () => {
+      const result = await queryEntitiesWithCount({
+        userId: typesUserId,
+        entityTypes: ["plan", "note"],
+        includeMerged: false,
+        limit: 100,
+        offset: 0,
+      });
+
+      expect(result.total).toBe(planIds.length + noteIds.length);
+      expect(result.entities).toHaveLength(planIds.length + noteIds.length);
+      expect(result.entities.every((e) => ["plan", "note"].includes(e.entity_type))).toBe(true);
+      // Excludes the unrequested type entirely.
+      expect(result.entities.some((e) => e.entity_type === "task")).toBe(false);
+    });
+
+    it("OR-combines singular entity_type with plural entity_types", async () => {
+      const result = await queryEntitiesWithCount({
+        userId: typesUserId,
+        entityType: "task",
+        entityTypes: ["plan"],
+        includeMerged: false,
+        limit: 100,
+        offset: 0,
+      });
+
+      expect(result.total).toBe(taskIds.length + planIds.length);
+      expect(result.entities.every((e) => ["task", "plan"].includes(e.entity_type))).toBe(true);
+      expect(result.entities.some((e) => e.entity_type === "note")).toBe(false);
+    });
+
+    it("treats an empty entity_types array as no type filter", async () => {
+      const result = await queryEntitiesWithCount({
+        userId: typesUserId,
+        entityTypes: [],
+        includeMerged: false,
+        limit: 100,
+        offset: 0,
+      });
+
+      // All seeded types are returned when no filter is applied.
+      expect(result.total).toBe(planIds.length + noteIds.length + taskIds.length);
+    });
+  });
+
   describe("retrieve_entity_by_identifier variations", () => {
     it("should find entity by canonical_name", async () => {
       const canonicalName = `Unique Task ${Date.now()}`;


### PR DESCRIPTION
## Summary

`retrieve_entities` (MCP) / `POST /entities/query` advertised an `entity_types` array input, but the handler never read it. Callers passing `entity_types: ["plan"]` silently received an **unfiltered** semantic/text search across all entity types — not a type-scoped list. This implements option (a) from the issue: **honor the parameter**.

- Added `entity_types` (string array) to the OpenAPI request schema (spec-first), regenerated `src/shared/openapi_types.ts`.
- Added `entity_types` to both canonical request schemas (`RetrieveEntitiesRequestBaseSchema` + `EntitiesQueryRequestBaseSchema`) and to the MCP `retrieve_entities` tool inputSchema, keeping tool/canonical/OpenAPI in sync.
- Applied an `IN`-filter over the **union** of singular `entity_type` + plural `entity_types` across every retrieval path: plain listing (`queryEntities`, `countVisibleEntities`), lexical search (`lexicalSearchEntityIds`), and semantic search (`semanticSearchEntities` → `searchLocalEntityEmbeddings` SQL). A non-empty `entity_types` is never silently ignored; an empty array is treated as no filter.
- Threaded the new param through both call sites (`src/server.ts` MCP handler and `src/actions.ts` HTTP route).

## Test plan

- [x] New integration tests in `tests/integration/mcp_entity_variations.test.ts`:
  - `entity_types: ["plan"]` → deterministic type-filtered list, `total` == true plan count.
  - multi-type `["plan", "note"]` → filters across both, excludes other types.
  - singular `entity_type` OR-combined with plural `entity_types`.
  - empty `entity_types: []` → no filter (all types returned).
- [x] `npx vitest run tests/contract/` → 132 passed (after `npm run build`).
- [x] Entity query suites pass: `entity_search_mode`, `lexical_search`, `mcp_entity_variations`, `entity_queries_status_projection`, MCP schema parity (`mcp_schema_variations`, `cli_to_mcp_schemas`).
- [x] `npx tsc --noEmit` clean; lint + prettier clean.

> Note: the full pre-commit suite has pre-existing failures in `cursor_hook_stop_backfill` / `hook_failure_hint` / `v0.2.0_ingestion` (require an unbuilt `@neotoma/client` workspace dist); these reproduce identically on `origin/main` and are unrelated to this change. Committed via the repo-sanctioned `SKIP_TESTS=1` (type-check/lint/format still enforced), not `--no-verify`.

Fixes #1562