### PR TITLE
fix(evals): re-record Tier 1 agentic-eval snapshots for post-#316 client behavior

### DIFF
--- a/tests/__snapshots__/agentic_eval/agent_skips_store__cursor-hooks__claude-haiku-4.snap.json
+++ b/tests/__snapshots__/agentic_eval/agent_skips_store__cursor-hooks__claude-haiku-4.snap.json
@@ -2,6 +2,33 @@
   "requests": [
     {
       "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_3",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_9",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_14",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
       "endpoint": "/store",
       "body": {
         "entities": [
@@ -50,7 +77,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
@@ -63,12 +90,15 @@
             "model": "claude-haiku-4",
             "session_id": "<id:1>",
             "started_at": "<ts>",
-            "turn_id": "<id:3>",
+            "stored_entity_ids": [
+              "ent_mock_3"
+            ],
+            "turn_id": "<id:4>",
             "turn_key": "agent_skips_store__cursor-hooks__claude-haiku-4:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     },
     {
@@ -89,31 +119,6 @@
             "turn_key": "agent_skips_store__cursor-hooks__claude-haiku-4:turn-1:assistant"
           }
         ],
-        "idempotency_key": "<id:5>"
-      }
-    },
-    {
-      "method": "POST",
-      "endpoint": "/store",
-      "body": {
-        "entities": [
-          {
-            "client_name": "Cursor",
-            "conversation_id": "<id:1>",
-            "cwd": "<env>",
-            "data_source": "cursor-hook",
-            "entity_type": "conversation",
-            "harness": "cursor-hook",
-            "hook_event": "stop_backfill",
-            "repository_name": "<env>",
-            "repository_remote": "<env>",
-            "repository_root": "<env>",
-            "scope_summary": "<env>",
-            "thread_kind": "human_agent",
-            "title": "<env>",
-            "workspace_kind": "<env>"
-          }
-        ],
         "idempotency_key": "<id:6>"
       }
     },
@@ -124,10 +129,10 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
-            "diagnosis_confidence": "high",
+            "diagnosis_confidence": "medium",
             "ended_at": "<ts>",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -150,11 +155,10 @@
                 "reminder_hooks": [],
                 "reminder_injected": false,
                 "tool_invocation_count": 0,
-                "user_message_stored": false
+                "user_message_stored": true
               }
             },
             "missed_steps": [
-              "user_message_store",
               "user_phase_store"
             ],
             "model": "claude-haiku-4",
@@ -171,12 +175,12 @@
             "status": "backfilled_by_hook",
             "store_structured_calls": 0,
             "tool_invocation_count": 0,
-            "turn_id": "<id:3>",
+            "turn_id": "<id:4>",
             "turn_key": "agent_skips_store__cursor-hooks__claude-haiku-4:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     }
   ],

--- a/tests/__snapshots__/agentic_eval/agent_skips_store__cursor-hooks__claude-sonnet-4.5.snap.json
+++ b/tests/__snapshots__/agentic_eval/agent_skips_store__cursor-hooks__claude-sonnet-4.5.snap.json
@@ -2,6 +2,33 @@
   "requests": [
     {
       "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_3",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_9",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_14",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
       "endpoint": "/store",
       "body": {
         "entities": [
@@ -50,7 +77,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
@@ -63,12 +90,15 @@
             "model": "claude-sonnet-4.5",
             "session_id": "<id:1>",
             "started_at": "<ts>",
-            "turn_id": "<id:3>",
+            "stored_entity_ids": [
+              "ent_mock_3"
+            ],
+            "turn_id": "<id:4>",
             "turn_key": "agent_skips_store__cursor-hooks__claude-sonnet-4.5:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     },
     {
@@ -89,31 +119,6 @@
             "turn_key": "agent_skips_store__cursor-hooks__claude-sonnet-4.5:turn-1:assistant"
           }
         ],
-        "idempotency_key": "<id:5>"
-      }
-    },
-    {
-      "method": "POST",
-      "endpoint": "/store",
-      "body": {
-        "entities": [
-          {
-            "client_name": "Cursor",
-            "conversation_id": "<id:1>",
-            "cwd": "<env>",
-            "data_source": "cursor-hook",
-            "entity_type": "conversation",
-            "harness": "cursor-hook",
-            "hook_event": "stop_backfill",
-            "repository_name": "<env>",
-            "repository_remote": "<env>",
-            "repository_root": "<env>",
-            "scope_summary": "<env>",
-            "thread_kind": "human_agent",
-            "title": "<env>",
-            "workspace_kind": "<env>"
-          }
-        ],
         "idempotency_key": "<id:6>"
       }
     },
@@ -124,10 +129,10 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
-            "diagnosis_confidence": "high",
+            "diagnosis_confidence": "medium",
             "ended_at": "<ts>",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -150,11 +155,10 @@
                 "reminder_hooks": [],
                 "reminder_injected": false,
                 "tool_invocation_count": 0,
-                "user_message_stored": false
+                "user_message_stored": true
               }
             },
             "missed_steps": [
-              "user_message_store",
               "user_phase_store"
             ],
             "model": "claude-sonnet-4.5",
@@ -171,12 +175,12 @@
             "status": "backfilled_by_hook",
             "store_structured_calls": 0,
             "tool_invocation_count": 0,
-            "turn_id": "<id:3>",
+            "turn_id": "<id:4>",
             "turn_key": "agent_skips_store__cursor-hooks__claude-sonnet-4.5:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     }
   ],

--- a/tests/__snapshots__/agentic_eval/agent_skips_store__cursor-hooks__composer-2.snap.json
+++ b/tests/__snapshots__/agentic_eval/agent_skips_store__cursor-hooks__composer-2.snap.json
@@ -2,6 +2,33 @@
   "requests": [
     {
       "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_3",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_9",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_14",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
       "endpoint": "/store",
       "body": {
         "entities": [
@@ -50,7 +77,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
@@ -63,12 +90,15 @@
             "model": "composer-2",
             "session_id": "<id:1>",
             "started_at": "<ts>",
-            "turn_id": "<id:3>",
+            "stored_entity_ids": [
+              "ent_mock_3"
+            ],
+            "turn_id": "<id:4>",
             "turn_key": "agent_skips_store__cursor-hooks__composer-2:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     },
     {
@@ -89,31 +119,6 @@
             "turn_key": "agent_skips_store__cursor-hooks__composer-2:turn-1:assistant"
           }
         ],
-        "idempotency_key": "<id:5>"
-      }
-    },
-    {
-      "method": "POST",
-      "endpoint": "/store",
-      "body": {
-        "entities": [
-          {
-            "client_name": "Cursor",
-            "conversation_id": "<id:1>",
-            "cwd": "<env>",
-            "data_source": "cursor-hook",
-            "entity_type": "conversation",
-            "harness": "cursor-hook",
-            "hook_event": "stop_backfill",
-            "repository_name": "<env>",
-            "repository_remote": "<env>",
-            "repository_root": "<env>",
-            "scope_summary": "<env>",
-            "thread_kind": "human_agent",
-            "title": "<env>",
-            "workspace_kind": "<env>"
-          }
-        ],
         "idempotency_key": "<id:6>"
       }
     },
@@ -124,10 +129,10 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
-            "diagnosis_confidence": "high",
+            "diagnosis_confidence": "medium",
             "ended_at": "<ts>",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -150,11 +155,10 @@
                 "reminder_hooks": [],
                 "reminder_injected": false,
                 "tool_invocation_count": 0,
-                "user_message_stored": false
+                "user_message_stored": true
               }
             },
             "missed_steps": [
-              "user_message_store",
               "user_phase_store"
             ],
             "model": "composer-2",
@@ -171,12 +175,12 @@
             "status": "backfilled_by_hook",
             "store_structured_calls": 0,
             "tool_invocation_count": 0,
-            "turn_id": "<id:3>",
+            "turn_id": "<id:4>",
             "turn_key": "agent_skips_store__cursor-hooks__composer-2:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     }
   ],

--- a/tests/__snapshots__/agentic_eval/agent_skips_store__cursor-hooks__gpt-5.5-fast.snap.json
+++ b/tests/__snapshots__/agentic_eval/agent_skips_store__cursor-hooks__gpt-5.5-fast.snap.json
@@ -2,6 +2,33 @@
   "requests": [
     {
       "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_3",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_9",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_14",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
       "endpoint": "/store",
       "body": {
         "entities": [
@@ -50,7 +77,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
@@ -63,12 +90,15 @@
             "model": "gpt-5.5-fast",
             "session_id": "<id:1>",
             "started_at": "<ts>",
-            "turn_id": "<id:3>",
+            "stored_entity_ids": [
+              "ent_mock_3"
+            ],
+            "turn_id": "<id:4>",
             "turn_key": "agent_skips_store__cursor-hooks__gpt-5.5-fast:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     },
     {
@@ -89,31 +119,6 @@
             "turn_key": "agent_skips_store__cursor-hooks__gpt-5.5-fast:turn-1:assistant"
           }
         ],
-        "idempotency_key": "<id:5>"
-      }
-    },
-    {
-      "method": "POST",
-      "endpoint": "/store",
-      "body": {
-        "entities": [
-          {
-            "client_name": "Cursor",
-            "conversation_id": "<id:1>",
-            "cwd": "<env>",
-            "data_source": "cursor-hook",
-            "entity_type": "conversation",
-            "harness": "cursor-hook",
-            "hook_event": "stop_backfill",
-            "repository_name": "<env>",
-            "repository_remote": "<env>",
-            "repository_root": "<env>",
-            "scope_summary": "<env>",
-            "thread_kind": "human_agent",
-            "title": "<env>",
-            "workspace_kind": "<env>"
-          }
-        ],
         "idempotency_key": "<id:6>"
       }
     },
@@ -124,10 +129,10 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
-            "diagnosis_confidence": "high",
+            "diagnosis_confidence": "medium",
             "ended_at": "<ts>",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -150,11 +155,10 @@
                 "reminder_hooks": [],
                 "reminder_injected": false,
                 "tool_invocation_count": 0,
-                "user_message_stored": false
+                "user_message_stored": true
               }
             },
             "missed_steps": [
-              "user_message_store",
               "user_phase_store"
             ],
             "model": "gpt-5.5-fast",
@@ -171,12 +175,12 @@
             "status": "backfilled_by_hook",
             "store_structured_calls": 0,
             "tool_invocation_count": 0,
-            "turn_id": "<id:3>",
+            "turn_id": "<id:4>",
             "turn_key": "agent_skips_store__cursor-hooks__gpt-5.5-fast:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     }
   ],

--- a/tests/__snapshots__/agentic_eval/agent_skips_store__cursor-hooks__gpt-5.5-medium.snap.json
+++ b/tests/__snapshots__/agentic_eval/agent_skips_store__cursor-hooks__gpt-5.5-medium.snap.json
@@ -2,6 +2,33 @@
   "requests": [
     {
       "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_3",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_9",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_14",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
       "endpoint": "/store",
       "body": {
         "entities": [
@@ -50,7 +77,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
@@ -63,12 +90,15 @@
             "model": "gpt-5.5-medium",
             "session_id": "<id:1>",
             "started_at": "<ts>",
-            "turn_id": "<id:3>",
+            "stored_entity_ids": [
+              "ent_mock_3"
+            ],
+            "turn_id": "<id:4>",
             "turn_key": "agent_skips_store__cursor-hooks__gpt-5.5-medium:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     },
     {
@@ -89,31 +119,6 @@
             "turn_key": "agent_skips_store__cursor-hooks__gpt-5.5-medium:turn-1:assistant"
           }
         ],
-        "idempotency_key": "<id:5>"
-      }
-    },
-    {
-      "method": "POST",
-      "endpoint": "/store",
-      "body": {
-        "entities": [
-          {
-            "client_name": "Cursor",
-            "conversation_id": "<id:1>",
-            "cwd": "<env>",
-            "data_source": "cursor-hook",
-            "entity_type": "conversation",
-            "harness": "cursor-hook",
-            "hook_event": "stop_backfill",
-            "repository_name": "<env>",
-            "repository_remote": "<env>",
-            "repository_root": "<env>",
-            "scope_summary": "<env>",
-            "thread_kind": "human_agent",
-            "title": "<env>",
-            "workspace_kind": "<env>"
-          }
-        ],
         "idempotency_key": "<id:6>"
       }
     },
@@ -124,10 +129,10 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
-            "diagnosis_confidence": "high",
+            "diagnosis_confidence": "medium",
             "ended_at": "<ts>",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -150,11 +155,10 @@
                 "reminder_hooks": [],
                 "reminder_injected": false,
                 "tool_invocation_count": 0,
-                "user_message_stored": false
+                "user_message_stored": true
               }
             },
             "missed_steps": [
-              "user_message_store",
               "user_phase_store"
             ],
             "model": "gpt-5.5-medium",
@@ -171,12 +175,12 @@
             "status": "backfilled_by_hook",
             "store_structured_calls": 0,
             "tool_invocation_count": 0,
-            "turn_id": "<id:3>",
+            "turn_id": "<id:4>",
             "turn_key": "agent_skips_store__cursor-hooks__gpt-5.5-medium:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     }
   ],

--- a/tests/__snapshots__/agentic_eval/agent_skips_store_after_reminder__cursor-hooks__claude-haiku-4.snap.json
+++ b/tests/__snapshots__/agentic_eval/agent_skips_store_after_reminder__cursor-hooks__claude-haiku-4.snap.json
@@ -2,6 +2,33 @@
   "requests": [
     {
       "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "REFERS_TO",
+        "source_entity_id": "ent_mock_4",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_8",
+        "target_entity_id": "ent_mock_11"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_15",
+        "target_entity_id": "ent_mock_11"
+      }
+    },
+    {
+      "method": "POST",
       "endpoint": "/session/profile",
       "body": {
         "connection_id": null,
@@ -53,6 +80,9 @@
             "retrieve_calls": 0,
             "session_id": "<id:1>",
             "store_structured_calls": 0,
+            "stored_entity_ids": [
+              "ent_mock_1"
+            ],
             "tool_invocation_count": 1,
             "turn_id": "<id:3>",
             "turn_key": "agent_skips_store_after_reminder__cursor-hooks__claude-haiku-4:turn-1",
@@ -115,7 +145,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:7>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
             "diagnosis_confidence": "high",

--- a/tests/__snapshots__/agentic_eval/agent_skips_store_after_reminder__cursor-hooks__claude-sonnet-4.5.snap.json
+++ b/tests/__snapshots__/agentic_eval/agent_skips_store_after_reminder__cursor-hooks__claude-sonnet-4.5.snap.json
@@ -2,6 +2,33 @@
   "requests": [
     {
       "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "REFERS_TO",
+        "source_entity_id": "ent_mock_4",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_8",
+        "target_entity_id": "ent_mock_11"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_15",
+        "target_entity_id": "ent_mock_11"
+      }
+    },
+    {
+      "method": "POST",
       "endpoint": "/session/profile",
       "body": {
         "connection_id": null,
@@ -53,6 +80,9 @@
             "retrieve_calls": 0,
             "session_id": "<id:1>",
             "store_structured_calls": 0,
+            "stored_entity_ids": [
+              "ent_mock_1"
+            ],
             "tool_invocation_count": 1,
             "turn_id": "<id:3>",
             "turn_key": "agent_skips_store_after_reminder__cursor-hooks__claude-sonnet-4.5:turn-1",
@@ -115,7 +145,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:7>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
             "diagnosis_confidence": "high",

--- a/tests/__snapshots__/agentic_eval/agent_skips_store_after_reminder__cursor-hooks__composer-2.snap.json
+++ b/tests/__snapshots__/agentic_eval/agent_skips_store_after_reminder__cursor-hooks__composer-2.snap.json
@@ -2,6 +2,33 @@
   "requests": [
     {
       "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "REFERS_TO",
+        "source_entity_id": "ent_mock_4",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_8",
+        "target_entity_id": "ent_mock_11"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_15",
+        "target_entity_id": "ent_mock_11"
+      }
+    },
+    {
+      "method": "POST",
       "endpoint": "/session/profile",
       "body": {
         "connection_id": null,
@@ -53,6 +80,9 @@
             "retrieve_calls": 0,
             "session_id": "<id:1>",
             "store_structured_calls": 0,
+            "stored_entity_ids": [
+              "ent_mock_1"
+            ],
             "tool_invocation_count": 1,
             "turn_id": "<id:3>",
             "turn_key": "agent_skips_store_after_reminder__cursor-hooks__composer-2:turn-1",
@@ -115,7 +145,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:7>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
             "diagnosis_confidence": "high",

--- a/tests/__snapshots__/agentic_eval/agent_skips_store_after_reminder__cursor-hooks__gpt-5.5-fast.snap.json
+++ b/tests/__snapshots__/agentic_eval/agent_skips_store_after_reminder__cursor-hooks__gpt-5.5-fast.snap.json
@@ -2,6 +2,33 @@
   "requests": [
     {
       "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "REFERS_TO",
+        "source_entity_id": "ent_mock_4",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_8",
+        "target_entity_id": "ent_mock_11"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_15",
+        "target_entity_id": "ent_mock_11"
+      }
+    },
+    {
+      "method": "POST",
       "endpoint": "/session/profile",
       "body": {
         "connection_id": null,
@@ -53,6 +80,9 @@
             "retrieve_calls": 0,
             "session_id": "<id:1>",
             "store_structured_calls": 0,
+            "stored_entity_ids": [
+              "ent_mock_1"
+            ],
             "tool_invocation_count": 1,
             "turn_id": "<id:3>",
             "turn_key": "agent_skips_store_after_reminder__cursor-hooks__gpt-5.5-fast:turn-1",
@@ -115,7 +145,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:7>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
             "diagnosis_confidence": "high",

--- a/tests/__snapshots__/agentic_eval/agent_skips_store_after_reminder__cursor-hooks__gpt-5.5-medium.snap.json
+++ b/tests/__snapshots__/agentic_eval/agent_skips_store_after_reminder__cursor-hooks__gpt-5.5-medium.snap.json
@@ -2,6 +2,33 @@
   "requests": [
     {
       "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "REFERS_TO",
+        "source_entity_id": "ent_mock_4",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_8",
+        "target_entity_id": "ent_mock_11"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_15",
+        "target_entity_id": "ent_mock_11"
+      }
+    },
+    {
+      "method": "POST",
       "endpoint": "/session/profile",
       "body": {
         "connection_id": null,
@@ -53,6 +80,9 @@
             "retrieve_calls": 0,
             "session_id": "<id:1>",
             "store_structured_calls": 0,
+            "stored_entity_ids": [
+              "ent_mock_1"
+            ],
             "tool_invocation_count": 1,
             "turn_id": "<id:3>",
             "turn_key": "agent_skips_store_after_reminder__cursor-hooks__gpt-5.5-medium:turn-1",
@@ -115,7 +145,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:7>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
             "diagnosis_confidence": "high",

--- a/tests/__snapshots__/agentic_eval/attachment_with_extracted_entities__cursor-hooks__claude-haiku-4.snap.json
+++ b/tests/__snapshots__/agentic_eval/attachment_with_extracted_entities__cursor-hooks__claude-haiku-4.snap.json
@@ -2,6 +2,33 @@
   "requests": [
     {
       "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_3",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_9",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_14",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
       "endpoint": "/store",
       "body": {
         "entities": [
@@ -50,7 +77,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
@@ -63,12 +90,15 @@
             "model": "claude-haiku-4",
             "session_id": "<id:1>",
             "started_at": "<ts>",
-            "turn_id": "<id:3>",
+            "stored_entity_ids": [
+              "ent_mock_3"
+            ],
+            "turn_id": "<id:4>",
             "turn_key": "attachment_with_extracted_entities__cursor-hooks__claude-haiku-4:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     },
     {
@@ -89,31 +119,6 @@
             "turn_key": "attachment_with_extracted_entities__cursor-hooks__claude-haiku-4:turn-1:assistant"
           }
         ],
-        "idempotency_key": "<id:5>"
-      }
-    },
-    {
-      "method": "POST",
-      "endpoint": "/store",
-      "body": {
-        "entities": [
-          {
-            "client_name": "Cursor",
-            "conversation_id": "<id:1>",
-            "cwd": "<env>",
-            "data_source": "cursor-hook",
-            "entity_type": "conversation",
-            "harness": "cursor-hook",
-            "hook_event": "stop_backfill",
-            "repository_name": "<env>",
-            "repository_remote": "<env>",
-            "repository_root": "<env>",
-            "scope_summary": "<env>",
-            "thread_kind": "human_agent",
-            "title": "<env>",
-            "workspace_kind": "<env>"
-          }
-        ],
         "idempotency_key": "<id:6>"
       }
     },
@@ -124,10 +129,10 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
-            "diagnosis_confidence": "high",
+            "diagnosis_confidence": "medium",
             "ended_at": "<ts>",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -150,11 +155,10 @@
                 "reminder_hooks": [],
                 "reminder_injected": false,
                 "tool_invocation_count": 0,
-                "user_message_stored": false
+                "user_message_stored": true
               }
             },
             "missed_steps": [
-              "user_message_store",
               "user_phase_store"
             ],
             "model": "claude-haiku-4",
@@ -171,12 +175,12 @@
             "status": "backfilled_by_hook",
             "store_structured_calls": 0,
             "tool_invocation_count": 0,
-            "turn_id": "<id:3>",
+            "turn_id": "<id:4>",
             "turn_key": "attachment_with_extracted_entities__cursor-hooks__claude-haiku-4:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     }
   ],

--- a/tests/__snapshots__/agentic_eval/attachment_with_extracted_entities__cursor-hooks__claude-sonnet-4.5.snap.json
+++ b/tests/__snapshots__/agentic_eval/attachment_with_extracted_entities__cursor-hooks__claude-sonnet-4.5.snap.json
@@ -2,6 +2,33 @@
   "requests": [
     {
       "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_3",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_9",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_14",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
       "endpoint": "/store",
       "body": {
         "entities": [
@@ -50,7 +77,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
@@ -63,12 +90,15 @@
             "model": "claude-sonnet-4.5",
             "session_id": "<id:1>",
             "started_at": "<ts>",
-            "turn_id": "<id:3>",
+            "stored_entity_ids": [
+              "ent_mock_3"
+            ],
+            "turn_id": "<id:4>",
             "turn_key": "attachment_with_extracted_entities__cursor-hooks__claude-sonnet-4.5:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     },
     {
@@ -89,31 +119,6 @@
             "turn_key": "attachment_with_extracted_entities__cursor-hooks__claude-sonnet-4.5:turn-1:assistant"
           }
         ],
-        "idempotency_key": "<id:5>"
-      }
-    },
-    {
-      "method": "POST",
-      "endpoint": "/store",
-      "body": {
-        "entities": [
-          {
-            "client_name": "Cursor",
-            "conversation_id": "<id:1>",
-            "cwd": "<env>",
-            "data_source": "cursor-hook",
-            "entity_type": "conversation",
-            "harness": "cursor-hook",
-            "hook_event": "stop_backfill",
-            "repository_name": "<env>",
-            "repository_remote": "<env>",
-            "repository_root": "<env>",
-            "scope_summary": "<env>",
-            "thread_kind": "human_agent",
-            "title": "<env>",
-            "workspace_kind": "<env>"
-          }
-        ],
         "idempotency_key": "<id:6>"
       }
     },
@@ -124,10 +129,10 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
-            "diagnosis_confidence": "high",
+            "diagnosis_confidence": "medium",
             "ended_at": "<ts>",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -150,11 +155,10 @@
                 "reminder_hooks": [],
                 "reminder_injected": false,
                 "tool_invocation_count": 0,
-                "user_message_stored": false
+                "user_message_stored": true
               }
             },
             "missed_steps": [
-              "user_message_store",
               "user_phase_store"
             ],
             "model": "claude-sonnet-4.5",
@@ -171,12 +175,12 @@
             "status": "backfilled_by_hook",
             "store_structured_calls": 0,
             "tool_invocation_count": 0,
-            "turn_id": "<id:3>",
+            "turn_id": "<id:4>",
             "turn_key": "attachment_with_extracted_entities__cursor-hooks__claude-sonnet-4.5:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     }
   ],

--- a/tests/__snapshots__/agentic_eval/attachment_with_extracted_entities__cursor-hooks__composer-2.snap.json
+++ b/tests/__snapshots__/agentic_eval/attachment_with_extracted_entities__cursor-hooks__composer-2.snap.json
@@ -2,6 +2,33 @@
   "requests": [
     {
       "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_3",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_9",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_14",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
       "endpoint": "/store",
       "body": {
         "entities": [
@@ -50,7 +77,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
@@ -63,12 +90,15 @@
             "model": "composer-2",
             "session_id": "<id:1>",
             "started_at": "<ts>",
-            "turn_id": "<id:3>",
+            "stored_entity_ids": [
+              "ent_mock_3"
+            ],
+            "turn_id": "<id:4>",
             "turn_key": "attachment_with_extracted_entities__cursor-hooks__composer-2:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     },
     {
@@ -89,31 +119,6 @@
             "turn_key": "attachment_with_extracted_entities__cursor-hooks__composer-2:turn-1:assistant"
           }
         ],
-        "idempotency_key": "<id:5>"
-      }
-    },
-    {
-      "method": "POST",
-      "endpoint": "/store",
-      "body": {
-        "entities": [
-          {
-            "client_name": "Cursor",
-            "conversation_id": "<id:1>",
-            "cwd": "<env>",
-            "data_source": "cursor-hook",
-            "entity_type": "conversation",
-            "harness": "cursor-hook",
-            "hook_event": "stop_backfill",
-            "repository_name": "<env>",
-            "repository_remote": "<env>",
-            "repository_root": "<env>",
-            "scope_summary": "<env>",
-            "thread_kind": "human_agent",
-            "title": "<env>",
-            "workspace_kind": "<env>"
-          }
-        ],
         "idempotency_key": "<id:6>"
       }
     },
@@ -124,10 +129,10 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
-            "diagnosis_confidence": "high",
+            "diagnosis_confidence": "medium",
             "ended_at": "<ts>",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -150,11 +155,10 @@
                 "reminder_hooks": [],
                 "reminder_injected": false,
                 "tool_invocation_count": 0,
-                "user_message_stored": false
+                "user_message_stored": true
               }
             },
             "missed_steps": [
-              "user_message_store",
               "user_phase_store"
             ],
             "model": "composer-2",
@@ -171,12 +175,12 @@
             "status": "backfilled_by_hook",
             "store_structured_calls": 0,
             "tool_invocation_count": 0,
-            "turn_id": "<id:3>",
+            "turn_id": "<id:4>",
             "turn_key": "attachment_with_extracted_entities__cursor-hooks__composer-2:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     }
   ],

--- a/tests/__snapshots__/agentic_eval/attachment_with_extracted_entities__cursor-hooks__gpt-5.5-fast.snap.json
+++ b/tests/__snapshots__/agentic_eval/attachment_with_extracted_entities__cursor-hooks__gpt-5.5-fast.snap.json
@@ -2,6 +2,33 @@
   "requests": [
     {
       "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_3",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_9",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_14",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
       "endpoint": "/store",
       "body": {
         "entities": [
@@ -50,7 +77,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
@@ -63,12 +90,15 @@
             "model": "gpt-5.5-fast",
             "session_id": "<id:1>",
             "started_at": "<ts>",
-            "turn_id": "<id:3>",
+            "stored_entity_ids": [
+              "ent_mock_3"
+            ],
+            "turn_id": "<id:4>",
             "turn_key": "attachment_with_extracted_entities__cursor-hooks__gpt-5.5-fast:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     },
     {
@@ -89,31 +119,6 @@
             "turn_key": "attachment_with_extracted_entities__cursor-hooks__gpt-5.5-fast:turn-1:assistant"
           }
         ],
-        "idempotency_key": "<id:5>"
-      }
-    },
-    {
-      "method": "POST",
-      "endpoint": "/store",
-      "body": {
-        "entities": [
-          {
-            "client_name": "Cursor",
-            "conversation_id": "<id:1>",
-            "cwd": "<env>",
-            "data_source": "cursor-hook",
-            "entity_type": "conversation",
-            "harness": "cursor-hook",
-            "hook_event": "stop_backfill",
-            "repository_name": "<env>",
-            "repository_remote": "<env>",
-            "repository_root": "<env>",
-            "scope_summary": "<env>",
-            "thread_kind": "human_agent",
-            "title": "<env>",
-            "workspace_kind": "<env>"
-          }
-        ],
         "idempotency_key": "<id:6>"
       }
     },
@@ -124,10 +129,10 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
-            "diagnosis_confidence": "high",
+            "diagnosis_confidence": "medium",
             "ended_at": "<ts>",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -150,11 +155,10 @@
                 "reminder_hooks": [],
                 "reminder_injected": false,
                 "tool_invocation_count": 0,
-                "user_message_stored": false
+                "user_message_stored": true
               }
             },
             "missed_steps": [
-              "user_message_store",
               "user_phase_store"
             ],
             "model": "gpt-5.5-fast",
@@ -171,12 +175,12 @@
             "status": "backfilled_by_hook",
             "store_structured_calls": 0,
             "tool_invocation_count": 0,
-            "turn_id": "<id:3>",
+            "turn_id": "<id:4>",
             "turn_key": "attachment_with_extracted_entities__cursor-hooks__gpt-5.5-fast:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     }
   ],

--- a/tests/__snapshots__/agentic_eval/attachment_with_extracted_entities__cursor-hooks__gpt-5.5-medium.snap.json
+++ b/tests/__snapshots__/agentic_eval/attachment_with_extracted_entities__cursor-hooks__gpt-5.5-medium.snap.json
@@ -2,6 +2,33 @@
   "requests": [
     {
       "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_3",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_9",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_14",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
       "endpoint": "/store",
       "body": {
         "entities": [
@@ -50,7 +77,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
@@ -63,12 +90,15 @@
             "model": "gpt-5.5-medium",
             "session_id": "<id:1>",
             "started_at": "<ts>",
-            "turn_id": "<id:3>",
+            "stored_entity_ids": [
+              "ent_mock_3"
+            ],
+            "turn_id": "<id:4>",
             "turn_key": "attachment_with_extracted_entities__cursor-hooks__gpt-5.5-medium:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     },
     {
@@ -89,31 +119,6 @@
             "turn_key": "attachment_with_extracted_entities__cursor-hooks__gpt-5.5-medium:turn-1:assistant"
           }
         ],
-        "idempotency_key": "<id:5>"
-      }
-    },
-    {
-      "method": "POST",
-      "endpoint": "/store",
-      "body": {
-        "entities": [
-          {
-            "client_name": "Cursor",
-            "conversation_id": "<id:1>",
-            "cwd": "<env>",
-            "data_source": "cursor-hook",
-            "entity_type": "conversation",
-            "harness": "cursor-hook",
-            "hook_event": "stop_backfill",
-            "repository_name": "<env>",
-            "repository_remote": "<env>",
-            "repository_root": "<env>",
-            "scope_summary": "<env>",
-            "thread_kind": "human_agent",
-            "title": "<env>",
-            "workspace_kind": "<env>"
-          }
-        ],
         "idempotency_key": "<id:6>"
       }
     },
@@ -124,10 +129,10 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
-            "diagnosis_confidence": "high",
+            "diagnosis_confidence": "medium",
             "ended_at": "<ts>",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -150,11 +155,10 @@
                 "reminder_hooks": [],
                 "reminder_injected": false,
                 "tool_invocation_count": 0,
-                "user_message_stored": false
+                "user_message_stored": true
               }
             },
             "missed_steps": [
-              "user_message_store",
               "user_phase_store"
             ],
             "model": "gpt-5.5-medium",
@@ -171,12 +175,12 @@
             "status": "backfilled_by_hook",
             "store_structured_calls": 0,
             "tool_invocation_count": 0,
-            "turn_id": "<id:3>",
+            "turn_id": "<id:4>",
             "turn_key": "attachment_with_extracted_entities__cursor-hooks__gpt-5.5-medium:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     }
   ],

--- a/tests/__snapshots__/agentic_eval/multi_tool_then_reply__cursor-hooks__claude-haiku-4.snap.json
+++ b/tests/__snapshots__/agentic_eval/multi_tool_then_reply__cursor-hooks__claude-haiku-4.snap.json
@@ -2,6 +2,51 @@
   "requests": [
     {
       "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "REFERS_TO",
+        "source_entity_id": "ent_mock_12",
+        "target_entity_id": "ent_mock_9"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "REFERS_TO",
+        "source_entity_id": "ent_mock_19",
+        "target_entity_id": "ent_mock_16"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_3",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_23",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_28",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
       "endpoint": "/store",
       "body": {
         "entities": [
@@ -50,7 +95,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
@@ -63,12 +108,15 @@
             "model": "claude-haiku-4",
             "session_id": "<id:1>",
             "started_at": "<ts>",
-            "turn_id": "<id:3>",
+            "stored_entity_ids": [
+              "ent_mock_3"
+            ],
+            "turn_id": "<id:4>",
             "turn_key": "multi_tool_then_reply__cursor-hooks__claude-haiku-4:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     },
     {
@@ -88,59 +136,6 @@
             "output_summary": "{\"ok\":true,\"bytes_read\":1024}",
             "status": null,
             "tool_name": "Read",
-            "turn_key": "multi_tool_then_reply__cursor-hooks__claude-haiku-4:turn-1"
-          }
-        ],
-        "idempotency_key": "<id:5>"
-      }
-    },
-    {
-      "method": "POST",
-      "endpoint": "/store",
-      "body": {
-        "entities": [
-          {
-            "context_source": "cursor-hook",
-            "cwd": "<env>",
-            "data_source": "cursor-hook",
-            "entity_type": "conversation_turn",
-            "git_branch": "<env>",
-            "harness": "cursor",
-            "hook_event": "post_tool_use",
-            "hook_events": [
-              "post_tool_use"
-            ],
-            "model": "claude-haiku-4",
-            "neotoma_tool_failures": 0,
-            "retrieve_calls": 0,
-            "session_id": "<id:1>",
-            "store_structured_calls": 0,
-            "tool_invocation_count": 1,
-            "turn_id": "<id:3>",
-            "turn_key": "multi_tool_then_reply__cursor-hooks__claude-haiku-4:turn-1",
-            "working_directory": "<env>"
-          }
-        ],
-        "idempotency_key": "<id:4>"
-      }
-    },
-    {
-      "method": "POST",
-      "endpoint": "/store",
-      "body": {
-        "entities": [
-          {
-            "cwd": "<env>",
-            "data_source": "cursor-hook",
-            "entity_type": "tool_invocation",
-            "harness": "cursor",
-            "has_error": false,
-            "hook_event": "postToolUse",
-            "input_summary": "{\"pattern\":\"createSession\"}",
-            "invoked_at": "<ts>",
-            "output_summary": "{\"ok\":true,\"matches\":3}",
-            "status": null,
-            "tool_name": "Grep",
             "turn_key": "multi_tool_then_reply__cursor-hooks__claude-haiku-4:turn-1"
           }
         ],
@@ -168,13 +163,72 @@
             "retrieve_calls": 0,
             "session_id": "<id:1>",
             "store_structured_calls": 0,
-            "tool_invocation_count": 2,
-            "turn_id": "<id:3>",
+            "stored_entity_ids": [
+              "ent_mock_9"
+            ],
+            "tool_invocation_count": 1,
+            "turn_id": "<id:4>",
             "turn_key": "multi_tool_then_reply__cursor-hooks__claude-haiku-4:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/store",
+      "body": {
+        "entities": [
+          {
+            "cwd": "<env>",
+            "data_source": "cursor-hook",
+            "entity_type": "tool_invocation",
+            "harness": "cursor",
+            "has_error": false,
+            "hook_event": "postToolUse",
+            "input_summary": "{\"pattern\":\"createSession\"}",
+            "invoked_at": "<ts>",
+            "output_summary": "{\"ok\":true,\"matches\":3}",
+            "status": null,
+            "tool_name": "Grep",
+            "turn_key": "multi_tool_then_reply__cursor-hooks__claude-haiku-4:turn-1"
+          }
+        ],
+        "idempotency_key": "<id:7>"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/store",
+      "body": {
+        "entities": [
+          {
+            "context_source": "cursor-hook",
+            "cwd": "<env>",
+            "data_source": "cursor-hook",
+            "entity_type": "conversation_turn",
+            "git_branch": "<env>",
+            "harness": "cursor",
+            "hook_event": "post_tool_use",
+            "hook_events": [
+              "post_tool_use"
+            ],
+            "model": "claude-haiku-4",
+            "neotoma_tool_failures": 0,
+            "retrieve_calls": 0,
+            "session_id": "<id:1>",
+            "store_structured_calls": 0,
+            "stored_entity_ids": [
+              "ent_mock_16"
+            ],
+            "tool_invocation_count": 2,
+            "turn_id": "<id:4>",
+            "turn_key": "multi_tool_then_reply__cursor-hooks__claude-haiku-4:turn-1",
+            "working_directory": "<env>"
+          }
+        ],
+        "idempotency_key": "<id:5>"
       }
     },
     {
@@ -195,31 +249,6 @@
             "turn_key": "multi_tool_then_reply__cursor-hooks__claude-haiku-4:turn-1:assistant"
           }
         ],
-        "idempotency_key": "<id:7>"
-      }
-    },
-    {
-      "method": "POST",
-      "endpoint": "/store",
-      "body": {
-        "entities": [
-          {
-            "client_name": "Cursor",
-            "conversation_id": "<id:1>",
-            "cwd": "<env>",
-            "data_source": "cursor-hook",
-            "entity_type": "conversation",
-            "harness": "cursor-hook",
-            "hook_event": "stop_backfill",
-            "repository_name": "<env>",
-            "repository_remote": "<env>",
-            "repository_root": "<env>",
-            "scope_summary": "<env>",
-            "thread_kind": "human_agent",
-            "title": "<env>",
-            "workspace_kind": "<env>"
-          }
-        ],
         "idempotency_key": "<id:8>"
       }
     },
@@ -230,7 +259,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
             "diagnosis_confidence": "high",
@@ -258,11 +287,10 @@
                 ],
                 "reminder_injected": true,
                 "tool_invocation_count": 2,
-                "user_message_stored": false
+                "user_message_stored": true
               }
             },
             "missed_steps": [
-              "user_message_store",
               "user_phase_store"
             ],
             "model": "claude-haiku-4",
@@ -279,12 +307,12 @@
             "status": "backfilled_by_hook",
             "store_structured_calls": 0,
             "tool_invocation_count": 2,
-            "turn_id": "<id:3>",
+            "turn_id": "<id:4>",
             "turn_key": "multi_tool_then_reply__cursor-hooks__claude-haiku-4:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     }
   ],

--- a/tests/__snapshots__/agentic_eval/multi_tool_then_reply__cursor-hooks__claude-sonnet-4.5.snap.json
+++ b/tests/__snapshots__/agentic_eval/multi_tool_then_reply__cursor-hooks__claude-sonnet-4.5.snap.json
@@ -2,6 +2,51 @@
   "requests": [
     {
       "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "REFERS_TO",
+        "source_entity_id": "ent_mock_12",
+        "target_entity_id": "ent_mock_9"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "REFERS_TO",
+        "source_entity_id": "ent_mock_19",
+        "target_entity_id": "ent_mock_16"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_3",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_23",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_28",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
       "endpoint": "/store",
       "body": {
         "entities": [
@@ -50,7 +95,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
@@ -63,12 +108,15 @@
             "model": "claude-sonnet-4.5",
             "session_id": "<id:1>",
             "started_at": "<ts>",
-            "turn_id": "<id:3>",
+            "stored_entity_ids": [
+              "ent_mock_3"
+            ],
+            "turn_id": "<id:4>",
             "turn_key": "multi_tool_then_reply__cursor-hooks__claude-sonnet-4.5:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     },
     {
@@ -88,59 +136,6 @@
             "output_summary": "{\"ok\":true,\"bytes_read\":1024}",
             "status": null,
             "tool_name": "Read",
-            "turn_key": "multi_tool_then_reply__cursor-hooks__claude-sonnet-4.5:turn-1"
-          }
-        ],
-        "idempotency_key": "<id:5>"
-      }
-    },
-    {
-      "method": "POST",
-      "endpoint": "/store",
-      "body": {
-        "entities": [
-          {
-            "context_source": "cursor-hook",
-            "cwd": "<env>",
-            "data_source": "cursor-hook",
-            "entity_type": "conversation_turn",
-            "git_branch": "<env>",
-            "harness": "cursor",
-            "hook_event": "post_tool_use",
-            "hook_events": [
-              "post_tool_use"
-            ],
-            "model": "claude-sonnet-4.5",
-            "neotoma_tool_failures": 0,
-            "retrieve_calls": 0,
-            "session_id": "<id:1>",
-            "store_structured_calls": 0,
-            "tool_invocation_count": 1,
-            "turn_id": "<id:3>",
-            "turn_key": "multi_tool_then_reply__cursor-hooks__claude-sonnet-4.5:turn-1",
-            "working_directory": "<env>"
-          }
-        ],
-        "idempotency_key": "<id:4>"
-      }
-    },
-    {
-      "method": "POST",
-      "endpoint": "/store",
-      "body": {
-        "entities": [
-          {
-            "cwd": "<env>",
-            "data_source": "cursor-hook",
-            "entity_type": "tool_invocation",
-            "harness": "cursor",
-            "has_error": false,
-            "hook_event": "postToolUse",
-            "input_summary": "{\"pattern\":\"createSession\"}",
-            "invoked_at": "<ts>",
-            "output_summary": "{\"ok\":true,\"matches\":3}",
-            "status": null,
-            "tool_name": "Grep",
             "turn_key": "multi_tool_then_reply__cursor-hooks__claude-sonnet-4.5:turn-1"
           }
         ],
@@ -168,13 +163,72 @@
             "retrieve_calls": 0,
             "session_id": "<id:1>",
             "store_structured_calls": 0,
-            "tool_invocation_count": 2,
-            "turn_id": "<id:3>",
+            "stored_entity_ids": [
+              "ent_mock_9"
+            ],
+            "tool_invocation_count": 1,
+            "turn_id": "<id:4>",
             "turn_key": "multi_tool_then_reply__cursor-hooks__claude-sonnet-4.5:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/store",
+      "body": {
+        "entities": [
+          {
+            "cwd": "<env>",
+            "data_source": "cursor-hook",
+            "entity_type": "tool_invocation",
+            "harness": "cursor",
+            "has_error": false,
+            "hook_event": "postToolUse",
+            "input_summary": "{\"pattern\":\"createSession\"}",
+            "invoked_at": "<ts>",
+            "output_summary": "{\"ok\":true,\"matches\":3}",
+            "status": null,
+            "tool_name": "Grep",
+            "turn_key": "multi_tool_then_reply__cursor-hooks__claude-sonnet-4.5:turn-1"
+          }
+        ],
+        "idempotency_key": "<id:7>"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/store",
+      "body": {
+        "entities": [
+          {
+            "context_source": "cursor-hook",
+            "cwd": "<env>",
+            "data_source": "cursor-hook",
+            "entity_type": "conversation_turn",
+            "git_branch": "<env>",
+            "harness": "cursor",
+            "hook_event": "post_tool_use",
+            "hook_events": [
+              "post_tool_use"
+            ],
+            "model": "claude-sonnet-4.5",
+            "neotoma_tool_failures": 0,
+            "retrieve_calls": 0,
+            "session_id": "<id:1>",
+            "store_structured_calls": 0,
+            "stored_entity_ids": [
+              "ent_mock_16"
+            ],
+            "tool_invocation_count": 2,
+            "turn_id": "<id:4>",
+            "turn_key": "multi_tool_then_reply__cursor-hooks__claude-sonnet-4.5:turn-1",
+            "working_directory": "<env>"
+          }
+        ],
+        "idempotency_key": "<id:5>"
       }
     },
     {
@@ -195,31 +249,6 @@
             "turn_key": "multi_tool_then_reply__cursor-hooks__claude-sonnet-4.5:turn-1:assistant"
           }
         ],
-        "idempotency_key": "<id:7>"
-      }
-    },
-    {
-      "method": "POST",
-      "endpoint": "/store",
-      "body": {
-        "entities": [
-          {
-            "client_name": "Cursor",
-            "conversation_id": "<id:1>",
-            "cwd": "<env>",
-            "data_source": "cursor-hook",
-            "entity_type": "conversation",
-            "harness": "cursor-hook",
-            "hook_event": "stop_backfill",
-            "repository_name": "<env>",
-            "repository_remote": "<env>",
-            "repository_root": "<env>",
-            "scope_summary": "<env>",
-            "thread_kind": "human_agent",
-            "title": "<env>",
-            "workspace_kind": "<env>"
-          }
-        ],
         "idempotency_key": "<id:8>"
       }
     },
@@ -230,7 +259,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
             "diagnosis_confidence": "high",
@@ -258,11 +287,10 @@
                 ],
                 "reminder_injected": true,
                 "tool_invocation_count": 2,
-                "user_message_stored": false
+                "user_message_stored": true
               }
             },
             "missed_steps": [
-              "user_message_store",
               "user_phase_store"
             ],
             "model": "claude-sonnet-4.5",
@@ -279,12 +307,12 @@
             "status": "backfilled_by_hook",
             "store_structured_calls": 0,
             "tool_invocation_count": 2,
-            "turn_id": "<id:3>",
+            "turn_id": "<id:4>",
             "turn_key": "multi_tool_then_reply__cursor-hooks__claude-sonnet-4.5:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     }
   ],

--- a/tests/__snapshots__/agentic_eval/multi_tool_then_reply__cursor-hooks__composer-2.snap.json
+++ b/tests/__snapshots__/agentic_eval/multi_tool_then_reply__cursor-hooks__composer-2.snap.json
@@ -2,6 +2,51 @@
   "requests": [
     {
       "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "REFERS_TO",
+        "source_entity_id": "ent_mock_12",
+        "target_entity_id": "ent_mock_9"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "REFERS_TO",
+        "source_entity_id": "ent_mock_19",
+        "target_entity_id": "ent_mock_16"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_3",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_23",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_28",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
       "endpoint": "/store",
       "body": {
         "entities": [
@@ -50,7 +95,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
@@ -63,12 +108,15 @@
             "model": "composer-2",
             "session_id": "<id:1>",
             "started_at": "<ts>",
-            "turn_id": "<id:3>",
+            "stored_entity_ids": [
+              "ent_mock_3"
+            ],
+            "turn_id": "<id:4>",
             "turn_key": "multi_tool_then_reply__cursor-hooks__composer-2:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     },
     {
@@ -88,59 +136,6 @@
             "output_summary": "{\"ok\":true,\"bytes_read\":1024}",
             "status": null,
             "tool_name": "Read",
-            "turn_key": "multi_tool_then_reply__cursor-hooks__composer-2:turn-1"
-          }
-        ],
-        "idempotency_key": "<id:5>"
-      }
-    },
-    {
-      "method": "POST",
-      "endpoint": "/store",
-      "body": {
-        "entities": [
-          {
-            "context_source": "cursor-hook",
-            "cwd": "<env>",
-            "data_source": "cursor-hook",
-            "entity_type": "conversation_turn",
-            "git_branch": "<env>",
-            "harness": "cursor",
-            "hook_event": "post_tool_use",
-            "hook_events": [
-              "post_tool_use"
-            ],
-            "model": "composer-2",
-            "neotoma_tool_failures": 0,
-            "retrieve_calls": 0,
-            "session_id": "<id:1>",
-            "store_structured_calls": 0,
-            "tool_invocation_count": 1,
-            "turn_id": "<id:3>",
-            "turn_key": "multi_tool_then_reply__cursor-hooks__composer-2:turn-1",
-            "working_directory": "<env>"
-          }
-        ],
-        "idempotency_key": "<id:4>"
-      }
-    },
-    {
-      "method": "POST",
-      "endpoint": "/store",
-      "body": {
-        "entities": [
-          {
-            "cwd": "<env>",
-            "data_source": "cursor-hook",
-            "entity_type": "tool_invocation",
-            "harness": "cursor",
-            "has_error": false,
-            "hook_event": "postToolUse",
-            "input_summary": "{\"pattern\":\"createSession\"}",
-            "invoked_at": "<ts>",
-            "output_summary": "{\"ok\":true,\"matches\":3}",
-            "status": null,
-            "tool_name": "Grep",
             "turn_key": "multi_tool_then_reply__cursor-hooks__composer-2:turn-1"
           }
         ],
@@ -168,13 +163,72 @@
             "retrieve_calls": 0,
             "session_id": "<id:1>",
             "store_structured_calls": 0,
-            "tool_invocation_count": 2,
-            "turn_id": "<id:3>",
+            "stored_entity_ids": [
+              "ent_mock_9"
+            ],
+            "tool_invocation_count": 1,
+            "turn_id": "<id:4>",
             "turn_key": "multi_tool_then_reply__cursor-hooks__composer-2:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/store",
+      "body": {
+        "entities": [
+          {
+            "cwd": "<env>",
+            "data_source": "cursor-hook",
+            "entity_type": "tool_invocation",
+            "harness": "cursor",
+            "has_error": false,
+            "hook_event": "postToolUse",
+            "input_summary": "{\"pattern\":\"createSession\"}",
+            "invoked_at": "<ts>",
+            "output_summary": "{\"ok\":true,\"matches\":3}",
+            "status": null,
+            "tool_name": "Grep",
+            "turn_key": "multi_tool_then_reply__cursor-hooks__composer-2:turn-1"
+          }
+        ],
+        "idempotency_key": "<id:7>"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/store",
+      "body": {
+        "entities": [
+          {
+            "context_source": "cursor-hook",
+            "cwd": "<env>",
+            "data_source": "cursor-hook",
+            "entity_type": "conversation_turn",
+            "git_branch": "<env>",
+            "harness": "cursor",
+            "hook_event": "post_tool_use",
+            "hook_events": [
+              "post_tool_use"
+            ],
+            "model": "composer-2",
+            "neotoma_tool_failures": 0,
+            "retrieve_calls": 0,
+            "session_id": "<id:1>",
+            "store_structured_calls": 0,
+            "stored_entity_ids": [
+              "ent_mock_16"
+            ],
+            "tool_invocation_count": 2,
+            "turn_id": "<id:4>",
+            "turn_key": "multi_tool_then_reply__cursor-hooks__composer-2:turn-1",
+            "working_directory": "<env>"
+          }
+        ],
+        "idempotency_key": "<id:5>"
       }
     },
     {
@@ -195,31 +249,6 @@
             "turn_key": "multi_tool_then_reply__cursor-hooks__composer-2:turn-1:assistant"
           }
         ],
-        "idempotency_key": "<id:7>"
-      }
-    },
-    {
-      "method": "POST",
-      "endpoint": "/store",
-      "body": {
-        "entities": [
-          {
-            "client_name": "Cursor",
-            "conversation_id": "<id:1>",
-            "cwd": "<env>",
-            "data_source": "cursor-hook",
-            "entity_type": "conversation",
-            "harness": "cursor-hook",
-            "hook_event": "stop_backfill",
-            "repository_name": "<env>",
-            "repository_remote": "<env>",
-            "repository_root": "<env>",
-            "scope_summary": "<env>",
-            "thread_kind": "human_agent",
-            "title": "<env>",
-            "workspace_kind": "<env>"
-          }
-        ],
         "idempotency_key": "<id:8>"
       }
     },
@@ -230,7 +259,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
             "diagnosis_confidence": "high",
@@ -258,11 +287,10 @@
                 ],
                 "reminder_injected": true,
                 "tool_invocation_count": 2,
-                "user_message_stored": false
+                "user_message_stored": true
               }
             },
             "missed_steps": [
-              "user_message_store",
               "user_phase_store"
             ],
             "model": "composer-2",
@@ -279,12 +307,12 @@
             "status": "backfilled_by_hook",
             "store_structured_calls": 0,
             "tool_invocation_count": 2,
-            "turn_id": "<id:3>",
+            "turn_id": "<id:4>",
             "turn_key": "multi_tool_then_reply__cursor-hooks__composer-2:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     }
   ],

--- a/tests/__snapshots__/agentic_eval/multi_tool_then_reply__cursor-hooks__gpt-5.5-fast.snap.json
+++ b/tests/__snapshots__/agentic_eval/multi_tool_then_reply__cursor-hooks__gpt-5.5-fast.snap.json
@@ -2,6 +2,51 @@
   "requests": [
     {
       "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "REFERS_TO",
+        "source_entity_id": "ent_mock_12",
+        "target_entity_id": "ent_mock_9"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "REFERS_TO",
+        "source_entity_id": "ent_mock_19",
+        "target_entity_id": "ent_mock_16"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_3",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_23",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_28",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
       "endpoint": "/store",
       "body": {
         "entities": [
@@ -50,7 +95,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
@@ -63,12 +108,15 @@
             "model": "gpt-5.5-fast",
             "session_id": "<id:1>",
             "started_at": "<ts>",
-            "turn_id": "<id:3>",
+            "stored_entity_ids": [
+              "ent_mock_3"
+            ],
+            "turn_id": "<id:4>",
             "turn_key": "multi_tool_then_reply__cursor-hooks__gpt-5.5-fast:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     },
     {
@@ -88,59 +136,6 @@
             "output_summary": "{\"ok\":true,\"bytes_read\":1024}",
             "status": null,
             "tool_name": "Read",
-            "turn_key": "multi_tool_then_reply__cursor-hooks__gpt-5.5-fast:turn-1"
-          }
-        ],
-        "idempotency_key": "<id:5>"
-      }
-    },
-    {
-      "method": "POST",
-      "endpoint": "/store",
-      "body": {
-        "entities": [
-          {
-            "context_source": "cursor-hook",
-            "cwd": "<env>",
-            "data_source": "cursor-hook",
-            "entity_type": "conversation_turn",
-            "git_branch": "<env>",
-            "harness": "cursor",
-            "hook_event": "post_tool_use",
-            "hook_events": [
-              "post_tool_use"
-            ],
-            "model": "gpt-5.5-fast",
-            "neotoma_tool_failures": 0,
-            "retrieve_calls": 0,
-            "session_id": "<id:1>",
-            "store_structured_calls": 0,
-            "tool_invocation_count": 1,
-            "turn_id": "<id:3>",
-            "turn_key": "multi_tool_then_reply__cursor-hooks__gpt-5.5-fast:turn-1",
-            "working_directory": "<env>"
-          }
-        ],
-        "idempotency_key": "<id:4>"
-      }
-    },
-    {
-      "method": "POST",
-      "endpoint": "/store",
-      "body": {
-        "entities": [
-          {
-            "cwd": "<env>",
-            "data_source": "cursor-hook",
-            "entity_type": "tool_invocation",
-            "harness": "cursor",
-            "has_error": false,
-            "hook_event": "postToolUse",
-            "input_summary": "{\"pattern\":\"createSession\"}",
-            "invoked_at": "<ts>",
-            "output_summary": "{\"ok\":true,\"matches\":3}",
-            "status": null,
-            "tool_name": "Grep",
             "turn_key": "multi_tool_then_reply__cursor-hooks__gpt-5.5-fast:turn-1"
           }
         ],
@@ -168,13 +163,72 @@
             "retrieve_calls": 0,
             "session_id": "<id:1>",
             "store_structured_calls": 0,
-            "tool_invocation_count": 2,
-            "turn_id": "<id:3>",
+            "stored_entity_ids": [
+              "ent_mock_9"
+            ],
+            "tool_invocation_count": 1,
+            "turn_id": "<id:4>",
             "turn_key": "multi_tool_then_reply__cursor-hooks__gpt-5.5-fast:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/store",
+      "body": {
+        "entities": [
+          {
+            "cwd": "<env>",
+            "data_source": "cursor-hook",
+            "entity_type": "tool_invocation",
+            "harness": "cursor",
+            "has_error": false,
+            "hook_event": "postToolUse",
+            "input_summary": "{\"pattern\":\"createSession\"}",
+            "invoked_at": "<ts>",
+            "output_summary": "{\"ok\":true,\"matches\":3}",
+            "status": null,
+            "tool_name": "Grep",
+            "turn_key": "multi_tool_then_reply__cursor-hooks__gpt-5.5-fast:turn-1"
+          }
+        ],
+        "idempotency_key": "<id:7>"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/store",
+      "body": {
+        "entities": [
+          {
+            "context_source": "cursor-hook",
+            "cwd": "<env>",
+            "data_source": "cursor-hook",
+            "entity_type": "conversation_turn",
+            "git_branch": "<env>",
+            "harness": "cursor",
+            "hook_event": "post_tool_use",
+            "hook_events": [
+              "post_tool_use"
+            ],
+            "model": "gpt-5.5-fast",
+            "neotoma_tool_failures": 0,
+            "retrieve_calls": 0,
+            "session_id": "<id:1>",
+            "store_structured_calls": 0,
+            "stored_entity_ids": [
+              "ent_mock_16"
+            ],
+            "tool_invocation_count": 2,
+            "turn_id": "<id:4>",
+            "turn_key": "multi_tool_then_reply__cursor-hooks__gpt-5.5-fast:turn-1",
+            "working_directory": "<env>"
+          }
+        ],
+        "idempotency_key": "<id:5>"
       }
     },
     {
@@ -195,31 +249,6 @@
             "turn_key": "multi_tool_then_reply__cursor-hooks__gpt-5.5-fast:turn-1:assistant"
           }
         ],
-        "idempotency_key": "<id:7>"
-      }
-    },
-    {
-      "method": "POST",
-      "endpoint": "/store",
-      "body": {
-        "entities": [
-          {
-            "client_name": "Cursor",
-            "conversation_id": "<id:1>",
-            "cwd": "<env>",
-            "data_source": "cursor-hook",
-            "entity_type": "conversation",
-            "harness": "cursor-hook",
-            "hook_event": "stop_backfill",
-            "repository_name": "<env>",
-            "repository_remote": "<env>",
-            "repository_root": "<env>",
-            "scope_summary": "<env>",
-            "thread_kind": "human_agent",
-            "title": "<env>",
-            "workspace_kind": "<env>"
-          }
-        ],
         "idempotency_key": "<id:8>"
       }
     },
@@ -230,7 +259,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
             "diagnosis_confidence": "high",
@@ -258,11 +287,10 @@
                 ],
                 "reminder_injected": true,
                 "tool_invocation_count": 2,
-                "user_message_stored": false
+                "user_message_stored": true
               }
             },
             "missed_steps": [
-              "user_message_store",
               "user_phase_store"
             ],
             "model": "gpt-5.5-fast",
@@ -279,12 +307,12 @@
             "status": "backfilled_by_hook",
             "store_structured_calls": 0,
             "tool_invocation_count": 2,
-            "turn_id": "<id:3>",
+            "turn_id": "<id:4>",
             "turn_key": "multi_tool_then_reply__cursor-hooks__gpt-5.5-fast:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     }
   ],

--- a/tests/__snapshots__/agentic_eval/multi_tool_then_reply__cursor-hooks__gpt-5.5-medium.snap.json
+++ b/tests/__snapshots__/agentic_eval/multi_tool_then_reply__cursor-hooks__gpt-5.5-medium.snap.json
@@ -2,6 +2,51 @@
   "requests": [
     {
       "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "REFERS_TO",
+        "source_entity_id": "ent_mock_12",
+        "target_entity_id": "ent_mock_9"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "REFERS_TO",
+        "source_entity_id": "ent_mock_19",
+        "target_entity_id": "ent_mock_16"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_3",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_23",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_28",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
       "endpoint": "/store",
       "body": {
         "entities": [
@@ -50,7 +95,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
@@ -63,12 +108,15 @@
             "model": "gpt-5.5-medium",
             "session_id": "<id:1>",
             "started_at": "<ts>",
-            "turn_id": "<id:3>",
+            "stored_entity_ids": [
+              "ent_mock_3"
+            ],
+            "turn_id": "<id:4>",
             "turn_key": "multi_tool_then_reply__cursor-hooks__gpt-5.5-medium:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     },
     {
@@ -88,59 +136,6 @@
             "output_summary": "{\"ok\":true,\"bytes_read\":1024}",
             "status": null,
             "tool_name": "Read",
-            "turn_key": "multi_tool_then_reply__cursor-hooks__gpt-5.5-medium:turn-1"
-          }
-        ],
-        "idempotency_key": "<id:5>"
-      }
-    },
-    {
-      "method": "POST",
-      "endpoint": "/store",
-      "body": {
-        "entities": [
-          {
-            "context_source": "cursor-hook",
-            "cwd": "<env>",
-            "data_source": "cursor-hook",
-            "entity_type": "conversation_turn",
-            "git_branch": "<env>",
-            "harness": "cursor",
-            "hook_event": "post_tool_use",
-            "hook_events": [
-              "post_tool_use"
-            ],
-            "model": "gpt-5.5-medium",
-            "neotoma_tool_failures": 0,
-            "retrieve_calls": 0,
-            "session_id": "<id:1>",
-            "store_structured_calls": 0,
-            "tool_invocation_count": 1,
-            "turn_id": "<id:3>",
-            "turn_key": "multi_tool_then_reply__cursor-hooks__gpt-5.5-medium:turn-1",
-            "working_directory": "<env>"
-          }
-        ],
-        "idempotency_key": "<id:4>"
-      }
-    },
-    {
-      "method": "POST",
-      "endpoint": "/store",
-      "body": {
-        "entities": [
-          {
-            "cwd": "<env>",
-            "data_source": "cursor-hook",
-            "entity_type": "tool_invocation",
-            "harness": "cursor",
-            "has_error": false,
-            "hook_event": "postToolUse",
-            "input_summary": "{\"pattern\":\"createSession\"}",
-            "invoked_at": "<ts>",
-            "output_summary": "{\"ok\":true,\"matches\":3}",
-            "status": null,
-            "tool_name": "Grep",
             "turn_key": "multi_tool_then_reply__cursor-hooks__gpt-5.5-medium:turn-1"
           }
         ],
@@ -168,13 +163,72 @@
             "retrieve_calls": 0,
             "session_id": "<id:1>",
             "store_structured_calls": 0,
-            "tool_invocation_count": 2,
-            "turn_id": "<id:3>",
+            "stored_entity_ids": [
+              "ent_mock_9"
+            ],
+            "tool_invocation_count": 1,
+            "turn_id": "<id:4>",
             "turn_key": "multi_tool_then_reply__cursor-hooks__gpt-5.5-medium:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/store",
+      "body": {
+        "entities": [
+          {
+            "cwd": "<env>",
+            "data_source": "cursor-hook",
+            "entity_type": "tool_invocation",
+            "harness": "cursor",
+            "has_error": false,
+            "hook_event": "postToolUse",
+            "input_summary": "{\"pattern\":\"createSession\"}",
+            "invoked_at": "<ts>",
+            "output_summary": "{\"ok\":true,\"matches\":3}",
+            "status": null,
+            "tool_name": "Grep",
+            "turn_key": "multi_tool_then_reply__cursor-hooks__gpt-5.5-medium:turn-1"
+          }
+        ],
+        "idempotency_key": "<id:7>"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/store",
+      "body": {
+        "entities": [
+          {
+            "context_source": "cursor-hook",
+            "cwd": "<env>",
+            "data_source": "cursor-hook",
+            "entity_type": "conversation_turn",
+            "git_branch": "<env>",
+            "harness": "cursor",
+            "hook_event": "post_tool_use",
+            "hook_events": [
+              "post_tool_use"
+            ],
+            "model": "gpt-5.5-medium",
+            "neotoma_tool_failures": 0,
+            "retrieve_calls": 0,
+            "session_id": "<id:1>",
+            "store_structured_calls": 0,
+            "stored_entity_ids": [
+              "ent_mock_16"
+            ],
+            "tool_invocation_count": 2,
+            "turn_id": "<id:4>",
+            "turn_key": "multi_tool_then_reply__cursor-hooks__gpt-5.5-medium:turn-1",
+            "working_directory": "<env>"
+          }
+        ],
+        "idempotency_key": "<id:5>"
       }
     },
     {
@@ -195,31 +249,6 @@
             "turn_key": "multi_tool_then_reply__cursor-hooks__gpt-5.5-medium:turn-1:assistant"
           }
         ],
-        "idempotency_key": "<id:7>"
-      }
-    },
-    {
-      "method": "POST",
-      "endpoint": "/store",
-      "body": {
-        "entities": [
-          {
-            "client_name": "Cursor",
-            "conversation_id": "<id:1>",
-            "cwd": "<env>",
-            "data_source": "cursor-hook",
-            "entity_type": "conversation",
-            "harness": "cursor-hook",
-            "hook_event": "stop_backfill",
-            "repository_name": "<env>",
-            "repository_remote": "<env>",
-            "repository_root": "<env>",
-            "scope_summary": "<env>",
-            "thread_kind": "human_agent",
-            "title": "<env>",
-            "workspace_kind": "<env>"
-          }
-        ],
         "idempotency_key": "<id:8>"
       }
     },
@@ -230,7 +259,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
             "diagnosis_confidence": "high",
@@ -258,11 +287,10 @@
                 ],
                 "reminder_injected": true,
                 "tool_invocation_count": 2,
-                "user_message_stored": false
+                "user_message_stored": true
               }
             },
             "missed_steps": [
-              "user_message_store",
               "user_phase_store"
             ],
             "model": "gpt-5.5-medium",
@@ -279,12 +307,12 @@
             "status": "backfilled_by_hook",
             "store_structured_calls": 0,
             "tool_invocation_count": 2,
-            "turn_id": "<id:3>",
+            "turn_id": "<id:4>",
             "turn_key": "multi_tool_then_reply__cursor-hooks__gpt-5.5-medium:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     }
   ],

--- a/tests/__snapshots__/agentic_eval/plan_creation_stores_to_neotoma__cursor-hooks__claude-haiku-4.snap.json
+++ b/tests/__snapshots__/agentic_eval/plan_creation_stores_to_neotoma__cursor-hooks__claude-haiku-4.snap.json
@@ -2,6 +2,42 @@
   "requests": [
     {
       "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "REFERS_TO",
+        "source_entity_id": "ent_mock_12",
+        "target_entity_id": "ent_mock_9"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_3",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_16",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_21",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
       "endpoint": "/store",
       "body": {
         "entities": [
@@ -50,7 +86,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
@@ -63,12 +99,15 @@
             "model": "claude-haiku-4",
             "session_id": "<id:1>",
             "started_at": "<ts>",
-            "turn_id": "<id:3>",
+            "stored_entity_ids": [
+              "ent_mock_3"
+            ],
+            "turn_id": "<id:4>",
             "turn_key": "plan_creation_stores_to_neotoma__cursor-hooks__claude-haiku-4:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     },
     {
@@ -91,7 +130,7 @@
             "turn_key": "plan_creation_stores_to_neotoma__cursor-hooks__claude-haiku-4:turn-1"
           }
         ],
-        "idempotency_key": "<id:5>"
+        "idempotency_key": "<id:6>"
       }
     },
     {
@@ -115,13 +154,16 @@
             "retrieve_calls": 0,
             "session_id": "<id:1>",
             "store_structured_calls": 0,
+            "stored_entity_ids": [
+              "ent_mock_9"
+            ],
             "tool_invocation_count": 1,
-            "turn_id": "<id:3>",
+            "turn_id": "<id:4>",
             "turn_key": "plan_creation_stores_to_neotoma__cursor-hooks__claude-haiku-4:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     },
     {
@@ -142,31 +184,6 @@
             "turn_key": "plan_creation_stores_to_neotoma__cursor-hooks__claude-haiku-4:turn-1:assistant"
           }
         ],
-        "idempotency_key": "<id:6>"
-      }
-    },
-    {
-      "method": "POST",
-      "endpoint": "/store",
-      "body": {
-        "entities": [
-          {
-            "client_name": "Cursor",
-            "conversation_id": "<id:1>",
-            "cwd": "<env>",
-            "data_source": "cursor-hook",
-            "entity_type": "conversation",
-            "harness": "cursor-hook",
-            "hook_event": "stop_backfill",
-            "repository_name": "<env>",
-            "repository_remote": "<env>",
-            "repository_root": "<env>",
-            "scope_summary": "<env>",
-            "thread_kind": "human_agent",
-            "title": "<env>",
-            "workspace_kind": "<env>"
-          }
-        ],
         "idempotency_key": "<id:7>"
       }
     },
@@ -177,7 +194,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
             "diagnosis_confidence": "high",
@@ -205,11 +222,10 @@
                 ],
                 "reminder_injected": true,
                 "tool_invocation_count": 1,
-                "user_message_stored": false
+                "user_message_stored": true
               }
             },
             "missed_steps": [
-              "user_message_store",
               "user_phase_store"
             ],
             "model": "claude-haiku-4",
@@ -226,12 +242,12 @@
             "status": "backfilled_by_hook",
             "store_structured_calls": 0,
             "tool_invocation_count": 1,
-            "turn_id": "<id:3>",
+            "turn_id": "<id:4>",
             "turn_key": "plan_creation_stores_to_neotoma__cursor-hooks__claude-haiku-4:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     }
   ],

--- a/tests/__snapshots__/agentic_eval/plan_creation_stores_to_neotoma__cursor-hooks__claude-sonnet-4.5.snap.json
+++ b/tests/__snapshots__/agentic_eval/plan_creation_stores_to_neotoma__cursor-hooks__claude-sonnet-4.5.snap.json
@@ -2,6 +2,42 @@
   "requests": [
     {
       "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "REFERS_TO",
+        "source_entity_id": "ent_mock_12",
+        "target_entity_id": "ent_mock_9"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_3",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_16",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_21",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
       "endpoint": "/store",
       "body": {
         "entities": [
@@ -50,7 +86,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
@@ -63,12 +99,15 @@
             "model": "claude-sonnet-4.5",
             "session_id": "<id:1>",
             "started_at": "<ts>",
-            "turn_id": "<id:3>",
+            "stored_entity_ids": [
+              "ent_mock_3"
+            ],
+            "turn_id": "<id:4>",
             "turn_key": "plan_creation_stores_to_neotoma__cursor-hooks__claude-sonnet-4.5:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     },
     {
@@ -91,7 +130,7 @@
             "turn_key": "plan_creation_stores_to_neotoma__cursor-hooks__claude-sonnet-4.5:turn-1"
           }
         ],
-        "idempotency_key": "<id:5>"
+        "idempotency_key": "<id:6>"
       }
     },
     {
@@ -115,13 +154,16 @@
             "retrieve_calls": 0,
             "session_id": "<id:1>",
             "store_structured_calls": 0,
+            "stored_entity_ids": [
+              "ent_mock_9"
+            ],
             "tool_invocation_count": 1,
-            "turn_id": "<id:3>",
+            "turn_id": "<id:4>",
             "turn_key": "plan_creation_stores_to_neotoma__cursor-hooks__claude-sonnet-4.5:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     },
     {
@@ -142,31 +184,6 @@
             "turn_key": "plan_creation_stores_to_neotoma__cursor-hooks__claude-sonnet-4.5:turn-1:assistant"
           }
         ],
-        "idempotency_key": "<id:6>"
-      }
-    },
-    {
-      "method": "POST",
-      "endpoint": "/store",
-      "body": {
-        "entities": [
-          {
-            "client_name": "Cursor",
-            "conversation_id": "<id:1>",
-            "cwd": "<env>",
-            "data_source": "cursor-hook",
-            "entity_type": "conversation",
-            "harness": "cursor-hook",
-            "hook_event": "stop_backfill",
-            "repository_name": "<env>",
-            "repository_remote": "<env>",
-            "repository_root": "<env>",
-            "scope_summary": "<env>",
-            "thread_kind": "human_agent",
-            "title": "<env>",
-            "workspace_kind": "<env>"
-          }
-        ],
         "idempotency_key": "<id:7>"
       }
     },
@@ -177,7 +194,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
             "diagnosis_confidence": "high",
@@ -205,11 +222,10 @@
                 ],
                 "reminder_injected": true,
                 "tool_invocation_count": 1,
-                "user_message_stored": false
+                "user_message_stored": true
               }
             },
             "missed_steps": [
-              "user_message_store",
               "user_phase_store"
             ],
             "model": "claude-sonnet-4.5",
@@ -226,12 +242,12 @@
             "status": "backfilled_by_hook",
             "store_structured_calls": 0,
             "tool_invocation_count": 1,
-            "turn_id": "<id:3>",
+            "turn_id": "<id:4>",
             "turn_key": "plan_creation_stores_to_neotoma__cursor-hooks__claude-sonnet-4.5:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     }
   ],

--- a/tests/__snapshots__/agentic_eval/plan_creation_stores_to_neotoma__cursor-hooks__composer-2.snap.json
+++ b/tests/__snapshots__/agentic_eval/plan_creation_stores_to_neotoma__cursor-hooks__composer-2.snap.json
@@ -2,6 +2,42 @@
   "requests": [
     {
       "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "REFERS_TO",
+        "source_entity_id": "ent_mock_12",
+        "target_entity_id": "ent_mock_9"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_3",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_16",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_21",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
       "endpoint": "/store",
       "body": {
         "entities": [
@@ -50,7 +86,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
@@ -63,12 +99,15 @@
             "model": "composer-2",
             "session_id": "<id:1>",
             "started_at": "<ts>",
-            "turn_id": "<id:3>",
+            "stored_entity_ids": [
+              "ent_mock_3"
+            ],
+            "turn_id": "<id:4>",
             "turn_key": "plan_creation_stores_to_neotoma__cursor-hooks__composer-2:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     },
     {
@@ -91,7 +130,7 @@
             "turn_key": "plan_creation_stores_to_neotoma__cursor-hooks__composer-2:turn-1"
           }
         ],
-        "idempotency_key": "<id:5>"
+        "idempotency_key": "<id:6>"
       }
     },
     {
@@ -115,13 +154,16 @@
             "retrieve_calls": 0,
             "session_id": "<id:1>",
             "store_structured_calls": 0,
+            "stored_entity_ids": [
+              "ent_mock_9"
+            ],
             "tool_invocation_count": 1,
-            "turn_id": "<id:3>",
+            "turn_id": "<id:4>",
             "turn_key": "plan_creation_stores_to_neotoma__cursor-hooks__composer-2:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     },
     {
@@ -142,31 +184,6 @@
             "turn_key": "plan_creation_stores_to_neotoma__cursor-hooks__composer-2:turn-1:assistant"
           }
         ],
-        "idempotency_key": "<id:6>"
-      }
-    },
-    {
-      "method": "POST",
-      "endpoint": "/store",
-      "body": {
-        "entities": [
-          {
-            "client_name": "Cursor",
-            "conversation_id": "<id:1>",
-            "cwd": "<env>",
-            "data_source": "cursor-hook",
-            "entity_type": "conversation",
-            "harness": "cursor-hook",
-            "hook_event": "stop_backfill",
-            "repository_name": "<env>",
-            "repository_remote": "<env>",
-            "repository_root": "<env>",
-            "scope_summary": "<env>",
-            "thread_kind": "human_agent",
-            "title": "<env>",
-            "workspace_kind": "<env>"
-          }
-        ],
         "idempotency_key": "<id:7>"
       }
     },
@@ -177,7 +194,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
             "diagnosis_confidence": "high",
@@ -205,11 +222,10 @@
                 ],
                 "reminder_injected": true,
                 "tool_invocation_count": 1,
-                "user_message_stored": false
+                "user_message_stored": true
               }
             },
             "missed_steps": [
-              "user_message_store",
               "user_phase_store"
             ],
             "model": "composer-2",
@@ -226,12 +242,12 @@
             "status": "backfilled_by_hook",
             "store_structured_calls": 0,
             "tool_invocation_count": 1,
-            "turn_id": "<id:3>",
+            "turn_id": "<id:4>",
             "turn_key": "plan_creation_stores_to_neotoma__cursor-hooks__composer-2:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     }
   ],

--- a/tests/__snapshots__/agentic_eval/plan_creation_stores_to_neotoma__cursor-hooks__gpt-5.5-fast.snap.json
+++ b/tests/__snapshots__/agentic_eval/plan_creation_stores_to_neotoma__cursor-hooks__gpt-5.5-fast.snap.json
@@ -2,6 +2,42 @@
   "requests": [
     {
       "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "REFERS_TO",
+        "source_entity_id": "ent_mock_12",
+        "target_entity_id": "ent_mock_9"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_3",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_16",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_21",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
       "endpoint": "/store",
       "body": {
         "entities": [
@@ -50,7 +86,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
@@ -63,12 +99,15 @@
             "model": "gpt-5.5-fast",
             "session_id": "<id:1>",
             "started_at": "<ts>",
-            "turn_id": "<id:3>",
+            "stored_entity_ids": [
+              "ent_mock_3"
+            ],
+            "turn_id": "<id:4>",
             "turn_key": "plan_creation_stores_to_neotoma__cursor-hooks__gpt-5.5-fast:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     },
     {
@@ -91,7 +130,7 @@
             "turn_key": "plan_creation_stores_to_neotoma__cursor-hooks__gpt-5.5-fast:turn-1"
           }
         ],
-        "idempotency_key": "<id:5>"
+        "idempotency_key": "<id:6>"
       }
     },
     {
@@ -115,13 +154,16 @@
             "retrieve_calls": 0,
             "session_id": "<id:1>",
             "store_structured_calls": 0,
+            "stored_entity_ids": [
+              "ent_mock_9"
+            ],
             "tool_invocation_count": 1,
-            "turn_id": "<id:3>",
+            "turn_id": "<id:4>",
             "turn_key": "plan_creation_stores_to_neotoma__cursor-hooks__gpt-5.5-fast:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     },
     {
@@ -142,31 +184,6 @@
             "turn_key": "plan_creation_stores_to_neotoma__cursor-hooks__gpt-5.5-fast:turn-1:assistant"
           }
         ],
-        "idempotency_key": "<id:6>"
-      }
-    },
-    {
-      "method": "POST",
-      "endpoint": "/store",
-      "body": {
-        "entities": [
-          {
-            "client_name": "Cursor",
-            "conversation_id": "<id:1>",
-            "cwd": "<env>",
-            "data_source": "cursor-hook",
-            "entity_type": "conversation",
-            "harness": "cursor-hook",
-            "hook_event": "stop_backfill",
-            "repository_name": "<env>",
-            "repository_remote": "<env>",
-            "repository_root": "<env>",
-            "scope_summary": "<env>",
-            "thread_kind": "human_agent",
-            "title": "<env>",
-            "workspace_kind": "<env>"
-          }
-        ],
         "idempotency_key": "<id:7>"
       }
     },
@@ -177,7 +194,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
             "diagnosis_confidence": "high",
@@ -205,11 +222,10 @@
                 ],
                 "reminder_injected": true,
                 "tool_invocation_count": 1,
-                "user_message_stored": false
+                "user_message_stored": true
               }
             },
             "missed_steps": [
-              "user_message_store",
               "user_phase_store"
             ],
             "model": "gpt-5.5-fast",
@@ -226,12 +242,12 @@
             "status": "backfilled_by_hook",
             "store_structured_calls": 0,
             "tool_invocation_count": 1,
-            "turn_id": "<id:3>",
+            "turn_id": "<id:4>",
             "turn_key": "plan_creation_stores_to_neotoma__cursor-hooks__gpt-5.5-fast:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     }
   ],

--- a/tests/__snapshots__/agentic_eval/plan_creation_stores_to_neotoma__cursor-hooks__gpt-5.5-medium.snap.json
+++ b/tests/__snapshots__/agentic_eval/plan_creation_stores_to_neotoma__cursor-hooks__gpt-5.5-medium.snap.json
@@ -2,6 +2,42 @@
   "requests": [
     {
       "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "REFERS_TO",
+        "source_entity_id": "ent_mock_12",
+        "target_entity_id": "ent_mock_9"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_3",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_16",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_21",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
       "endpoint": "/store",
       "body": {
         "entities": [
@@ -50,7 +86,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
@@ -63,12 +99,15 @@
             "model": "gpt-5.5-medium",
             "session_id": "<id:1>",
             "started_at": "<ts>",
-            "turn_id": "<id:3>",
+            "stored_entity_ids": [
+              "ent_mock_3"
+            ],
+            "turn_id": "<id:4>",
             "turn_key": "plan_creation_stores_to_neotoma__cursor-hooks__gpt-5.5-medium:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     },
     {
@@ -91,7 +130,7 @@
             "turn_key": "plan_creation_stores_to_neotoma__cursor-hooks__gpt-5.5-medium:turn-1"
           }
         ],
-        "idempotency_key": "<id:5>"
+        "idempotency_key": "<id:6>"
       }
     },
     {
@@ -115,13 +154,16 @@
             "retrieve_calls": 0,
             "session_id": "<id:1>",
             "store_structured_calls": 0,
+            "stored_entity_ids": [
+              "ent_mock_9"
+            ],
             "tool_invocation_count": 1,
-            "turn_id": "<id:3>",
+            "turn_id": "<id:4>",
             "turn_key": "plan_creation_stores_to_neotoma__cursor-hooks__gpt-5.5-medium:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     },
     {
@@ -142,31 +184,6 @@
             "turn_key": "plan_creation_stores_to_neotoma__cursor-hooks__gpt-5.5-medium:turn-1:assistant"
           }
         ],
-        "idempotency_key": "<id:6>"
-      }
-    },
-    {
-      "method": "POST",
-      "endpoint": "/store",
-      "body": {
-        "entities": [
-          {
-            "client_name": "Cursor",
-            "conversation_id": "<id:1>",
-            "cwd": "<env>",
-            "data_source": "cursor-hook",
-            "entity_type": "conversation",
-            "harness": "cursor-hook",
-            "hook_event": "stop_backfill",
-            "repository_name": "<env>",
-            "repository_remote": "<env>",
-            "repository_root": "<env>",
-            "scope_summary": "<env>",
-            "thread_kind": "human_agent",
-            "title": "<env>",
-            "workspace_kind": "<env>"
-          }
-        ],
         "idempotency_key": "<id:7>"
       }
     },
@@ -177,7 +194,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
             "diagnosis_confidence": "high",
@@ -205,11 +222,10 @@
                 ],
                 "reminder_injected": true,
                 "tool_invocation_count": 1,
-                "user_message_stored": false
+                "user_message_stored": true
               }
             },
             "missed_steps": [
-              "user_message_store",
               "user_phase_store"
             ],
             "model": "gpt-5.5-medium",
@@ -226,12 +242,12 @@
             "status": "backfilled_by_hook",
             "store_structured_calls": 0,
             "tool_invocation_count": 1,
-            "turn_id": "<id:3>",
+            "turn_id": "<id:4>",
             "turn_key": "plan_creation_stores_to_neotoma__cursor-hooks__gpt-5.5-medium:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     }
   ],

--- a/tests/__snapshots__/agentic_eval/single_turn_with_extracted_entity__cursor-hooks__claude-haiku-4.snap.json
+++ b/tests/__snapshots__/agentic_eval/single_turn_with_extracted_entity__cursor-hooks__claude-haiku-4.snap.json
@@ -2,6 +2,33 @@
   "requests": [
     {
       "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_3",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_9",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_14",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
       "endpoint": "/store",
       "body": {
         "entities": [
@@ -50,7 +77,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
@@ -63,12 +90,15 @@
             "model": "claude-haiku-4",
             "session_id": "<id:1>",
             "started_at": "<ts>",
-            "turn_id": "<id:3>",
+            "stored_entity_ids": [
+              "ent_mock_3"
+            ],
+            "turn_id": "<id:4>",
             "turn_key": "single_turn_with_extracted_entity__cursor-hooks__claude-haiku-4:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     },
     {
@@ -89,31 +119,6 @@
             "turn_key": "single_turn_with_extracted_entity__cursor-hooks__claude-haiku-4:turn-1:assistant"
           }
         ],
-        "idempotency_key": "<id:5>"
-      }
-    },
-    {
-      "method": "POST",
-      "endpoint": "/store",
-      "body": {
-        "entities": [
-          {
-            "client_name": "Cursor",
-            "conversation_id": "<id:1>",
-            "cwd": "<env>",
-            "data_source": "cursor-hook",
-            "entity_type": "conversation",
-            "harness": "cursor-hook",
-            "hook_event": "stop_backfill",
-            "repository_name": "<env>",
-            "repository_remote": "<env>",
-            "repository_root": "<env>",
-            "scope_summary": "<env>",
-            "thread_kind": "human_agent",
-            "title": "<env>",
-            "workspace_kind": "<env>"
-          }
-        ],
         "idempotency_key": "<id:6>"
       }
     },
@@ -124,10 +129,10 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
-            "diagnosis_confidence": "high",
+            "diagnosis_confidence": "medium",
             "ended_at": "<ts>",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -150,11 +155,10 @@
                 "reminder_hooks": [],
                 "reminder_injected": false,
                 "tool_invocation_count": 0,
-                "user_message_stored": false
+                "user_message_stored": true
               }
             },
             "missed_steps": [
-              "user_message_store",
               "user_phase_store"
             ],
             "model": "claude-haiku-4",
@@ -171,12 +175,12 @@
             "status": "backfilled_by_hook",
             "store_structured_calls": 0,
             "tool_invocation_count": 0,
-            "turn_id": "<id:3>",
+            "turn_id": "<id:4>",
             "turn_key": "single_turn_with_extracted_entity__cursor-hooks__claude-haiku-4:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     }
   ],

--- a/tests/__snapshots__/agentic_eval/single_turn_with_extracted_entity__cursor-hooks__claude-sonnet-4.5.snap.json
+++ b/tests/__snapshots__/agentic_eval/single_turn_with_extracted_entity__cursor-hooks__claude-sonnet-4.5.snap.json
@@ -2,6 +2,33 @@
   "requests": [
     {
       "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_3",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_9",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_14",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
       "endpoint": "/store",
       "body": {
         "entities": [
@@ -50,7 +77,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
@@ -63,12 +90,15 @@
             "model": "claude-sonnet-4.5",
             "session_id": "<id:1>",
             "started_at": "<ts>",
-            "turn_id": "<id:3>",
+            "stored_entity_ids": [
+              "ent_mock_3"
+            ],
+            "turn_id": "<id:4>",
             "turn_key": "single_turn_with_extracted_entity__cursor-hooks__claude-sonnet-4.5:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     },
     {
@@ -89,31 +119,6 @@
             "turn_key": "single_turn_with_extracted_entity__cursor-hooks__claude-sonnet-4.5:turn-1:assistant"
           }
         ],
-        "idempotency_key": "<id:5>"
-      }
-    },
-    {
-      "method": "POST",
-      "endpoint": "/store",
-      "body": {
-        "entities": [
-          {
-            "client_name": "Cursor",
-            "conversation_id": "<id:1>",
-            "cwd": "<env>",
-            "data_source": "cursor-hook",
-            "entity_type": "conversation",
-            "harness": "cursor-hook",
-            "hook_event": "stop_backfill",
-            "repository_name": "<env>",
-            "repository_remote": "<env>",
-            "repository_root": "<env>",
-            "scope_summary": "<env>",
-            "thread_kind": "human_agent",
-            "title": "<env>",
-            "workspace_kind": "<env>"
-          }
-        ],
         "idempotency_key": "<id:6>"
       }
     },
@@ -124,10 +129,10 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
-            "diagnosis_confidence": "high",
+            "diagnosis_confidence": "medium",
             "ended_at": "<ts>",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -150,11 +155,10 @@
                 "reminder_hooks": [],
                 "reminder_injected": false,
                 "tool_invocation_count": 0,
-                "user_message_stored": false
+                "user_message_stored": true
               }
             },
             "missed_steps": [
-              "user_message_store",
               "user_phase_store"
             ],
             "model": "claude-sonnet-4.5",
@@ -171,12 +175,12 @@
             "status": "backfilled_by_hook",
             "store_structured_calls": 0,
             "tool_invocation_count": 0,
-            "turn_id": "<id:3>",
+            "turn_id": "<id:4>",
             "turn_key": "single_turn_with_extracted_entity__cursor-hooks__claude-sonnet-4.5:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     }
   ],

--- a/tests/__snapshots__/agentic_eval/single_turn_with_extracted_entity__cursor-hooks__composer-2.snap.json
+++ b/tests/__snapshots__/agentic_eval/single_turn_with_extracted_entity__cursor-hooks__composer-2.snap.json
@@ -2,6 +2,33 @@
   "requests": [
     {
       "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_3",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_9",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_14",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
       "endpoint": "/store",
       "body": {
         "entities": [
@@ -50,7 +77,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
@@ -63,12 +90,15 @@
             "model": "composer-2",
             "session_id": "<id:1>",
             "started_at": "<ts>",
-            "turn_id": "<id:3>",
+            "stored_entity_ids": [
+              "ent_mock_3"
+            ],
+            "turn_id": "<id:4>",
             "turn_key": "single_turn_with_extracted_entity__cursor-hooks__composer-2:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     },
     {
@@ -89,31 +119,6 @@
             "turn_key": "single_turn_with_extracted_entity__cursor-hooks__composer-2:turn-1:assistant"
           }
         ],
-        "idempotency_key": "<id:5>"
-      }
-    },
-    {
-      "method": "POST",
-      "endpoint": "/store",
-      "body": {
-        "entities": [
-          {
-            "client_name": "Cursor",
-            "conversation_id": "<id:1>",
-            "cwd": "<env>",
-            "data_source": "cursor-hook",
-            "entity_type": "conversation",
-            "harness": "cursor-hook",
-            "hook_event": "stop_backfill",
-            "repository_name": "<env>",
-            "repository_remote": "<env>",
-            "repository_root": "<env>",
-            "scope_summary": "<env>",
-            "thread_kind": "human_agent",
-            "title": "<env>",
-            "workspace_kind": "<env>"
-          }
-        ],
         "idempotency_key": "<id:6>"
       }
     },
@@ -124,10 +129,10 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
-            "diagnosis_confidence": "high",
+            "diagnosis_confidence": "medium",
             "ended_at": "<ts>",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -150,11 +155,10 @@
                 "reminder_hooks": [],
                 "reminder_injected": false,
                 "tool_invocation_count": 0,
-                "user_message_stored": false
+                "user_message_stored": true
               }
             },
             "missed_steps": [
-              "user_message_store",
               "user_phase_store"
             ],
             "model": "composer-2",
@@ -171,12 +175,12 @@
             "status": "backfilled_by_hook",
             "store_structured_calls": 0,
             "tool_invocation_count": 0,
-            "turn_id": "<id:3>",
+            "turn_id": "<id:4>",
             "turn_key": "single_turn_with_extracted_entity__cursor-hooks__composer-2:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     }
   ],

--- a/tests/__snapshots__/agentic_eval/single_turn_with_extracted_entity__cursor-hooks__gpt-5.5-fast.snap.json
+++ b/tests/__snapshots__/agentic_eval/single_turn_with_extracted_entity__cursor-hooks__gpt-5.5-fast.snap.json
@@ -2,6 +2,33 @@
   "requests": [
     {
       "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_3",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_9",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_14",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
       "endpoint": "/store",
       "body": {
         "entities": [
@@ -50,7 +77,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
@@ -63,12 +90,15 @@
             "model": "gpt-5.5-fast",
             "session_id": "<id:1>",
             "started_at": "<ts>",
-            "turn_id": "<id:3>",
+            "stored_entity_ids": [
+              "ent_mock_3"
+            ],
+            "turn_id": "<id:4>",
             "turn_key": "single_turn_with_extracted_entity__cursor-hooks__gpt-5.5-fast:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     },
     {
@@ -89,31 +119,6 @@
             "turn_key": "single_turn_with_extracted_entity__cursor-hooks__gpt-5.5-fast:turn-1:assistant"
           }
         ],
-        "idempotency_key": "<id:5>"
-      }
-    },
-    {
-      "method": "POST",
-      "endpoint": "/store",
-      "body": {
-        "entities": [
-          {
-            "client_name": "Cursor",
-            "conversation_id": "<id:1>",
-            "cwd": "<env>",
-            "data_source": "cursor-hook",
-            "entity_type": "conversation",
-            "harness": "cursor-hook",
-            "hook_event": "stop_backfill",
-            "repository_name": "<env>",
-            "repository_remote": "<env>",
-            "repository_root": "<env>",
-            "scope_summary": "<env>",
-            "thread_kind": "human_agent",
-            "title": "<env>",
-            "workspace_kind": "<env>"
-          }
-        ],
         "idempotency_key": "<id:6>"
       }
     },
@@ -124,10 +129,10 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
-            "diagnosis_confidence": "high",
+            "diagnosis_confidence": "medium",
             "ended_at": "<ts>",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -150,11 +155,10 @@
                 "reminder_hooks": [],
                 "reminder_injected": false,
                 "tool_invocation_count": 0,
-                "user_message_stored": false
+                "user_message_stored": true
               }
             },
             "missed_steps": [
-              "user_message_store",
               "user_phase_store"
             ],
             "model": "gpt-5.5-fast",
@@ -171,12 +175,12 @@
             "status": "backfilled_by_hook",
             "store_structured_calls": 0,
             "tool_invocation_count": 0,
-            "turn_id": "<id:3>",
+            "turn_id": "<id:4>",
             "turn_key": "single_turn_with_extracted_entity__cursor-hooks__gpt-5.5-fast:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     }
   ],

--- a/tests/__snapshots__/agentic_eval/single_turn_with_extracted_entity__cursor-hooks__gpt-5.5-medium.snap.json
+++ b/tests/__snapshots__/agentic_eval/single_turn_with_extracted_entity__cursor-hooks__gpt-5.5-medium.snap.json
@@ -2,6 +2,33 @@
   "requests": [
     {
       "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_3",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_9",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_14",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
       "endpoint": "/store",
       "body": {
         "entities": [
@@ -50,7 +77,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
@@ -63,12 +90,15 @@
             "model": "gpt-5.5-medium",
             "session_id": "<id:1>",
             "started_at": "<ts>",
-            "turn_id": "<id:3>",
+            "stored_entity_ids": [
+              "ent_mock_3"
+            ],
+            "turn_id": "<id:4>",
             "turn_key": "single_turn_with_extracted_entity__cursor-hooks__gpt-5.5-medium:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     },
     {
@@ -89,31 +119,6 @@
             "turn_key": "single_turn_with_extracted_entity__cursor-hooks__gpt-5.5-medium:turn-1:assistant"
           }
         ],
-        "idempotency_key": "<id:5>"
-      }
-    },
-    {
-      "method": "POST",
-      "endpoint": "/store",
-      "body": {
-        "entities": [
-          {
-            "client_name": "Cursor",
-            "conversation_id": "<id:1>",
-            "cwd": "<env>",
-            "data_source": "cursor-hook",
-            "entity_type": "conversation",
-            "harness": "cursor-hook",
-            "hook_event": "stop_backfill",
-            "repository_name": "<env>",
-            "repository_remote": "<env>",
-            "repository_root": "<env>",
-            "scope_summary": "<env>",
-            "thread_kind": "human_agent",
-            "title": "<env>",
-            "workspace_kind": "<env>"
-          }
-        ],
         "idempotency_key": "<id:6>"
       }
     },
@@ -124,10 +129,10 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
-            "diagnosis_confidence": "high",
+            "diagnosis_confidence": "medium",
             "ended_at": "<ts>",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -150,11 +155,10 @@
                 "reminder_hooks": [],
                 "reminder_injected": false,
                 "tool_invocation_count": 0,
-                "user_message_stored": false
+                "user_message_stored": true
               }
             },
             "missed_steps": [
-              "user_message_store",
               "user_phase_store"
             ],
             "model": "gpt-5.5-medium",
@@ -171,12 +175,12 @@
             "status": "backfilled_by_hook",
             "store_structured_calls": 0,
             "tool_invocation_count": 0,
-            "turn_id": "<id:3>",
+            "turn_id": "<id:4>",
             "turn_key": "single_turn_with_extracted_entity__cursor-hooks__gpt-5.5-medium:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     }
   ],

--- a/tests/__snapshots__/agentic_eval/tool_failure_recovery__cursor-hooks__claude-haiku-4.snap.json
+++ b/tests/__snapshots__/agentic_eval/tool_failure_recovery__cursor-hooks__claude-haiku-4.snap.json
@@ -2,6 +2,33 @@
   "requests": [
     {
       "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_3",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_9",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_14",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
       "endpoint": "/store",
       "body": {
         "entities": [
@@ -50,7 +77,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
@@ -63,12 +90,15 @@
             "model": "claude-haiku-4",
             "session_id": "<id:1>",
             "started_at": "<ts>",
-            "turn_id": "<id:3>",
+            "stored_entity_ids": [
+              "ent_mock_3"
+            ],
+            "turn_id": "<id:4>",
             "turn_key": "tool_failure_recovery__cursor-hooks__claude-haiku-4:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     },
     {
@@ -89,31 +119,6 @@
             "turn_key": "tool_failure_recovery__cursor-hooks__claude-haiku-4:turn-1:assistant"
           }
         ],
-        "idempotency_key": "<id:5>"
-      }
-    },
-    {
-      "method": "POST",
-      "endpoint": "/store",
-      "body": {
-        "entities": [
-          {
-            "client_name": "Cursor",
-            "conversation_id": "<id:1>",
-            "cwd": "<env>",
-            "data_source": "cursor-hook",
-            "entity_type": "conversation",
-            "harness": "cursor-hook",
-            "hook_event": "stop_backfill",
-            "repository_name": "<env>",
-            "repository_remote": "<env>",
-            "repository_root": "<env>",
-            "scope_summary": "<env>",
-            "thread_kind": "human_agent",
-            "title": "<env>",
-            "workspace_kind": "<env>"
-          }
-        ],
         "idempotency_key": "<id:6>"
       }
     },
@@ -124,10 +129,10 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
-            "diagnosis_confidence": "high",
+            "diagnosis_confidence": "medium",
             "ended_at": "<ts>",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -150,11 +155,10 @@
                 "reminder_hooks": [],
                 "reminder_injected": false,
                 "tool_invocation_count": 0,
-                "user_message_stored": false
+                "user_message_stored": true
               }
             },
             "missed_steps": [
-              "user_message_store",
               "user_phase_store"
             ],
             "model": "claude-haiku-4",
@@ -171,12 +175,12 @@
             "status": "backfilled_by_hook",
             "store_structured_calls": 0,
             "tool_invocation_count": 0,
-            "turn_id": "<id:3>",
+            "turn_id": "<id:4>",
             "turn_key": "tool_failure_recovery__cursor-hooks__claude-haiku-4:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     }
   ],

--- a/tests/__snapshots__/agentic_eval/tool_failure_recovery__cursor-hooks__claude-sonnet-4.5.snap.json
+++ b/tests/__snapshots__/agentic_eval/tool_failure_recovery__cursor-hooks__claude-sonnet-4.5.snap.json
@@ -2,6 +2,33 @@
   "requests": [
     {
       "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_3",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_9",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_14",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
       "endpoint": "/store",
       "body": {
         "entities": [
@@ -50,7 +77,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
@@ -63,12 +90,15 @@
             "model": "claude-sonnet-4.5",
             "session_id": "<id:1>",
             "started_at": "<ts>",
-            "turn_id": "<id:3>",
+            "stored_entity_ids": [
+              "ent_mock_3"
+            ],
+            "turn_id": "<id:4>",
             "turn_key": "tool_failure_recovery__cursor-hooks__claude-sonnet-4.5:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     },
     {
@@ -89,31 +119,6 @@
             "turn_key": "tool_failure_recovery__cursor-hooks__claude-sonnet-4.5:turn-1:assistant"
           }
         ],
-        "idempotency_key": "<id:5>"
-      }
-    },
-    {
-      "method": "POST",
-      "endpoint": "/store",
-      "body": {
-        "entities": [
-          {
-            "client_name": "Cursor",
-            "conversation_id": "<id:1>",
-            "cwd": "<env>",
-            "data_source": "cursor-hook",
-            "entity_type": "conversation",
-            "harness": "cursor-hook",
-            "hook_event": "stop_backfill",
-            "repository_name": "<env>",
-            "repository_remote": "<env>",
-            "repository_root": "<env>",
-            "scope_summary": "<env>",
-            "thread_kind": "human_agent",
-            "title": "<env>",
-            "workspace_kind": "<env>"
-          }
-        ],
         "idempotency_key": "<id:6>"
       }
     },
@@ -124,10 +129,10 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
-            "diagnosis_confidence": "high",
+            "diagnosis_confidence": "medium",
             "ended_at": "<ts>",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -150,11 +155,10 @@
                 "reminder_hooks": [],
                 "reminder_injected": false,
                 "tool_invocation_count": 0,
-                "user_message_stored": false
+                "user_message_stored": true
               }
             },
             "missed_steps": [
-              "user_message_store",
               "user_phase_store"
             ],
             "model": "claude-sonnet-4.5",
@@ -171,12 +175,12 @@
             "status": "backfilled_by_hook",
             "store_structured_calls": 0,
             "tool_invocation_count": 0,
-            "turn_id": "<id:3>",
+            "turn_id": "<id:4>",
             "turn_key": "tool_failure_recovery__cursor-hooks__claude-sonnet-4.5:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     }
   ],

--- a/tests/__snapshots__/agentic_eval/tool_failure_recovery__cursor-hooks__composer-2.snap.json
+++ b/tests/__snapshots__/agentic_eval/tool_failure_recovery__cursor-hooks__composer-2.snap.json
@@ -2,6 +2,33 @@
   "requests": [
     {
       "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_3",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_9",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_14",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
       "endpoint": "/store",
       "body": {
         "entities": [
@@ -50,7 +77,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
@@ -63,12 +90,15 @@
             "model": "composer-2",
             "session_id": "<id:1>",
             "started_at": "<ts>",
-            "turn_id": "<id:3>",
+            "stored_entity_ids": [
+              "ent_mock_3"
+            ],
+            "turn_id": "<id:4>",
             "turn_key": "tool_failure_recovery__cursor-hooks__composer-2:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     },
     {
@@ -89,31 +119,6 @@
             "turn_key": "tool_failure_recovery__cursor-hooks__composer-2:turn-1:assistant"
           }
         ],
-        "idempotency_key": "<id:5>"
-      }
-    },
-    {
-      "method": "POST",
-      "endpoint": "/store",
-      "body": {
-        "entities": [
-          {
-            "client_name": "Cursor",
-            "conversation_id": "<id:1>",
-            "cwd": "<env>",
-            "data_source": "cursor-hook",
-            "entity_type": "conversation",
-            "harness": "cursor-hook",
-            "hook_event": "stop_backfill",
-            "repository_name": "<env>",
-            "repository_remote": "<env>",
-            "repository_root": "<env>",
-            "scope_summary": "<env>",
-            "thread_kind": "human_agent",
-            "title": "<env>",
-            "workspace_kind": "<env>"
-          }
-        ],
         "idempotency_key": "<id:6>"
       }
     },
@@ -124,10 +129,10 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
-            "diagnosis_confidence": "high",
+            "diagnosis_confidence": "medium",
             "ended_at": "<ts>",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -150,11 +155,10 @@
                 "reminder_hooks": [],
                 "reminder_injected": false,
                 "tool_invocation_count": 0,
-                "user_message_stored": false
+                "user_message_stored": true
               }
             },
             "missed_steps": [
-              "user_message_store",
               "user_phase_store"
             ],
             "model": "composer-2",
@@ -171,12 +175,12 @@
             "status": "backfilled_by_hook",
             "store_structured_calls": 0,
             "tool_invocation_count": 0,
-            "turn_id": "<id:3>",
+            "turn_id": "<id:4>",
             "turn_key": "tool_failure_recovery__cursor-hooks__composer-2:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     }
   ],

--- a/tests/__snapshots__/agentic_eval/tool_failure_recovery__cursor-hooks__gpt-5.5-fast.snap.json
+++ b/tests/__snapshots__/agentic_eval/tool_failure_recovery__cursor-hooks__gpt-5.5-fast.snap.json
@@ -2,6 +2,33 @@
   "requests": [
     {
       "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_3",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_9",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_14",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
       "endpoint": "/store",
       "body": {
         "entities": [
@@ -50,7 +77,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
@@ -63,12 +90,15 @@
             "model": "gpt-5.5-fast",
             "session_id": "<id:1>",
             "started_at": "<ts>",
-            "turn_id": "<id:3>",
+            "stored_entity_ids": [
+              "ent_mock_3"
+            ],
+            "turn_id": "<id:4>",
             "turn_key": "tool_failure_recovery__cursor-hooks__gpt-5.5-fast:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     },
     {
@@ -89,31 +119,6 @@
             "turn_key": "tool_failure_recovery__cursor-hooks__gpt-5.5-fast:turn-1:assistant"
           }
         ],
-        "idempotency_key": "<id:5>"
-      }
-    },
-    {
-      "method": "POST",
-      "endpoint": "/store",
-      "body": {
-        "entities": [
-          {
-            "client_name": "Cursor",
-            "conversation_id": "<id:1>",
-            "cwd": "<env>",
-            "data_source": "cursor-hook",
-            "entity_type": "conversation",
-            "harness": "cursor-hook",
-            "hook_event": "stop_backfill",
-            "repository_name": "<env>",
-            "repository_remote": "<env>",
-            "repository_root": "<env>",
-            "scope_summary": "<env>",
-            "thread_kind": "human_agent",
-            "title": "<env>",
-            "workspace_kind": "<env>"
-          }
-        ],
         "idempotency_key": "<id:6>"
       }
     },
@@ -124,10 +129,10 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
-            "diagnosis_confidence": "high",
+            "diagnosis_confidence": "medium",
             "ended_at": "<ts>",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -150,11 +155,10 @@
                 "reminder_hooks": [],
                 "reminder_injected": false,
                 "tool_invocation_count": 0,
-                "user_message_stored": false
+                "user_message_stored": true
               }
             },
             "missed_steps": [
-              "user_message_store",
               "user_phase_store"
             ],
             "model": "gpt-5.5-fast",
@@ -171,12 +175,12 @@
             "status": "backfilled_by_hook",
             "store_structured_calls": 0,
             "tool_invocation_count": 0,
-            "turn_id": "<id:3>",
+            "turn_id": "<id:4>",
             "turn_key": "tool_failure_recovery__cursor-hooks__gpt-5.5-fast:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     }
   ],

--- a/tests/__snapshots__/agentic_eval/tool_failure_recovery__cursor-hooks__gpt-5.5-medium.snap.json
+++ b/tests/__snapshots__/agentic_eval/tool_failure_recovery__cursor-hooks__gpt-5.5-medium.snap.json
@@ -2,6 +2,33 @@
   "requests": [
     {
       "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_3",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_9",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "PART_OF",
+        "source_entity_id": "ent_mock_14",
+        "target_entity_id": "ent_mock_1"
+      }
+    },
+    {
+      "method": "POST",
       "endpoint": "/store",
       "body": {
         "entities": [
@@ -50,7 +77,7 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
             "entity_type": "conversation_turn",
@@ -63,12 +90,15 @@
             "model": "gpt-5.5-medium",
             "session_id": "<id:1>",
             "started_at": "<ts>",
-            "turn_id": "<id:3>",
+            "stored_entity_ids": [
+              "ent_mock_3"
+            ],
+            "turn_id": "<id:4>",
             "turn_key": "tool_failure_recovery__cursor-hooks__gpt-5.5-medium:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     },
     {
@@ -89,31 +119,6 @@
             "turn_key": "tool_failure_recovery__cursor-hooks__gpt-5.5-medium:turn-1:assistant"
           }
         ],
-        "idempotency_key": "<id:5>"
-      }
-    },
-    {
-      "method": "POST",
-      "endpoint": "/store",
-      "body": {
-        "entities": [
-          {
-            "client_name": "Cursor",
-            "conversation_id": "<id:1>",
-            "cwd": "<env>",
-            "data_source": "cursor-hook",
-            "entity_type": "conversation",
-            "harness": "cursor-hook",
-            "hook_event": "stop_backfill",
-            "repository_name": "<env>",
-            "repository_remote": "<env>",
-            "repository_root": "<env>",
-            "scope_summary": "<env>",
-            "thread_kind": "human_agent",
-            "title": "<env>",
-            "workspace_kind": "<env>"
-          }
-        ],
         "idempotency_key": "<id:6>"
       }
     },
@@ -124,10 +129,10 @@
         "entities": [
           {
             "context_source": "cursor-hook",
-            "conversation_id": "<id:1>",
+            "conversation_id": "<id:3>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
-            "diagnosis_confidence": "high",
+            "diagnosis_confidence": "medium",
             "ended_at": "<ts>",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",
@@ -150,11 +155,10 @@
                 "reminder_hooks": [],
                 "reminder_injected": false,
                 "tool_invocation_count": 0,
-                "user_message_stored": false
+                "user_message_stored": true
               }
             },
             "missed_steps": [
-              "user_message_store",
               "user_phase_store"
             ],
             "model": "gpt-5.5-medium",
@@ -171,12 +175,12 @@
             "status": "backfilled_by_hook",
             "store_structured_calls": 0,
             "tool_invocation_count": 0,
-            "turn_id": "<id:3>",
+            "turn_id": "<id:4>",
             "turn_key": "tool_failure_recovery__cursor-hooks__gpt-5.5-medium:turn-1",
             "working_directory": "<env>"
           }
         ],
-        "idempotency_key": "<id:4>"
+        "idempotency_key": "<id:5>"
       }
     }
   ],

--- a/tests/fixtures/agentic_eval/agent_skips_store.json
+++ b/tests/fixtures/agentic_eval/agent_skips_store.json
@@ -36,7 +36,7 @@
       {
         "type": "turn_diagnosis",
         "classification": "hook_state_incomplete",
-        "confidence": "high",
+        "confidence": "medium",
         "reminder_injected": false,
         "recommends_includes": "install.mjs"
       },


### PR DESCRIPTION
`agentic_evals` is red on `main` (first run after #375's lane landed alongside #318's merge). Root cause: #375's snapshots and the `agent_skips_store` fixture were recorded against a `packages/client` build predating the #316 store-shape fix — the hook's user-phase store silently failed to parse the mock response, so `user_message_stored` stayed false and the classifier returned `confidence=high` for `hook_state_incomplete`. With the fixed client, the user-phase store succeeds (extra `/store` + `PART_OF` requests in the sequence) and the classifier correctly weakens to `medium` because the hook demonstrably stored the user message.

- Re-recorded all Tier 1 snapshots (`UPDATE_AGENTIC_EVAL_SNAPSHOTS=1`)
- `agent_skips_store` fixture: expected confidence `high` → `medium`
- 35/35 cells green locally

Unblocks the `agentic_evals` lane for every open PR (currently inherited-red, e.g. #322).