### PR TITLE
fix(issues-sync): include issue.updated_at in the comment-sync key

### DIFF
--- a/src/services/issues/sync_issues_from_github.ts
+++ b/src/services/issues/sync_issues_from_github.ts
@@ -381,7 +381,13 @@ async function syncSingleComment(
     ops.store({
       entities,
       relationships,
-      idempotency_key: `issue-comment-sync-${repo}-${issue.number}-${comment.id}-${SYNC_KEY_MIGRATION}`,
+      // Include the issue's updated_at: this store re-stores the issue entity
+      // (whose deterministic payload tracks issue.updated_at), so when the issue
+      // changes the comment store must re-key too — otherwise the new issue
+      // content collides with the stale row under a comment.id-only key and
+      // trips ERR_IDEMPOTENCY_MISMATCH. (Observed accumulating once the swarm
+      // began bumping issue.updated_at on synced issues.)
+      idempotency_key: `issue-comment-sync-${repo}-${issue.number}-${comment.id}-${issue.updated_at}-${SYNC_KEY_MIGRATION}`,
     })
   ) as Promise<StoreResult>;
 }

--- a/tests/services/sync_issues_from_github.test.ts
+++ b/tests/services/sync_issues_from_github.test.ts
@@ -172,7 +172,7 @@ describe("syncIssuesFromGitHub", () => {
     expect(seenIdempotencyKeys).toEqual(
       new Set([
         "issue-sync-test/repo-1-2026-05-01T00:00:00Z-m2",
-        "issue-comment-sync-test/repo-1-101-m2",
+        "issue-comment-sync-test/repo-1-101-2026-05-01T00:00:00Z-m2",
       ])
     );
   });
@@ -219,6 +219,32 @@ describe("syncIssuesFromGitHub", () => {
     const issueEntity = store.mock.calls[0]?.[0]?.entities?.[0] as Record<string, unknown>;
     expect(issueEntity.last_synced_at).toBe("2026-05-01T00:00:00Z");
     expect(issueEntity.data_source).toContain("2026-05-01");
+  });
+
+  it("gives a comment a fresh key when its issue's updated_at changes", async () => {
+    // The comment store re-stores the issue entity (deterministic, tracks
+    // issue.updated_at). When the issue changes, the comment payload changes
+    // too, so its key must include issue.updated_at — otherwise the new content
+    // collides with the stale row under a comment.id-only key. This accumulated
+    // in production once the swarm started bumping issue.updated_at.
+    const { ops, seenIdempotencyKeys } = createOps();
+    mockListIssueComments.mockResolvedValue([comment(101)]);
+
+    mockListIssues.mockResolvedValueOnce([
+      { ...issue(1), updated_at: "2026-05-01T00:00:00Z" },
+    ]);
+    await syncIssuesFromGitHub(ops);
+    mockListIssues.mockResolvedValueOnce([
+      { ...issue(1, "Edited"), updated_at: "2026-05-02T12:00:00Z" },
+    ]);
+    await syncIssuesFromGitHub(ops);
+
+    expect(
+      seenIdempotencyKeys.has("issue-comment-sync-test/repo-1-101-2026-05-01T00:00:00Z-m2")
+    ).toBe(true);
+    expect(
+      seenIdempotencyKeys.has("issue-comment-sync-test/repo-1-101-2026-05-02T12:00:00Z-m2")
+    ).toBe(true);
   });
 
   describe("push leg — local public issues without github_number", () => {


### PR DESCRIPTION
## Problem

After #1655 the issues-sync feed worked (Synced 100, 300 messages, 0 errors on the first run). But a **multi-run idempotency check** revealed an *accumulating* tail on the comment path:

```
run 1: Synced 100, 286 messages | errors=1  (issue 1634)
run 2: Synced 100, 269 messages | errors=2  (issues 1534, 1634)
run 3: Synced 100, 265 messages | errors=3  (issues 1644, 1534)
```

Growing, different issues each run, message count dropping.

## Root cause

The comment store re-stores the **issue entity** (deterministic payload, tracks `issue.updated_at`), but the comment key was `issue-comment-sync-<repo>-<number>-<comment.id>-<migration>` — **no `updated_at`**. Once the swarm began processing the freshly-synced issues and bumping their `updated_at`, the re-stored issue content drifted under a stable comment key → `ERR_IDEMPOTENCY_MISMATCH`, accumulating as more issues were touched.

This is the same stable-key/drifting-content pattern as the original bug, now in the comment path's embedded issue re-store.

## Fix

Fold `issue.updated_at` into the comment-sync key (mirroring the issue-sync key), so an issue change re-keys its comment stores too. Regression test added: a comment gets a fresh key when its issue's `updated_at` changes. Suite green (14 passed).

## Verification

The decisive check is a **multi-run** live sync on the deployed RC: errors must stay at 0 across repeated runs (not just the first). Runs after merge + RC autodeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)