### PR TITLE
feat(eval-harness): CI scenario lane + first tool-behavior eval (correct) — #1704

### DIFF
--- a/.github/workflows/ci_test_lanes.yml
+++ b/.github/workflows/ci_test_lanes.yml
@@ -173,6 +173,31 @@ jobs:
       - name: Run Tier 1 agentic evals
         run: npm run eval:tier1
 
+  eval_scenarios:
+    # eval-harness SCENARIO lane (Tier 2). Runs the agent-driving scenarios in
+    # packages/eval-harness/scenarios/ against a real in-process isolated
+    # Neotoma server in REPLAY mode (committed cassettes — no API key required).
+    # This is the CI gate for tool-behavior evals (agent calls correct / merge /
+    # subscribe / …), which the hook-lifecycle agentic_evals lane cannot model.
+    # Quarantined scenarios (meta.quarantine, tracked by neotoma#1726) are
+    # skipped, not failed; cassette-less scenarios skip until recorded.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run eval-harness scenarios (replay)
+        run: npm run eval:scenarios
+
   python_sdk:
     runs-on: ubuntu-latest
     steps:

--- a/docs/subsystems/agentic_eval.md
+++ b/docs/subsystems/agentic_eval.md
@@ -228,6 +228,15 @@ Supported predicates (see `packages/eval-harness/src/assertions.ts`):
 returns a structured `{ pass, expected, actual, message }` and the
 failure message is what the TTY/JUnit reporter surfaces.
 
+### CI lanes — two systems, two layers
+
+Two eval systems run in CI, testing different layers (do not conflate them):
+
+- **`agentic_evals` lane** (`npm run eval:tier1`) runs the `tests/fixtures/agentic_eval/*.json` fixtures: the **hook-lifecycle** layer (replays `beforeSubmitPrompt`/`postToolUse`/`stop` events through harness adapters against a mock server). Asserts the hook stack's turn-lifecycle compliance.
+- **`eval_scenarios` lane** (`npm run eval:scenarios`) runs `packages/eval-harness/scenarios/*` in **replay** against a real in-process isolated Neotoma server: the **agent-tool-driving** layer (an agent calls `store`/`correct`/`merge`/… and the call executes for real). This is the CI gate for tool-behavior evals — the hook-lifecycle fixtures cannot express "agent calls correct". Replay needs no API key (committed cassettes).
+
+**Quarantine.** A scenario whose `meta.quarantine` is set is *skipped* (not failed) by the runner, with the reason logged, so the `eval_scenarios` lane stays green on a clean main while a known gap is tracked + fixed. The value references the tracking issue (e.g. `neotoma#1726: …`). Un-quarantine as the underlying support lands.
+
 ### Cassettes
 
 Each `(scenario, provider, model)` triple has one cassette under

--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,15 +61,15 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **480**
-- Backend and repo Vitest files: **447**
+- Total automated test files: **481**
+- Backend and repo Vitest files: **448**
 - Frontend Vitest files: **9**
 - Playwright spec files: **24**
 
 ### Suite counts
 | Suite | Files |
 |---|---:|
-| Vitest unit tests | 127 |
+| Vitest unit tests | 128 |
 | Vitest service tests | 34 |
 | Source-adjacent tests | 58 |
 | Vitest integration tests | 135 |
@@ -109,7 +109,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/unit`
 **Requirements:** Basic `.env` if required by the module under test.
-**Files (127):**
+**Files (128):**
 - `tests/unit/aauth_admission.test.ts`
 - `tests/unit/aauth_attestation_apple_se.test.ts`
 - `tests/unit/aauth_attestation_revocation.test.ts`
@@ -159,6 +159,7 @@ flowchart TD
 - `tests/unit/entity_queries_status_projection.test.ts`
 - `tests/unit/env_contamination_audit.test.ts`
 - `tests/unit/eval_harness_assertion_primitives.test.ts`
+- `tests/unit/eval_harness_quarantine.test.ts`
 - `tests/unit/ext_apps_widget_host.test.ts`
 - `tests/unit/external_actor_badge.test.ts`
 - `tests/unit/external_actor_builder.test.ts`

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "test:remote:critical:report": "cross-env RUN_REMOTE_TESTS=1 WRITE_TEST_RUN_REPORT=1 npm run test:remote:critical",
     "eval:tier1": "vitest run tests/integration/agentic_eval_matrix.test.ts",
     "eval:tier1:update": "cross-env UPDATE_AGENTIC_EVAL_SNAPSHOTS=1 vitest run tests/integration/agentic_eval_matrix.test.ts",
+    "eval:scenarios": "tsx packages/eval-harness/src/cli.ts run --mode replay --provider stub --reporter tty",
     "test:remote:critical": "cross-env RUN_REMOTE_TESTS=1 vitest run tests/integration/mcp_actions_matrix.test.ts tests/integration/mcp_resources.test.ts tests/integration/mcp_store_unstructured.test.ts tests/integration/mcp_store_parquet.test.ts tests/integration/mcp_schema_actions.test.ts tests/integration/schema_recommendation_integration.test.ts tests/integration/observation_ingestion.test.ts tests/integration/relationship_snapshots.test.ts tests/services/auto_enhancement_converter_detection.test.ts tests/services/auto_enhancement_processor.test.ts",
     "test:contract": "vitest run tests/contract",
     "test:bench": "cross-env RUN_BENCH=1 vitest run tests/performance",

--- a/packages/eval-harness/cassettes/correct_overrides_snapshot__stub__replay-only.cassette.json
+++ b/packages/eval-harness/cassettes/correct_overrides_snapshot__stub__replay-only.cassette.json
@@ -1,0 +1,47 @@
+{
+  "meta": {
+    "format_version": 1,
+    "scenario_id": "correct_overrides_snapshot",
+    "provider": "stub",
+    "model": "replay-only",
+    "instruction_profile": "auto",
+    "recorded_at": "2026-06-22T00:00:00.000Z",
+    "cost_usd": 0
+  },
+  "user_prompt": "Mark the task \"Backfill correct eval target\" as done.\n",
+  "system_prompt": "You are an assistant integrated with the Neotoma memory system. When the user asks you to change a field on an existing entity, use the correct tool with the entity_id, entity_type, field, and value. Persist the conversation and user message via the store tool with PART_OF relationships.\n",
+  "tool_calls": [
+    {
+      "name": "store",
+      "input": {
+        "idempotency_key": "conv-correct-001",
+        "entities": [
+          { "entity_type": "conversation", "conversation_id": "conv-correct-001" },
+          {
+            "entity_type": "conversation_message",
+            "turn_key": "conv-correct-001:1",
+            "role": "user",
+            "sender_kind": "user",
+            "content": "Mark the task \"Backfill correct eval target\" as done."
+          }
+        ],
+        "relationships": [
+          { "relationship_type": "PART_OF", "source_index": 1, "target_index": 0 }
+        ]
+      },
+      "sequence": 0
+    },
+    {
+      "name": "correct",
+      "input": {
+        "entity_id": "ent_db0aa822a731f249345bc160",
+        "entity_type": "task",
+        "field": "status",
+        "value": "done",
+        "idempotency_key": "correct-task-status-001"
+      },
+      "sequence": 1
+    }
+  ],
+  "assistant_text": "Done — I marked the task \"Backfill correct eval target\" as done."
+}

--- a/packages/eval-harness/scenarios/closing_assistant_store.scenario.yaml
+++ b/packages/eval-harness/scenarios/closing_assistant_store.scenario.yaml
@@ -1,5 +1,6 @@
 meta:
   id: closing_assistant_store
+  quarantine: "neotoma#1726: store_structured.calls reads the /stats counter, under-reported by the isolated replay server."
   description: >
     Agent must produce a closing assistant store even for simple factual
     answers. Tests Turn Lifecycle Step 5a/5b — the assistant reply must be

--- a/packages/eval-harness/scenarios/compact_profile_still_stores.scenario.yaml
+++ b/packages/eval-harness/scenarios/compact_profile_still_stores.scenario.yaml
@@ -1,5 +1,6 @@
 meta:
   id: compact_profile_still_stores
+  quarantine: "neotoma#1726: instruction_profile.served reads profile counters the isolated replay server does not emit."
   description: >
     Even under the compact instruction profile, the agent must still
     perform store-first. Tests that profile reduction does not skip

--- a/packages/eval-harness/scenarios/correct_overrides_snapshot.scenario.yaml
+++ b/packages/eval-harness/scenarios/correct_overrides_snapshot.scenario.yaml
@@ -1,0 +1,67 @@
+meta:
+  id: correct_overrides_snapshot
+  description: >
+    A task is pre-seeded with status="todo". The agent issues a correction
+    setting status="done". Validates the highest-blast-radius write
+    (mcp__mcpsrv_neotoma__correct): the priority-1000 correction observation
+    must WIN the recomputed snapshot (status==done, and no entity still reads
+    todo), not merely append an observation. Exercises the #1703 primitives
+    mcp_tool.invocations + snapshot.field_present against a real /correct
+    execution. Closes part of neotoma#1704 (CA eval-coverage backfill).
+  tags:
+    - tier2
+    - correct
+    - eval-coverage
+    - writ:correction
+
+seed_strategy: generated
+source_pattern: "No agentic eval exercised `correct`; a regression that appended a non-winning observation (correction looks applied but the field is unchanged) would have been invisible."
+privacy_transform: "Fully synthetic task; no PII."
+
+seed_entities:
+  - entity_type: task
+    title: Backfill correct eval target
+    status: todo
+
+system_prompt: >
+  You are an assistant integrated with the Neotoma memory system. When the
+  user asks you to change a field on an existing entity, use the correct tool
+  with the entity_id, entity_type, field, and value. Persist the conversation
+  and user message via the store tool with PART_OF relationships.
+
+user_prompt: |
+  Mark the task "Backfill correct eval target" as done.
+
+host_tools: []
+
+models:
+  - provider: stub
+    model: replay-only
+
+expected:
+  # The agent actually invoked correct with the intended field/value.
+  - type: mcp_tool.invocations
+    tool_name: correct
+    op: gte
+    value: 1
+    arg_subset:
+      field: status
+      value: done
+  # The priority-1000 correction WON the snapshot — the task now reads done.
+  - type: entity.exists
+    entity_type: task
+    where:
+      status: done
+  # ...and nothing still reads the pre-correction value (override, not append).
+  - type: entity.count
+    entity_type: task
+    where:
+      status: todo
+    op: eq
+    value: 0
+  # The corrected field is present on the recomputed snapshot.
+  - type: snapshot.field_present
+    entity_type: task
+    where:
+      status: done
+    field: status

--- a/packages/eval-harness/scenarios/file_source_provenance.scenario.yaml
+++ b/packages/eval-harness/scenarios/file_source_provenance.scenario.yaml
@@ -1,5 +1,6 @@
 meta:
   id: file_source_provenance
+  quarantine: "neotoma#1726: observation.with_field + EMBEDS read /observations, which the isolated replay server does not populate for file-sourced provenance."
   description: >
     User provides a CSV file of transactions. Agent must extract
     transaction entities with source_file provenance and create an EMBEDS

--- a/packages/eval-harness/src/assertions.ts
+++ b/packages/eval-harness/src/assertions.ts
@@ -342,7 +342,14 @@ export async function evaluatePredicate(
       };
     }
     case "entity.count": {
-      const entities = await fetchEntities(ctx, predicate.entity_type, predicate.where);
+      // Re-filter client-side with whereMatches: the isolated server's
+      // /entities/query does not honor the `filters` body param, so a `where`
+      // clause must be applied here (mirroring entity.exists). Without this,
+      // entity.count(where: {...}) silently counts ALL entities of the type.
+      const fetched = await fetchEntities(ctx, predicate.entity_type, predicate.where);
+      const entities = predicate.where
+        ? fetched.filter((e) => whereMatches(e, predicate.where))
+        : fetched;
       const expected = typeof predicate.value === "number" ? predicate.value : 0;
       const op = predicate.op ?? "eq";
       if (compareNumber(entities.length, op, expected)) return null;

--- a/packages/eval-harness/src/runner.ts
+++ b/packages/eval-harness/src/runner.ts
@@ -140,6 +140,23 @@ async function runCell(plan: CellPlan, opts: RunnerOptions): Promise<CellReport>
   const cellLabel = `${plan.scenario.meta.id} | ${plan.model.provider}/${plan.model.model} | profile=${effectiveProfile} | hooks=${plan.hooksEnabled}`;
   log(`[runner] starting cell: ${cellLabel}`);
 
+  // Quarantined scenarios are skipped (not failed) so the CI scenario lane
+  // stays green on a clean main while a known gap is tracked + fixed.
+  if (plan.scenario.meta.quarantine) {
+    log(`[runner] QUARANTINED: ${plan.scenario.meta.id} — ${plan.scenario.meta.quarantine}`);
+    return {
+      scenario: plan.scenario.meta,
+      model: plan.model,
+      effectiveProfile,
+      mode: opts.mode,
+      assertionFailures: [],
+      startedAt,
+      endedAt: new Date().toISOString(),
+      pass: false,
+      skipped: { reason: `quarantined: ${plan.scenario.meta.quarantine}` },
+    };
+  }
+
   const driver = getDriver(plan.model.provider);
   const preflight = driver.preflight(opts.mode);
   if (!preflight.ok) {

--- a/packages/eval-harness/src/scenario.ts
+++ b/packages/eval-harness/src/scenario.ts
@@ -69,6 +69,7 @@ function normalizeScenario(raw: unknown, file: string): ScenarioFile {
       id: meta!.id as string,
       description: meta!.description as string,
       tags: Array.isArray(meta!.tags) ? (meta!.tags as string[]) : undefined,
+      quarantine: typeof meta!.quarantine === "string" ? (meta!.quarantine as string) : undefined,
     },
     system_prompt: typeof o.system_prompt === "string" ? o.system_prompt : undefined,
     user_prompt: o.user_prompt as string,

--- a/packages/eval-harness/src/types.ts
+++ b/packages/eval-harness/src/types.ts
@@ -12,6 +12,13 @@ export interface ScenarioMeta {
   id: string;
   description: string;
   tags?: string[];
+  /**
+   * When set, the scenario is skipped by the runner (not counted as a failure)
+   * and the reason is logged. Use for known-failing scenarios tracked by an
+   * issue so the CI scenario lane stays green on a clean main while the gap is
+   * fixed. The value SHOULD reference the tracking issue (e.g. "neotoma#NNNN: …").
+   */
+  quarantine?: string;
 }
 
 export interface HostToolStubResponse {

--- a/packages/eval-harness/src/types.ts
+++ b/packages/eval-harness/src/types.ts
@@ -268,11 +268,20 @@ export interface CellReport {
   assertionFailures: AssertionFailure[];
   startedAt: string;
   endedAt: string;
-  /** True when the cell ran without skip and assertions passed. */
+  /**
+   * True when the cell ran without skip and assertions passed.
+   *
+   * IMPORTANT: `pass` is only meaningful when `skipped` is unset. Skipped cells
+   * (missing cassette, failed preflight, budget guard, or `meta.quarantine`)
+   * carry `pass: false` even though they did not "fail" — they never ran.
+   * Any consumer classifying outcomes MUST check `skipped` first:
+   * passed = `pass && !skipped`; failed = `!pass && !skipped`; skipped = `!!skipped`.
+   * (The RunSummary aggregator does exactly this.)
+   */
   pass: boolean;
   /** Human-readable failure summary; empty when `pass`. */
   errorMessage?: string;
-  /** Set when the cell was skipped (e.g. driver lacks live capability + no cassette). */
+  /** Set when the cell was skipped (missing cassette, preflight, budget, or quarantine). */
   skipped?: { reason: string };
 }
 

--- a/tests/unit/eval_harness_quarantine.test.ts
+++ b/tests/unit/eval_harness_quarantine.test.ts
@@ -1,0 +1,44 @@
+/**
+ * #1704 — eval-harness quarantine.
+ *
+ * A scenario carrying meta.quarantine must be SKIPPED (not failed) by the
+ * runner, so the eval_scenarios CI lane stays green on a clean main while a
+ * known-broken scenario is tracked + fixed. Guards against a regression that
+ * silently drops the quarantine check (which would let CI go red on the three
+ * quarantined scenarios — neotoma#1726).
+ */
+import { describe, expect, it } from "vitest";
+import { runScenarios } from "../../packages/eval-harness/src/index.js";
+import type { ScenarioFile } from "../../packages/eval-harness/src/types.js";
+
+function quarantinedScenario(): ScenarioFile {
+  return {
+    meta: {
+      id: "unit_quarantine_probe",
+      description: "Quarantine unit probe — never runs.",
+      quarantine: "test#0: deliberately quarantined for the unit test.",
+    },
+    user_prompt: "noop",
+    host_tools: [],
+    // A stub model whose cassette does not exist — if quarantine did NOT
+    // short-circuit, this would surface as a skip (missing cassette) anyway,
+    // but the reason must be the QUARANTINE reason, proving the branch ran.
+    models: [{ provider: "stub", model: "replay-only" }],
+    expected: [],
+  };
+}
+
+describe("#1704 eval-harness quarantine", () => {
+  it("skips a quarantined scenario (not failed) with a quarantine reason", async () => {
+    const summary = await runScenarios({
+      scenarios: [quarantinedScenario()],
+      mode: "replay",
+    });
+    expect(summary.failed).toBe(0);
+    expect(summary.skipped).toBe(1);
+    expect(summary.passed).toBe(0);
+    const cell = summary.cells[0];
+    expect(cell.skipped?.reason.startsWith("quarantined:")).toBe(true);
+    expect(cell.skipped?.reason).toContain("test#0");
+  });
+});


### PR DESCRIPTION
Lands the first CA tool-behavior eval **and** the CI lane that gates it. Closes #1704; part of the eval-coverage backfill (umbrella #230, builds on the #1703 primitives).

## Why a new lane (the key finding)
neotoma has **two** eval systems testing different layers:
- The existing **`agentic_evals`** lane (`eval:tier1`) runs hook-**lifecycle** fixtures — it replays hook events (`beforeSubmitPrompt`/`postToolUse`/`stop`) and **cannot express "agent calls correct/merge/subscribe"**.
- The **eval-harness scenario** system models exactly that (an agent driving MCP tools against a real isolated server) but had **no CI lane** — so tool-behavior evals couldn't gate in CI, violating the QA-evals QE1/QE2 requirement.

This adds the **`eval_scenarios`** lane so tool-behavior evals are CI-gated.

## What's in it
- **`eval_scenarios` CI lane** + `npm run eval:scenarios` — `neotoma-eval run --mode replay --provider stub` against a real in-process isolated Neotoma server, committed cassettes, **no API key**. Exits non-zero on any failure.
- **#1704 `correct` eval** (scenario + cassette) — seeds a `task` status=todo, replays the agent calling `/correct` to status=done, asserts the **priority-1000 override won the snapshot** (not just appended) via the #1703 `mcp_tool.invocations` + `snapshot.field_present` primitives + `entity.count`. Verified passing.
- **`entity.count` where-filter fix** (pre-existing bug) — the isolated server's `/entities/query` ignores the `filters` body param, so `entity.count(where:{…})` silently counted **all** entities of the type. Now re-filters client-side via `whereMatches` (mirroring `entity.exists`). Strengthens every existing scenario.
- **`meta.quarantine` infra** — a quarantined scenario is skipped (not failed) with its reason logged, keeping the lane green on a clean main. Quarantined the 3 pre-existing replay failures (isolated-server support gaps) referencing #1726.
- Docs: `agentic_eval.md` documents the two lanes/layers + quarantine.

## Verification
Full replay run: **17 passed / 0 failed / 8 skipped** (5 cassette-less + 3 quarantined). Typecheck clean. `validate:test-catalog` ✅.

Follow-up: #1726 tracks un-quarantining the 3; a note on #1703/#230 clarifies the two-engine split.