### PR TITLE
feat(security): override_validation service with per-field write policies (salvage #398)

### DIFF
--- a/docs/reference/error_codes.md
+++ b/docs/reference/error_codes.md
@@ -56,6 +56,7 @@ interface ErrorEnvelope {
 | `AUTH_EXPIRED`   | 401  | No     | Bearer token has expired                        |
 | `AUTH_MALFORMED` | 401  | No     | Bearer token format is invalid                  |
 | `FORBIDDEN`      | 403  | No     | Insufficient permissions (RLS policy violation) |
+| `OVERRIDE_POLICY_VIOLATION` | 403 | No | Write to a policy-protected field on an `agent_definition` entity denied for the calling agent role (see `src/services/override_validation.ts`; details carry `field_name`, `agent_role`, `entity_id`) |
 
 **Common Causes:**
 

--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,8 +61,8 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **454**
-- Backend and repo Vitest files: **421**
+- Total automated test files: **455**
+- Backend and repo Vitest files: **422**
 - Frontend Vitest files: **9**
 - Playwright spec files: **24**
 
@@ -72,7 +72,7 @@ flowchart TD
 | Vitest unit tests | 116 |
 | Vitest service tests | 34 |
 | Source-adjacent tests | 52 |
-| Vitest integration tests | 130 |
+| Vitest integration tests | 131 |
 | Vitest CLI tests | 62 |
 | Vitest contract tests | 13 |
 | Vitest security tests | 3 |
@@ -332,7 +332,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm run test:integration` or `npx vitest run tests/integration`
 **Requirements:** Database configured; remote-dependent subsets additionally need `RUN_REMOTE_TESTS=1`.
-**Files (130):**
+**Files (131):**
 - `tests/integration/aauth_attribution_stamping.test.ts`
 - `tests/integration/aauth_resource_metadata.test.ts`
 - `tests/integration/aauth_revocation_e2e.test.ts`
@@ -416,6 +416,7 @@ flowchart TD
 - `tests/integration/mcp_store_unstructured.test.ts`
 - `tests/integration/mcp_store_variations.test.ts`
 - `tests/integration/mcp_target_id_identity_conflict.test.ts`
+- `tests/integration/merge_repoint_relationship_edges.test.ts`
 - `tests/integration/nonjson_csv_store_behavior.test.ts`
 - `tests/integration/nonjson_fixtures_mcp_replay.test.ts`
 - `tests/integration/observation_ingestion.test.ts`

--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,8 +61,8 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **452**
-- Backend and repo Vitest files: **419**
+- Total automated test files: **453**
+- Backend and repo Vitest files: **420**
 - Frontend Vitest files: **9**
 - Playwright spec files: **24**
 
@@ -71,7 +71,7 @@ flowchart TD
 |---|---:|
 | Vitest unit tests | 116 |
 | Vitest service tests | 34 |
-| Source-adjacent tests | 51 |
+| Source-adjacent tests | 52 |
 | Vitest integration tests | 129 |
 | Vitest CLI tests | 62 |
 | Vitest contract tests | 13 |
@@ -273,7 +273,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- src`
 **Requirements:** Basic `.env` if required by the module under test.
-**Files (51):**
+**Files (52):**
 - `src/cli/parse_cli_corrected_value.test.ts`
 - `src/crypto/crypto.test.ts`
 - `src/record_types.test.ts`
@@ -288,6 +288,7 @@ flowchart TD
 - `src/services/__tests__/mcp_oauth.test.ts`
 - `src/services/__tests__/oauth_key_gate.test.ts`
 - `src/services/__tests__/oauth_state.test.ts`
+- `src/services/__tests__/override_validation.test.ts`
 - `src/services/__tests__/schema_icon_service.test.ts`
 - `src/services/__tests__/tunnel_oauth.test.ts`
 - `src/services/access_policy.test.ts`
@@ -415,7 +416,6 @@ flowchart TD
 - `tests/integration/mcp_store_unstructured.test.ts`
 - `tests/integration/mcp_store_variations.test.ts`
 - `tests/integration/mcp_target_id_identity_conflict.test.ts`
-- `tests/integration/merge_repoint_relationship_edges.test.ts`
 - `tests/integration/nonjson_csv_store_behavior.test.ts`
 - `tests/integration/nonjson_fixtures_mcp_replay.test.ts`
 - `tests/integration/observation_ingestion.test.ts`
@@ -435,6 +435,7 @@ flowchart TD
 - `tests/integration/relationship_query_determinism.test.ts`
 - `tests/integration/relationship_snapshots.test.ts`
 - `tests/integration/retrieval_transport_reliability.test.ts`
+- `tests/integration/retrieve_graph_neighborhood_tenant_isolation.test.ts`
 - `tests/integration/root_landing.test.ts`
 - `tests/integration/sandbox_mode.test.ts`
 - `tests/integration/sandbox_report.test.ts`

--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,8 +61,8 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **453**
-- Backend and repo Vitest files: **420**
+- Total automated test files: **454**
+- Backend and repo Vitest files: **421**
 - Frontend Vitest files: **9**
 - Playwright spec files: **24**
 
@@ -72,7 +72,7 @@ flowchart TD
 | Vitest unit tests | 116 |
 | Vitest service tests | 34 |
 | Source-adjacent tests | 52 |
-| Vitest integration tests | 129 |
+| Vitest integration tests | 130 |
 | Vitest CLI tests | 62 |
 | Vitest contract tests | 13 |
 | Vitest security tests | 3 |
@@ -332,7 +332,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm run test:integration` or `npx vitest run tests/integration`
 **Requirements:** Database configured; remote-dependent subsets additionally need `RUN_REMOTE_TESTS=1`.
-**Files (129):**
+**Files (130):**
 - `tests/integration/aauth_attribution_stamping.test.ts`
 - `tests/integration/aauth_resource_metadata.test.ts`
 - `tests/integration/aauth_revocation_e2e.test.ts`
@@ -420,6 +420,7 @@ flowchart TD
 - `tests/integration/nonjson_fixtures_mcp_replay.test.ts`
 - `tests/integration/observation_ingestion.test.ts`
 - `tests/integration/observation_source_round_trip.test.ts`
+- `tests/integration/override_policy_enforcement.test.ts`
 - `tests/integration/payload_compiler.test.ts`
 - `tests/integration/payload/payload_submission.test.ts`
 - `tests/integration/peer_sync.test.ts`

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4351,6 +4351,15 @@ paths:
                 oneOf:
                   - { $ref: "#/components/schemas/StoreResolutionErrorEnvelope" }
                   - { $ref: "#/components/schemas/ErrorEnvelope" }
+        "403":
+          description: |
+            Write rejected by policy. `OVERRIDE_POLICY_VIOLATION` is returned
+            when an `agent_definition` entity's `override_policy` denies the
+            calling agent role a field being written; the envelope details
+            carry `field_name`, `agent_role`, and `entity_id`.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ErrorEnvelope" }
         "409":
           description: |
             Idempotency key collision (`ERR_IDEMPOTENCY_COLLISION`). The
@@ -6052,6 +6061,15 @@ paths:
                         type: string
                       field:
                         type: string
+        "403":
+          description: |
+            Correction rejected by policy. `OVERRIDE_POLICY_VIOLATION` is
+            returned when an `agent_definition` entity's `override_policy`
+            denies the calling agent role the corrected field; the envelope
+            details carry `field_name`, `agent_role`, and `entity_id`.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ErrorEnvelope" }
 
   /turn_summary:
     post:

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -30,6 +30,7 @@ import { attributionContext } from "./middleware/attribution_context.js";
 import { aauthAdmission, getAAuthAdmissionFromRequest } from "./middleware/aauth_admission.js";
 import { buildSessionInfo } from "./services/session_info.js";
 import { AttributionPolicyError, enforceAttributionPolicy } from "./services/attribution_policy.js";
+import { OverridePolicyViolationError } from "./services/override_validation.js";
 import {
   AgentCapabilityError,
   contextFromAgentIdentity,
@@ -3657,6 +3658,12 @@ function handleApiError(
   }
   if (error instanceof AccessPolicyError) {
     logWarn(logContext || "AccessPolicyRejection", req, error.toErrorEnvelope());
+    return res
+      .status(403)
+      .json(buildErrorEnvelope(error.code, error.message, error.toErrorEnvelope()));
+  }
+  if (error instanceof OverridePolicyViolationError) {
+    logWarn(logContext || "OverridePolicyRejection", req, error.toErrorEnvelope());
     return res
       .status(403)
       .json(buildErrorEnvelope(error.code, error.message, error.toErrorEnvelope()));

--- a/src/server.ts
+++ b/src/server.ts
@@ -75,6 +75,7 @@ import {
 import { getLatestFromRegistry, isUpdateAvailable, formatUpgradeCommand } from "./version_check.js";
 import { buildSessionInfo } from "./services/session_info.js";
 import { AttributionPolicyError } from "./services/attribution_policy.js";
+import { OverridePolicyViolationError } from "./services/override_validation.js";
 import {
   getCurrentAAuthAdmission,
   getCurrentAttributionDecision,
@@ -1689,6 +1690,12 @@ export class NeotomaServer {
           // branch on `ATTRIBUTION_REQUIRED` without string-matching. The
           // envelope carries `min_tier` / `current_tier` / `hint` in the MCP
           // `data` field (see src/services/attribution_policy.ts).
+          throw new McpError(ErrorCode.InvalidRequest, error.message, error.toErrorEnvelope());
+        }
+        if (error instanceof OverridePolicyViolationError) {
+          // Same structured-envelope contract for override-policy rejections:
+          // clients branch on `OVERRIDE_POLICY_VIOLATION` via the MCP `data`
+          // field (see src/services/override_validation.ts).
           throw new McpError(ErrorCode.InvalidRequest, error.message, error.toErrorEnvelope());
         }
         // Safely extract error message, handling BigInt values

--- a/src/services/__tests__/override_validation.test.ts
+++ b/src/services/__tests__/override_validation.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Unit tests for the override_validation service.
+ *
+ * Tests cover the two pure functions (`checkFieldAllowed` and
+ * `parseOverridePolicy`) exhaustively without hitting the database. The async
+ * `enforceOverridePolicy` function is integration-tested separately as it
+ * requires a live DB context.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  checkFieldAllowed,
+  parseOverridePolicy,
+  OverridePolicyViolationError,
+  type FieldPolicy,
+} from "../override_validation.js";
+
+// ---------------------------------------------------------------------------
+// checkFieldAllowed
+// ---------------------------------------------------------------------------
+
+describe("checkFieldAllowed", () => {
+  const operatorOnlyPolicy: FieldPolicy = {
+    allowed_roles: ["operator"],
+    deny_message: "Only operators may change this field",
+  };
+
+  const multiRolePolicy: FieldPolicy = {
+    allowed_roles: ["operator", "service"],
+  };
+
+  const tieredPolicy: FieldPolicy = {
+    allowed_roles: ["operator", "service"],
+    min_tier: "software",
+  };
+
+  it("allows when agent role is in allowed_roles", () => {
+    const result = checkFieldAllowed("agent_grant", operatorOnlyPolicy, "operator");
+    expect(result.allowed).toBe(true);
+    expect(result.reason).toBeUndefined();
+  });
+
+  it("denies when agent role is NOT in allowed_roles", () => {
+    const result = checkFieldAllowed("agent_grant", operatorOnlyPolicy, "service");
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain("operator");
+  });
+
+  it("uses deny_message when provided on denial", () => {
+    const result = checkFieldAllowed("agent_grant", operatorOnlyPolicy, "service");
+    expect(result.reason).toBe("Only operators may change this field");
+  });
+
+  it("allows any role listed in a multi-role policy", () => {
+    const resultOp = checkFieldAllowed("prompt_markdown", multiRolePolicy, "operator");
+    const resultSvc = checkFieldAllowed("prompt_markdown", multiRolePolicy, "service");
+    expect(resultOp.allowed).toBe(true);
+    expect(resultSvc.allowed).toBe(true);
+  });
+
+  it("denies an unlisted role from a multi-role policy", () => {
+    const result = checkFieldAllowed("prompt_markdown", multiRolePolicy, "guest");
+    expect(result.allowed).toBe(false);
+  });
+
+  it("denies when tier is below min_tier even if role matches", () => {
+    const result = checkFieldAllowed(
+      "prompt_markdown",
+      tieredPolicy,
+      "service",
+      "unverified_client"
+    );
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain("unverified_client");
+    expect(result.reason).toContain("software");
+  });
+
+  it("allows when role matches and tier meets min_tier", () => {
+    const result = checkFieldAllowed("prompt_markdown", tieredPolicy, "service", "software");
+    expect(result.allowed).toBe(true);
+  });
+
+  it("allows when min_tier is specified but no agentTier is provided (unknown tier is not blocked)", () => {
+    // When tier is unknown we can't verify the constraint — fail-open per spec.
+    const result = checkFieldAllowed("prompt_markdown", tieredPolicy, "service", undefined);
+    expect(result.allowed).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseOverridePolicy
+// ---------------------------------------------------------------------------
+
+describe("parseOverridePolicy", () => {
+  it("parses a valid full policy", () => {
+    const json = JSON.stringify({
+      field_policies: {
+        agent_grant: { allowed_roles: ["operator"], deny_message: "Operators only" },
+        prompt_markdown: { allowed_roles: ["operator", "service"] },
+      },
+      default_policy: "allow",
+    });
+    const policy = parseOverridePolicy(json);
+    expect(policy).not.toBeNull();
+    expect(policy!.field_policies["agent_grant"].allowed_roles).toEqual(["operator"]);
+    expect(policy!.field_policies["agent_grant"].deny_message).toBe("Operators only");
+    expect(policy!.field_policies["prompt_markdown"].allowed_roles).toEqual([
+      "operator",
+      "service",
+    ]);
+    expect(policy!.default_policy).toBe("allow");
+  });
+
+  it("parses policy with default_policy omitted (defaults to allow)", () => {
+    const json = JSON.stringify({
+      field_policies: {
+        name: { allowed_roles: ["operator"] },
+      },
+    });
+    const policy = parseOverridePolicy(json);
+    expect(policy).not.toBeNull();
+    expect(policy!.default_policy).toBeUndefined();
+  });
+
+  it("parses policy with default_policy deny", () => {
+    const json = JSON.stringify({
+      field_policies: {
+        name: { allowed_roles: ["operator"] },
+      },
+      default_policy: "deny",
+    });
+    const policy = parseOverridePolicy(json);
+    expect(policy!.default_policy).toBe("deny");
+  });
+
+  it("returns null for invalid JSON (fail-open)", () => {
+    expect(parseOverridePolicy("{not valid json")).toBeNull();
+  });
+
+  it("returns null for JSON that is not an object", () => {
+    expect(parseOverridePolicy('"just a string"')).toBeNull();
+    expect(parseOverridePolicy("[1, 2, 3]")).toBeNull();
+  });
+
+  it("returns null when field_policies is missing", () => {
+    expect(parseOverridePolicy('{"default_policy":"allow"}')).toBeNull();
+  });
+
+  it("silently skips malformed field entries while keeping valid ones", () => {
+    const json = JSON.stringify({
+      field_policies: {
+        good_field: { allowed_roles: ["operator"] },
+        bad_field: "not an object",
+        no_roles: { allowed_roles: "not an array" },
+      },
+    });
+    const policy = parseOverridePolicy(json);
+    expect(policy).not.toBeNull();
+    expect(Object.keys(policy!.field_policies)).toEqual(["good_field"]);
+  });
+
+  it("parses min_tier from a field policy", () => {
+    const json = JSON.stringify({
+      field_policies: {
+        secure_field: { allowed_roles: ["operator"], min_tier: "hardware" },
+      },
+    });
+    const policy = parseOverridePolicy(json);
+    expect(policy!.field_policies["secure_field"].min_tier).toBe("hardware");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// OverridePolicyViolationError shape
+// ---------------------------------------------------------------------------
+
+describe("OverridePolicyViolationError", () => {
+  it("carries structured fields and toErrorEnvelope()", () => {
+    const err = new OverridePolicyViolationError({
+      fieldName: "agent_grant",
+      agentRole: "service",
+      entityId: "entity-abc",
+      reason: "Only operators may change agent grants",
+    });
+    expect(err.code).toBe("OVERRIDE_POLICY_VIOLATION");
+    expect(err.statusCode).toBe(403);
+    expect(err.fieldName).toBe("agent_grant");
+    expect(err.agentRole).toBe("service");
+    expect(err.entityId).toBe("entity-abc");
+    const envelope = err.toErrorEnvelope();
+    expect(envelope.code).toBe("OVERRIDE_POLICY_VIOLATION");
+    expect(envelope.field_name).toBe("agent_grant");
+    expect(envelope.agent_role).toBe("service");
+    expect(envelope.entity_id).toBe("entity-abc");
+  });
+});

--- a/src/services/correction.ts
+++ b/src/services/correction.ts
@@ -55,6 +55,7 @@ export async function createCorrection(params: CreateCorrectionParams): Promise<
     fields: { [params.field]: params.value },
     identity: getCurrentAgentIdentity(),
     admission: getCurrentAAuthAdmission(),
+    userId: params.user_id,
     db,
   });
   const { entity_id, entity_type, field, value, schema_version, user_id, idempotency_key } = params;

--- a/src/services/correction.ts
+++ b/src/services/correction.ts
@@ -16,6 +16,7 @@ import {
 } from "./request_context.js";
 import { enforceAttributionPolicy } from "./attribution_policy.js";
 import { assertCanWriteProtected } from "./protected_entity_types.js";
+import { enforceOverridePolicy } from "./override_validation.js";
 import {
   emitEntitySnapshotChange,
   emitObservationCreated,
@@ -47,6 +48,14 @@ export async function createCorrection(params: CreateCorrectionParams): Promise<
     op: "correct",
     identity: getCurrentAgentIdentity(),
     admission: getCurrentAAuthAdmission(),
+  });
+  await enforceOverridePolicy({
+    entityType: params.entity_type,
+    entityId: params.entity_id,
+    fields: { [params.field]: params.value },
+    identity: getCurrentAgentIdentity(),
+    admission: getCurrentAAuthAdmission(),
+    db,
   });
   const { entity_id, entity_type, field, value, schema_version, user_id, idempotency_key } = params;
 

--- a/src/services/observation_storage.ts
+++ b/src/services/observation_storage.ts
@@ -15,6 +15,7 @@ import {
 } from "./request_context.js";
 import { enforceAttributionPolicy } from "./attribution_policy.js";
 import { assertCanWriteProtected } from "./protected_entity_types.js";
+import { enforceOverridePolicy } from "./override_validation.js";
 import type { ObservationSource } from "../shared/action_schemas.js";
 
 /**
@@ -87,6 +88,14 @@ export async function createObservation(
     op: "store",
     identity: getCurrentAgentIdentity(),
     admission: getCurrentAAuthAdmission(),
+  });
+  await enforceOverridePolicy({
+    entityType: params.entity_type,
+    entityId: params.entity_id,
+    fields: params.fields,
+    identity: getCurrentAgentIdentity(),
+    admission: getCurrentAAuthAdmission(),
+    db,
   });
   const observationId = generateObservationId(
     params.source_id,

--- a/src/services/observation_storage.ts
+++ b/src/services/observation_storage.ts
@@ -95,6 +95,7 @@ export async function createObservation(
     fields: params.fields,
     identity: getCurrentAgentIdentity(),
     admission: getCurrentAAuthAdmission(),
+    userId: params.user_id,
     db,
   });
   const observationId = generateObservationId(

--- a/src/services/override_validation.ts
+++ b/src/services/override_validation.ts
@@ -275,6 +275,13 @@ export interface EnforceOverridePolicyParams {
   entityId: string | null;
   /** Fields being written by this observation. */
   fields: Record<string, unknown>;
+  /**
+   * Owning user id for the write. The snapshot lookup is scoped to this user
+   * so a colliding entity_id in another tenant can never supply the policy
+   * (same failure class as the 2026-05-21 relationship tenant-isolation
+   * advisory).
+   */
+  userId: string;
   /** Calling agent identity from the active request context. */
   identity: AgentIdentity | null;
   /** AAuth admission context, if available (used for role derivation). */
@@ -295,23 +302,24 @@ export interface EnforceOverridePolicyParams {
  *   {@link OverridePolicyViolationError} on the first violation.
  */
 export async function enforceOverridePolicy(params: EnforceOverridePolicyParams): Promise<void> {
-  const { entityType, entityId, fields, identity, admission, db: dbClient } = params;
+  const { entityType, entityId, fields, identity, admission, userId, db: dbClient } = params;
 
-  // Phase 1: only agent_definition entities carry a policy.
+  // Phase 1: only agent_definition entities carry a policy. No agent_definition
+  // schema is seeded yet, so this guard is inert until that schema lands;
+  // shipping the enforcement hook first keeps the write path ready.
   if (entityType !== "agent_definition") return;
 
   // New entities have no snapshot, so no policy to enforce yet.
   if (entityId === null) return;
 
-  // Fetch the current snapshot for this entity.
-  const queryResult = await (dbClient
+  // Fetch the current snapshot for this entity, scoped to the owning user so a
+  // cross-tenant entity_id collision can never supply the policy.
+  const { data: snapshotData, error: snapshotError } = await dbClient
     .from("entity_snapshots")
     .select("snapshot")
-    .eq("entity_id", entityId) as unknown as Promise<{
-    data: { snapshot: Record<string, unknown> | null } | null;
-    error: { message: string } | null;
-  }>);
-  const { data: snapshotData, error: snapshotError } = queryResult;
+    .eq("entity_id", entityId)
+    .eq("user_id", userId)
+    .maybeSingle();
 
   if (snapshotError) {
     // Fail-open: if we can't read the snapshot, don't block the write.
@@ -327,8 +335,19 @@ export async function enforceOverridePolicy(params: EnforceOverridePolicyParams)
 
   if (!snapshotData) return;
 
-  const snapshot =
-    (snapshotData as { snapshot?: Record<string, unknown> | null } | null)?.snapshot ?? null;
+  // The `snapshot` column is JSON TEXT; the local adapter may surface it as a
+  // parsed object or a raw string depending on the read path. Accept both.
+  const rawSnapshot = (snapshotData as { snapshot?: unknown }).snapshot ?? null;
+  let snapshot: Record<string, unknown> | null = null;
+  if (typeof rawSnapshot === "string") {
+    try {
+      snapshot = JSON.parse(rawSnapshot) as Record<string, unknown>;
+    } catch {
+      snapshot = null;
+    }
+  } else if (rawSnapshot && typeof rawSnapshot === "object") {
+    snapshot = rawSnapshot as Record<string, unknown>;
+  }
   if (!snapshot) return;
 
   const rawPolicy = snapshot["override_policy"];

--- a/src/services/override_validation.ts
+++ b/src/services/override_validation.ts
@@ -1,0 +1,375 @@
+/**
+ * Override validation service.
+ *
+ * Enforces `override_policy` — a JSON field stored on `agent_definition`
+ * entities — at observation write time. This enables per-field write
+ * restrictions based on the calling agent's role or tier, so individual
+ * Ateles swarm daemons can be restricted from overwriting sensitive fields
+ * they should never touch (e.g. `agent_grant`, `prompt_markdown`).
+ *
+ * Phase 1 scope: only `agent_definition` entities carry a policy; all other
+ * entity types are passed through without inspection.
+ *
+ * # override_policy JSON format (stored in agent_definition.override_policy)
+ *
+ * ```json
+ * {
+ *   "field_policies": {
+ *     "agent_grant": {
+ *       "allowed_roles": ["operator"],
+ *       "deny_message": "Only operators may change agent grants"
+ *     },
+ *     "prompt_markdown": {
+ *       "allowed_roles": ["operator", "service"]
+ *     }
+ *   },
+ *   "default_policy": "allow"
+ * }
+ * ```
+ *
+ * `default_policy` defaults to `"allow"` when omitted (fail-open). Fields
+ * not mentioned in `field_policies` inherit `default_policy`.
+ *
+ * Role derivation:
+ *   - If identity is null, or identity.tier is "operator_attested"/"hardware"
+ *     → role is "operator".
+ *   - If identity.sub ends in `@ateles-swarm`:
+ *       → derive role from `agent_grant` field in the AAuth admission context,
+ *         falling back to "service" when the admission did not carry one.
+ *   - Otherwise → role is "service".
+ */
+
+import type { AgentIdentity } from "../crypto/agent_identity.js";
+import type { LocalDbClient } from "../repositories/sqlite/local_db_adapter.js";
+import type { AAuthAdmissionContext } from "./protected_entity_types.js";
+import { logger } from "../utils/logger.js";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-field access policy. `allowed_roles` is the exhaustive allow-list; a
+ * caller whose role is absent is denied. `min_tier` is an optional additional
+ * constraint — the caller's `AgentIdentity.tier` is compared against it when
+ * present. Either constraint alone is sufficient to deny a write.
+ */
+export interface FieldPolicy {
+  /** Role strings that are allowed to write this field. */
+  allowed_roles: string[];
+  /**
+   * Optional minimum attribution tier the caller must carry.
+   * Valid values mirror {@link AttributionTier}: "hardware" | "operator_attested"
+   * | "software" | "unverified_client" | "anonymous".
+   */
+  min_tier?: string;
+  /** Human-readable message surfaced in the thrown error. */
+  deny_message?: string;
+}
+
+/**
+ * Top-level shape of the `override_policy` JSON blob stored on an
+ * `agent_definition` entity.
+ */
+export interface OverridePolicy {
+  /** Per-field rules. Keys are field names as they appear in `observations.fields`. */
+  field_policies: Record<string, FieldPolicy>;
+  /**
+   * Fallback when a field is not listed in `field_policies`.
+   * Defaults to `"allow"` (fail-open) when omitted.
+   */
+  default_policy?: "allow" | "deny";
+}
+
+// ---------------------------------------------------------------------------
+// Error class
+// ---------------------------------------------------------------------------
+
+/**
+ * Thrown by {@link enforceOverridePolicy} when a field write is blocked.
+ * HTTP handlers should surface this as 403 with `code: "OVERRIDE_POLICY_VIOLATION"`.
+ */
+export class OverridePolicyViolationError extends Error {
+  readonly code = "OVERRIDE_POLICY_VIOLATION" as const;
+  readonly statusCode = 403;
+  readonly fieldName: string;
+  readonly agentRole: string;
+  readonly entityId: string;
+
+  constructor(params: { fieldName: string; agentRole: string; entityId: string; reason?: string }) {
+    const reason =
+      params.reason ??
+      `Role "${params.agentRole}" is not permitted to write field "${params.fieldName}"`;
+    super(
+      `Override policy blocked write to field "${params.fieldName}" on entity "${params.entityId}": ${reason}`
+    );
+    this.name = "OverridePolicyViolationError";
+    this.fieldName = params.fieldName;
+    this.agentRole = params.agentRole;
+    this.entityId = params.entityId;
+  }
+
+  toErrorEnvelope(): {
+    code: string;
+    message: string;
+    field_name: string;
+    agent_role: string;
+    entity_id: string;
+  } {
+    return {
+      code: this.code,
+      message: this.message,
+      field_name: this.fieldName,
+      agent_role: this.agentRole,
+      entity_id: this.entityId,
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tier ordering (mirrors attribution_policy.ts TIER_RANK)
+// ---------------------------------------------------------------------------
+
+const TIER_RANK: Record<string, number> = {
+  anonymous: 0,
+  unverified_client: 1,
+  software: 2,
+  operator_attested: 3,
+  hardware: 4,
+};
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Determine whether `agentRole` (and optionally `agentTier`) is allowed to
+ * write a field governed by `policy`. Returns a structured result so callers
+ * can distinguish "allowed" from "denied with reason" without catching errors.
+ *
+ * @param fieldName   - The field name being written (used only in the reason string).
+ * @param policy      - The {@link FieldPolicy} for this field.
+ * @param agentRole   - Derived role string for the calling agent ("operator" | "service" | …).
+ * @param agentTier   - Optional attribution tier string from {@link AgentIdentity.tier}.
+ */
+export function checkFieldAllowed(
+  fieldName: string,
+  policy: FieldPolicy,
+  agentRole: string,
+  agentTier?: string
+): { allowed: boolean; reason?: string } {
+  // Role check — must appear in the allow-list.
+  if (!policy.allowed_roles.includes(agentRole)) {
+    const reason =
+      policy.deny_message ??
+      `Role "${agentRole}" is not in allowed_roles [${policy.allowed_roles.join(", ")}] for field "${fieldName}"`;
+    return { allowed: false, reason };
+  }
+
+  // Optional tier floor — only evaluated when both min_tier and agentTier are known.
+  if (policy.min_tier && agentTier) {
+    const requiredRank = TIER_RANK[policy.min_tier] ?? 0;
+    const currentRank = TIER_RANK[agentTier] ?? 0;
+    if (currentRank < requiredRank) {
+      const reason = `Attribution tier "${agentTier}" is below required minimum "${policy.min_tier}" for field "${fieldName}"`;
+      return { allowed: false, reason };
+    }
+  }
+
+  return { allowed: true };
+}
+
+/**
+ * Parse a raw JSON string into an {@link OverridePolicy}. Returns `null` on
+ * invalid / missing JSON (fail-open: callers treat `null` as "no restrictions").
+ */
+export function parseOverridePolicy(json: string): OverridePolicy | null {
+  try {
+    const parsed = JSON.parse(json);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return null;
+    }
+    // field_policies is required; if absent or wrong type, treat as invalid.
+    if (!parsed.field_policies || typeof parsed.field_policies !== "object") {
+      return null;
+    }
+    const fieldPolicies: Record<string, FieldPolicy> = {};
+    for (const [key, val] of Object.entries(parsed.field_policies)) {
+      if (!val || typeof val !== "object" || Array.isArray(val)) continue;
+      const v = val as Record<string, unknown>;
+      if (!Array.isArray(v.allowed_roles)) continue;
+      const fp: FieldPolicy = {
+        allowed_roles: (v.allowed_roles as unknown[]).filter(
+          (r): r is string => typeof r === "string"
+        ),
+      };
+      if (typeof v.min_tier === "string") fp.min_tier = v.min_tier;
+      if (typeof v.deny_message === "string") fp.deny_message = v.deny_message;
+      fieldPolicies[key] = fp;
+    }
+    const policy: OverridePolicy = { field_policies: fieldPolicies };
+    if (parsed.default_policy === "allow" || parsed.default_policy === "deny") {
+      policy.default_policy = parsed.default_policy;
+    }
+    return policy;
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Role derivation
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive a role string from the agent identity and optional admission context.
+ * The role is intentionally coarse (operator | service | …) and distinct from
+ * the attribution tier, which measures cryptographic assurance rather than
+ * business permission.
+ *
+ * Role derivation rules (in priority order):
+ *   1. No identity → "operator" (local/CLI write with no agent context).
+ *   2. AAuth tier of "operator_attested" or "hardware" → "operator".
+ *   3. Sub ends in "@ateles-swarm" → use `agent_label` from admission if
+ *      admitted, otherwise "service".
+ *   4. All other identities → "service".
+ */
+function deriveAgentRole(
+  identity: AgentIdentity | null,
+  admission: AAuthAdmissionContext | null
+): string {
+  // No identity or operator-tier AAuth → treat as operator.
+  if (!identity) return "operator";
+  if (identity.tier === "operator_attested" || identity.tier === "hardware") {
+    return "operator";
+  }
+
+  // Ateles swarm daemons: sub ends in @ateles-swarm.
+  if (identity.sub && identity.sub.endsWith("@ateles-swarm")) {
+    // Use the grant label from the admission context as the role when available.
+    if (admission?.admitted && admission.agent_label) {
+      return admission.agent_label;
+    }
+    return "service";
+  }
+
+  // Default: non-swarm, non-operator AAuth identity → "service".
+  return "service";
+}
+
+// ---------------------------------------------------------------------------
+// Main enforcement function
+// ---------------------------------------------------------------------------
+
+/**
+ * Params accepted by {@link enforceOverridePolicy}.
+ *
+ * `db` is the database client so the function is testable without patching
+ * the module-level singleton, but callers on the write path should pass the
+ * imported `db` instance from `../../db.js`.
+ */
+export interface EnforceOverridePolicyParams {
+  /** Entity type of the observation being written. */
+  entityType: string;
+  /** Entity id of the target entity. `null` for brand-new entities (no policy to enforce). */
+  entityId: string | null;
+  /** Fields being written by this observation. */
+  fields: Record<string, unknown>;
+  /** Calling agent identity from the active request context. */
+  identity: AgentIdentity | null;
+  /** AAuth admission context, if available (used for role derivation). */
+  admission?: AAuthAdmissionContext | null;
+  /** Database client. Pass the `db` singleton from `../../db.js`. */
+  db: LocalDbClient;
+}
+
+/**
+ * Enforce the `override_policy` attached to an `agent_definition` entity.
+ *
+ * - Skips immediately for any entity type other than `"agent_definition"`.
+ * - Skips when `entityId` is null (new entity has no existing policy).
+ * - Looks up the current entity snapshot; if no snapshot exists, or the
+ *   snapshot lacks an `override_policy` field, allows the write (fail-open).
+ * - Iterates over the fields being written and calls
+ *   {@link checkFieldAllowed} for each; throws
+ *   {@link OverridePolicyViolationError} on the first violation.
+ */
+export async function enforceOverridePolicy(params: EnforceOverridePolicyParams): Promise<void> {
+  const { entityType, entityId, fields, identity, admission, db: dbClient } = params;
+
+  // Phase 1: only agent_definition entities carry a policy.
+  if (entityType !== "agent_definition") return;
+
+  // New entities have no snapshot, so no policy to enforce yet.
+  if (entityId === null) return;
+
+  // Fetch the current snapshot for this entity.
+  const queryResult = await (dbClient
+    .from("entity_snapshots")
+    .select("snapshot")
+    .eq("entity_id", entityId) as unknown as Promise<{
+    data: { snapshot: Record<string, unknown> | null } | null;
+    error: { message: string } | null;
+  }>);
+  const { data: snapshotData, error: snapshotError } = queryResult;
+
+  if (snapshotError) {
+    // Fail-open: if we can't read the snapshot, don't block the write.
+    logger.warn(
+      JSON.stringify({
+        event: "override_policy_snapshot_fetch_error",
+        entity_id: entityId,
+        error: snapshotError.message,
+      })
+    );
+    return;
+  }
+
+  if (!snapshotData) return;
+
+  const snapshot =
+    (snapshotData as { snapshot?: Record<string, unknown> | null } | null)?.snapshot ?? null;
+  if (!snapshot) return;
+
+  const rawPolicy = snapshot["override_policy"];
+  if (typeof rawPolicy !== "string" || !rawPolicy) return;
+
+  const policy = parseOverridePolicy(rawPolicy);
+  if (!policy) {
+    // Fail-open on invalid JSON.
+    logger.warn(
+      JSON.stringify({
+        event: "override_policy_invalid_json",
+        entity_id: entityId,
+      })
+    );
+    return;
+  }
+
+  const agentRole = deriveAgentRole(identity, admission ?? null);
+  const agentTier = identity?.tier;
+
+  for (const fieldName of Object.keys(fields)) {
+    const fieldPolicy = policy.field_policies[fieldName];
+
+    if (fieldPolicy) {
+      const result = checkFieldAllowed(fieldName, fieldPolicy, agentRole, agentTier);
+      if (!result.allowed) {
+        throw new OverridePolicyViolationError({
+          fieldName,
+          agentRole,
+          entityId,
+          reason: result.reason,
+        });
+      }
+    } else if (policy.default_policy === "deny") {
+      throw new OverridePolicyViolationError({
+        fieldName,
+        agentRole,
+        entityId,
+        reason: `Field "${fieldName}" is not explicitly allowed and default_policy is "deny"`,
+      });
+    }
+    // default_policy === "allow" (or omitted) → allow unlisted fields.
+  }
+}

--- a/src/shared/openapi_types.ts
+++ b/src/shared/openapi_types.ts
@@ -5520,6 +5520,20 @@ export interface operations {
         };
       };
       /**
+       * @description Write rejected by policy. `OVERRIDE_POLICY_VIOLATION` is returned
+       *     when an `agent_definition` entity's `override_policy` denies the
+       *     calling agent role a field being written; the envelope details
+       *     carry `field_name`, `agent_role`, and `entity_id`.
+       */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["ErrorEnvelope"];
+        };
+      };
+      /**
        * @description Idempotency key collision (`ERR_IDEMPOTENCY_COLLISION`). The
        *     idempotency_key was already used for a store call with different
        *     content. Use a new idempotency_key to write the updated payload.
@@ -6877,6 +6891,20 @@ export interface operations {
               field?: string;
             };
           };
+        };
+      };
+      /**
+       * @description Correction rejected by policy. `OVERRIDE_POLICY_VIOLATION` is
+       *     returned when an `agent_definition` entity's `override_policy`
+       *     denies the calling agent role the corrected field; the envelope
+       *     details carry `field_name`, `agent_role`, and `entity_id`.
+       */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["ErrorEnvelope"];
         };
       };
     };

--- a/tests/integration/override_policy_enforcement.test.ts
+++ b/tests/integration/override_policy_enforcement.test.ts
@@ -1,0 +1,179 @@
+/**
+ * End-to-end enforcement test for `override_policy` on `agent_definition`
+ * entities (#1634, re-derived from #398).
+ *
+ * Exercises the REAL write path — `createObservation` / `createCorrection`
+ * with the request-scoped agent identity — against a live local DB with a
+ * seeded `entity_snapshots` row. This is the test the original branch lacked:
+ * it fails if the snapshot lookup silently no-ops (the `.maybeSingle()` bug)
+ * or if enforcement is skipped for any other reason.
+ *
+ * Matrix:
+ *  - operator identity (null / hardware tier) → write allowed
+ *  - service identity (software tier)         → denied field throws
+ *    OverridePolicyViolationError with code/statusCode/envelope
+ *  - unlisted field                           → allowed for any role
+ *  - cross-tenant: a policy row owned by ANOTHER user must NOT be consulted
+ *    for this user's write (tenant-scoped snapshot lookup)
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { db } from "../../src/db.js";
+import { createObservation } from "../../src/services/observation_storage.js";
+import { createCorrection } from "../../src/services/correction.js";
+import { OverridePolicyViolationError } from "../../src/services/override_validation.js";
+import { runWithRequestContext } from "../../src/services/request_context.js";
+import type { AgentIdentity } from "../../src/crypto/agent_identity.js";
+
+const USER_A = "00000000-0000-0000-0000-00000000aaa1";
+const USER_B = "00000000-0000-0000-0000-00000000bbb2";
+const ENTITY_ID = "ent_override_policy_e2e_test";
+const CROSS_TENANT_ENTITY_ID = "ent_override_policy_xtenant_test";
+
+const DENY_SERVICE_POLICY = JSON.stringify({
+  field_policies: {
+    agent_grant: {
+      allowed_roles: ["operator"],
+      deny_message: "Only operators may change agent_grant",
+    },
+  },
+});
+
+const OPERATOR_IDENTITY: AgentIdentity | null = null; // no identity → operator
+
+const SERVICE_IDENTITY: AgentIdentity = {
+  tier: "software",
+  sub: "ci-service@example.com",
+  algorithm: "ES256",
+};
+
+function seedSnapshot(entityId: string, userId: string, overridePolicy: string) {
+  return db.from("entity_snapshots").insert({
+    entity_id: entityId,
+    entity_type: "agent_definition",
+    schema_version: "1.0",
+    canonical_name: entityId,
+    snapshot: { agent_grant: "initial", override_policy: overridePolicy },
+    computed_at: new Date().toISOString(),
+    observation_count: 1,
+    last_observation_at: new Date().toISOString(),
+    provenance: {},
+    user_id: userId,
+  });
+}
+
+function observationParams(userId: string, fields: Record<string, unknown>) {
+  return {
+    entity_id: ENTITY_ID,
+    entity_type: "agent_definition",
+    schema_version: "1.0",
+    source_id: null,
+    interpretation_id: null,
+    observed_at: new Date().toISOString(),
+    specificity_score: 1,
+    source_priority: 500,
+    fields,
+    user_id: userId,
+    idempotency_key: `override-e2e-${Math.random().toString(36).slice(2)}`,
+  };
+}
+
+async function cleanup() {
+  for (const table of ["observations", "entity_snapshots", "entities"]) {
+    for (const id of [ENTITY_ID, CROSS_TENANT_ENTITY_ID]) {
+      await db
+        .from(table)
+        .delete()
+        .eq(table === "observations" ? "entity_id" : table === "entities" ? "id" : "entity_id", id);
+    }
+  }
+}
+
+describe("override_policy end-to-end enforcement (agent_definition)", () => {
+  beforeAll(async () => {
+    await cleanup();
+    await seedSnapshot(ENTITY_ID, USER_A, DENY_SERVICE_POLICY);
+    // Cross-tenant probe: USER_B owns a deny-everything policy under a
+    // DIFFERENT entity id; USER_A's write to that id must not see it.
+    await seedSnapshot(CROSS_TENANT_ENTITY_ID, USER_B, DENY_SERVICE_POLICY);
+  });
+
+  afterAll(async () => {
+    await cleanup();
+  });
+
+  it("denies a service-identity observation write to a protected field", async () => {
+    let caught: unknown;
+    try {
+      await runWithRequestContext({ agentIdentity: SERVICE_IDENTITY }, () =>
+        createObservation(observationParams(USER_A, { agent_grant: "escalated" }))
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(OverridePolicyViolationError);
+    const violation = caught as OverridePolicyViolationError;
+    expect(violation.code).toBe("OVERRIDE_POLICY_VIOLATION");
+    expect(violation.statusCode).toBe(403);
+    const envelope = violation.toErrorEnvelope();
+    expect(envelope).toMatchObject({
+      code: "OVERRIDE_POLICY_VIOLATION",
+      field_name: "agent_grant",
+      entity_id: ENTITY_ID,
+    });
+    expect(envelope.agent_role).toBe("service");
+    expect(envelope.message).toContain("agent_grant");
+  });
+
+  it("denies a service-identity correction to a protected field", async () => {
+    await expect(
+      runWithRequestContext({ agentIdentity: SERVICE_IDENTITY }, () =>
+        createCorrection({
+          entity_id: ENTITY_ID,
+          entity_type: "agent_definition",
+          field: "agent_grant",
+          value: "escalated",
+          schema_version: "1.0",
+          user_id: USER_A,
+        })
+      )
+    ).rejects.toBeInstanceOf(OverridePolicyViolationError);
+  });
+
+  it("allows an operator (no identity) to write the protected field", async () => {
+    const record = await runWithRequestContext({ agentIdentity: OPERATOR_IDENTITY }, () =>
+      createObservation(observationParams(USER_A, { agent_grant: "rotated-by-operator" }))
+    );
+    expect(record.entity_id).toBe(ENTITY_ID);
+    expect(record.fields.agent_grant).toBe("rotated-by-operator");
+  });
+
+  it("allows a service identity to write an unlisted field", async () => {
+    const record = await runWithRequestContext({ agentIdentity: SERVICE_IDENTITY }, () =>
+      createObservation(observationParams(USER_A, { description: "harmless metadata edit" }))
+    );
+    expect(record.entity_id).toBe(ENTITY_ID);
+  });
+
+  it("does not consult another tenant's policy row (user-scoped lookup)", async () => {
+    // USER_A writes to the entity id whose ONLY policy row belongs to USER_B.
+    // The lookup is scoped to USER_A → no snapshot → fail-open → allowed.
+    const record = await runWithRequestContext({ agentIdentity: SERVICE_IDENTITY }, () =>
+      createObservation({
+        ...observationParams(USER_A, { agent_grant: "cross-tenant-probe" }),
+        entity_id: CROSS_TENANT_ENTITY_ID,
+      })
+    );
+    expect(record.entity_id).toBe(CROSS_TENANT_ENTITY_ID);
+  });
+
+  it("ignores entity types other than agent_definition", async () => {
+    const record = await runWithRequestContext({ agentIdentity: SERVICE_IDENTITY }, () =>
+      createObservation({
+        ...observationParams(USER_A, { agent_grant: "not-an-agent-definition" }),
+        entity_type: "note",
+      })
+    );
+    expect(record.entity_type).toBe("note");
+  });
+});

--- a/tests/integration/retrieve_graph_neighborhood_tenant_isolation.test.ts
+++ b/tests/integration/retrieve_graph_neighborhood_tenant_isolation.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Regression test for GHSA-wrr4-782v-jhwh /
+ * docs/security/advisories/2026-05-21-relationship-endpoint-tenant-isolation.md
+ *
+ * Invariant: the /retrieve_graph_neighborhood HTTP endpoint MUST scope all
+ * database queries to the authenticated user. Specifically, when invoked
+ * by user A with an entity_id belonging to user B, the endpoint MUST NOT
+ * return user B's entity, relationships, observations, or sources.
+ *
+ * This test seeds two distinct user_ids' worth of data in the database
+ * and verifies that calls authenticated as user A only see user A's data,
+ * regardless of which node_id is queried.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { db } from "../../src/db.js";
+import { randomUUID } from "node:crypto";
+
+const TEST_PREFIX = "rgn_tenant_iso_test";
+const PORT = process.env.NEOTOMA_SESSION_DEV_PORT ?? "18099";
+const BASE_URL = `http://127.0.0.1:${PORT}`;
+
+describe("retrieve_graph_neighborhood tenant isolation (GHSA-wrr4-782v-jhwh)", () => {
+  const userA = randomUUID();
+  const userB = randomUUID();
+  const entityA = `${TEST_PREFIX}_ent_a_${Date.now()}`;
+  const entityB = `${TEST_PREFIX}_ent_b_${Date.now()}`;
+
+  beforeAll(async () => {
+    // Seed two entities, one per user
+    await db.from("entities").insert([
+      {
+        id: entityA,
+        user_id: userA,
+        entity_type: "test",
+        canonical_name: "Alice's Entity",
+      },
+      {
+        id: entityB,
+        user_id: userB,
+        entity_type: "test",
+        canonical_name: "Bob's Entity",
+      },
+    ]);
+  });
+
+  afterAll(async () => {
+    await db.from("entities").delete().eq("id", entityA);
+    await db.from("entities").delete().eq("id", entityB);
+  });
+
+  it("user A querying their own entity returns it", async () => {
+    const res = await fetch(`${BASE_URL}/retrieve_graph_neighborhood`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        node_id: entityA,
+        node_type: "entity",
+        user_id: userA,
+      }),
+    });
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.entity).toBeDefined();
+    expect(json.entity.id).toBe(entityA);
+  });
+
+  it("user A querying user B's entity does NOT return user B's data", async () => {
+    const res = await fetch(`${BASE_URL}/retrieve_graph_neighborhood`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        node_id: entityB,
+        node_type: "entity",
+        user_id: userA,
+      }),
+    });
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    // Either entity is undefined or it does not match userB's entity
+    // (the .single() should not find a row scoped to userA)
+    expect(json.entity).toBeUndefined();
+  });
+
+  it("user B querying their own entity returns it", async () => {
+    const res = await fetch(`${BASE_URL}/retrieve_graph_neighborhood`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        node_id: entityB,
+        node_type: "entity",
+        user_id: userB,
+      }),
+    });
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.entity).toBeDefined();
+    expect(json.entity.id).toBe(entityB);
+  });
+});


### PR DESCRIPTION
## Summary

Clean re-derivation of #398 (`feat/override-validation`) onto current `main`. The original branch was 10 commits and conflicted on security-advisory docs that **already landed on `main`**; this PR preserves only the genuinely net-new `override_validation` feature.

- **`src/services/override_validation.ts`** — `enforceOverridePolicy()` reads an `override_policy` JSON stored on `agent_definition` entities and enforces per-field write restrictions based on the caller's derived role (operator/service). Phase 1 scope: only `agent_definition` carries a policy; all other entity types pass through untouched (fail-open default).
- **Hooks** — wired into `createObservation` (`observation_storage.ts`) and `createCorrection` (`correction.ts`), after the existing attribution / protected-type checks.
- **Tests** — `override_validation.test.ts` (17) and `retrieve_graph_neighborhood_tenant_isolation.test.ts` (3); both net-new, both green.

## Intentionally excluded from #398

- `docs/security/advisories/*` and `.claude/skills/advisory/SKILL.md` — already on `main`.
- `docs/security/practices.md` edits — stale doc drift (`run_semgrep`->`lint` rename), no override-validation content.
- `tests/services/relationships_tenant_isolation.test.ts` — asserts a `user_id` tenant filter in `relationships.ts` that `main`'s **service layer does not implement** (advisory GHSA-wrr4-782v-jhwh documented on `main` but `getRelationshipsForEntity`/`getRelationshipsByType` take no `userId`). Filed separately as a security finding; not bundled here.

## Test plan

- [x] tsc --noEmit clean
- [x] override_validation.test.ts 17/17
- [x] retrieve_graph_neighborhood_tenant_isolation.test.ts 3/3
- [x] agent_capabilities_store.test.ts 4/4 (hook transparent for normal store)
- [ ] CI: full suite + security gates