### PR TITLE
feat(eval-harness): merge_entities dedup eval (#1706)

### DIFF
--- a/packages/eval-harness/cassettes/merge_entities_dedup__stub__replay-only.cassette.json
+++ b/packages/eval-harness/cassettes/merge_entities_dedup__stub__replay-only.cassette.json
@@ -1,0 +1,40 @@
+{
+  "meta": {
+    "format_version": 1,
+    "scenario_id": "merge_entities_dedup",
+    "provider": "stub",
+    "model": "replay-only",
+    "instruction_profile": "auto",
+    "recorded_at": "2026-06-22T00:00:00.000Z",
+    "cost_usd": 0
+  },
+  "user_prompt": "\"Dup Person A\" and \"Dup Person B\" are the same person. Merge B into A. Then confirm you cannot merge B again, and that merging a non-existent record errors.\n",
+  "system_prompt": "You are an assistant integrated with the Neotoma memory system. When two records are the same entity, merge them with merge_entities using from_entity_id (the duplicate to absorb) and to_entity_id (the survivor).\n",
+  "tool_calls": [
+    {
+      "name": "merge_entities",
+      "input": {
+        "from_entity_id": "ent_bdc757e97ec2eee216712c6d",
+        "to_entity_id": "ent_c9af1e64adc6c96fd53e3ff1"
+      },
+      "sequence": 0
+    },
+    {
+      "name": "merge_entities",
+      "input": {
+        "from_entity_id": "ent_bdc757e97ec2eee216712c6d",
+        "to_entity_id": "ent_c9af1e64adc6c96fd53e3ff1"
+      },
+      "sequence": 1
+    },
+    {
+      "name": "merge_entities",
+      "input": {
+        "from_entity_id": "ent_nope000000000000000000",
+        "to_entity_id": "ent_c9af1e64adc6c96fd53e3ff1"
+      },
+      "sequence": 2
+    }
+  ],
+  "assistant_text": "Merged Dup Person B into Dup Person A — one contact remains. Re-merging B failed (already merged), and merging a non-existent record returned a not-found error, as expected."
+}

--- a/packages/eval-harness/scenarios/merge_entities_dedup.scenario.yaml
+++ b/packages/eval-harness/scenarios/merge_entities_dedup.scenario.yaml
@@ -1,0 +1,76 @@
+meta:
+  id: merge_entities_dedup
+  description: >
+    Two near-duplicate contacts (same email) are pre-seeded. The agent merges
+    one into the other; the source must be excluded from the active set
+    (merged_to), its observations moved onto the survivor, and the merge is
+    irreversible-feeling, so guard cases matter: re-merging an already-merged
+    source errors, and merging a non-existent id 404s — neither performs a
+    second merge. Validates merge_entities (data-corruption class) which had
+    zero agentic coverage. Asserts via #1703 tool_result.matches. Part of
+    neotoma#1706.
+  tags:
+    - tier2
+    - merge
+    - dedup
+    - eval-coverage
+
+seed_strategy: generated
+source_pattern: "merge_entities had only non-agentic integration tests; no eval asserted the source is excluded post-merge (merged_to) or that already-merged/not-found guards prevent a second merge."
+privacy_transform: "Fully synthetic duplicate contacts; no PII."
+
+seed_entities:
+  - entity_type: contact
+    name: Dup Person A
+    email: dup@example.com
+  - entity_type: contact
+    name: Dup Person B
+    email: dup@example.com
+
+system_prompt: >
+  You are an assistant integrated with the Neotoma memory system. When two
+  records are the same entity, merge them with merge_entities using
+  from_entity_id (the duplicate to absorb) and to_entity_id (the survivor).
+
+user_prompt: |
+  "Dup Person A" and "Dup Person B" are the same person. Merge B into A. Then
+  confirm you cannot merge B again, and that merging a non-existent record errors.
+
+host_tools: []
+
+models:
+  - provider: stub
+    model: replay-only
+
+expected:
+  # The merge was issued and moved observations onto the survivor.
+  - type: mcp_tool.invocations
+    tool_name: merge_entities
+    op: gte
+    value: 1
+  - type: tool_result.matches
+    tool_name: merge_entities
+    which: 0
+    result_key: observations_moved
+    present: true
+  # Post-merge, exactly one active contact remains (source excluded via merged_to).
+  - type: entity.count
+    entity_type: contact
+    op: eq
+    value: 1
+  - type: entity.exists
+    entity_type: contact
+    where:
+      name: Dup Person A
+  # Re-merging the already-merged source errors (no second merge).
+  - type: tool_result.matches
+    tool_name: merge_entities
+    which: 1
+    result_key: error
+    present: true
+  # Merging a non-existent id errors (404), not a false success.
+  - type: tool_result.matches
+    tool_name: merge_entities
+    which: 2
+    result_key: error
+    present: true

--- a/packages/eval-harness/src/drivers/base.ts
+++ b/packages/eval-harness/src/drivers/base.ts
@@ -34,6 +34,8 @@ const TOOL_ENDPOINTS: Record<string, string> = {
   // Entity soft-delete lifecycle (#1705 eval-coverage backfill).
   delete_entity: "/delete_entity",
   restore_entity: "/restore_entity",
+  // Entity merge (#1706 eval-coverage backfill). Endpoint is /entities/merge.
+  merge_entities: "/entities/merge",
   // Relationship lifecycle tools (#1708 eval-coverage backfill).
   create_relationships: "/create_relationships",
   delete_relationship: "/delete_relationship",


### PR DESCRIPTION
Adds an agentic eval for `merge_entities` (data-corruption class) — previously only non-agentic integration tests; no eval asserted the source is excluded post-merge (`merged_to`) or that guards prevent a second merge. Part of the backfill (umbrella #230); runs in the `eval_scenarios` lane.

## Eval
Seeds two near-duplicate contacts (same email), merges B into A, then retries the already-merged source and a non-existent id. Asserts via #1703 `tool_result.matches`:
- merge returns `observations_moved` (moved onto the survivor)
- active `contact.count` drops to **1** (source excluded via `merged_to`) with the survivor present
- already-merged + not-found both surface errors (no second merge)

## Probe findings
Merge endpoint is `/entities/merge` with `from_entity_id` + `to_entity_id` (not source/target/entity_type); already-merged → 400 "Source entity already merged"; missing → 404. Added `merge_entities` to the unified `TOOL_ENDPOINTS` registry.

## Verification
Passing in replay; full suite **21 passed / 0 failed / 8 skipped**. No `.test.ts` → catalog unaffected. Closes #1706.

_Advisory review GHA is erroring on an Anthropic-API auth issue (tracked separately); merging on `security_gates` + substantive lanes green._