### PR TITLE
fix(issues-sync): extend migration token to the comment-sync key

### DIFF
--- a/src/services/issues/sync_issues_from_github.ts
+++ b/src/services/issues/sync_issues_from_github.ts
@@ -37,18 +37,21 @@ import { runRedactionGuard } from "./redaction_guard.js";
 import type { GitHubIssue, GitHubComment, IssueSyncParams } from "./types.js";
 
 /**
- * One-time migration token folded into the pull-leg sync idempotency_key.
+ * One-time migration token folded into BOTH pull-leg sync idempotency keys
+ * (`issue-sync-*` and `issue-comment-sync-*`).
  *
  * Before the deterministic-provenance fix, the issue store payload contained a
  * wall-clock `last_synced_at`/`data_source`, so existing `sources` rows under
- * `issue-sync-<repo>-<number>-<updated_at>` carry a content_hash that no longer
- * matches the (now deterministic) payload. Those rows can't be overwritten —
- * the idempotency check rejects the mismatched content — so ~98 already-synced
- * issues were frozen with ERR_IDEMPOTENCY_MISMATCH and never updated.
+ * the sync keys carry a content_hash that no longer matches the (now
+ * deterministic) payload. Those rows can't be overwritten — the idempotency
+ * check rejects the mismatched content — so already-synced issues were frozen
+ * with ERR_IDEMPOTENCY_MISMATCH and never updated. The comment path re-stores
+ * the issue entity too, so it strands the same way under its own key.
  *
- * Bumping this token gives every issue a brand-new key, sidestepping the stale
- * rows without any destructive DB repair. The old rows simply go inert. Bump it
- * again only if a future payload-shape change strands keys the same way.
+ * Bumping this token gives every issue/comment a brand-new key, sidestepping
+ * the stale rows without any destructive DB repair. The old rows simply go
+ * inert. Bump it again only if a future payload-shape change strands keys the
+ * same way.
  */
 const SYNC_KEY_MIGRATION = "m2";
 
@@ -378,7 +381,7 @@ async function syncSingleComment(
     ops.store({
       entities,
       relationships,
-      idempotency_key: `issue-comment-sync-${repo}-${issue.number}-${comment.id}`,
+      idempotency_key: `issue-comment-sync-${repo}-${issue.number}-${comment.id}-${SYNC_KEY_MIGRATION}`,
     })
   ) as Promise<StoreResult>;
 }

--- a/tests/services/sync_issues_from_github.test.ts
+++ b/tests/services/sync_issues_from_github.test.ts
@@ -172,7 +172,7 @@ describe("syncIssuesFromGitHub", () => {
     expect(seenIdempotencyKeys).toEqual(
       new Set([
         "issue-sync-test/repo-1-2026-05-01T00:00:00Z-m2",
-        "issue-comment-sync-test/repo-1-101",
+        "issue-comment-sync-test/repo-1-101-m2",
       ])
     );
   });


### PR DESCRIPTION
## Problem

#1654 added the `SYNC_KEY_MIGRATION` token to the **issue-sync** key, which freed most stuck issues — verified live: "Synced 6 issues" → **"Synced 100 issues"**. But **78 `ERR_IDEMPOTENCY_MISMATCH` remained**, all on the **`issue-comment-sync`** path (stable across runs).

The comment-sync key (`issue-comment-sync-<repo>-<number>-<comment.id>`) re-stores the issue entity too, so its old wall-clock `sources` rows strand it exactly the same way — and it never got the migration token in #1654.

## Fix

Fold `SYNC_KEY_MIGRATION` into the comment-sync key as well, so every comment gets a fresh key and writes under a clean row. Same non-destructive approach as #1654; the doc comment now notes the token covers both keys. Test assertion updated. Suite green (13 passed).

## Verification

The decisive live run (sync returns "Synced N, **0** errors") happens on the deployed RC after merge — both sync keys now carry the token, so the remaining 78 comment-path mismatches should clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)