### PR TITLE
docs(rendered_page): make usage self-documenting (#1620)

### DIFF
--- a/docs/rendered_page.md
+++ b/docs/rendered_page.md
@@ -1,0 +1,69 @@
+# rendered_page
+
+A `rendered_page` is a bespoke HTML expression of something — a proposal page, public memo, report, one-pager, or shareable narrative. It is intentionally **distinct from the data entities it describes**: the `rendered_page` holds presentation, and `REFERS_TO` relationships link it to the data. Keeping presentation separate from data prevents evidence (`source`) and presentation from colliding, and keeps every other entity type from growing presentation fields it doesn't need.
+
+## Fields
+
+| Field              | Required | Notes                                                                                                                                                           |
+| ------------------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `title`            | ✓        | Rendered into `<title>` and the `<h1>` if `html_body` has no header override.                                                                                   |
+| `html_body`        | ✓        | Injected **verbatim** into `<body>`. **Do not include `<html>`/`<head>`/`<body>` wrappers** — the server wraps it in a minimal template. Not escaped on render. |
+| `meta_description` |          | Optional `<meta name=description>`; escaped on render.                                                                                                          |
+| `custom_css`       |          | Optional CSS injected as an inline `<style>` in `<head>`.                                                                                                       |
+| `slug`             |          | Optional URL-safe identifier; reserved for future pretty-URL routing (`/p/<slug>`).                                                                             |
+| `created_at`       |          | Page creation timestamp.                                                                                                                                        |
+
+## Serving
+
+A `rendered_page` is served as standalone HTML at:
+
+```
+GET /entities/:id/html
+```
+
+This route 404s for any entity type other than `rendered_page`, keeping the publish surface explicit.
+
+## Guest access (sharing with a non-user)
+
+The schema ships `guest_access_policy: submitter_scoped`. A **bare** `…/entities/:id/html` URL therefore **401s for an unauthenticated viewer**. To share the page with someone outside the operator's account, the URL must carry a guest token:
+
+```
+GET /entities/:id/html?access_token=<guest_token>
+```
+
+The token is a `guest_access_token` scoped to that page's entity id.
+
+### The one-step path: `publish_rendered_page`
+
+Rather than minting the token by hand, call the **`publish_rendered_page`** MCP tool. It:
+
+1. accepts an existing `rendered_page` `entity_id`, **or** inline `{ title, html_body, custom_css, meta_description }` to create one first;
+2. mints a `guest_access_token` scoped to that entity;
+3. returns the ready-to-share `…/entities/<id>/html?access_token=<token>` URL plus `ttl_seconds`.
+
+Notes:
+
+- The existing-entity path is **owner-scoped**: you can only publish a `rendered_page` you own (tenant isolation).
+- Guest tokens are stored **hash-only** (SHA-256) at rest; the raw token cannot be recovered, so each call mints a fresh token rather than re-returning a prior one.
+- Token lifetime is bounded by `NEOTOMA_GUEST_TOKEN_TTL_SECONDS` (default 30 days).
+
+## Example
+
+```jsonc
+// 1. store a rendered_page (or pass these inline to publish_rendered_page)
+{
+  "entity_type": "rendered_page",
+  "title": "Q3 Preview",
+  "html_body": "<h1>Q3 Preview</h1><p>…</p>",
+  "custom_css": "body { font-family: system-ui; max-width: 42rem; margin: 2rem auto; }"
+}
+
+// 2. publish_rendered_page → returns:
+{
+  "entity_id": "ent_…",
+  "share_url": "https://…/entities/ent_…/html?access_token=…",
+  "access_token": "…",
+  "ttl_seconds": 2592000,
+  "created": false
+}
+```

--- a/src/services/rendered_page/seed_schema.ts
+++ b/src/services/rendered_page/seed_schema.ts
@@ -45,7 +45,7 @@ const RENDERED_PAGE_FIELDS: FieldSpec = [
     type: "string",
     required: true,
     description:
-      "Body HTML injected verbatim into <body>. Do not include <html>/<head>/<body> wrappers — the server wraps this in a minimal template. Not escaped on render.",
+      "Body HTML injected verbatim into <body>. Do not include <html>/<head>/<body> wrappers — the server wraps this in a minimal template. Not escaped on render. Served at GET /entities/:id/html; to share with a non-user, call publish_rendered_page for a guest URL (the bare URL requires ?access_token under the submitter_scoped policy).",
   },
   {
     name: "meta_description",
@@ -117,7 +117,10 @@ export async function seedRenderedPageSchema(options?: {
       metadata: {
         label: "Rendered page",
         description:
-          "A bespoke HTML expression of something — proposal pages, public memos, shareable narratives. Distinct from the data entities it describes; uses REFERS_TO to link them. Served via GET /entities/:id/html.",
+          "A bespoke HTML expression of something — proposal pages, public memos, shareable narratives. Distinct from the data entities it describes; uses REFERS_TO to link them. " +
+          "Served as standalone HTML at GET /entities/:id/html: html_body is injected verbatim into a minimal server template (do NOT include <html>/<head>/<body> wrappers) and custom_css is injected as an inline <style> in <head>. " +
+          "Guest viewing requires ?access_token=<guest_token> because guest_access_policy is submitter_scoped (a bare URL 401s for non-authenticated viewers). " +
+          "To get a working share link in one step, call the publish_rendered_page MCP tool — it mints the guest token and returns the ready …/entities/<id>/html?access_token=<token> URL plus its TTL. See docs/rendered_page.md.",
         category: "knowledge",
         // submitter_scoped lets a guest read a specific rendered_page when they
         // present a guest_access_token bound to that page's entity_id. This is


### PR DESCRIPTION
Closes #1620.

## What

Makes `rendered_page` usage discoverable where agents already look, so a fresh agent can produce and share one without reading source.

- **Schema description** (`describe_entity_type rendered_page`): the schema-level metadata.description now states the serve-URL pattern (`GET /entities/:id/html`), the no-`<html>/<head>/<body>`-wrappers rule, the `custom_css` `<head>` injection, and the guest-access requirement (`?access_token` / `submitter_scoped`), plus a pointer to `publish_rendered_page` and `docs/rendered_page.md`. The `html_body` field description gets the serve/guest-URL note too.
- **docs/rendered_page.md**: fields table, serving, guest-access, and the one-step `publish_rendered_page` path with an example.

## Companion / sequencing

The MCP turn-lifecycle instruction line (the other companion deliverable in #1620) already shipped with the `publish_rendered_page` tool in #1619 (`docs/developer/mcp/instructions.md` + `tool_descriptions.yaml`). This PR completes the remaining schema-description + standalone-doc piece. References the tool by its final name, so it reads cleanly whether or not #1619 has merged yet.

## Known limitation (pre-existing)

`seedRenderedPageSchema`'s incremental-update path only adds *missing fields* — it does not refresh descriptions or metadata on an already-registered schema. So these description improvements take effect on a fresh registration; refreshing an existing deployment's stored schema description would need a separate migration/correct. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)