### PR TITLE
feat(inspector): sidebar build version and duplicate badge

### DIFF
--- a/inspector/src/api/endpoints/entities.ts
+++ b/inspector/src/api/endpoints/entities.ts
@@ -130,3 +130,31 @@ export function restoreEntity(
     fetch,
   );
 }
+
+export type DuplicateCandidate = {
+  entity_a: { id: string; canonical_name?: string; snapshot_fields?: Record<string, unknown> };
+  entity_b: { id: string; canonical_name?: string; snapshot_fields?: Record<string, unknown> };
+  score: number;
+  matched_fields?: string[];
+  entity_type: string;
+};
+
+export type PotentialDuplicatesResponse = {
+  candidates: DuplicateCandidate[];
+  entity_type: string;
+  threshold: number;
+};
+
+export function listPotentialDuplicates(
+  entityType: string,
+  options?: { threshold?: number; limit?: number; signal?: AbortSignal },
+) {
+  const params = new URLSearchParams({ entity_type: entityType });
+  if (options?.threshold != null) params.set("threshold", String(options.threshold));
+  if (options?.limit != null) params.set("limit", String(options.limit));
+  return get<PotentialDuplicatesResponse>(
+    `/entities/duplicates?${params.toString()}`,
+    undefined,
+    { signal: options?.signal },
+  );
+}

--- a/inspector/src/components/layout/sidebar_external_links.tsx
+++ b/inspector/src/components/layout/sidebar_external_links.tsx
@@ -1,6 +1,7 @@
 import { Fragment } from "react";
 import { SiGithub, SiNpm } from "react-icons/si";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { useServerInfo } from "@/hooks/use_infra";
 import { cn } from "@/lib/utils";
 
 const GITHUB_URL = "https://github.com/markmhendrickson/neotoma";
@@ -15,12 +16,43 @@ type SidebarExternalLinksProps = {
   collapsed: boolean;
 };
 
+function formatBuildVersionLabel(version?: string, gitSha?: string | null): string | null {
+  const trimmedVersion = version?.trim();
+  const trimmedSha = gitSha?.trim();
+  if (!trimmedVersion && !trimmedSha) return null;
+  if (trimmedVersion && trimmedSha) {
+    return `v${trimmedVersion} · ${trimmedSha.slice(0, 7)}`;
+  }
+  if (trimmedVersion) return `v${trimmedVersion}`;
+  return trimmedSha!.slice(0, 7);
+}
+
 export function SidebarExternalLinks({ collapsed }: SidebarExternalLinksProps) {
+  const serverInfo = useServerInfo();
+  const buildVersionLabel = formatBuildVersionLabel(
+    serverInfo.data?.version,
+    serverInfo.data?.git_sha,
+  );
+
+  const buildVersion = buildVersionLabel ? (
+    <span
+      className={cn(
+        "font-mono text-sidebar-foreground/60",
+        collapsed ? "max-w-full truncate text-[10px] leading-none" : "ml-auto truncate text-xs",
+      )}
+      title={buildVersionLabel}
+    >
+      {buildVersionLabel}
+    </span>
+  ) : null;
+
   return (
     <div
       className={cn(
         "shrink-0 border-t border-sidebar-border",
-        collapsed ? "flex flex-col items-center gap-0.5 px-2 py-2" : "flex items-center gap-0.5 px-3 py-2",
+        collapsed
+          ? "flex flex-col items-center gap-0.5 px-2 py-2"
+          : "flex min-w-0 items-center gap-0.5 px-3 py-2",
       )}
     >
       {externalLinks.map(({ href, label, Icon }) => {
@@ -50,6 +82,15 @@ export function SidebarExternalLinks({ collapsed }: SidebarExternalLinksProps) {
 
         return <Fragment key={href}>{link}</Fragment>;
       })}
+      {buildVersion && !collapsed ? buildVersion : null}
+      {buildVersion && collapsed ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="inline-flex max-w-full">{buildVersion}</span>
+          </TooltipTrigger>
+          <TooltipContent side="right">Build {buildVersionLabel}</TooltipContent>
+        </Tooltip>
+      ) : null}
     </div>
   );
 }

--- a/inspector/src/components/shared/duplicate_badge.tsx
+++ b/inspector/src/components/shared/duplicate_badge.tsx
@@ -1,0 +1,35 @@
+import { Link } from "react-router-dom";
+import { Badge } from "@/components/ui/badge";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+
+interface DuplicateBadgeProps {
+  entityId: string;
+}
+
+/**
+ * Inline indicator for entities that appear in a duplicate-candidate pair.
+ * Links to the entity detail page for review/merge.
+ */
+export function DuplicateBadge({ entityId }: DuplicateBadgeProps) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Link
+          to={`/entities/${encodeURIComponent(entityId)}`}
+          onClick={(e) => e.stopPropagation()}
+          aria-label="Potential duplicate — click to review"
+        >
+          <Badge
+            variant="outline"
+            className="ml-1.5 shrink-0 cursor-pointer border-amber-400 text-amber-600 hover:bg-amber-50 dark:border-amber-500 dark:text-amber-400 dark:hover:bg-amber-950/30"
+          >
+            ~dup
+          </Badge>
+        </Link>
+      </TooltipTrigger>
+      <TooltipContent side="right">
+        Potential duplicate detected. Open entity to review and merge.
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/inspector/src/hooks/use_entities.ts
+++ b/inspector/src/hooks/use_entities.ts
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { isApiUrlConfigured } from "@/api/client";
 import {
@@ -6,6 +7,7 @@ import {
   getEntityObservations,
   getEntityRelationships,
   getFieldProvenance,
+  listPotentialDuplicates,
 } from "@/api/endpoints/entities";
 import type { EntitiesQueryParams } from "@/types/api";
 
@@ -55,4 +57,25 @@ export function useFieldProvenance(entityId: string | undefined, field: string |
     queryFn: ({ signal }) => getFieldProvenance(entityId!, field!, { signal }),
     enabled: isApiUrlConfigured() && !!entityId && !!field,
   });
+}
+
+/** Entity IDs appearing in at least one duplicate candidate pair for entity_type. */
+export function useDuplicateCandidateIds(entityType: string | undefined) {
+  const query = useQuery({
+    queryKey: ["potential-duplicates", entityType],
+    queryFn: ({ signal }) => listPotentialDuplicates(entityType!, { limit: 200, signal }),
+    enabled: isApiUrlConfigured() && !!entityType,
+    staleTime: 2 * 60 * 1000,
+  });
+
+  const ids = useMemo<Set<string>>(() => {
+    const set = new Set<string>();
+    for (const c of query.data?.candidates ?? []) {
+      if (c.entity_a.id) set.add(c.entity_a.id);
+      if (c.entity_b.id) set.add(c.entity_b.id);
+    }
+    return set;
+  }, [query.data]);
+
+  return { ids, query };
 }

--- a/inspector/src/pages/entities.tsx
+++ b/inspector/src/pages/entities.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
-import { useEntitiesQuery } from "@/hooks/use_entities";
+import { useDuplicateCandidateIds, useEntitiesQuery } from "@/hooks/use_entities";
 import { useAgentGrants } from "@/hooks/use_agents";
 import { PageShell } from "@/components/layout/page_shell";
 import type { HeaderSearchContextValue } from "@/components/layout/page_title_context";
@@ -16,6 +16,7 @@ import { QueryRefreshIndicator } from "@/components/shared/query_refresh_indicat
 import type { ColumnDef, RowSelectionState } from "@tanstack/react-table";
 import type { EntitySnapshot, SnapshotFilter } from "@/types/api";
 import { EntityListAdmissionCell } from "@/components/shared/entity_list_admission_cell";
+import { DuplicateBadge } from "@/components/shared/duplicate_badge";
 import { EntityTypeSelect } from "@/components/shared/entity_type_select";
 import { EntityTableColumnToggle } from "@/components/shared/entity_table_column_toggle";
 import { InlineEditCell } from "@/components/shared/inline_edit_cell";
@@ -72,6 +73,7 @@ export default function EntitiesPage({ typeSlug }: { typeSlug?: string } = {}) {
   const schemasQ = useSchemas();
   const schemaQ = useSchemaByType(entityType || undefined);
   const admissionGrants = grantsQ.data?.grants ?? [];
+  const { ids: duplicateIds } = useDuplicateCandidateIds(entityType || undefined);
 
   const listColumnConfig = useMemo(
     () => buildEntitiesListColumnConfig(entityType ? schemaQ.data : null),
@@ -264,14 +266,17 @@ export default function EntitiesPage({ typeSlug }: { typeSlug?: string } = {}) {
         cell: ({ row }) => {
           const eid = entityRowId(row.original);
           return (
-            <Link to={`/entities/${encodeURIComponent(eid)}`} className="font-medium text-primary hover:underline">
-              {String(
-                row.original.canonical_name ||
-                  row.original.snapshot?.name ||
-                  row.original.snapshot?.title ||
-                  truncateId(eid),
-              )}
-            </Link>
+            <span className="inline-flex min-w-0 items-center">
+              <Link to={`/entities/${encodeURIComponent(eid)}`} className="font-medium text-primary hover:underline">
+                {String(
+                  row.original.canonical_name ||
+                    row.original.snapshot?.name ||
+                    row.original.snapshot?.title ||
+                    truncateId(eid),
+                )}
+              </Link>
+              {duplicateIds.has(eid) ? <DuplicateBadge entityId={eid} /> : null}
+            </span>
           );
         },
       },
@@ -315,7 +320,7 @@ export default function EntitiesPage({ typeSlug }: { typeSlug?: string } = {}) {
     );
 
     return [...fixed, ...snapshotColumns];
-  }, [admissionGrants, entityType, schemaQ.data]);
+  }, [admissionGrants, duplicateIds, entityType, schemaQ.data]);
 
   function handleSaveView() {
     if (!entityType) return;


### PR DESCRIPTION
## Summary
- Sidebar footer shows package version and git SHA from `/server-info` (salvaged from `worktree-dev` / `3652f878c`).
- Entities list shows a duplicate-candidate badge when an entity-type filter is active (from `app` commit `5ec3d0a`).

## Intentionally not included
- Rename train (`inspector`→`app`, `frontend`→`site`) — structural migration, not incremental cherry-pick.
- #948 `timeline_user_query` / `inspector_mount` backend refactor — separate rebase decision.
- Superseded `feat/inspector-skinning` and `feat/app-home-page-pinned-panel` branches (already on main via #1585 / #1656).

## Test plan
- [x] `npx tsc --noEmit` in `inspector/`
- [x] `npm run build:inspector:dev-target`
- [ ] Manual: sidebar footer shows `vX.Y.Z · <sha>` when API URL is configured
- [ ] Manual: duplicate badge appears on entities list with type filter active