### PR TITLE
chore(test-catalog): regenerate to fix stale baseline gate on main

### DIFF
--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,8 +61,8 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **465**
-- Backend and repo Vitest files: **432**
+- Total automated test files: **466**
+- Backend and repo Vitest files: **433**
 - Frontend Vitest files: **9**
 - Playwright spec files: **24**
 


### PR DESCRIPTION
## Summary

main's `baseline` CI lane is currently **failing** on `validate:test-catalog --check` — the committed `docs/testing/automated_test_catalog.md` reports **465** total test files but the tree has **466**. This is a queue-wide gate failure: every open PR inherits a red `baseline` regardless of its own content (the same class as the earlier `openapi_types.ts` drift and the `agentic_evals` fixture issue).

Verified the generator is otherwise deterministic — running `npm run generate:test-catalog` on a clean `origin/main` produces exactly this 2-line count delta, confirming the committed catalog simply drifted one test file behind (a recently-merged PR's post-merge catalog count was stale).

## Change
- Regenerated `automated_test_catalog.md` on current main (count 465→466 / backend 432→433). No other content.

## Verification
- [x] `npm run validate:test-catalog` passes after regen.
- [x] Confirmed `baseline: failure` on current main HEAD before this fix.
- [x] Diff is the 2-line summary count only.

Once merged, the queue-wide `baseline` failure clears and the in-flight rebased PRs (#305, #306, …) stop re-staling on the catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)