### PR TITLE
fix(issues-sync): derive sync provenance from updated_at, not wall-clock

### DIFF
--- a/src/services/issues/sync_issues_from_github.ts
+++ b/src/services/issues/sync_issues_from_github.ts
@@ -224,7 +224,13 @@ async function syncSingleIssue(
   issue: GitHubIssue,
   repo: string
 ): Promise<StoreResult> {
-  const now = new Date().toISOString();
+  // Derive sync-provenance fields from the issue's own updated_at, NOT wall-clock
+  // `now`. The idempotency check hashes the full entity payload; a wall-clock
+  // last_synced_at/data_source changes every run, so an unchanged issue re-synced
+  // under the same (updated_at-keyed) idempotency_key tripped
+  // ERR_IDEMPOTENCY_MISMATCH and never synced. Deterministic provenance keeps the
+  // payload byte-stable across runs so the idempotent no-op actually holds.
+  const syncedAt = issue.updated_at;
   const threadConversationId = githubIssueThreadConversationId(repo, issue.number);
   const actor = buildExternalActorFromGithubIssue(issue, { repository: repo });
 
@@ -243,9 +249,9 @@ async function syncSingleIssue(
       github_actor: actor ? { login: actor.login, id: actor.id, type: actor.type } : undefined,
       created_at: issue.created_at,
       closed_at: issue.closed_at,
-      last_synced_at: now,
+      last_synced_at: syncedAt,
       sync_pending: false,
-      data_source: `github issues api ${repo} #${issue.number} ${now.slice(0, 10)}`,
+      data_source: `github issues api ${repo} #${issue.number} ${syncedAt.slice(0, 10)}`,
     } as StoreEntityInput,
     {
       entity_type: "conversation",
@@ -297,7 +303,10 @@ async function syncSingleComment(
   issue: GitHubIssue,
   repo: string
 ): Promise<StoreResult> {
-  const now = new Date().toISOString();
+  // Deterministic provenance from the issue's updated_at (see syncSingleIssue) —
+  // keeps the re-stored issue entity payload byte-stable across runs so the
+  // idempotency content-hash holds.
+  const syncedAt = issue.updated_at;
   const threadConversationId = githubIssueThreadConversationId(repo, issue.number);
   const commentActor = buildExternalActorFromGithubComment(comment, issue, { repository: repo });
   const issueActor = buildExternalActorFromGithubIssue(issue, { repository: repo });
@@ -319,9 +328,9 @@ async function syncSingleComment(
         : undefined,
       created_at: issue.created_at,
       closed_at: issue.closed_at,
-      last_synced_at: now,
+      last_synced_at: syncedAt,
       sync_pending: false,
-      data_source: `github issues api ${repo} #${issue.number} ${now.slice(0, 10)}`,
+      data_source: `github issues api ${repo} #${issue.number} ${syncedAt.slice(0, 10)}`,
     } as StoreEntityInput,
     {
       entity_type: "conversation",

--- a/tests/services/sync_issues_from_github.test.ts
+++ b/tests/services/sync_issues_from_github.test.ts
@@ -196,6 +196,31 @@ describe("syncIssuesFromGitHub", () => {
     expect(seenIdempotencyKeys.has("issue-sync-test/repo-1-2026-05-02T12:00:00Z")).toBe(true);
   });
 
+  it("re-stores an unchanged issue with a byte-identical payload (no wall-clock drift)", async () => {
+    // The idempotency check hashes the FULL entity payload. A wall-clock
+    // last_synced_at/data_source made the payload differ every run, so an
+    // unchanged issue under its stable updated_at key tripped
+    // ERR_IDEMPOTENCY_MISMATCH. Provenance is now derived from updated_at, so
+    // two runs over identical GitHub data must produce identical store payloads.
+    const { ops, store } = createOps();
+    mockListIssues.mockResolvedValue([issue(1)]);
+    mockListIssueComments.mockResolvedValue([]);
+
+    await syncIssuesFromGitHub(ops);
+    const firstPayload = JSON.stringify(store.mock.calls[0]?.[0]?.entities);
+
+    store.mockClear();
+    mockListIssues.mockResolvedValue([issue(1)]);
+    await syncIssuesFromGitHub(ops);
+    const secondPayload = JSON.stringify(store.mock.calls[0]?.[0]?.entities);
+
+    expect(secondPayload).toBe(firstPayload);
+    // And provenance reflects the issue's updated_at, not wall-clock.
+    const issueEntity = store.mock.calls[0]?.[0]?.entities?.[0] as Record<string, unknown>;
+    expect(issueEntity.last_synced_at).toBe("2026-05-01T00:00:00Z");
+    expect(issueEntity.data_source).toContain("2026-05-01");
+  });
+
   describe("push leg — local public issues without github_number", () => {
     function makeEntityList(
       entities: Array<{ entity_id: string; snapshot: Record<string, unknown> }>


### PR DESCRIPTION
## Problem

Despite #1648 adding `updated_at` to the pull-leg idempotency key, the live launchd `issues sync` **still fails every run** with `ERR_IDEMPOTENCY_MISMATCH` and reports "Synced 0 issues":

```
Issue #1613: ERR_IDEMPOTENCY_MISMATCH: idempotency_key
"issue-sync-markmhendrickson/neotoma-1613-2026-06-09T11:38:38Z"
was already used with different content.
```

## Root cause

The idempotency check (`src/actions.ts`) hashes the **full entity payload** (`JSON.stringify(entities)`), not just identity fields. The issue entity sets:

```ts
last_synced_at: now,                                  // new Date() — wall clock
data_source: `github issues api ${repo} #${n} ${now.slice(0,10)}`,
```

`now` changes on every run, so even with a stable `updated_at`-keyed `idempotency_key`, the **content hash differs every time** → Neotoma rejects the write. #1648's key fix was necessary but not sufficient; the payload itself wasn't stable.

## Fix

Derive `last_synced_at` and `data_source` from `issue.updated_at` (deterministic) instead of `now`, in both `syncSingleIssue` and `syncSingleComment` (the latter re-stores the issue entity too). Now:

- **Unchanged issue, re-synced** → byte-identical payload → same content hash → idempotent no-op (the bug is fixed).
- **Edited issue** → new `updated_at` → new key *and* new payload → the update lands.

## Tests

Adds a regression test asserting the re-stored payload is **byte-identical across two runs** and that provenance reflects `updated_at` (not wall-clock). Full `sync_issues_from_github.test.ts` suite green (13 passed), including #1648's `updated_at` key tests.

## Context

I initially opened #1649 (a content-digest variant) and closed it as redundant to #1648 — but then verified against the live launchd sync and found #1648 alone doesn't actually clear the error. This is the real fix: the wall-clock provenance fields were the missing half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)