### PR TITLE
fix(security): sync protected_routes_manifest with openapi.yaml

### DIFF
--- a/scripts/security/protected_routes_manifest.json
+++ b/scripts/security/protected_routes_manifest.json
@@ -1307,6 +1307,7 @@
       "method": "GET",
       "operation_id": "getUsage",
       "requires_auth": true,
+      "sandbox_allowed": "none",
       "expected_no_auth_status": [
         401
       ],


### PR DESCRIPTION
main's `security:manifest:check` is currently failing on a plain `origin/main` checkout (manifest drifted after a route change merged without regeneration — one missing `sandbox_allowed: "none"` on `getUsage`). This red-flags the `security_gates` lane on every open PR. Regenerated via `npm run security:manifest:write` (109 routes). Verified `security:manifest:check` passes after.