### PR TITLE
ci(security): weekly G5 probe reads NEOTOMA_PROBE_HOSTS (sandbox + prod)

### DIFF
--- a/.github/workflows/sandbox-weekly-reset.yml
+++ b/.github/workflows/sandbox-weekly-reset.yml
@@ -45,9 +45,13 @@ jobs:
       - name: Sync protected routes manifest (drift check)
         run: npm run security:manifest:check
 
-      - name: Run deployed protected-route probes (sandbox)
+      - name: Run deployed protected-route probes (sandbox + prod)
         env:
-          NEOTOMA_PROBE_HOSTS: "https://sandbox.neotoma.io"
+          # Read the NEOTOMA_PROBE_HOSTS repo secret (newline-separated hosts —
+          # sandbox + prod) so the weekly G5 auth-probe also verifies production's
+          # protected routes reject unauthenticated requests. Falls back to
+          # sandbox-only when the secret is unset (e.g. on forks).
+          NEOTOMA_PROBE_HOSTS: ${{ secrets.NEOTOMA_PROBE_HOSTS || 'https://sandbox.neotoma.io' }}
         run: |
           mkdir -p docs/security/probes
           bash scripts/security/deployed_probes.sh \


### PR DESCRIPTION
## What

The weekly `sandbox-weekly-reset` workflow hardcoded `NEOTOMA_PROBE_HOSTS` to `https://sandbox.neotoma.io`, so the G5 deployed-probe auth check (asserts protected routes return 401/403 without a bearer) only ever exercised **sandbox** — never production.

Read the `NEOTOMA_PROBE_HOSTS` repo secret instead (now set to `sandbox + neotoma.markmhendrickson.com`), with a sandbox-only fallback when unset (forks).

## Why

Widens the weekly external auth probe to cover production's protected routes — the consumer the long-pending `NEOTOMA_PROBE_HOSTS` secret was meant for. Confirmed it does **not** affect the required `security_gates` PR check (G1–G3), which never referenced it. Pure additive coverage to the weekly job.

## Verification

YAML validated; `${{ secrets.X || 'default' }}` is the standard fallback form. First real exercise is the next weekly cron run (or manual dispatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)