### PR TITLE
feat(eval-harness): entity delete/restore lifecycle eval (#1705)

### DIFF
--- a/packages/eval-harness/cassettes/entity_delete_restore__stub__replay-only.cassette.json
+++ b/packages/eval-harness/cassettes/entity_delete_restore__stub__replay-only.cassette.json
@@ -1,0 +1,43 @@
+{
+  "meta": {
+    "format_version": 1,
+    "scenario_id": "entity_delete_restore",
+    "provider": "stub",
+    "model": "replay-only",
+    "instruction_profile": "auto",
+    "recorded_at": "2026-06-22T00:00:00.000Z",
+    "cost_usd": 0
+  },
+  "user_prompt": "Delete the task \"Delete Me Task\", then restore it. Also try to delete a task that doesn't exist to confirm it errors.\n",
+  "system_prompt": "You are an assistant integrated with the Neotoma memory system. Use delete_entity to soft-delete and restore_entity to revive entities, passing entity_id, entity_type, and a reason.\n",
+  "tool_calls": [
+    {
+      "name": "delete_entity",
+      "input": {
+        "entity_id": "ent_ff73925e556986d623c5aff8",
+        "entity_type": "task",
+        "reason": "eval: soft-delete the seeded task"
+      },
+      "sequence": 0
+    },
+    {
+      "name": "restore_entity",
+      "input": {
+        "entity_id": "ent_ff73925e556986d623c5aff8",
+        "entity_type": "task",
+        "reason": "eval: revive the task"
+      },
+      "sequence": 1
+    },
+    {
+      "name": "delete_entity",
+      "input": {
+        "entity_id": "ent_nonexistent000000000000",
+        "entity_type": "task",
+        "reason": "eval: expect 404"
+      },
+      "sequence": 2
+    }
+  ],
+  "assistant_text": "Deleted \"Delete Me Task\" then restored it — it's live again. Deleting a non-existent task returned a 404 not-found error, as expected."
+}

--- a/packages/eval-harness/scenarios/entity_delete_restore.scenario.yaml
+++ b/packages/eval-harness/scenarios/entity_delete_restore.scenario.yaml
@@ -1,0 +1,81 @@
+meta:
+  id: entity_delete_restore
+  description: >
+    A task is pre-seeded. The agent deletes it (soft-delete observation hides it
+    from live snapshots), then restores it (priority-1001 observation overrides
+    the priority-1000 deletion so it reappears), and also attempts to delete a
+    non-existent id. Validates the entity soft-delete lifecycle — a priority-
+    ladder regression would silently lose data (delete fails to hide, or restore
+    fails to revive). Asserts via #1703 tool_result.matches that both ops
+    succeed, the bad delete surfaces a 404, and the entity is live again at the
+    end. Part of neotoma#1705.
+  tags:
+    - tier2
+    - lifecycle
+    - delete-restore
+    - eval-coverage
+
+seed_strategy: generated
+source_pattern: "delete_entity / restore_entity had zero agentic coverage; a soft-delete-liveness or priority-ladder regression (delete doesn't hide, or restore doesn't revive) would silently lose or orphan data."
+privacy_transform: "Fully synthetic task; no PII."
+
+seed_entities:
+  - entity_type: task
+    title: Delete Me Task
+    status: todo
+
+system_prompt: >
+  You are an assistant integrated with the Neotoma memory system. Use
+  delete_entity to soft-delete and restore_entity to revive entities, passing
+  entity_id, entity_type, and a reason.
+
+user_prompt: |
+  Delete the task "Delete Me Task", then restore it. Also try to delete a
+  task that doesn't exist to confirm it errors.
+
+host_tools: []
+
+models:
+  - provider: stub
+    model: replay-only
+
+expected:
+  # Delete + restore were both issued for the seeded task.
+  - type: mcp_tool.invocations
+    tool_name: delete_entity
+    op: gte
+    value: 2
+  - type: mcp_tool.invocations
+    tool_name: restore_entity
+    op: gte
+    value: 1
+  # The real delete (call 0) succeeded.
+  - type: tool_result.matches
+    tool_name: delete_entity
+    which: 0
+    result_subset:
+      success: true
+  # The restore succeeded — priority-1001 override revives the entity.
+  - type: tool_result.matches
+    tool_name: restore_entity
+    which: last
+    result_subset:
+      success: true
+  # Deleting a non-existent id surfaces an error (the harness captures a non-2xx
+  # as {error: "<tool> returned status 404: …"}), not a false success.
+  - type: tool_result.matches
+    tool_name: delete_entity
+    which: last
+    result_key: error
+    present: true
+  # End state: the task is live again (restore won the priority ladder).
+  - type: entity.exists
+    entity_type: task
+    where:
+      status: todo
+  - type: entity.count
+    entity_type: task
+    where:
+      status: todo
+    op: eq
+    value: 1

--- a/packages/eval-harness/src/drivers/base.ts
+++ b/packages/eval-harness/src/drivers/base.ts
@@ -31,6 +31,9 @@ const TOOL_ENDPOINTS: Record<string, string> = {
   create_relationship: "/create_relationship",
   correct: "/correct",
   get_session_identity: "/session",
+  // Entity soft-delete lifecycle (#1705 eval-coverage backfill).
+  delete_entity: "/delete_entity",
+  restore_entity: "/restore_entity",
   // Relationship lifecycle tools (#1708 eval-coverage backfill).
   create_relationships: "/create_relationships",
   delete_relationship: "/delete_relationship",


### PR DESCRIPTION
Adds an agentic eval for the entity soft-delete lifecycle (data-corruption class) — `delete_entity` + `restore_entity` had zero agentic coverage. Part of the backfill (umbrella #230); runs in the `eval_scenarios` lane.

## Eval
Seeds a task, deletes it (priority-1000 soft-delete hides it from live snapshots), restores it (priority-1001 override revives it), and attempts a delete of a non-existent id. Asserts via #1703 `tool_result.matches`:
- both real ops `success: true`
- the bad delete surfaces an error (the harness captures a non-2xx as `{error: '<tool> returned status 404: …'}`) — not a false success
- the entity is **live again** at the end (`entity.exists` + `entity.count == 1`), proving the priority ladder works rather than silently losing data

Adds `delete_entity` + `restore_entity` to the unified `TOOL_ENDPOINTS` registry (one block now, post-#1729).

## Verification
Passing in replay; full suite **20 passed / 0 failed / 8 skipped**. No `.test.ts` → catalog unaffected. Closes #1705.

_Note: the neotoma Claude-review GHA + swarm Vanellus are currently erroring on an Anthropic-API auth issue (advisory checks; tracked separately). Merging on `security_gates` + substantive lanes green._