### PR TITLE
fix(issues): content-hash the sync idempotency key (ERR_IDEMPOTENCY_MISMATCH)

### DIFF
--- a/src/services/issues/sync_issues_from_github.ts
+++ b/src/services/issues/sync_issues_from_github.ts
@@ -18,6 +18,7 @@
  * schema `turn_key` (see `github_thread_keys.ts` — not `github_comment_id` alone).
  */
 
+import { createHash } from "node:crypto";
 import type {
   Operations,
   StoreEntityInput,
@@ -217,6 +218,28 @@ function extractEntitiesArray(raw: unknown): Array<Record<string, unknown>> {
 }
 
 /**
+ * Short, stable digest of an issue's mutable content (title, body, state,
+ * labels, closed_at). Folded into the sync idempotency_key so that:
+ *   - a re-sync of an UNCHANGED issue keeps the same key → idempotent no-op,
+ *   - a re-sync after the issue was edited on GitHub (new title/body/labels/
+ *     state) yields a NEW key → the update lands as a fresh observation.
+ *
+ * Without this, the key was constant per issue (`issue-sync-<repo>-<number>`)
+ * while the entity content drifted, so every post-edit sync tripped
+ * ERR_IDEMPOTENCY_MISMATCH and the whole run reported "Synced 0 issues".
+ */
+function issueContentDigest(issue: GitHubIssue): string {
+  const material = JSON.stringify({
+    title: issue.title,
+    body: issue.body ?? "",
+    state: issue.state,
+    labels: issue.labels.map((l) => l.name).sort(),
+    closed_at: issue.closed_at ?? null,
+  });
+  return createHash("sha256").update(material).digest("hex").slice(0, 16);
+}
+
+/**
  * Sync a single issue and its first message (the issue body).
  */
 async function syncSingleIssue(
@@ -275,7 +298,7 @@ async function syncSingleIssue(
     ops.store({
       entities,
       relationships,
-      idempotency_key: `issue-sync-${repo}-${issue.number}`,
+      idempotency_key: `issue-sync-${repo}-${issue.number}-${issueContentDigest(issue)}`,
     })
   ) as Promise<StoreResult>;
 }

--- a/src/services/issues/sync_issues_idempotency.test.ts
+++ b/src/services/issues/sync_issues_idempotency.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Regression coverage for the issues-sync ERR_IDEMPOTENCY_MISMATCH failure:
+// the pull leg keyed each issue store on a CONSTANT `issue-sync-<repo>-<number>`
+// while the stored entity content (title/body/state/labels) drifted as the
+// GitHub issue was edited. Neotoma enforces "same idempotency_key => identical
+// content", so every post-edit sync was rejected and the run reported
+// "Synced 0 issues". The key now folds in a content digest: stable when the
+// issue is unchanged (idempotent no-op), new when the content drifts.
+
+const mockCreateIssue = vi.fn();
+const mockListIssues = vi.fn();
+const mockListIssueComments = vi.fn();
+
+const { mockLoadIssuesConfig } = vi.hoisted(() => ({
+  mockLoadIssuesConfig: vi.fn(),
+}));
+
+const defaultIssuesConfig = {
+  target_url: "https://neotoma.example.com",
+  repo: "test/repo",
+  github_auth: "gh_cli" as const,
+  reporting_mode: "consent" as const,
+  sync_staleness_ms: 300000,
+  configured_at: "2026-01-01T00:00:00Z",
+  author_alias: null,
+};
+
+vi.mock("./github_client.js", () => ({
+  createIssue: (...args: unknown[]) => mockCreateIssue(...args),
+  listIssues: (...args: unknown[]) => mockListIssues(...args),
+  listIssueComments: (...args: unknown[]) => mockListIssueComments(...args),
+  addIssueComment: vi.fn(),
+  mergeNeotomaToolingIssueLabels: (labels?: string[]) => [
+    "neotoma",
+    ...(labels ?? []).filter((label) => label !== "neotoma"),
+  ],
+}));
+
+vi.mock("./config.js", () => ({
+  loadIssuesConfig: (...args: unknown[]) => mockLoadIssuesConfig(...args),
+}));
+
+vi.mock("./redaction_guard.js", () => ({
+  runRedactionGuard: ({ title, body }: { title: string; body: string }) => ({ title, body }),
+}));
+
+import { syncIssuesFromGitHub } from "./sync_issues_from_github.js";
+import type { Operations } from "../../core/operations.js";
+
+function makeGithubIssue(over: Partial<Record<string, unknown>> = {}) {
+  return {
+    number: 1619,
+    html_url: "https://github.com/test/repo/issues/1619",
+    title: "Original title",
+    body: "Original body",
+    state: "open",
+    labels: [{ name: "bug" }],
+    user: { login: "octocat", id: 1, type: "User" },
+    created_at: "2026-06-01T00:00:00Z",
+    closed_at: null,
+    updated_at: "2026-06-01T00:00:00Z",
+    ...over,
+  };
+}
+
+function makeOps(store: ReturnType<typeof vi.fn>): Operations {
+  return {
+    store,
+    correct: vi.fn(async () => ({ ok: true })),
+    // Push leg finds nothing local; we only exercise the pull leg here.
+    retrieveEntities: vi.fn(async () => ({ entities: [] })),
+    executeTool: vi.fn(async () => ({})),
+  } as unknown as Operations;
+}
+
+function issueStoreKeys(store: ReturnType<typeof vi.fn>): string[] {
+  return store.mock.calls
+    .map((c) => (c[0] as { idempotency_key?: string }).idempotency_key ?? "")
+    .filter((k) => k.startsWith("issue-sync-"));
+}
+
+describe("issues-sync pull leg idempotency key (ERR_IDEMPOTENCY_MISMATCH)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLoadIssuesConfig.mockResolvedValue(defaultIssuesConfig);
+    mockListIssueComments.mockResolvedValue([]);
+  });
+
+  it("includes the repo and issue number in the sync key", async () => {
+    mockListIssues.mockResolvedValue([makeGithubIssue()]);
+    const store = vi.fn(async () => ({ entities: [] }));
+    await syncIssuesFromGitHub(makeOps(store), {});
+
+    const keys = issueStoreKeys(store);
+    expect(keys.length).toBe(1);
+    expect(keys[0]).toMatch(/^issue-sync-test\/repo-1619-/);
+  });
+
+  it("keeps the SAME key when the issue content is unchanged (idempotent re-sync)", async () => {
+    const store = vi.fn(async () => ({ entities: [] }));
+
+    mockListIssues.mockResolvedValue([makeGithubIssue()]);
+    await syncIssuesFromGitHub(makeOps(store), {});
+    const firstKey = issueStoreKeys(store)[0];
+
+    store.mockClear();
+    mockListIssues.mockResolvedValue([makeGithubIssue()]);
+    await syncIssuesFromGitHub(makeOps(store), {});
+    const secondKey = issueStoreKeys(store)[0];
+
+    expect(secondKey).toBe(firstKey);
+  });
+
+  it("changes the key when title/body/state/labels drift (so the update lands)", async () => {
+    const store = vi.fn(async () => ({ entities: [] }));
+
+    mockListIssues.mockResolvedValue([makeGithubIssue()]);
+    await syncIssuesFromGitHub(makeOps(store), {});
+    const baseKey = issueStoreKeys(store)[0];
+
+    const variants = [
+      { title: "Edited title" },
+      { body: "Edited body" },
+      { state: "closed", closed_at: "2026-06-10T00:00:00Z" },
+      { labels: [{ name: "bug" }, { name: "priority/high" }] },
+    ];
+
+    for (const over of variants) {
+      store.mockClear();
+      mockListIssues.mockResolvedValue([makeGithubIssue(over)]);
+      await syncIssuesFromGitHub(makeOps(store), {});
+      const variantKey = issueStoreKeys(store)[0];
+      expect(variantKey).not.toBe(baseKey);
+    }
+  });
+
+  it("is insensitive to label ordering (same labels, different order => same key)", async () => {
+    const store = vi.fn(async () => ({ entities: [] }));
+
+    mockListIssues.mockResolvedValue([
+      makeGithubIssue({ labels: [{ name: "bug" }, { name: "neotoma" }] }),
+    ]);
+    await syncIssuesFromGitHub(makeOps(store), {});
+    const keyA = issueStoreKeys(store)[0];
+
+    store.mockClear();
+    mockListIssues.mockResolvedValue([
+      makeGithubIssue({ labels: [{ name: "neotoma" }, { name: "bug" }] }),
+    ]);
+    await syncIssuesFromGitHub(makeOps(store), {});
+    const keyB = issueStoreKeys(store)[0];
+
+    expect(keyB).toBe(keyA);
+  });
+});

--- a/tests/services/sync_issues_from_github.test.ts
+++ b/tests/services/sync_issues_from_github.test.ts
@@ -167,9 +167,14 @@ describe("syncIssuesFromGitHub", () => {
     await syncIssuesFromGitHub(ops);
 
     expect(store).toHaveBeenCalledTimes(4);
-    expect(seenIdempotencyKeys).toEqual(
-      new Set(["issue-sync-test/repo-1", "issue-comment-sync-test/repo-1-101"])
-    );
+    // Two runs over identical content collapse to exactly two distinct keys:
+    // one for the issue, one for its comment. The issue key carries a content
+    // digest suffix (issue-sync-<repo>-<number>-<digest>) so an EDITED issue
+    // gets a fresh key, while unchanged re-syncs keep the same digest → stable.
+    expect(seenIdempotencyKeys.size).toBe(2);
+    const issueKey = [...seenIdempotencyKeys].find((k) => k.startsWith("issue-sync-"));
+    expect(issueKey).toMatch(/^issue-sync-test\/repo-1-[0-9a-f]{16}$/);
+    expect(seenIdempotencyKeys).toContain("issue-comment-sync-test/repo-1-101");
   });
 
   describe("push leg — local public issues without github_number", () => {


### PR DESCRIPTION
## Problem

The launchd `issues sync` job has been failing on essentially every issue with:

```
Issue #1619: MCP error -32602: ERR_IDEMPOTENCY_MISMATCH: idempotency_key
"issue-sync-markmhendrickson/neotoma-1619" was already used with different
content.
```

…and reporting **"Synced 0 issues, 0 messages."** every run. The GitHub→Neotoma issue feed — the swarm's primary intake of maintainer issues — was effectively dead.

## Root cause

`syncSingleIssue` keyed the store on a **constant** `issue-sync-<repo>-<number>` (sync_issues_from_github.ts:278). But the entity it stores carries the issue's mutable content — `title`, `body`, `status`, `labels`. Neotoma's idempotency contract is *same key ⇒ identical content*, so the first sync of an issue succeeds and every later sync (after the issue is edited, relabeled, or closed on GitHub) is rejected.

This is the same class of bug as the earlier #1610 push-leg fix — a key that doesn't track the content it guards.

## Fix

Fold a 16-char sha256 digest of the issue's mutable fields (title, body, state, sorted labels, closed_at) into the key:

```
issue-sync-<repo>-<number>-<contentDigest>
```

- **Unchanged issue re-sync** → same digest → same key → idempotent no-op (no spurious observation).
- **Edited issue re-sync** → new digest → new key → the update lands as a fresh observation.
- **Label reorder alone** → labels are sorted before hashing → same key (no churn).

## Tests

`sync_issues_idempotency.test.ts` (4 cases): key shape (`issue-sync-test/repo-1619-…`), stable-when-unchanged, changes-on-drift across title/body/state/labels, and label-order-insensitivity. Sibling `sync_issues_push_writeback.test.ts` still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)