### PR TITLE
fix(cli): skills sync --json reads the global json option

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -8845,11 +8845,13 @@ skillsCommand
       "Creates and populates the skills directory for any harness whose base directory exists."
   )
   .option("--scope <scope>", "Mirror at user or project level", "user")
-  .option("--json", "Output machine-readable JSON")
   .action(async (opts) => {
     const { mirrorSkillsToAllHarnesses } = await import("./skills_mirror.js");
     const scope = opts.scope === "project" ? "project" : "user";
-    const json = Boolean(opts.json);
+    // `--json` is the global program option; Commander binds it to program.opts(),
+    // not the subcommand's local opts (a locally-declared --json stays undefined
+    // when a global one exists). Read the global flag, like other commands here.
+    const json = Boolean((program.opts() as { json?: boolean }).json);
     const report = mirrorSkillsToAllHarnesses({
       scope,
       onLog: json ? undefined : (msg) => console.log(`  ${msg}`),


### PR DESCRIPTION
## Problem

Follow-up to #1644. `neotoma skills sync --json` silently printed human output instead of JSON.

Root cause: #1644 declared a **subcommand-local** `--json` and read `opts.json`, but the `neotoma` program already declares a **global** `--json` option. When a global option of the same name exists, Commander binds `--json` to `program.opts()` and the subcommand's local `opts.json` stays `undefined`. (Confirmed with a minimal Commander repro: with both a global and a local `--json`, `program.opts().json === true` while the action's local `opts.json === undefined`.)

This was missed because the unit tests exercise the reconciler module directly, not the CLI argv → Commander → stdout round-trip (the prior review noted that gap as optional).

## Fix

Read `program.opts().json` — the established pattern for `--json` elsewhere in `src/cli/index.ts` (e.g. the `access` commands) — and drop the redundant subcommand-local `--json` declaration.

## Verification

Built and run end-to-end against the global binary:
- `neotoma skills sync --json` → emits the JSON report (`source`, `source_present`, `scope`, per-harness `results`, `changed`, `has_errors`).
- `neotoma skills sync` (no flag) → unchanged human summary.

Existing `tests/cli/skills_mirror.test.ts` (14) and the coverage guard still pass; format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)