### PR TITLE
chore(release): v0.17.0 — resolver, capability delta, intake/sightings, embeddable graph

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,9 +4,9 @@
 
 | Version  | Supported |
 |----------|-----------|
+| `0.17.x` | Yes       |
 | `0.16.x` | Yes       |
-| `0.15.x` | Yes       |
-| `< 0.15` | No (patch only on critical advisories — see [advisories index](docs/security/advisories/README.md)) |
+| `< 0.16` | No (patch only on critical advisories — see [advisories index](docs/security/advisories/README.md)) |
 
 The most recent published Neotoma version is the only one that receives proactive support. Critical advisories may produce a one-off patch on the previous minor when the affected range is large; see the per-advisory file under [`docs/security/advisories/`](docs/security/advisories/README.md) for the exact range.
 

--- a/docs/releases/in_progress/v0.17.0/github_release_supplement.md
+++ b/docs/releases/in_progress/v0.17.0/github_release_supplement.md
@@ -1,0 +1,27 @@
+# v0.17.0 Release Supplement
+
+## Summary
+
+v0.17.0 ships four agent-facing capabilities surfaced from a high-volume production integration: a single-call entity-identity resolver, a machine-readable per-release capability delta, discard-by-default high-velocity intake with read-time sightings aggregation, and an embeddable (chrome-less) Inspector graph. All four are additive and backward-compatible — existing callers that pass no new fields behave exactly as before.
+
+1. **`identify_entity_by_signals` — single-call multi-signal resolver (#1603, #1670)** — resolve "is this the same person/company I already have?" in one MCP call. Accepts a set of identity signals (`name`, `email`, `company`, `domain`, `phone`, …) plus optional `entity_type`, and returns the best-match entity (id + medium-density snapshot) with an identity score and `matched_signals`, plus top-N disambiguation candidates. No LLM-invented ids — unknown inputs stay unresolved rather than creating orphans. Lets an agent auto-merge on a high score, ask a human on a medium score, and create-new on a low score without chaining `retrieve_entity_by_identifier` → `list_potential_duplicates` → `retrieve_entity_snapshot`.
+
+2. **Machine-readable per-release capability delta (#1605, #1693, #1694)** — `npm_check_update` gains an opt-in `include_capability_delta` boolean. When true, the response carries `new_tools` / `removed_tools` (string arrays) and a one-line `capability_delta_recommendation` ("upgrade then extend your integration to use: …"), plus a `capability_delta_note` that is present **only** when the delta degraded (unparseable versions or a missing manifest). Sourced from a generated `src/shared/capability_manifest.json` (built by `scripts/generate-capability-manifest.ts`, which walks `vX.Y.Z` release tags — no hand-maintained list). An auto-upgrading agent can enumerate newly added tools after an upgrade in one call. Complements the real-server-version-in-`initialize` work already shipped in #1689.
+
+3. **Discard-by-default intake + `canonical_key` sightings (#1604, #1697)** — two disciplines for high-velocity sources (news/social/firehose) made first-class:
+   - **Overflow sink:** `store` accepts an optional `intake: { mode: "graph" | "overflow", reason? }`. Default `"graph"` is today's behavior. `mode: "overflow"` appends the raw payload as a JSONL line to a configured sink (`NEOTOMA_OVERFLOW_SINK`, daily `overflow-YYYY-MM-DD.jsonl`) and returns `{ overflowed: true, sink_path, line_offset }` **without** creating entities/observations — so a firehose never pollutes the graph. If `mode: "overflow"` is used with the env unset, a structured hint is returned (never a silent write or uncaught throw).
+   - **Sightings + read-time aggregation:** new indexed `canonical_key` + `sighting_source_id` columns on observations (additive migration via the existing `addColumnIfMissing` pattern). Each sighting is an idempotent row keyed by `{source_id}:{canonical_key}`. `retrieve_entities` gains `collapse_by: "canonical_key"`, which groups rows sharing a key at **read time** into one synthesized result (union of sources, max caller-supplied `significance`, `sightings[]`). Underlying rows are never merged or deleted — dedup is a view, not a write-path merge, so dedup bugs can't corrupt stored data. CI enforces manifest/catalog freshness.
+
+4. **Embeddable Inspector graph — phases 1–2 (#1606, #1698)** — white-label the Inspector graph inside another product:
+   - **Phase 1 — `apiBase`-parameterized API client:** an `ApiBaseProvider` / `useApiBase` context and `*WithBase` helpers let Inspector views target an arbitrary API origin instead of assuming same-origin (TanStack Query cache keyed by `apiBase` so multiple origins stay isolated). Zero behavior change when no provider is mounted.
+   - **Phase 2 — chrome-less `/embed/graph` route:** renders the graph explorer with no app shell (no sidebar/header), accepts `?apiBase=<url>` and `?node=<id>`, inherits the existing CSS-variable skin tokens (`NEOTOMA_INSPECTOR_SKIN`), and emits `postMessage` on node double-click so a host iframe can react. The normal in-app `/graph` route is unchanged. Entity-list embed and the multi-instance aggregate view remain as later phases of #1606.
+
+## Upgrade notes
+
+- **Fully backward-compatible.** Every new surface is opt-in: `include_capability_delta`, `intake`, `canonical_key`/`sighting_source_id`, and `collapse_by` all default to prior behavior when omitted. The `canonical_key` columns are nullable additive columns — existing rows stay `NULL`.
+- **New env var:** `NEOTOMA_OVERFLOW_SINK` (absolute path or directory). Only consulted when a `store` call passes `intake.mode: "overflow"`; unset = overflow disabled (a hint is returned if overflow is requested without it).
+- **Embedders:** point an iframe at `/embed/graph?apiBase=<your-api-origin>`; theme via the existing `NEOTOMA_INSPECTOR_SKIN` / `NEOTOMA_INSPECTOR_SKIN_CONFIG` mechanism from v0.16.0.
+
+## Breaking changes
+
+None. This release is additive.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neotoma",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neotoma",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
         "@hellocoop/httpsig": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neotoma",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "MCP server for structured personal data memory with unified source ingestion",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
## v0.17.0 — incremental release

Bumps `package.json` 0.16.0 → **0.17.0**, adds the v0.17.0 GitHub release supplement, and updates SECURITY.md supported versions (0.17.x + 0.16.x).

### What ships (all additive, backward-compatible)
- **`identify_entity_by_signals`** single-call multi-signal entity resolver — #1603 (PR #1670)
- **`npm_check_update` `include_capability_delta`** machine-readable per-release capability delta — #1605 (PRs #1693, #1694)
- **Discard-by-default intake + `canonical_key` read-time sightings** (`store intake.mode=overflow` + `retrieve_entities collapse_by=canonical_key`) — #1604 (PR #1697)
- **Embeddable chrome-less `/embed/graph` route + `apiBase` client** (phases 1–2) — #1606 (PR #1698)
- (also includes the real-server-version-in-`initialize` fix #1689 that landed after the v0.16.0 tag)

Full details in `docs/releases/in_progress/v0.17.0/github_release_supplement.md`.

### Operator publish steps (manual — not automated by CI)
After this PR merges to `main`:
1. `git checkout main && git pull`
2. `git tag v0.17.0 && git push origin v0.17.0`
3. `npm publish` (requires npm auth; this is the outward, irreversible step)
4. Cut the GitHub release from the tag using the supplement as the body (`npm run release-notes:render` if used)
5. Deploy to production (neotoma.io) per the normal deploy flow
6. Move `docs/releases/in_progress/v0.17.0/` → `docs/releases/completed/` once published

Once 0.17.0 is on npm, the four features become installable for integrators (e.g. Simon, currently on 0.15.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)