### PR TITLE
feat(access): set guest_access_policy in schema_metadata live (no restart)

### DIFF
--- a/src/cli/access.ts
+++ b/src/cli/access.ts
@@ -7,12 +7,16 @@
  *   reset <entity_type>       -- Reset an entity type to default (closed)
  *   enable-issues             -- Shortcut: set issue/conversation/conversation_message to submitter_scoped
  *   disable-issues            -- Shortcut: reset all three to closed
+ *
+ * By default, `access set` writes to schema_metadata (canonical, live — no restart
+ * needed). Pass `--config-file` for the deprecated config-file path.
  */
 
 import {
   loadAccessPolicyEntries,
   resolveAccessPolicyWithSource,
   setAccessPolicy,
+  setAccessPolicyInSchemaMetadata,
   resetAccessPolicy,
   ISSUE_SUBMISSION_ENTITY_TYPES,
   VALID_MODES,
@@ -23,6 +27,8 @@ import {
 
 export interface AccessSetOpts {
   json?: boolean;
+  /** Use the deprecated config-file path instead of schema_metadata. */
+  configFile?: boolean;
 }
 
 export interface AccessListOpts {
@@ -48,15 +54,13 @@ function output(data: unknown, json: boolean): void {
 }
 
 /**
- * Try to write guest_access_policy to SchemaMetadata via the registry.
- * Falls back to the config-file path with a deprecation warning when the
- * schema registry is unavailable or the schema doesn't exist.
+ * Write guest_access_policy to the canonical schema_metadata path.
+ * Falls back to the deprecated config-file path with a warning when the
+ * schema registry is unavailable or no active schema exists for the type.
  */
 async function setViaMetadata(entityType: string, mode: AccessPolicyMode): Promise<void> {
   try {
-    const { SchemaRegistryService } = await import("../services/schema_registry.js");
-    const registry = new SchemaRegistryService();
-    await registry.updateMetadata(entityType, { guest_access_policy: mode });
+    await setAccessPolicyInSchemaMetadata(entityType, mode);
   } catch {
     process.stderr.write(
       `Warning: Could not update SchemaMetadata for "${entityType}"; ` +
@@ -97,10 +101,21 @@ export async function accessSet(
     return;
   }
 
-  await setViaMetadata(entityType, mode as AccessPolicyMode);
+  let storageSource: "schema_metadata" | "config_file";
+  if (opts.configFile) {
+    process.stderr.write(
+      `Deprecation notice: --config-file writes to the deprecated config-file path. ` +
+        `Omit the flag to write to schema_metadata (canonical, live — no restart needed).\n`
+    );
+    await setAccessPolicy(entityType, mode as AccessPolicyMode);
+    storageSource = "config_file";
+  } else {
+    await setViaMetadata(entityType, mode as AccessPolicyMode);
+    storageSource = "schema_metadata";
+  }
 
   if (opts.json) {
-    output({ entity_type: entityType, mode, status: "set" }, true);
+    output({ entity_type: entityType, mode, status: "set", storage_source: storageSource }, true);
   } else {
     process.stdout.write(`Access policy for "${entityType}" set to "${mode}".\n`);
   }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -9100,13 +9100,22 @@ const accessCommand = program
 accessCommand
   .command("set <entity_type> <mode>")
   .description(
-    "Set access policy for an entity type (closed, read_only, submit_only, submitter_scoped, open)"
+    "Set access policy for an entity type (closed, read_only, submit_only, submitter_scoped, open). " +
+      "Writes to schema_metadata by default (canonical, live — no restart needed). " +
+      "Use --config-file for the deprecated config-file path."
   )
-  .action(async (entityType, mode) => {
+  .option(
+    "--config-file",
+    "Write to the deprecated config-file path instead of schema_metadata (requires server restart to take effect)"
+  )
+  .action(async (entityType, mode, cmdOpts) => {
     const opts = program.opts() as { json?: boolean; baseUrl?: string; apiOnly?: boolean };
     if (rejectRemoteAccessMutationIfNeeded(opts)) return;
     const { accessSet } = await import("./access.js");
-    await accessSet(entityType, mode, { json: Boolean(opts.json) });
+    await accessSet(entityType, mode, {
+      json: Boolean(opts.json),
+      configFile: Boolean(cmdOpts.configFile),
+    });
   });
 
 accessCommand

--- a/src/services/access_policy.test.ts
+++ b/src/services/access_policy.test.ts
@@ -3,15 +3,24 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 const schemaRegistryMockState = vi.hoisted(() => ({
   activeSchemas: [] as Array<{
     entity_type: string;
-    metadata?: { guest_access_policy?: string };
+    metadata?: { guest_access_policy?: string; [k: string]: unknown };
   }>,
   globalSchemas: new Map<
     string,
     {
       entity_type: string;
-      metadata?: { guest_access_policy?: string };
+      metadata?: { guest_access_policy?: string; [k: string]: unknown };
     }
   >(),
+  activeSchemaStore: new Map<
+    string,
+    {
+      id: string;
+      entity_type: string;
+      metadata?: { guest_access_policy?: string; [k: string]: unknown };
+    }
+  >(),
+  updateMetadataCalls: [] as Array<{ entityType: string; patch: Record<string, unknown> }>,
 }));
 
 vi.mock("../services/schema_registry.js", () => ({
@@ -23,6 +32,27 @@ vi.mock("../services/schema_registry.js", () => ({
     async loadGlobalSchema(entityType: string) {
       return schemaRegistryMockState.globalSchemas.get(entityType) ?? null;
     }
+
+    async loadActiveSchema(entityType: string) {
+      return schemaRegistryMockState.activeSchemaStore.get(entityType) ?? null;
+    }
+
+    async updateMetadata(entityType: string, patch: Record<string, unknown>) {
+      schemaRegistryMockState.updateMetadataCalls.push({ entityType, patch });
+
+      // Apply the patch to activeSchemaStore and globalSchemas so the read
+      // path picks up the new value without a restart.
+      const existing = schemaRegistryMockState.activeSchemaStore.get(entityType);
+      if (!existing) {
+        throw new Error(
+          `No active schema found for entity type "${entityType}"; cannot update metadata.`
+        );
+      }
+      const updated = { ...existing, metadata: { ...(existing.metadata ?? {}), ...patch } };
+      schemaRegistryMockState.activeSchemaStore.set(entityType, updated);
+      // Mirror into globalSchemas so resolveAccessPolicyWithSource picks it up.
+      schemaRegistryMockState.globalSchemas.set(entityType, updated);
+    }
   },
 }));
 
@@ -32,6 +62,7 @@ import {
   resolveAccessPolicy,
   resolveAccessPolicyWithSource,
   setAccessPolicy,
+  setAccessPolicyInSchemaMetadata,
   enforceGuestAccess,
   assertGuestWriteAllowed,
   resolveGuestReadAccess,
@@ -68,6 +99,8 @@ describe("Access Policy Service", () => {
     delete process.env.NEOTOMA_ACCESS_POLICY_LEGACY_TYPE;
     schemaRegistryMockState.activeSchemas = [];
     schemaRegistryMockState.globalSchemas.clear();
+    schemaRegistryMockState.activeSchemaStore.clear();
+    schemaRegistryMockState.updateMetadataCalls = [];
     await fs.mkdir(path.dirname(TEST_CONFIG_PATH), { recursive: true });
     await fs.writeFile(TEST_CONFIG_PATH, JSON.stringify({}), "utf8");
   });
@@ -334,6 +367,108 @@ describe("Access Policy Service", () => {
       expect(VALID_MODES.has("submit_only")).toBe(true);
       expect(VALID_MODES.has("submitter_scoped")).toBe(true);
       expect(VALID_MODES.has("open")).toBe(true);
+    });
+  });
+
+  describe("setAccessPolicyInSchemaMetadata", () => {
+    it("writes guest_access_policy onto the active schema row via updateMetadata", async () => {
+      schemaRegistryMockState.activeSchemaStore.set("my_type", {
+        id: "schema-id-1",
+        entity_type: "my_type",
+        metadata: { label: "My Type" },
+      });
+
+      await setAccessPolicyInSchemaMetadata("my_type", "read_only");
+
+      expect(schemaRegistryMockState.updateMetadataCalls).toHaveLength(1);
+      expect(schemaRegistryMockState.updateMetadataCalls[0]).toEqual({
+        entityType: "my_type",
+        patch: { guest_access_policy: "read_only" },
+      });
+    });
+
+    it("preserves other metadata fields on the active schema row", async () => {
+      schemaRegistryMockState.activeSchemaStore.set("my_type", {
+        id: "schema-id-2",
+        entity_type: "my_type",
+        metadata: { label: "My Label", description: "Some description" },
+      });
+
+      await setAccessPolicyInSchemaMetadata("my_type", "open");
+
+      // The mock applies the patch; verify the stored metadata still has the original fields.
+      const stored = schemaRegistryMockState.activeSchemaStore.get("my_type");
+      expect(stored?.metadata?.label).toBe("My Label");
+      expect(stored?.metadata?.description).toBe("Some description");
+      expect(stored?.metadata?.guest_access_policy).toBe("open");
+    });
+
+    it("throws for invalid mode values without calling updateMetadata", async () => {
+      schemaRegistryMockState.activeSchemaStore.set("my_type", {
+        id: "schema-id-3",
+        entity_type: "my_type",
+        metadata: {},
+      });
+
+      await expect(
+        setAccessPolicyInSchemaMetadata("my_type", "invalid_mode" as never)
+      ).rejects.toThrow(/Invalid access policy mode/);
+      expect(schemaRegistryMockState.updateMetadataCalls).toHaveLength(0);
+    });
+
+    it("throws when no active schema exists for the entity type", async () => {
+      // activeSchemaStore is empty; updateMetadata will throw.
+      await expect(setAccessPolicyInSchemaMetadata("nonexistent_type", "open")).rejects.toThrow(
+        /No active schema found/
+      );
+    });
+
+    it("live read path: after schema-metadata write, resolveAccessPolicyWithSource returns schema_metadata source without restart", async () => {
+      // Seed both the activeSchemaStore (for the write path) and globalSchemas
+      // (for the read path in resolveAccessPolicyWithSource).
+      schemaRegistryMockState.activeSchemaStore.set("widget", {
+        id: "schema-id-4",
+        entity_type: "widget",
+        metadata: {},
+      });
+      // No config-file entry, no env var.
+
+      // Before the write: default closed.
+      await expect(resolveAccessPolicyWithSource("widget")).resolves.toEqual({
+        mode: "closed",
+        source: "default",
+      });
+
+      // Write via schema_metadata.
+      await setAccessPolicyInSchemaMetadata("widget", "read_only");
+
+      // After the write: the mock mirrors the update into globalSchemas, simulating
+      // the per-request read from the active schema row — no restart needed.
+      await expect(resolveAccessPolicyWithSource("widget")).resolves.toEqual({
+        mode: "read_only",
+        source: "schema_metadata",
+      });
+    });
+
+    it("live read path: schema_metadata takes precedence over a pre-existing config_file entry", async () => {
+      // Set a config-file entry for the type.
+      await setAccessPolicy("article", "submit_only");
+
+      // Seed the active schema store.
+      schemaRegistryMockState.activeSchemaStore.set("article", {
+        id: "schema-id-5",
+        entity_type: "article",
+        metadata: {},
+      });
+
+      // Write the canonical schema_metadata value.
+      await setAccessPolicyInSchemaMetadata("article", "open");
+
+      // The read path must prefer schema_metadata over config_file.
+      await expect(resolveAccessPolicyWithSource("article")).resolves.toEqual({
+        mode: "open",
+        source: "schema_metadata",
+      });
     });
   });
 });

--- a/src/services/access_policy.ts
+++ b/src/services/access_policy.ts
@@ -210,7 +210,32 @@ export async function resolveAccessPolicy(entityType: string): Promise<AccessPol
 }
 
 /**
+ * Set guest_access_policy in the active schema row's metadata for an entity type.
+ *
+ * This is the canonical, live path: the policy is read per-request from the active
+ * schema row (precedence #2: env > schema_metadata > config_file > default), so
+ * this change takes effect on the running server immediately — no restart needed.
+ *
+ * Throws if the schema registry is unavailable or no active schema exists for the type.
+ * Preserves all other metadata fields on the active schema row.
+ */
+export async function setAccessPolicyInSchemaMetadata(
+  entityType: string,
+  mode: AccessPolicyMode
+): Promise<void> {
+  if (!VALID_MODES.has(mode)) {
+    throw new Error(
+      `Invalid access policy mode "${mode}". Valid modes: ${Array.from(VALID_MODES).join(", ")}`
+    );
+  }
+  const { SchemaRegistryService } = await import("./schema_registry.js");
+  const registry = new SchemaRegistryService();
+  await registry.updateMetadata(entityType, { guest_access_policy: mode });
+}
+
+/**
  * Set the access policy for an entity type in persisted config.
+ * @deprecated Use setAccessPolicyInSchemaMetadata for live, canonical writes.
  */
 export async function setAccessPolicy(entityType: string, mode: AccessPolicyMode): Promise<void> {
   if (!VALID_MODES.has(mode)) {


### PR DESCRIPTION
## Summary

- Adds `setAccessPolicyInSchemaMetadata(entityType, mode)` as a named export from `src/services/access_policy.ts` — the canonical, live setter for `guest_access_policy`. It validates `mode` against `VALID_MODES`, then calls `registry.updateMetadata()`, preserving all other metadata fields on the active schema row.
- Because the read path (`resolveAccessPolicyWithSource`) queries the active schema row per-request (precedence: env > schema_metadata > config_file > default), the change takes effect on the running server **immediately — no process restart needed**.
- Annotates the existing `setAccessPolicy()` (config-file path) as `@deprecated` with a pointer to the new function.
- Updates `access set` to default to the canonical schema_metadata path, and adds a `--config-file` flag for the legacy path (prints a deprecation notice when used).
- Extends the `SchemaRegistryService` mock in the test file with `loadActiveSchema()` and `updateMetadata()` so the read path can observe the write within the same test run, then adds 6 focused tests:
  - `updateMetadata` is called with the correct entity type and patch
  - Other metadata fields are preserved after the write
  - Invalid modes throw before calling `updateMetadata`
  - Missing active schema throws
  - **Live read path**: `resolveAccessPolicyWithSource` returns `schema_metadata` source after a `setAccessPolicyInSchemaMetadata` call — no restart required
  - `schema_metadata` takes precedence over a pre-existing `config_file` entry

## Test results

32 tests pass (26 prior + 6 new), typecheck clean, lint clean (no new warnings), Prettier applied.

```
✓ src/services/access_policy.test.ts (32 tests) 55ms
Test Files  1 passed (1)
      Tests  32 passed (32)
```

## CLI behavior

**Default (canonical, live):**
```sh
neotoma access set my_type read_only
# → writes guest_access_policy to schema_metadata; effective immediately
```

**Legacy path with deprecation notice:**
```sh
neotoma access set my_type read_only --config-file
# stderr: Deprecation notice: --config-file writes to the deprecated config-file path...
# → writes to ~/.config/neotoma/config.json; requires server restart
```

Closes #1699