### PR TITLE
feat(entities): add GET /entities REST alias + hinted 404 (closes #1499)

### DIFF
--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,20 +61,20 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **461**
-- Backend and repo Vitest files: **428**
+- Total automated test files: **463**
+- Backend and repo Vitest files: **430**
 - Frontend Vitest files: **9**
 - Playwright spec files: **24**
 
 ### Suite counts
 | Suite | Files |
 |---|---:|
-| Vitest unit tests | 118 |
+| Vitest unit tests | 119 |
 | Vitest service tests | 34 |
 | Source-adjacent tests | 53 |
 | Vitest integration tests | 133 |
 | Vitest CLI tests | 63 |
-| Vitest contract tests | 13 |
+| Vitest contract tests | 14 |
 | Vitest security tests | 3 |
 | Vitest subscription tests | 5 |
 | Vitest agent tests | 1 |
@@ -109,7 +109,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/unit`
 **Requirements:** Basic `.env` if required by the module under test.
-**Files (118):**
+**Files (119):**
 - `tests/unit/aauth_admission.test.ts`
 - `tests/unit/aauth_attestation_apple_se.test.ts`
 - `tests/unit/aauth_attestation_revocation.test.ts`
@@ -546,10 +546,11 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/contract`
 **Requirements:** Generated contract artifacts present when the suite expects them.
-**Files (13):**
+**Files (14):**
 - `tests/contract/cli_handler_dist_smoke.test.ts`
 - `tests/contract/contract_mapping.test.ts`
 - `tests/contract/contract_mcp_cli_parity.test.ts`
+- `tests/contract/get_entities_alias.test.ts`
 - `tests/contract/ironclaw_integration.test.ts`
 - `tests/contract/legacy_payloads/replay.test.ts`
 - `tests/contract/mcp_stdio_output_safety.test.ts`

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2759,6 +2759,163 @@ paths:
               schema:
                 type: object
 
+  /entities:
+    get:
+      summary: List entities
+      description: >
+        REST/GET alias of `POST /entities/query`. Maps query-string parameters
+        to the same handler so consumers that issue
+        `GET /entities?entity_type=...&search=...` reach the canonical list
+        behavior instead of a 404. Scoped to the authenticated user. The
+        request body of `POST /entities/query` and the query string here accept
+        the same field names; complex object fields (`snapshot_filters`) are
+        passed as a JSON-encoded string. Unmatched verbs on `/entities` return
+        a 404 whose `details.hint` points back at this endpoint and
+        `POST /entities/query`.
+      operationId: listEntities
+      parameters:
+        - in: query
+          name: entity_type
+          required: false
+          schema: { type: string }
+        - in: query
+          name: search
+          required: false
+          description: Canonical free-text query parameter for retrieval relevance.
+          schema: { type: string }
+        - in: query
+          name: query
+          required: false
+          description: Compatibility alias for `search`.
+          schema: { type: string }
+        - in: query
+          name: search_query
+          required: false
+          description: Compatibility alias for `search`.
+          schema: { type: string }
+        - in: query
+          name: limit
+          required: false
+          schema: { type: integer }
+        - in: query
+          name: offset
+          required: false
+          schema: { type: integer }
+        - in: query
+          name: sort_by
+          required: false
+          description: |
+            Sort field. Non-default values cannot be combined with `search`.
+            Mirrors the `sort_by` body field of `POST /entities/query`.
+          schema: { type: string }
+        - in: query
+          name: sort_order
+          required: false
+          description: "`desc` cannot be combined with `search`."
+          schema:
+            type: string
+            enum: [asc, desc]
+        - in: query
+          name: published
+          required: false
+          description: "Cannot be combined with `search`."
+          schema: { type: boolean }
+        - in: query
+          name: published_after
+          required: false
+          description: "Inclusive lower bound for snapshot.published_date. Cannot be combined with `search`."
+          schema: { type: string }
+        - in: query
+          name: published_before
+          required: false
+          description: "Inclusive upper bound for snapshot.published_date. Cannot be combined with `search`."
+          schema: { type: string }
+        - in: query
+          name: include_snapshots
+          required: false
+          description: When false, omit snapshot/provenance/raw_fragments payloads for lighter responses.
+          schema: { type: boolean }
+        - in: query
+          name: include_merged
+          required: false
+          schema: { type: boolean }
+        - in: query
+          name: user_id
+          required: false
+          description: Optional user scope. When omitted the authenticated user is used.
+          schema: { type: string }
+        - in: query
+          name: updated_since
+          required: false
+          description: ISO 8601 timestamp; return only entities updated at or after this value.
+          schema: { type: string }
+        - in: query
+          name: created_since
+          required: false
+          description: ISO 8601 timestamp; return only entities created at or after this value.
+          schema: { type: string }
+        - in: query
+          name: identity_basis
+          required: false
+          description: Return only entities with at least one observation resolved with the given identity_basis.
+          schema:
+            type: string
+            enum:
+              - schema_rule
+              - schema_lookup
+              - heuristic_name
+              - heuristic_fallback
+              - target_id
+        - in: query
+          name: exclude_bookkeeping
+          required: false
+          description: When true, omit chat bookkeeping types from results.
+          schema: { type: boolean }
+        - in: query
+          name: snapshot_filters
+          required: false
+          description: |
+            JSON-encoded object filtering entities by snapshot field values,
+            equivalent to the `snapshot_filters` body field of
+            `POST /entities/query`. Example:
+            `{"status":{"op":"eq","value":"active"}}`.
+          schema: { type: string }
+      responses:
+        "200":
+          description: Entity list
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  entities:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/EntitySnapshot"
+                  total:
+                    type: integer
+                  limit:
+                    type: integer
+                  offset:
+                    type: integer
+                  applied_search_strategies:
+                    type: array
+                    items:
+                      type: string
+                      enum:
+                        - strict
+                        - semantic
+                        - partial_overlap
+                        - concept_bridge
+                  search_mode:
+                    type: string
+                    enum: [none, semantic, lexical_typed, lexical_fallback]
+        "400":
+          description: Invalid query parameters
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ErrorEnvelope" }
+
   /entities/query:
     post:
       summary: Query entities

--- a/scripts/security/protected_routes_manifest.json
+++ b/scripts/security/protected_routes_manifest.json
@@ -303,6 +303,19 @@
       ]
     },
     {
+      "path": "/entities",
+      "method": "GET",
+      "operation_id": "listEntities",
+      "requires_auth": true,
+      "sandbox_allowed": "none",
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
+    },
+    {
       "path": "/entities/duplicates",
       "method": "GET",
       "operation_id": "listPotentialDuplicates",

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -3705,10 +3705,16 @@ function handleApiError(
 // v0.2.15 Entity-Based HTTP API Endpoints
 // ============================================================================
 
-// POST /api/entities/query - Query entities with filters
-// REQUIRES AUTHENTICATION - all queries filtered by authenticated user_id
-app.post("/entities/query", async (req, res) => {
-  const parsed = EntitiesQueryRequestSchema.safeParse(req.body);
+// Shared entity-query executor backing both POST /entities/query and the
+// GET /entities REST alias. `rawInput` is the already-shaped request payload
+// (POST body, or query-string params coerced by coerceEntitiesQueryParams).
+// REQUIRES AUTHENTICATION - all queries filtered by authenticated user_id.
+async function runEntitiesQuery(
+  req: express.Request,
+  res: express.Response,
+  rawInput: unknown
+): Promise<express.Response> {
+  const parsed = EntitiesQueryRequestSchema.safeParse(rawInput);
   if (!parsed.success) {
     logWarn("ValidationError:entities_query", req, {
       issues: parsed.error.issues,
@@ -3717,7 +3723,9 @@ app.post("/entities/query", async (req, res) => {
   }
 
   try {
-    // Get authenticated user_id (REQUIRED)
+    // Get authenticated user_id (REQUIRED). user_id is used for SECURITY
+    // scoping only via getAuthenticatedUserId; it is never read directly off
+    // the request for access control.
     const userId = await getAuthenticatedUserId(req, parsed.data.user_id);
 
     const {
@@ -3777,6 +3785,94 @@ app.post("/entities/query", async (req, res) => {
       "APIError:entities_query"
     );
   }
+}
+
+// Coerce GET /entities query-string parameters into the shape
+// EntitiesQueryRequestSchema expects. Query strings are always strings, so
+// numeric, boolean, and JSON-object fields are converted here; values that
+// fail conversion are passed through unchanged so Zod surfaces a 400.
+function coerceEntitiesQueryParams(query: express.Request["query"]): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  const readString = (key: string): string | undefined => {
+    const value = query[key];
+    if (typeof value === "string") return value;
+    if (Array.isArray(value) && typeof value[0] === "string") return value[0];
+    return undefined;
+  };
+  const parseBool = (value: string): boolean | string => {
+    if (value === "true") return true;
+    if (value === "false") return false;
+    return value;
+  };
+
+  for (const key of [
+    "entity_type",
+    "search",
+    "query",
+    "search_query",
+    "sort_by",
+    "sort_order",
+    "published_after",
+    "published_before",
+    "user_id",
+    "updated_since",
+    "created_since",
+    "identity_basis",
+  ]) {
+    const value = readString(key);
+    if (value !== undefined) out[key] = value;
+  }
+
+  for (const key of ["limit", "offset"]) {
+    const value = readString(key);
+    if (value !== undefined && value !== "") {
+      const num = Number(value);
+      out[key] = Number.isNaN(num) ? value : num;
+    }
+  }
+
+  for (const key of ["published", "include_snapshots", "include_merged", "exclude_bookkeeping"]) {
+    const value = readString(key);
+    if (value !== undefined) out[key] = parseBool(value);
+  }
+
+  const snapshotFilters = readString("snapshot_filters");
+  if (snapshotFilters !== undefined && snapshotFilters !== "") {
+    try {
+      out.snapshot_filters = JSON.parse(snapshotFilters);
+    } catch {
+      out.snapshot_filters = snapshotFilters;
+    }
+  }
+
+  return out;
+}
+
+// GET /entities - REST/GET alias of POST /entities/query (issue #1499).
+// Maps query-string params to the same handler so consumers that issue
+// `GET /entities?entity_type=...&search=...` no longer hit a 404 and silently
+// degrade. REQUIRES AUTHENTICATION - identical user scoping to the POST path.
+app.get("/entities", async (req, res) => {
+  return runEntitiesQuery(req, res, coerceEntitiesQueryParams(req.query));
+});
+
+// POST /api/entities/query - Query entities with filters
+// REQUIRES AUTHENTICATION - all queries filtered by authenticated user_id
+app.post("/entities/query", async (req, res) => {
+  return runEntitiesQuery(req, res, req.body);
+});
+
+// Hinted 404 fallback for the /entities collection path. GET is handled above
+// and POST/PUT/DELETE/PATCH on the bare collection are misuse; respond with a
+// structured hint (in `details`, never concatenated into `message`) that
+// points callers at the canonical list and query endpoints so the mistake is
+// self-correcting. See issue #1499.
+app.all("/entities", (req, res) => {
+  return sendError(res, 404, "RESOURCE_NOT_FOUND", `No ${req.method} route on /entities.`, {
+    hint: "List entities with GET /entities?entity_type=...&search=..., or query with POST /entities/query.",
+    method: req.method,
+    supported: ["GET /entities", "POST /entities/query"],
+  });
 });
 
 // GET /api/entities/:id - Get entity detail with snapshot and provenance (FU-601)

--- a/src/shared/contract_mappings.ts
+++ b/src/shared/contract_mappings.ts
@@ -162,6 +162,14 @@ export const OPENAPI_OPERATION_MAPPINGS: OpenApiOperationMapping[] = [
     cliCommand: "entities list",
   },
   {
+    operationId: "listEntities",
+    method: "get",
+    path: "/entities",
+    adapter: "cli",
+    cliCommand: "entities list",
+    notes: "REST/GET alias of queryEntities (#1499); query-string params map to the POST body.",
+  },
+  {
     operationId: "bulkCloseIssues",
     method: "post",
     path: "/issues/bulk_close",

--- a/src/shared/openapi_types.ts
+++ b/src/shared/openapi_types.ts
@@ -331,6 +331,26 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/entities": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * List entities
+     * @description REST/GET alias of `POST /entities/query`. Maps query-string parameters to the same handler so consumers that issue `GET /entities?entity_type=...&search=...` reach the canonical list behavior instead of a 404. Scoped to the authenticated user. The request body of `POST /entities/query` and the query string here accept the same field names; complex object fields (`snapshot_filters`) are passed as a JSON-encoded string. Unmatched verbs on `/entities` return a 404 whose `details.hint` points back at this endpoint and `POST /entities/query`.
+     */
+    get: operations["listEntities"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/entities/query": {
     parameters: {
       query?: never;
@@ -4272,6 +4292,96 @@ export interface operations {
         };
         content: {
           "application/json": Record<string, never>;
+        };
+      };
+    };
+  };
+  listEntities: {
+    parameters: {
+      query?: {
+        entity_type?: string;
+        /** @description Canonical free-text query parameter for retrieval relevance. */
+        search?: string;
+        /** @description Compatibility alias for `search`. */
+        query?: string;
+        /** @description Compatibility alias for `search`. */
+        search_query?: string;
+        limit?: number;
+        offset?: number;
+        /**
+         * @description Sort field. Non-default values cannot be combined with `search`.
+         *     Mirrors the `sort_by` body field of `POST /entities/query`.
+         */
+        sort_by?: string;
+        /** @description `desc` cannot be combined with `search`. */
+        sort_order?: "asc" | "desc";
+        /** @description Cannot be combined with `search`. */
+        published?: boolean;
+        /** @description Inclusive lower bound for snapshot.published_date. Cannot be combined with `search`. */
+        published_after?: string;
+        /** @description Inclusive upper bound for snapshot.published_date. Cannot be combined with `search`. */
+        published_before?: string;
+        /** @description When false, omit snapshot/provenance/raw_fragments payloads for lighter responses. */
+        include_snapshots?: boolean;
+        include_merged?: boolean;
+        /** @description Optional user scope. When omitted the authenticated user is used. */
+        user_id?: string;
+        /** @description ISO 8601 timestamp; return only entities updated at or after this value. */
+        updated_since?: string;
+        /** @description ISO 8601 timestamp; return only entities created at or after this value. */
+        created_since?: string;
+        /** @description Return only entities with at least one observation resolved with the given identity_basis. */
+        identity_basis?:
+          | "schema_rule"
+          | "schema_lookup"
+          | "heuristic_name"
+          | "heuristic_fallback"
+          | "target_id";
+        /** @description When true, omit chat bookkeeping types from results. */
+        exclude_bookkeeping?: boolean;
+        /**
+         * @description JSON-encoded object filtering entities by snapshot field values,
+         *     equivalent to the `snapshot_filters` body field of
+         *     `POST /entities/query`. Example:
+         *     `{"status":{"op":"eq","value":"active"}}`.
+         */
+        snapshot_filters?: string;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Entity list */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            entities?: components["schemas"]["EntitySnapshot"][];
+            total?: number;
+            limit?: number;
+            offset?: number;
+            applied_search_strategies?: (
+              | "strict"
+              | "semantic"
+              | "partial_overlap"
+              | "concept_bridge"
+            )[];
+            /** @enum {string} */
+            search_mode?: "none" | "semantic" | "lexical_typed" | "lexical_fallback";
+          };
+        };
+      };
+      /** @description Invalid query parameters */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["ErrorEnvelope"];
         };
       };
     };

--- a/tests/contract/get_entities_alias.test.ts
+++ b/tests/contract/get_entities_alias.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Contract + integration coverage for the GET /entities REST alias (#1499).
+ *
+ * `GET /entities?entity_type=...&search=...` MUST map its query string to the
+ * same handler as `POST /entities/query` and return the same result set, so
+ * consumers (daemons) that issue the intuitive GET no longer hit a 404 and
+ * silently degrade. Unmatched verbs on the bare collection path MUST return a
+ * hinted 404 that points back at the canonical endpoints so the misuse is
+ * self-correcting.
+ *
+ * Uses the shared HTTP server started by vitest.global_setup.ts (local SQLite
+ * backend, local-dev user-id override honored for the seeded user_id).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { randomUUID } from "node:crypto";
+import { db } from "../../src/db.js";
+
+const PORT = process.env.NEOTOMA_SESSION_DEV_PORT ?? "18099";
+const BASE_URL = `http://127.0.0.1:${PORT}`;
+const ENTITY_TYPE = "agent_definition";
+
+const userId = randomUUID();
+const marker = `getalias_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+const canonicalName = `Daemon Sync Agent ${marker}`;
+const createdEntityIds: string[] = [];
+
+async function post(path: string, body: Record<string, unknown>) {
+  const res = await fetch(`${BASE_URL}${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const json = await res.json().catch(() => ({}));
+  return { status: res.status, json };
+}
+
+async function get(path: string) {
+  const res = await fetch(`${BASE_URL}${path}`, {
+    method: "GET",
+    headers: { Accept: "application/json" },
+  });
+  const json = await res.json().catch(() => ({}));
+  return { status: res.status, json };
+}
+
+function entityIds(json: any): string[] {
+  return (json.entities ?? []).map((e: any) => e.entity_id ?? e.id).sort();
+}
+
+describe("GET /entities alias (#1499)", () => {
+  beforeAll(async () => {
+    const { status, json } = await post("/store", {
+      user_id: userId,
+      idempotency_key: marker,
+      commit: true,
+      entities: [{ entity_type: ENTITY_TYPE, canonical_name: canonicalName }],
+    });
+    expect(status).toBe(200);
+    const stored = (json.entities ?? [])[0] as { entity_id?: string } | undefined;
+    if (stored?.entity_id) createdEntityIds.push(stored.entity_id);
+  });
+
+  afterAll(async () => {
+    for (const id of createdEntityIds) {
+      await db.from("observations").delete().eq("entity_id", id);
+      await db.from("entity_snapshots").delete().eq("entity_id", id);
+      await db.from("entities").delete().eq("id", id);
+    }
+  });
+
+  it("returns 200 with the same results as the equivalent POST /entities/query", async () => {
+    const search = marker;
+    const getRes = await get(
+      `/entities?entity_type=${ENTITY_TYPE}&search=${search}&user_id=${userId}`
+    );
+    const postRes = await post("/entities/query", {
+      entity_type: ENTITY_TYPE,
+      search,
+      user_id: userId,
+    });
+
+    expect(getRes.status).toBe(200);
+    expect(postRes.status).toBe(200);
+    // Parity: identical result sets and totals from both transports.
+    expect(entityIds(getRes.json)).toEqual(entityIds(postRes.json));
+    expect(getRes.json.total).toBe(postRes.json.total);
+    // The seeded entity is present in the GET result.
+    expect(entityIds(getRes.json)).toContain(createdEntityIds[0]);
+  });
+
+  it("coerces numeric/boolean params and stays in parity with the POST handler", async () => {
+    // Coerced query string vs the equivalent typed POST body must reach the
+    // same handler and return identical status + echoed pagination. We compare
+    // against POST rather than asserting a fixed status so the test is robust
+    // to handler behavior that is shared by both transports.
+    const getRes = await get(
+      `/entities?entity_type=${ENTITY_TYPE}&search=${marker}&user_id=${userId}&limit=5&offset=0&include_snapshots=true`
+    );
+    const postRes = await post("/entities/query", {
+      entity_type: ENTITY_TYPE,
+      search: marker,
+      user_id: userId,
+      limit: 5,
+      offset: 0,
+      include_snapshots: true,
+    });
+    expect(getRes.status).toBe(postRes.status);
+    expect(getRes.status).toBe(200);
+    // Numeric coercion: strings "5"/"0" became integers echoed back in the body.
+    expect(getRes.json.limit).toBe(5);
+    expect(getRes.json.offset).toBe(0);
+    expect(getRes.json.limit).toBe(postRes.json.limit);
+    expect(getRes.json.offset).toBe(postRes.json.offset);
+  });
+
+  it("returns 400 for an invalid query parameter value", async () => {
+    const { status, json } = await get(
+      `/entities?entity_type=${ENTITY_TYPE}&user_id=${userId}&limit=not-a-number`
+    );
+    expect(status).toBe(400);
+    expect(json.error_code).toBeDefined();
+  });
+
+  it("fires a hinted 404 for an unsupported verb on /entities", async () => {
+    const res = await fetch(`${BASE_URL}/entities`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    const json = await res.json().catch(() => ({}));
+    expect(res.status).toBe(404);
+    expect(json.error_code).toBe("RESOURCE_NOT_FOUND");
+    // Structured hint lives in details, never concatenated into message.
+    expect(json.details?.hint).toContain("POST /entities/query");
+    expect(json.details?.supported).toContain("POST /entities/query");
+  });
+});

--- a/tests/security/tenant_isolation_matrix.test.ts
+++ b/tests/security/tenant_isolation_matrix.test.ts
@@ -138,6 +138,19 @@ async function callEndpoint(
   return { status: res.status, json };
 }
 
+async function callGet(
+  path: string,
+  query: Record<string, string>
+): Promise<{ status: number; json: any }> {
+  const qs = new URLSearchParams(query).toString();
+  const res = await fetch(`${BASE_URL}${path}${qs ? `?${qs}` : ""}`, {
+    method: "GET",
+    headers: { Accept: "application/json" },
+  });
+  const json = await res.json().catch(() => ({}));
+  return { status: res.status, json };
+}
+
 describe("Tenant isolation matrix (GHSA-wrr4-782v-jhwh)", () => {
   let userA: FixtureUserData;
   let userB: FixtureUserData;
@@ -235,6 +248,33 @@ describe("Tenant isolation matrix (GHSA-wrr4-782v-jhwh)", () => {
       expect(json.entity).toBeDefined();
       const obsIds = (json.observations ?? []).map((o: any) => o.id);
       expect(obsIds).toContain(userA.observationId);
+    });
+  });
+
+  describe("GET /entities (#1499 list alias)", () => {
+    it("user A listing entities sees their own entity, not user B's", async () => {
+      const { status, json } = await callGet("/entities", {
+        entity_type: "test",
+        user_id: userA.userId,
+        limit: "200",
+      });
+      expect(status).toBe(200);
+      const ids = (json.entities ?? []).map((e: any) => e.entity_id ?? e.id);
+      expect(ids).toContain(userA.entityId);
+      // Cross-user read MUST be blocked: user B's entity must not appear.
+      expect(ids).not.toContain(userB.entityId);
+    });
+
+    it("user B listing entities sees their own entity, not user A's", async () => {
+      const { status, json } = await callGet("/entities", {
+        entity_type: "test",
+        user_id: userB.userId,
+        limit: "200",
+      });
+      expect(status).toBe(200);
+      const ids = (json.entities ?? []).map((e: any) => e.entity_id ?? e.id);
+      expect(ids).toContain(userB.entityId);
+      expect(ids).not.toContain(userA.entityId);
     });
   });
 


### PR DESCRIPTION
## Summary

`GET /entities?entity_type=...&search=...` previously returned **404** — the only list path was `POST /entities/query`. Consumers (daemons) hit the 404 and silently degraded. This PR does **both** fixes requested in #1499:

1. **`GET /entities` alias** — maps query-string params (`entity_type`, `search`, `limit`, `offset`, `sort_by`, `published*`, `include_*`, `snapshot_filters` as JSON, etc.) to the **same handler** as `POST /entities/query` via a shared `runEntitiesQuery` executor. Query strings are coerced (numeric / boolean / JSON) before Zod validation.
2. **Self-correcting hinted 404** — an `app.all("/entities")` fallback returns a structured `404` whose `details.hint` and `details.supported` point back at `GET /entities` and `POST /entities/query`, so unsupported verbs on the collection path teach the caller the right path.

## New public route — security coverage

A **new public Express route** was added with full auth + manifest + tenant-isolation coverage:

- **Auth:** the route inherits the global `bearerAuth` security default (so it is `requires_auth: true`) and scopes data via `getAuthenticatedUserId(...)` + `user_id` — never reading body/query `user_id` for access control.
- **OpenAPI-first:** declared `GET /entities` (`operationId: listEntities`) in `openapi.yaml` with query params mirroring the POST body; regenerated `src/shared/openapi_types.ts`; added the `src/shared/contract_mappings.ts` row.
- **Security manifest:** route registered in `scripts/security/protected_routes_manifest.json` (regenerated via `npm run security:manifest:write`); `security:manifest:check` passes.
- **Tenant isolation:** added rows to `tests/security/tenant_isolation_matrix.test.ts` asserting cross-user reads are blocked for `GET /entities`.

## Test plan

- [x] `npx vitest run tests/contract/` — alias parity (GET == POST results), param coercion, invalid-param 400, hinted 404; `contract_mapping` + parity pass.
- [x] `npm run security:manifest:check` — in sync (109 routes).
- [x] `npx vitest run tests/security/tenant_isolation_matrix.test.ts` — 13 pass (incl. 2 new GET /entities rows).
- [x] `npx vitest run tests/security/auth_topology_matrix.test.ts` — passes (new route rejects unauth).
- [x] `npx tsc --noEmit` clean; lint/format/site-copy/doc-deps clean.

Note: the repo's full pre-commit suite is pre-existing flaky/environmental (same tests fail on clean `origin/main`, vary per run, pass in isolation, and require a built inspector bundle); the commit used the hook's sanctioned `NEOTOMA_SKIP_TESTS=1` branch (not `--no-verify`) after passing all required suites above.

Fixes #1499