### PR TITLE
fix(eval): agent_skips_store diagnosis_confidence should be medium, not high

### DIFF
--- a/tests/__snapshots__/agentic_eval/agent_skips_store__cursor-hooks__claude-haiku-4.snap.json
+++ b/tests/__snapshots__/agentic_eval/agent_skips_store__cursor-hooks__claude-haiku-4.snap.json
@@ -127,7 +127,7 @@
             "conversation_id": "<id:1>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
-            "diagnosis_confidence": "high",
+            "diagnosis_confidence": "medium",
             "ended_at": "<ts>",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",

--- a/tests/__snapshots__/agentic_eval/agent_skips_store__cursor-hooks__claude-sonnet-4.5.snap.json
+++ b/tests/__snapshots__/agentic_eval/agent_skips_store__cursor-hooks__claude-sonnet-4.5.snap.json
@@ -127,7 +127,7 @@
             "conversation_id": "<id:1>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
-            "diagnosis_confidence": "high",
+            "diagnosis_confidence": "medium",
             "ended_at": "<ts>",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",

--- a/tests/__snapshots__/agentic_eval/agent_skips_store__cursor-hooks__composer-2.snap.json
+++ b/tests/__snapshots__/agentic_eval/agent_skips_store__cursor-hooks__composer-2.snap.json
@@ -127,7 +127,7 @@
             "conversation_id": "<id:1>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
-            "diagnosis_confidence": "high",
+            "diagnosis_confidence": "medium",
             "ended_at": "<ts>",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",

--- a/tests/__snapshots__/agentic_eval/agent_skips_store__cursor-hooks__gpt-5.5-fast.snap.json
+++ b/tests/__snapshots__/agentic_eval/agent_skips_store__cursor-hooks__gpt-5.5-fast.snap.json
@@ -127,7 +127,7 @@
             "conversation_id": "<id:1>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
-            "diagnosis_confidence": "high",
+            "diagnosis_confidence": "medium",
             "ended_at": "<ts>",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",

--- a/tests/__snapshots__/agentic_eval/agent_skips_store__cursor-hooks__gpt-5.5-medium.snap.json
+++ b/tests/__snapshots__/agentic_eval/agent_skips_store__cursor-hooks__gpt-5.5-medium.snap.json
@@ -127,7 +127,7 @@
             "conversation_id": "<id:1>",
             "cwd": "<env>",
             "data_source": "cursor-hook",
-            "diagnosis_confidence": "high",
+            "diagnosis_confidence": "medium",
             "ended_at": "<ts>",
             "entity_type": "conversation_turn",
             "git_branch": "<env>",

--- a/tests/fixtures/agentic_eval/agent_skips_store.json
+++ b/tests/fixtures/agentic_eval/agent_skips_store.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "id": "agent_skips_store",
-    "description": "Agent finishes a turn without ever calling store_structured. The stop hook must (a) emit a turn_compliance observation with status=backfilled_by_hook, (b) attach an instruction_diagnostics block classifying the skipped store, and (c) with NEOTOMA_HOOK_COMPLIANCE_FOLLOWUP=auto/on, return a follow-up message that includes a likely-cause sentence for every model.",
+    "description": "Agent finishes a turn without ever calling store_structured. The stop hook must (a) emit a turn_compliance observation with status=backfilled_by_hook, (b) attach an instruction_diagnostics block classifying the skipped store, and (c) with NEOTOMA_HOOK_COMPLIANCE_FOLLOWUP=auto/on, return a follow-up message that includes a likely-cause sentence for every model. Confidence is medium (not high) because beforeSubmitPrompt successfully stored the user message (user_message_stored=true), so only the reminder/postToolUse path is missing — diagnoseSkippedStore deliberately downgrades hook_state_incomplete to medium when the user message was stored (see packages/cursor-hooks/hooks/_common.ts and tests/unit/cursor_hooks_small_model.test.ts).",
     "harnesses": ["cursor-hooks"],
     "models": ["composer-2", "gpt-5.5-fast", "claude-haiku-4", "claude-sonnet-4.5", "gpt-5.5-medium"],
     "tags": ["compliance", "stop-hook", "diagnosis"]
@@ -36,7 +36,7 @@
       {
         "type": "turn_diagnosis",
         "classification": "hook_state_incomplete",
-        "confidence": "high",
+        "confidence": "medium",
         "reminder_injected": false,
         "recommends_includes": "install.mjs"
       },


### PR DESCRIPTION
## Root cause

The blocking `agentic_evals` CI job (Tier 1 matrix, `tests/integration/agentic_eval_matrix.test.ts`) has been red on `main` since #375 merged, with all `agent_skips_store` cells failing identically:

```
[turn_diagnosis] Expected diagnosis_confidence="high", got "medium".
```

This is a **fixture-too-strict bug, not a producer regression**.

- #375 itself did **not** touch `agent_skips_store.json` or the classifier. Its diff added a new fixture (`plan_creation_stores_to_neotoma`), the `field_present` predicate, and the blocking CI lane (`ci_test_lanes.yml`). Making the job blocking is what surfaced a pre-existing mismatch.
- The live stop-hook classifier `diagnoseSkippedStore` (`packages/cursor-hooks/hooks/_common.ts`) deliberately returns `confidence: userMessageStored ? "medium" : "high"` for the `hook_state_incomplete` branch.
- In the `agent_skips_store` scenario, `beforeSubmitPrompt` successfully stores the user message against the mock server, so at stop-hook diagnosis time `user_message_stored === true`. Only the reminder/postToolUse path is missing — a **partial**, not total, hook failure — so the classifier correctly downgrades confidence to `medium`.
- The `medium`-for-`user_message_stored=true` behavior is the documented, **unit-tested** contract: `tests/unit/cursor_hooks_small_model.test.ts` explicitly asserts `expect(result.confidence).toBe("medium")` for that case (and `high` when the user message was NOT stored).
- The fixture's own assertions already encode this: `turn_compliance.missed_includes` is `["user_phase_store"]` and does **not** include `user_message_store`, i.e. the user message was stored.

The fixture's `confidence: "high"` and the classifier ternary were introduced in the same commit (`de411eec6`) and have always disagreed for this scenario; the eval only began enforcing it once the lane became blocking.

A turn that skips the store but where `beforeSubmitPrompt` still backfilled the user message is genuinely a partial hook failure, so `medium` is the correct, non-weakened expectation. Forcing `high` here would contradict the unit-tested producer contract.

## Change

- `tests/fixtures/agentic_eval/agent_skips_store.json`: `confidence` `high` → `medium`; description now explains why medium is correct.
- The five recorded `agent_skips_store__cursor-hooks__*.snap.json` snapshots: synced the single `diagnosis_confidence` field `high` → `medium`. This is the only delta — `classification`, `reason`, `signals`, and `recommended_repairs` are byte-identical between the high/medium branches (the ternary only flips the confidence string).
- `agent_skips_store_after_reminder` (the legitimately high-confidence `agent_ignored_available_instructions` case) is intentionally **untouched**.

The producer (`diagnoseSkippedStore`) is unchanged — it was already correct.

## Verification

- Reproduced the exact CI failure locally (built `@neotoma/client` + `cursor-hooks` dist, ran the matrix): all `agent_skips_store` cells failed with `got "medium"` before the change.
- After the fix, the `[turn_diagnosis]` assertion failure is gone.
- `tests/unit/cursor_hooks_small_model.test.ts`: 19/19 pass (classifier contract intact).
- `npm run type-check`: clean.

Residual local snapshot diffs on these fixtures are pre-existing environment noise (they appear on unmodified `origin/main` too, including on `after_reminder` which has no confidence change) and do not occur in CI's deterministic checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)