### PR TITLE
fix(issues-sync): include updated_at in pull-leg idempotency key

### DIFF
--- a/src/services/issues/sync_issues_from_github.ts
+++ b/src/services/issues/sync_issues_from_github.ts
@@ -271,11 +271,18 @@ async function syncSingleIssue(
     { relationship_type: "PART_OF", source_index: 2, target_index: 1 },
   ];
 
+  // Include updated_at so each distinct version of an issue gets a unique
+  // idempotency_key. A static `issue-sync-${repo}-${number}` key is reused
+  // verbatim on every sync, so once an issue's title/body/labels change on
+  // GitHub the store fails with ERR_IDEMPOTENCY_MISMATCH (same key, different
+  // content) and the issue never updates locally. Keying on updated_at keeps a
+  // genuine no-op re-sync idempotent (same key → dedup) while letting changed
+  // content through under a fresh key.
   return runWithExternalActor(actor, () =>
     ops.store({
       entities,
       relationships,
-      idempotency_key: `issue-sync-${repo}-${issue.number}`,
+      idempotency_key: `issue-sync-${repo}-${issue.number}-${issue.updated_at}`,
     })
   ) as Promise<StoreResult>;
 }

--- a/tests/services/sync_issues_from_github.test.ts
+++ b/tests/services/sync_issues_from_github.test.ts
@@ -166,10 +166,34 @@ describe("syncIssuesFromGitHub", () => {
     await syncIssuesFromGitHub(ops);
     await syncIssuesFromGitHub(ops);
 
+    // The issue key includes updated_at so a changed issue gets a fresh key,
+    // but an unchanged issue re-synced twice keeps the same key (dedup).
     expect(store).toHaveBeenCalledTimes(4);
     expect(seenIdempotencyKeys).toEqual(
-      new Set(["issue-sync-test/repo-1", "issue-comment-sync-test/repo-1-101"])
+      new Set([
+        "issue-sync-test/repo-1-2026-05-01T00:00:00Z",
+        "issue-comment-sync-test/repo-1-101",
+      ])
     );
+  });
+
+  it("gives a changed issue a fresh idempotency key (avoids ERR_IDEMPOTENCY_MISMATCH)", async () => {
+    const { ops, seenIdempotencyKeys } = createOps();
+    mockListIssueComments.mockResolvedValue([]);
+
+    // Same issue number, different content + later updated_at (as GitHub returns
+    // after an edit). The store must use a distinct key, or Neotoma rejects the
+    // write as a mismatch and the issue never updates locally.
+    const v1 = { ...issue(1, "Original title"), updated_at: "2026-05-01T00:00:00Z" };
+    const v2 = { ...issue(1, "Edited title"), updated_at: "2026-05-02T12:00:00Z" };
+
+    mockListIssues.mockResolvedValueOnce([v1]);
+    await syncIssuesFromGitHub(ops);
+    mockListIssues.mockResolvedValueOnce([v2]);
+    await syncIssuesFromGitHub(ops);
+
+    expect(seenIdempotencyKeys.has("issue-sync-test/repo-1-2026-05-01T00:00:00Z")).toBe(true);
+    expect(seenIdempotencyKeys.has("issue-sync-test/repo-1-2026-05-02T12:00:00Z")).toBe(true);
   });
 
   describe("push leg — local public issues without github_number", () => {


### PR DESCRIPTION
## Problem

The GitHub→Neotoma pull leg (`sync_issues_from_github.ts:278`) stored each issue with a **static** idempotency key:

```ts
idempotency_key: `issue-sync-${repo}-${issue.number}`
```

The key never varies with content, so the first time an issue's title/body/labels change on GitHub, the store fails:

```
ERR_IDEMPOTENCY_MISMATCH: idempotency_key "issue-sync-markmhendrickson/neotoma-1607"
was already used with different content.
```

The issue then never updates locally. Observed **live** — after fixing the daemon's auth/env config this session, every open issue in `markmhendrickson/neotoma` errored this way on each 5-minute sync cycle. This was the last blocker on GitHub→Neotoma intake.

## Fix

Append `issue.updated_at` to the key. GitHub bumps `updated_at` on every edit, so:
- An **unchanged** issue re-synced keeps the same key → still deduped (no row churn).
- An **edited** issue gets a fresh key → stores cleanly instead of mismatching.

One-line change at the store call site (`updated_at` is already on the `GitHubIssue` type).

## Tests

- Updated the existing stable-key assertion to the new format.
- Added a case proving a changed issue (later `updated_at`, same number) gets a distinct key.
- `sync_issues_from_github.test.ts`: **12 pass** (1 pre-existing todo).

## Context

The earlier merged fixes (`0a98c7deb` AUTH-retry, `dd001b1ef` Neotoma-first ordering) plus this session's deployment-config fix (prod-loopback env for the launchd daemon) got the sync authenticating and reaching GitHub; this is the remaining code bug on the store path. (Separate from the still-unmerged push-leg writeback fix on `feat/inspector-bundled-mount-cursor-handoff`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)