### PR TITLE
feat(eval-harness): retrieve_entity_by_identifier match_mode eval (#1711)

### DIFF
--- a/packages/eval-harness/cassettes/retrieve_identifier_match_modes__stub__replay-only.cassette.json
+++ b/packages/eval-harness/cassettes/retrieve_identifier_match_modes__stub__replay-only.cassette.json
@@ -1,0 +1,31 @@
+{
+  "meta": {
+    "format_version": 1,
+    "scenario_id": "retrieve_identifier_match_modes",
+    "provider": "stub",
+    "model": "replay-only",
+    "instruction_profile": "auto",
+    "recorded_at": "2026-06-22T00:00:00.000Z",
+    "cost_usd": 0
+  },
+  "user_prompt": "Look up the contact \"Alice Probe\" by name, by email, and confirm there's no contact named \"Zzz Nonexistent Person\".\n",
+  "system_prompt": "You are an assistant integrated with the Neotoma memory system. Before creating an entity, look it up with retrieve_entity_by_identifier to decide reuse vs create. Inspect the match_mode on the result.\n",
+  "tool_calls": [
+    {
+      "name": "retrieve_entity_by_identifier",
+      "input": { "identifier": "Alice Probe" },
+      "sequence": 0
+    },
+    {
+      "name": "retrieve_entity_by_identifier",
+      "input": { "identifier": "alice@probe.example" },
+      "sequence": 1
+    },
+    {
+      "name": "retrieve_entity_by_identifier",
+      "input": { "identifier": "Zzz Nonexistent Person" },
+      "sequence": 2
+    }
+  ],
+  "assistant_text": "Found \"Alice Probe\" by name (direct match) and by email (snapshot-field match) — same contact, no duplicate needed. No contact named \"Zzz Nonexistent Person\" exists."
+}

--- a/packages/eval-harness/scenarios/retrieve_identifier_match_modes.scenario.yaml
+++ b/packages/eval-harness/scenarios/retrieve_identifier_match_modes.scenario.yaml
@@ -1,0 +1,69 @@
+meta:
+  id: retrieve_identifier_match_modes
+  description: >
+    A contact (name + email + company) is pre-seeded. The agent looks it up
+    three ways via retrieve_entity_by_identifier and the results must carry the
+    correct match_mode discriminator: exact name -> "direct", email ->
+    "snapshot_field", and a true non-match -> "none" with total 0 (no false
+    positive). This is the dedup gate agents use before reuse-vs-create; a wrong
+    match_mode or a silent-empty result drives duplicate creation. Exercises the
+    #1703 tool_result.matches primitive against the real
+    retrieve_entity_by_identifier result shape. Part of neotoma#1711.
+  tags:
+    - tier2
+    - retrieval
+    - dedup
+    - eval-coverage
+
+seed_strategy: generated
+source_pattern: "retrieve_entity_by_identifier match_mode was never asserted; a relaxed/none fallback was indistinguishable from a direct hit, so wrong-entity or silent-empty results drove duplicate creation."
+privacy_transform: "Fully synthetic contact; no PII."
+
+seed_entities:
+  - entity_type: contact
+    name: Alice Probe
+    email: alice@probe.example
+    company: Probe Labs
+
+system_prompt: >
+  You are an assistant integrated with the Neotoma memory system. Before
+  creating an entity, look it up with retrieve_entity_by_identifier to decide
+  reuse vs create. Inspect the match_mode on the result.
+
+user_prompt: |
+  Look up the contact "Alice Probe" by name, by email, and confirm there's no
+  contact named "Zzz Nonexistent Person".
+
+host_tools: []
+
+models:
+  - provider: stub
+    model: replay-only
+
+expected:
+  # All three lookups were issued.
+  - type: mcp_tool.invocations
+    tool_name: retrieve_entity_by_identifier
+    op: gte
+    value: 3
+  # Exact-name lookup -> match_mode "direct", one hit, the seeded contact id.
+  - type: tool_result.matches
+    tool_name: retrieve_entity_by_identifier
+    which: 0
+    result_subset:
+      match_mode: direct
+      total: 1
+  # Email lookup -> relaxed snapshot_field match (distinguishable from direct).
+  - type: tool_result.matches
+    tool_name: retrieve_entity_by_identifier
+    which: 1
+    result_subset:
+      match_mode: snapshot_field
+      total: 1
+  # True non-match -> match_mode "none", total 0 (no false positive).
+  - type: tool_result.matches
+    tool_name: retrieve_entity_by_identifier
+    which: 2
+    result_subset:
+      match_mode: none
+      total: 0

--- a/packages/eval-harness/scenarios/retrieve_identifier_match_modes.scenario.yaml
+++ b/packages/eval-harness/scenarios/retrieve_identifier_match_modes.scenario.yaml
@@ -46,21 +46,42 @@ expected:
     tool_name: retrieve_entity_by_identifier
     op: gte
     value: 3
-  # Exact-name lookup -> match_mode "direct", one hit, the seeded contact id.
+  # Bind each positional lookup to its identifier (arg_subset) so the which:N
+  # tool_result assertions below are anchored to a specific call, not just an
+  # index — order-intent is explicit and a reordering refactor surfaces here.
+  - type: mcp_tool.invocations
+    tool_name: retrieve_entity_by_identifier
+    arg_subset:
+      identifier: Alice Probe
+    op: gte
+    value: 1
+  - type: mcp_tool.invocations
+    tool_name: retrieve_entity_by_identifier
+    arg_subset:
+      identifier: alice@probe.example
+    op: gte
+    value: 1
+  - type: mcp_tool.invocations
+    tool_name: retrieve_entity_by_identifier
+    arg_subset:
+      identifier: Zzz Nonexistent Person
+    op: gte
+    value: 1
+  # Exact-name lookup (call 0) -> match_mode "direct", one hit.
   - type: tool_result.matches
     tool_name: retrieve_entity_by_identifier
     which: 0
     result_subset:
       match_mode: direct
       total: 1
-  # Email lookup -> relaxed snapshot_field match (distinguishable from direct).
+  # Email lookup (call 1) -> relaxed snapshot_field match (distinguishable from direct).
   - type: tool_result.matches
     tool_name: retrieve_entity_by_identifier
     which: 1
     result_subset:
       match_mode: snapshot_field
       total: 1
-  # True non-match -> match_mode "none", total 0 (no false positive).
+  # True non-match (call 2) -> match_mode "none", total 0 (no false positive).
   - type: tool_result.matches
     tool_name: retrieve_entity_by_identifier
     which: 2


### PR DESCRIPTION
Adds an agentic eval for the dedup gate agents use before reuse-vs-create. Part of the eval-coverage backfill (umbrella #230); runs in the `eval_scenarios` lane added in #1727.

## What
Seeds a contact, looks it up three ways, and asserts the `match_mode` discriminator via the #1703 `tool_result.matches` primitive:
- exact name → `match_mode: direct`, total 1
- email → `match_mode: snapshot_field`, total 1 (relaxed match, distinct from direct)
- non-match → `match_mode: none`, total 0 (no false positive)

A wrong `match_mode` or silent-empty result drives duplicate creation — the data-corruption gap the CA audit flagged (only the dedup *precondition* was incidentally covered before, never `match_mode`).

## Verification
Passing in replay; full `eval_scenarios` suite: **18 passed / 0 failed / 8 skipped**. No API key (committed cassette). No `.test.ts` added → test-catalog unaffected.

## Scope note
The `ENTITY_ID_NOT_FOUND_HINT` (for an `ent_`-shaped missing identifier) is **not** asserted — the isolated replay server doesn't populate it (same isolated-server support-gap class as #1726). Follow-up to cover the hint once that support lands.

Closes #1711.