### PR TITLE
fix(issues-sync): bump sync key with migration token to clear stale rows

### DIFF
--- a/src/services/issues/sync_issues_from_github.ts
+++ b/src/services/issues/sync_issues_from_github.ts
@@ -36,6 +36,22 @@ import { githubIssueBodyTurnKey, githubIssueCommentTurnKey } from "./github_thre
 import { runRedactionGuard } from "./redaction_guard.js";
 import type { GitHubIssue, GitHubComment, IssueSyncParams } from "./types.js";
 
+/**
+ * One-time migration token folded into the pull-leg sync idempotency_key.
+ *
+ * Before the deterministic-provenance fix, the issue store payload contained a
+ * wall-clock `last_synced_at`/`data_source`, so existing `sources` rows under
+ * `issue-sync-<repo>-<number>-<updated_at>` carry a content_hash that no longer
+ * matches the (now deterministic) payload. Those rows can't be overwritten —
+ * the idempotency check rejects the mismatched content — so ~98 already-synced
+ * issues were frozen with ERR_IDEMPOTENCY_MISMATCH and never updated.
+ *
+ * Bumping this token gives every issue a brand-new key, sidestepping the stale
+ * rows without any destructive DB repair. The old rows simply go inert. Bump it
+ * again only if a future payload-shape change strands keys the same way.
+ */
+const SYNC_KEY_MIGRATION = "m2";
+
 export interface SyncResult {
   issues_synced: number;
   messages_synced: number;
@@ -288,7 +304,7 @@ async function syncSingleIssue(
     ops.store({
       entities,
       relationships,
-      idempotency_key: `issue-sync-${repo}-${issue.number}-${issue.updated_at}`,
+      idempotency_key: `issue-sync-${repo}-${issue.number}-${issue.updated_at}-${SYNC_KEY_MIGRATION}`,
     })
   ) as Promise<StoreResult>;
 }

--- a/tests/services/sync_issues_from_github.test.ts
+++ b/tests/services/sync_issues_from_github.test.ts
@@ -171,7 +171,7 @@ describe("syncIssuesFromGitHub", () => {
     expect(store).toHaveBeenCalledTimes(4);
     expect(seenIdempotencyKeys).toEqual(
       new Set([
-        "issue-sync-test/repo-1-2026-05-01T00:00:00Z",
+        "issue-sync-test/repo-1-2026-05-01T00:00:00Z-m2",
         "issue-comment-sync-test/repo-1-101",
       ])
     );
@@ -192,8 +192,8 @@ describe("syncIssuesFromGitHub", () => {
     mockListIssues.mockResolvedValueOnce([v2]);
     await syncIssuesFromGitHub(ops);
 
-    expect(seenIdempotencyKeys.has("issue-sync-test/repo-1-2026-05-01T00:00:00Z")).toBe(true);
-    expect(seenIdempotencyKeys.has("issue-sync-test/repo-1-2026-05-02T12:00:00Z")).toBe(true);
+    expect(seenIdempotencyKeys.has("issue-sync-test/repo-1-2026-05-01T00:00:00Z-m2")).toBe(true);
+    expect(seenIdempotencyKeys.has("issue-sync-test/repo-1-2026-05-02T12:00:00Z-m2")).toBe(true);
   });
 
   it("re-stores an unchanged issue with a byte-identical payload (no wall-clock drift)", async () => {


### PR DESCRIPTION
## Problem

#1650 made the issue store payload deterministic (provenance from `updated_at`, not wall-clock), which fixes the sync **going forward**. But verified live after deploy: **"Synced 6 issues, 98 ERR_IDEMPOTENCY_MISMATCH"**, stable across runs.

The 98 stuck issues already have `sources` rows written by the **old wall-clock code**. Neotoma keys idempotency on `(user_id, idempotency_key)` and compares the stored `content_hash`; those old rows carry a hash from the old payload, so a new deterministic write under the same `issue-sync-<repo>-<number>-<updated_at>` key still mismatches — and the check refuses to overwrite. Only issues edited on GitHub since (fresh `updated_at` → fresh key) recovered. The rest are frozen and won't self-heal.

## Fix (non-destructive)

Fold a one-time `SYNC_KEY_MIGRATION` token (`"m2"`) into the key:

```
issue-sync-<repo>-<number>-<updated_at>-m2
```

Every issue gets a brand-new key on the next sync → writes under fresh rows → the stale rows simply go inert. **No destructive DB repair**, fully reversible, and the next such migration is a one-line token bump. (Operator chose this over deleting prod source rows.)

## Verification

Unit tests updated for the new key shape; suite green (13 passed). The decisive end-to-end check — sync count returns to "Synced N, 0 errors" — runs on the deployed RC after merge (the launchd job has the auth env a bare worktree run lacks), same validation path as #1650.

🤖 Generated with [Claude Code](https://claude.com/claude-code)