### PR TITLE
feat(eval-harness): assertion primitives for MCP-tool + snapshot coverage (#1703)

### DIFF
--- a/docs/subsystems/agentic_eval.md
+++ b/docs/subsystems/agentic_eval.md
@@ -222,7 +222,9 @@ Supported predicates (see `packages/eval-harness/src/assertions.ts`):
 `store_structured.calls`, `entity.exists`, `entity.count`,
 `observation.with_field`, `relationship.exists`, `relationship.count`,
 `reply_text.contains`, `turn_compliance.backfilled`,
-`instruction_profile.served`, `host_tool.invocations`. Each predicate
+`instruction_profile.served`, `host_tool.invocations`,
+`mcp_tool.invocations`, `tool_result.matches`, `snapshot.field_present`,
+`snapshot.field_absent`. Each predicate
 returns a structured `{ pass, expected, actual, message }` and the
 failure message is what the TTY/JUnit reporter surfaces.
 
@@ -327,6 +329,17 @@ Supported predicates in `packages/eval-harness/src/assertions.ts`:
 | `turn_compliance.backfilled` | Whether the stop hook backfilled compliance |
 | `instruction_profile.served` | Whether the requested profile was served |
 | `host_tool.invocations` | Host tool invocation count |
+| `mcp_tool.invocations` | Count invocations of a named neotoma MCP tool, with optional `arg_subset` structural match on the call's input (#1703) |
+| `tool_result.matches` | Inspect the JSON result the agent received from a named tool: `result_subset` (deep subset), or `result_key` + `present` (dotted-path key present/absent, incl. `error.code` envelopes); `which` picks first/last/index (#1703) |
+| `snapshot.field_present` | A `field` is present on a retrieved entity snapshot (resolved by `entity_id` or `entity_type`+`where`) (#1703) |
+| `snapshot.field_absent` | A `field` is absent from a retrieved entity snapshot — e.g. an unknown field landed in raw_fragments, stored-but-invisible (#1703) |
+
+These four `#1703` primitives close the audit gap where wrong-tool / silent-no-op
+behavior was invisible: the older predicates could only observe store-side entity
+state, so an agent that never called the intended tool passed as long as the
+state happened to be right. `mcp_tool.invocations` + `tool_result.matches` assert
+the tool was actually called and returned the expected shape (including error
+envelopes); `snapshot.field_present/absent` assert schema-projection effects.
 
 ### Combined runner (WRIT + Tier 2)
 

--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,15 +61,15 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **479**
-- Backend and repo Vitest files: **446**
+- Total automated test files: **480**
+- Backend and repo Vitest files: **447**
 - Frontend Vitest files: **9**
 - Playwright spec files: **24**
 
 ### Suite counts
 | Suite | Files |
 |---|---:|
-| Vitest unit tests | 126 |
+| Vitest unit tests | 127 |
 | Vitest service tests | 34 |
 | Source-adjacent tests | 58 |
 | Vitest integration tests | 135 |
@@ -109,7 +109,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/unit`
 **Requirements:** Basic `.env` if required by the module under test.
-**Files (126):**
+**Files (127):**
 - `tests/unit/aauth_admission.test.ts`
 - `tests/unit/aauth_attestation_apple_se.test.ts`
 - `tests/unit/aauth_attestation_revocation.test.ts`
@@ -158,6 +158,7 @@ flowchart TD
 - `tests/unit/encrypt_response_middleware.test.ts`
 - `tests/unit/entity_queries_status_projection.test.ts`
 - `tests/unit/env_contamination_audit.test.ts`
+- `tests/unit/eval_harness_assertion_primitives.test.ts`
 - `tests/unit/ext_apps_widget_host.test.ts`
 - `tests/unit/external_actor_badge.test.ts`
 - `tests/unit/external_actor_builder.test.ts`

--- a/packages/eval-harness/src/assertions.ts
+++ b/packages/eval-harness/src/assertions.ts
@@ -268,6 +268,12 @@ async function fetchSnapshot(
       whereMatches(e, where)
     );
     if (matches.length === 0) return null;
+    // Determinism: when more than one entity matches, pick the first by a
+    // STABLE ordering (entity_id ascending) so the assertion is reproducible
+    // regardless of server return order. (docs/architecture/determinism.md)
+    matches.sort((a, b) =>
+      String(a.entity_id ?? a.id ?? "").localeCompare(String(b.entity_id ?? b.id ?? ""))
+    );
     id = (matches[0].entity_id ?? matches[0].id) as string | undefined;
     // If the listing already carries the snapshot, use it directly.
     const snap = matches[0].snapshot as Record<string, unknown> | undefined;
@@ -500,9 +506,17 @@ export async function evaluatePredicate(
       const calls = toolCallsNamed(ctx.toolCalls ?? [], predicate.tool_name);
       const call = pickToolCall(calls, predicate.which);
       if (!call) {
+        // Distinguish "tool never called" from "called, but `which` index is
+        // out of range" — the latter is a scenario-authoring bug with a
+        // concrete fix (docs/subsystems/errors.md — actionable hints).
+        const outOfRange =
+          typeof predicate.which === "number" && calls.length > 0;
+        const message = outOfRange
+          ? `tool_result.matches: "${predicate.tool_name ?? "(any)"}" was invoked ${calls.length} time(s), but which=${predicate.which} is out of range (valid 0..${calls.length - 1}).`
+          : `tool_result.matches: no invocation of "${predicate.tool_name ?? "(any)"}" was captured.`;
         return {
           predicate,
-          message: `tool_result.matches: no invocation of "${predicate.tool_name ?? "(any)"}" was captured.`,
+          message,
           expected: predicate,
           actual: (ctx.toolCalls ?? []).map((c) => c.name),
         };
@@ -516,12 +530,14 @@ export async function evaluatePredicate(
           : call.error !== undefined
             ? { error: { message: call.error } }
             : undefined;
+      // result_key and result_subset are ANDed when both are supplied: the
+      // key check must pass AND the subset must match. Either may be omitted.
       // (a) result_key present/absent check (dotted path).
       if (predicate.result_key) {
         const { found } = getPath(result, predicate.result_key);
         const wantPresent = predicate.present !== false;
         if (found === wantPresent) {
-          // key check satisfied; fall through to result_subset if also given.
+          // key check satisfied; fall through to the result_subset check below.
         } else {
           return {
             predicate,

--- a/packages/eval-harness/src/assertions.ts
+++ b/packages/eval-harness/src/assertions.ts
@@ -12,6 +12,7 @@ import type {
   AssertionFailure,
   ExpectedAssertion,
   InstructionProfile,
+  ToolCall,
 } from "./types.js";
 import type { HostToolInvocation, HostToolRegistry } from "./host_tools.js";
 
@@ -25,6 +26,12 @@ export interface AssertionContext {
   effectiveProfile: InstructionProfile;
   /** Final assistant reply text (used by reply_text.contains). */
   assistantText?: string;
+  /**
+   * Every MCP/tool call the agent issued this turn, in order (#1703). Carries
+   * name, input, output, and error — the substrate for mcp_tool.invocations
+   * and tool_result.matches.
+   */
+  toolCalls?: ToolCall[];
 }
 
 interface EntitiesQueryResponse {
@@ -188,6 +195,96 @@ function countHostToolInvocations(
 ): number {
   if (!toolName) return invocations.length;
   return invocations.filter((i) => i.name === toolName).length;
+}
+
+// ── #1703 helpers ────────────────────────────────────────────────────────────
+
+/** Deep structural subset match: every key in `subset` exists in `value` with a
+ * deep-equal value. Arrays match element-wise as subsets by index. */
+function isSubset(value: unknown, subset: unknown): boolean {
+  if (subset === null || typeof subset !== "object") {
+    return deepEqual(value, subset);
+  }
+  if (Array.isArray(subset)) {
+    if (!Array.isArray(value)) return false;
+    return subset.every((s, i) => isSubset(value[i], s));
+  }
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const v = value as Record<string, unknown>;
+  for (const [k, s] of Object.entries(subset as Record<string, unknown>)) {
+    if (!Object.prototype.hasOwnProperty.call(v, k)) return false;
+    if (!isSubset(v[k], s)) return false;
+  }
+  return true;
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a === null || b === null || typeof a !== "object" || typeof b !== "object") return false;
+  if (Array.isArray(a) !== Array.isArray(b)) return false;
+  const ae = Object.entries(a as Record<string, unknown>);
+  const be = Object.entries(b as Record<string, unknown>);
+  if (ae.length !== be.length) return false;
+  return ae.every(([k, av]) => deepEqual(av, (b as Record<string, unknown>)[k]));
+}
+
+/** Resolve a dotted path (e.g. "error.code") against a nested object. Returns
+ * { found, value }; found=false distinguishes a missing key from a null value. */
+function getPath(obj: unknown, path: string): { found: boolean; value: unknown } {
+  const parts = path.split(".");
+  let cur: unknown = obj;
+  for (const p of parts) {
+    if (cur === null || typeof cur !== "object") return { found: false, value: undefined };
+    if (!Object.prototype.hasOwnProperty.call(cur, p)) return { found: false, value: undefined };
+    cur = (cur as Record<string, unknown>)[p];
+  }
+  return { found: true, value: cur };
+}
+
+/** Tool calls matching a name (or all when name omitted). */
+function toolCallsNamed(calls: ToolCall[], name: string | undefined): ToolCall[] {
+  if (!name) return calls;
+  return calls.filter((c) => c.name === name);
+}
+
+/** Pick one tool call by `which` (default last). */
+function pickToolCall(calls: ToolCall[], which: "first" | "last" | number | undefined): ToolCall | undefined {
+  if (calls.length === 0) return undefined;
+  if (which === "first") return calls[0];
+  if (typeof which === "number") return calls[which];
+  return calls[calls.length - 1]; // "last" / default
+}
+
+/** Fetch a single entity snapshot, resolving by id or by entity_type+where. */
+async function fetchSnapshot(
+  ctx: AssertionContext,
+  entityId: string | undefined,
+  entityType: string | undefined,
+  where: Record<string, unknown> | undefined
+): Promise<Record<string, unknown> | null> {
+  let id = entityId;
+  if (!id) {
+    const matches = (await fetchEntities(ctx, entityType, where)).filter((e) =>
+      whereMatches(e, where)
+    );
+    if (matches.length === 0) return null;
+    id = (matches[0].entity_id ?? matches[0].id) as string | undefined;
+    // If the listing already carries the snapshot, use it directly.
+    const snap = matches[0].snapshot as Record<string, unknown> | undefined;
+    if (snap && typeof snap === "object") return snap;
+  }
+  if (!id) return null;
+  try {
+    const res = await fetch(`${ctx.baseUrl}/entities/${encodeURIComponent(id)}`, {
+      method: "GET",
+    });
+    if (!res.ok) return null;
+    const json = (await res.json()) as Record<string, unknown>;
+    const snap = (json.snapshot ?? json) as Record<string, unknown>;
+    return snap;
+  } catch {
+    return null;
+  }
 }
 
 export async function evaluatePredicate(
@@ -377,6 +474,112 @@ export async function evaluatePredicate(
         message: `Expected relationship.count of "${label}" ${op} ${expected}, got ${rels.length}.`,
         expected: { op, value: expected },
         actual: rels.length,
+      };
+    }
+    // ── #1703 eval-coverage primitives ──
+    case "mcp_tool.invocations": {
+      const calls = ctx.toolCalls ?? [];
+      let matching = toolCallsNamed(calls, predicate.tool_name);
+      if (predicate.arg_subset) {
+        matching = matching.filter((c) => isSubset(c.input, predicate.arg_subset));
+      }
+      const actual = matching.length;
+      const expected = typeof predicate.value === "number" ? predicate.value : 1;
+      const op = predicate.op ?? "gte";
+      if (compareNumber(actual, op, expected)) return null;
+      return {
+        predicate,
+        message: `Expected mcp_tool[${predicate.tool_name ?? "*"}]${
+          predicate.arg_subset ? ` with args ⊇ ${JSON.stringify(predicate.arg_subset)}` : ""
+        } invocations ${op} ${expected}, got ${actual}.`,
+        expected: { op, value: expected, tool_name: predicate.tool_name, arg_subset: predicate.arg_subset },
+        actual: calls.map((c) => ({ name: c.name, input: c.input })),
+      };
+    }
+    case "tool_result.matches": {
+      const calls = toolCallsNamed(ctx.toolCalls ?? [], predicate.tool_name);
+      const call = pickToolCall(calls, predicate.which);
+      if (!call) {
+        return {
+          predicate,
+          message: `tool_result.matches: no invocation of "${predicate.tool_name ?? "(any)"}" was captured.`,
+          expected: predicate,
+          actual: (ctx.toolCalls ?? []).map((c) => c.name),
+        };
+      }
+      // The result is the tool's output; failed calls expose {error:{...}} so
+      // error-surface assertions work. Prefer output, fall back to a synthesized
+      // error envelope when the call recorded an error string.
+      const result: unknown =
+        call.output !== undefined
+          ? call.output
+          : call.error !== undefined
+            ? { error: { message: call.error } }
+            : undefined;
+      // (a) result_key present/absent check (dotted path).
+      if (predicate.result_key) {
+        const { found } = getPath(result, predicate.result_key);
+        const wantPresent = predicate.present !== false;
+        if (found === wantPresent) {
+          // key check satisfied; fall through to result_subset if also given.
+        } else {
+          return {
+            predicate,
+            message: `Expected tool_result["${predicate.tool_name}"].${predicate.result_key} to be ${
+              wantPresent ? "present" : "absent"
+            }, but it was ${found ? "present" : "absent"}.`,
+            expected: { result_key: predicate.result_key, present: wantPresent },
+            actual: result,
+          };
+        }
+      }
+      // (b) result_subset structural match.
+      if (predicate.result_subset) {
+        if (!isSubset(result, predicate.result_subset)) {
+          return {
+            predicate,
+            message: `Expected tool_result["${predicate.tool_name}"] to match subset ${JSON.stringify(
+              predicate.result_subset
+            )}, but it did not.`,
+            expected: { result_subset: predicate.result_subset },
+            actual: result,
+          };
+        }
+      }
+      return null;
+    }
+    case "snapshot.field_present":
+    case "snapshot.field_absent": {
+      const field = predicate.field ?? "";
+      if (!field) {
+        return {
+          predicate,
+          message: `${predicate.type} requires a "field" to check.`,
+          expected: predicate,
+          actual: null,
+        };
+      }
+      const snap = await fetchSnapshot(ctx, predicate.entity_id, predicate.entity_type, predicate.where);
+      if (!snap) {
+        return {
+          predicate,
+          message: `${predicate.type}: could not resolve an entity snapshot (id=${
+            predicate.entity_id ?? "—"
+          }, type=${predicate.entity_type ?? "—"}, where=${JSON.stringify(predicate.where ?? {})}).`,
+          expected: predicate,
+          actual: null,
+        };
+      }
+      const { found } = getPath(snap, field);
+      const wantPresent = predicate.type === "snapshot.field_present";
+      if (found === wantPresent) return null;
+      return {
+        predicate,
+        message: `Expected snapshot field "${field}" to be ${
+          wantPresent ? "present" : "absent"
+        }, but it was ${found ? "present" : "absent"}.`,
+        expected: predicate,
+        actual: Object.keys(snap),
       };
     }
   }

--- a/packages/eval-harness/src/runner.ts
+++ b/packages/eval-harness/src/runner.ts
@@ -228,6 +228,7 @@ async function runCell(plan: CellPlan, opts: RunnerOptions): Promise<CellReport>
       hostToolRegistry: registryForAssertions,
       effectiveProfile,
       assistantText: driverResult.assistantText,
+      toolCalls: driverResult.toolCalls,
     });
     pass = assertionFailures.length === 0;
     if (!pass) {

--- a/packages/eval-harness/src/types.ts
+++ b/packages/eval-harness/src/types.ts
@@ -56,7 +56,16 @@ export interface ExpectedAssertion {
     | "reply_text.contains"
     | "turn_compliance.backfilled"
     | "instruction_profile.served"
-    | "host_tool.invocations";
+    | "host_tool.invocations"
+    // ── #1703 eval-coverage primitives ──
+    /** Count invocations of a named neotoma MCP tool (optional arg-subset match). */
+    | "mcp_tool.invocations"
+    /** Inspect the JSON result the agent received from a named MCP tool. */
+    | "tool_result.matches"
+    /** Assert a field is present on a retrieved entity snapshot. */
+    | "snapshot.field_present"
+    /** Assert a field is absent from a retrieved entity snapshot. */
+    | "snapshot.field_absent";
   /** Numeric comparison op for count-shaped predicates. */
   op?: "eq" | "gte" | "lte";
   value?: number | string | boolean;
@@ -82,6 +91,39 @@ export interface ExpectedAssertion {
   substring?: string;
   /** Regex pattern to match in `reply_text.contains`. */
   pattern?: string;
+  // ── #1703 eval-coverage primitive fields ──
+  /**
+   * For `mcp_tool.invocations`: a structural (subset) match on the tool's
+   * input args. The call counts only if every key here is present in the
+   * call's input with a deep-equal value. Omit to count all invocations of
+   * `tool_name`.
+   */
+  arg_subset?: Record<string, unknown>;
+  /**
+   * For `tool_result.matches`: which invocation of `tool_name` to inspect.
+   * `"last"` (default) or `"first"`, or a 0-based index.
+   */
+  which?: "first" | "last" | number;
+  /**
+   * For `tool_result.matches`: a subset match against the tool's JSON
+   * RESULT (output). Every key must be present with a deep-equal value.
+   * Supports dotted paths for nesting (e.g. "error.code").
+   */
+  result_subset?: Record<string, unknown>;
+  /**
+   * For `tool_result.matches`: assert the result contains (or, when false,
+   * does NOT contain) a key. Dotted paths allowed (e.g. "webhook_secret",
+   * "error.code"). Use with `present`.
+   */
+  result_key?: string;
+  /** For `tool_result.matches` with `result_key`: expect present (default true) or absent. */
+  present?: boolean;
+  /**
+   * For `snapshot.field_present` / `snapshot.field_absent`: the entity to
+   * project. Either an explicit id, or resolved from `entity_type` + `where`
+   * (first match). The `field` (above) is the snapshot key checked.
+   */
+  entity_id?: string;
 }
 
 export type SeedStrategy = "generated" | "real_derived" | "hybrid_amplified";

--- a/packages/eval-harness/src/types.ts
+++ b/packages/eval-harness/src/types.ts
@@ -105,9 +105,10 @@ export interface ExpectedAssertion {
    */
   which?: "first" | "last" | number;
   /**
-   * For `tool_result.matches`: a subset match against the tool's JSON
-   * RESULT (output). Every key must be present with a deep-equal value.
-   * Supports dotted paths for nesting (e.g. "error.code").
+   * For `tool_result.matches`: a deep structural subset match against the
+   * tool's JSON RESULT (output). Nesting is expressed by nested objects, NOT
+   * dotted paths — e.g. `{ error: { code: "ERR_X" } }`, not `{ "error.code": … }`.
+   * (Dotted paths are a `result_key` feature.) Every leaf must deep-equal.
    */
   result_subset?: Record<string, unknown>;
   /**

--- a/tests/unit/eval_harness_assertion_primitives.test.ts
+++ b/tests/unit/eval_harness_assertion_primitives.test.ts
@@ -141,6 +141,49 @@ describe("#1703 tool_result.matches", () => {
     expect(fail).not.toBeNull();
     expect(fail!.message).toContain("no invocation");
   });
+
+  it("gives an out-of-range hint when which exceeds the call count", async () => {
+    const c = ctx({ toolCalls: [call("store", {}, { ok: true })] });
+    const p: ExpectedAssertion = {
+      type: "tool_result.matches",
+      tool_name: "store",
+      which: 5,
+      result_key: "ok",
+    };
+    const fail = await evaluatePredicate(p, c);
+    expect(fail).not.toBeNull();
+    expect(fail!.message).toContain("out of range");
+  });
+
+  it("ANDs result_key and result_subset when both are supplied (both must pass)", async () => {
+    const c = ctx({
+      toolCalls: [call("subscribe", {}, { webhook_secret: "wh", active: true })],
+    });
+    // key present AND subset matches → pass
+    expect(
+      await evaluatePredicate(
+        { type: "tool_result.matches", tool_name: "subscribe", result_key: "webhook_secret", result_subset: { active: true } },
+        c
+      )
+    ).toBeNull();
+    // key present but subset mismatches → fail
+    expect(
+      await evaluatePredicate(
+        { type: "tool_result.matches", tool_name: "subscribe", result_key: "webhook_secret", result_subset: { active: false } },
+        c
+      )
+    ).not.toBeNull();
+  });
+
+  it("result_subset matches nested objects structurally (not dotted paths)", async () => {
+    const c = ctx({ toolCalls: [call("correct", {}, { error: { code: "ERR_NO_SCHEMA" } })] });
+    expect(
+      await evaluatePredicate(
+        { type: "tool_result.matches", tool_name: "correct", result_subset: { error: { code: "ERR_NO_SCHEMA" } } },
+        c
+      )
+    ).toBeNull();
+  });
 });
 
 describe("#1703 snapshot.field_present / field_absent", () => {
@@ -184,5 +227,30 @@ describe("#1703 snapshot.field_present / field_absent", () => {
     const fail = await evaluatePredicate(p, ctx());
     expect(fail).not.toBeNull();
     expect(fail!.message).toContain("could not resolve");
+  });
+
+  it("resolves multiple where-matches deterministically (lowest entity_id wins)", async () => {
+    // /entities/query returns out-of-order; the helper must sort by entity_id
+    // so the assertion is reproducible. ent_a carries the field, ent_b does not.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({
+          entities: [
+            { entity_id: "ent_b", snapshot: { status: "x" } },
+            { entity_id: "ent_a", snapshot: { status: "x", chosen: true } },
+          ],
+        }),
+      })) as never
+    );
+    // field_present "chosen" passes only if ent_a (lowest id) is chosen.
+    const p: ExpectedAssertion = {
+      type: "snapshot.field_present",
+      entity_type: "task",
+      where: { status: "x" },
+      field: "chosen",
+    };
+    expect(await evaluatePredicate(p, ctx())).toBeNull();
   });
 });

--- a/tests/unit/eval_harness_assertion_primitives.test.ts
+++ b/tests/unit/eval_harness_assertion_primitives.test.ts
@@ -1,0 +1,188 @@
+/**
+ * #1703 — eval-harness assertion primitives.
+ *
+ * Self-tests for the four new predicate types that unblock the eval-coverage
+ * backfill: mcp_tool.invocations, tool_result.matches, snapshot.field_present,
+ * snapshot.field_absent. The first two run purely against captured toolCalls
+ * (no network); the snapshot ones stub fetch.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  evaluatePredicate,
+  type AssertionContext,
+} from "../../packages/eval-harness/src/assertions.js";
+import type { ExpectedAssertion, ToolCall } from "../../packages/eval-harness/src/types.js";
+
+function ctx(overrides: Partial<AssertionContext> = {}): AssertionContext {
+  return {
+    baseUrl: "http://localhost:0",
+    stats: null,
+    hostToolRegistry: { stubs: new Map(), invocations: [], invoke: async () => ({}) } as never,
+    effectiveProfile: "auto",
+    ...overrides,
+  };
+}
+
+const call = (name: string, input: unknown, output?: unknown, error?: string, sequence = 0): ToolCall => ({
+  name,
+  input,
+  output,
+  error,
+  sequence,
+});
+
+describe("#1703 mcp_tool.invocations", () => {
+  it("counts invocations of a named tool (passes gte 1)", async () => {
+    const c = ctx({ toolCalls: [call("correct", { field: "status" }), call("store", {})] });
+    const p: ExpectedAssertion = { type: "mcp_tool.invocations", tool_name: "correct" };
+    expect(await evaluatePredicate(p, c)).toBeNull();
+  });
+
+  it("fails when the named tool was never called", async () => {
+    const c = ctx({ toolCalls: [call("store", {})] });
+    const p: ExpectedAssertion = { type: "mcp_tool.invocations", tool_name: "merge_entities" };
+    const fail = await evaluatePredicate(p, c);
+    expect(fail).not.toBeNull();
+    expect(fail!.message).toContain("merge_entities");
+  });
+
+  it("arg_subset matches structurally (subset, not exact)", async () => {
+    const c = ctx({
+      toolCalls: [call("correct", { entity_id: "ent_1", field: "status", value: "done", extra: 1 })],
+    });
+    const p: ExpectedAssertion = {
+      type: "mcp_tool.invocations",
+      tool_name: "correct",
+      arg_subset: { field: "status", value: "done" },
+    };
+    expect(await evaluatePredicate(p, c)).toBeNull();
+  });
+
+  it("arg_subset fails when a value differs", async () => {
+    const c = ctx({ toolCalls: [call("correct", { field: "status", value: "todo" })] });
+    const p: ExpectedAssertion = {
+      type: "mcp_tool.invocations",
+      tool_name: "correct",
+      arg_subset: { value: "done" },
+    };
+    expect(await evaluatePredicate(p, c)).not.toBeNull();
+  });
+
+  it("respects op + value (eq 2)", async () => {
+    const c = ctx({ toolCalls: [call("subscribe", {}), call("subscribe", {})] });
+    const p: ExpectedAssertion = { type: "mcp_tool.invocations", tool_name: "subscribe", op: "eq", value: 2 };
+    expect(await evaluatePredicate(p, c)).toBeNull();
+  });
+});
+
+describe("#1703 tool_result.matches", () => {
+  it("matches a result_subset on the last invocation", async () => {
+    const c = ctx({
+      toolCalls: [call("subscribe", {}, { id: "sub_1", webhook_secret: "wh_abc", active: true })],
+    });
+    const p: ExpectedAssertion = {
+      type: "tool_result.matches",
+      tool_name: "subscribe",
+      result_subset: { active: true },
+    };
+    expect(await evaluatePredicate(p, c)).toBeNull();
+  });
+
+  it("asserts a result key is present (webhook_secret)", async () => {
+    const c = ctx({ toolCalls: [call("subscribe", {}, { webhook_secret: "wh_abc" })] });
+    const p: ExpectedAssertion = {
+      type: "tool_result.matches",
+      tool_name: "subscribe",
+      result_key: "webhook_secret",
+      present: true,
+    };
+    expect(await evaluatePredicate(p, c)).toBeNull();
+  });
+
+  it("surfaces an error envelope via dotted result_key (error.code)", async () => {
+    const c = ctx({
+      toolCalls: [call("correct", {}, { error: { code: "ERR_NO_SCHEMA_FOR_ENTITY_TYPE" } })],
+    });
+    const p: ExpectedAssertion = {
+      type: "tool_result.matches",
+      tool_name: "correct",
+      result_key: "error.code",
+      present: true,
+    };
+    expect(await evaluatePredicate(p, c)).toBeNull();
+  });
+
+  it("synthesizes an error envelope when the call recorded an error string", async () => {
+    const c = ctx({ toolCalls: [call("delete_entity", {}, undefined, "Entity not found")] });
+    const p: ExpectedAssertion = {
+      type: "tool_result.matches",
+      tool_name: "delete_entity",
+      result_key: "error.message",
+      present: true,
+    };
+    expect(await evaluatePredicate(p, c)).toBeNull();
+  });
+
+  it("present:false asserts a key is absent", async () => {
+    const c = ctx({ toolCalls: [call("store", {}, { entity_id: "ent_1" })] });
+    const p: ExpectedAssertion = {
+      type: "tool_result.matches",
+      tool_name: "store",
+      result_key: "error",
+      present: false,
+    };
+    expect(await evaluatePredicate(p, c)).toBeNull();
+  });
+
+  it("fails when the tool was never invoked", async () => {
+    const c = ctx({ toolCalls: [] });
+    const p: ExpectedAssertion = { type: "tool_result.matches", tool_name: "merge_entities", result_key: "ok" };
+    const fail = await evaluatePredicate(p, c);
+    expect(fail).not.toBeNull();
+    expect(fail!.message).toContain("no invocation");
+  });
+});
+
+describe("#1703 snapshot.field_present / field_absent", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  function stubFetchSnapshot(snapshot: Record<string, unknown> | null) {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: snapshot !== null,
+        json: async () => ({ snapshot }),
+      })) as never
+    );
+  }
+
+  it("field_present passes when the snapshot carries the field", async () => {
+    stubFetchSnapshot({ status: "done", title: "x" });
+    const p: ExpectedAssertion = {
+      type: "snapshot.field_present",
+      entity_id: "ent_1",
+      field: "status",
+    };
+    expect(await evaluatePredicate(p, ctx())).toBeNull();
+  });
+
+  it("field_present fails when the field is missing", async () => {
+    stubFetchSnapshot({ title: "x" });
+    const p: ExpectedAssertion = { type: "snapshot.field_present", entity_id: "ent_1", field: "status" };
+    expect(await evaluatePredicate(p, ctx())).not.toBeNull();
+  });
+
+  it("field_absent passes when the field is missing (raw_fragments stored-but-invisible)", async () => {
+    stubFetchSnapshot({ title: "x" });
+    const p: ExpectedAssertion = { type: "snapshot.field_absent", entity_id: "ent_1", field: "unknown_field" };
+    expect(await evaluatePredicate(p, ctx())).toBeNull();
+  });
+
+  it("fails when no snapshot can be resolved", async () => {
+    stubFetchSnapshot(null);
+    const p: ExpectedAssertion = { type: "snapshot.field_present", entity_id: "missing", field: "x" };
+    const fail = await evaluatePredicate(p, ctx());
+    expect(fail).not.toBeNull();
+    expect(fail!.message).toContain("could not resolve");
+  });
+});


### PR DESCRIPTION
Closes #1703 — the **foundational blocker** for the eval-coverage backfill (CA audit 2026-06-22, umbrella #230).

## Why
The eval-harness assertion vocabulary could only observe store-side entity state. It could not assert that a named MCP tool was invoked, inspect a tool's return shape, or check snapshot field presence — so **wrong-tool / silent-no-op behavior was invisible**: an agent that never called the intended tool passed as long as the entity state happened to be right. ~Half of the filed gap evals (#1709, #1710, #1713, #1715, #1717, #1718, #1719, …) depend on these primitives.

## What
Four new predicate types (`assertions.ts` + `types.ts`):
- **`mcp_tool.invocations`** — count invocations of a named neotoma MCP tool, with optional `arg_subset` **structural (subset, not exact)** match on the call input.
- **`tool_result.matches`** — inspect the JSON result the agent received: `result_subset` (deep subset) or `result_key` + `present` (dotted-path key present/absent, incl. `error.code` envelopes); `which` picks first/last/index. Failed calls expose a synthesized `{error:{message}}` envelope so error-surface assertions work.
- **`snapshot.field_present` / `snapshot.field_absent`** — project a retrieved entity snapshot (by `entity_id` or `entity_type`+`where`) and assert a field is present/absent (e.g. an unknown field that landed in raw_fragments, stored-but-invisible).

**Wiring:** the runner already captured `driverResult.toolCalls` (name/input/output/error) — this just threads them into `AssertionContext`. One-line runner change; default behavior for every existing scenario is unchanged.

## Verification
- `tests/unit/eval_harness_assertion_primitives.test.ts` — **15 cases**, pure + fetch-stubbed (arg-subset, error envelopes, key present/absent, snapshot resolve/missing). All green.
- Typechecks (`tsc --noEmit`) + builds (`npm run build`) clean.
- `validate:test-catalog` ✅; docs `agentic_eval.md` predicate list + table updated with the four primitives.