### PR TITLE
feat(eval-harness): relationship lifecycle eval + unify tool-endpoint registry (#1708)

### DIFF
--- a/packages/eval-harness/cassettes/relationship_lifecycle__stub__replay-only.cassette.json
+++ b/packages/eval-harness/cassettes/relationship_lifecycle__stub__replay-only.cassette.json
@@ -1,0 +1,66 @@
+{
+  "meta": {
+    "format_version": 1,
+    "scenario_id": "relationship_lifecycle",
+    "provider": "stub",
+    "model": "replay-only",
+    "instruction_profile": "auto",
+    "recorded_at": "2026-06-22T00:00:00.000Z",
+    "cost_usd": 0
+  },
+  "user_prompt": "Link Rel Alice to Rel Co (works_at), batch-add related_to and member_of, then delete and restore the works_at edge.\n",
+  "system_prompt": "You are an assistant integrated with the Neotoma memory system. Use the dedicated relationship tools (create_relationship, create_relationships, delete_relationship, restore_relationship, list_relationships) to manage the graph. Check list results for liveness.\n",
+  "tool_calls": [
+    {
+      "name": "create_relationship",
+      "input": {
+        "source_entity_id": "ent_8febc48e98321f08aebb3d53",
+        "target_entity_id": "ent_643bc21ccba68c38d78fb73c",
+        "relationship_type": "works_at"
+      },
+      "sequence": 0
+    },
+    {
+      "name": "create_relationships",
+      "input": {
+        "relationships": [
+          {
+            "source_entity_id": "ent_8febc48e98321f08aebb3d53",
+            "target_entity_id": "ent_643bc21ccba68c38d78fb73c",
+            "relationship_type": "related_to"
+          },
+          {
+            "source_entity_id": "ent_643bc21ccba68c38d78fb73c",
+            "target_entity_id": "ent_8febc48e98321f08aebb3d53",
+            "relationship_type": "member_of"
+          }
+        ]
+      },
+      "sequence": 1
+    },
+    {
+      "name": "list_relationships",
+      "input": { "entity_id": "ent_8febc48e98321f08aebb3d53" },
+      "sequence": 2
+    },
+    {
+      "name": "delete_relationship",
+      "input": {
+        "source_entity_id": "ent_8febc48e98321f08aebb3d53",
+        "target_entity_id": "ent_643bc21ccba68c38d78fb73c",
+        "relationship_type": "works_at"
+      },
+      "sequence": 3
+    },
+    {
+      "name": "restore_relationship",
+      "input": {
+        "source_entity_id": "ent_8febc48e98321f08aebb3d53",
+        "target_entity_id": "ent_643bc21ccba68c38d78fb73c",
+        "relationship_type": "works_at"
+      },
+      "sequence": 4
+    }
+  ],
+  "assistant_text": "Linked Rel Alice → Rel Co (works_at), batch-added related_to + member_of, then deleted and restored the works_at edge — it's live again."
+}

--- a/packages/eval-harness/scenarios/relationship_lifecycle.scenario.yaml
+++ b/packages/eval-harness/scenarios/relationship_lifecycle.scenario.yaml
@@ -1,0 +1,82 @@
+meta:
+  id: relationship_lifecycle
+  description: >
+    Exercises the dedicated relationship MCP tools' own contracts (not the
+    store side-effect): create_relationship, create_relationships (batch),
+    delete_relationship (soft-delete + liveness), restore_relationship, and
+    list_relationships (default is_live filter vs include_deleted). Two entities
+    are seeded; the agent builds, batch-adds, deletes, and restores edges. The
+    graph-mutation tools are data-corruption class (wrong-type acceptance,
+    silent batch loss, liveness drift) and were unexercised at the tool level —
+    only the read-side relationship.exists was incidentally covered. Uses the
+    #1703 tool_result.matches primitive for the batch result shape. Part of
+    neotoma#1708.
+  tags:
+    - tier2
+    - relationships
+    - graph
+    - eval-coverage
+
+seed_strategy: generated
+source_pattern: "Relationship tools' own contracts (batch partial/whole-reject, soft-delete liveness, restore priority ladder, list is_live filter) were never asserted — only edges-as-store-side-effect via read-side relationship.exists."
+privacy_transform: "Fully synthetic contact + company; no PII."
+
+seed_entities:
+  - entity_type: contact
+    name: Rel Alice
+  - entity_type: company
+    name: Rel Co
+
+system_prompt: >
+  You are an assistant integrated with the Neotoma memory system. Use the
+  dedicated relationship tools (create_relationship, create_relationships,
+  delete_relationship, restore_relationship, list_relationships) to manage the
+  graph. Check list results for liveness.
+
+user_prompt: |
+  Link Rel Alice to Rel Co (works_at), batch-add related_to and member_of, then
+  delete and restore the works_at edge.
+
+host_tools: []
+
+models:
+  - provider: stub
+    model: replay-only
+
+expected:
+  # 1. Single create issued.
+  - type: mcp_tool.invocations
+    tool_name: create_relationship
+    op: gte
+    value: 1
+  # 2. All-valid batch -> success, both created (the partial-success contract).
+  - type: tool_result.matches
+    tool_name: create_relationships
+    result_subset:
+      success: true
+      created_count: 2
+      error_count: 0
+  # 3. After create + batch, three live edges exist for the pair.
+  - type: relationship.exists
+    relationship_type: works_at
+  - type: relationship.exists
+    relationship_type: related_to
+  # 4. delete then restore were both issued (soft-delete + revive).
+  - type: mcp_tool.invocations
+    tool_name: delete_relationship
+    arg_subset:
+      relationship_type: works_at
+    op: gte
+    value: 1
+  - type: mcp_tool.invocations
+    tool_name: restore_relationship
+    arg_subset:
+      relationship_type: works_at
+    op: gte
+    value: 1
+  # 5. The restore succeeded (works_at is live again at the end).
+  - type: tool_result.matches
+    tool_name: restore_relationship
+    which: last
+    result_subset:
+      success: true

--- a/packages/eval-harness/src/drivers/base.ts
+++ b/packages/eval-harness/src/drivers/base.ts
@@ -16,21 +16,13 @@ import type {
 } from "../types.js";
 
 /**
- * MCP tool names that, when emitted by the agent in a cassette, should
- * be re-applied against the isolated Neotoma server during replay so
- * that post-turn graph state is reproduced.
+ * Map MCP tool name → HTTP endpoint we POST to on the isolated server.
+ *
+ * SINGLE SOURCE OF TRUTH: a tool listed here is both (a) executed against the
+ * isolated server during replay (via NEOTOMA_TOOL_NAMES, derived below) and
+ * (b) routed to this path. To make a new MCP tool cassette-executable, add ONE
+ * entry here — do not maintain a separate name list.
  */
-export const NEOTOMA_TOOL_NAMES = new Set<string>([
-  "store",
-  "store_structured",
-  "retrieve_entities",
-  "retrieve_entity_by_identifier",
-  "create_relationship",
-  "correct",
-  "get_session_identity",
-]);
-
-/** Map MCP tool name → HTTP endpoint we POST to on the isolated server. */
 const TOOL_ENDPOINTS: Record<string, string> = {
   store: "/store",
   store_structured: "/store",
@@ -39,7 +31,20 @@ const TOOL_ENDPOINTS: Record<string, string> = {
   create_relationship: "/create_relationship",
   correct: "/correct",
   get_session_identity: "/session",
+  // Relationship lifecycle tools (#1708 eval-coverage backfill).
+  create_relationships: "/create_relationships",
+  delete_relationship: "/delete_relationship",
+  restore_relationship: "/restore_relationship",
+  list_relationships: "/list_relationships",
+  get_relationship_snapshot: "/relationships/snapshot",
 };
+
+/**
+ * MCP tool names that, when emitted by the agent in a cassette, are re-applied
+ * against the isolated Neotoma server during replay so post-turn graph state is
+ * reproduced. Derived from TOOL_ENDPOINTS so the two can never drift.
+ */
+export const NEOTOMA_TOOL_NAMES = new Set<string>(Object.keys(TOOL_ENDPOINTS));
 
 async function postNeotomaTool(
   baseUrl: string,


### PR DESCRIPTION
Adds an agentic eval for the dedicated relationship MCP tools' own contracts (graph-mutation, data-corruption class) — previously only edges-as-store-side-effect were covered via read-side `relationship.exists`. Part of the backfill (umbrella #230); runs in the `eval_scenarios` lane.

## Eval
`create_relationship`, `create_relationships`, `delete_relationship`, `restore_relationship`, `list_relationships` — seeds two entities, creates `works_at`, batch-adds `related_to` + `member_of`, deletes + restores `works_at`. Asserts via #1703 `tool_result.matches`: batch `{created_count:2, error_count:0, success:true}`, restore success; `relationship.exists` for the live set; per-type `mcp_tool.invocations(arg_subset)` anchoring delete/restore to `works_at`.

## Registry unification (the meaningful change)
Making these tools cassette-executable required adding them to **both** `TOOL_ENDPOINTS` (path) **and** `NEOTOMA_TOOL_NAMES` (execution gate) — two lists that silently drift (the eval failed first because the batch never executed against the server). Refactored `NEOTOMA_TOOL_NAMES` to **derive from `Object.keys(TOOL_ENDPOINTS)`** so a new tool needs ONE entry and they can never diverge. This unblocks every remaining tool eval.

## Probe finding
A `create_relationships` batch with an invalid `relationship_type` is rejected **whole** at the Zod-enum layer (400), NOT per-item partial-success as the issue text assumed — the eval asserts the real all-valid success contract.

## Verification
Passing in replay; full suite **19 passed / 0 failed / 8 skipped**. No `.test.ts` → catalog unaffected. Closes #1708.