### PR TITLE
feat(eval-harness): split_entity repair eval (#1707)

### DIFF
--- a/packages/eval-harness/cassettes/split_entity_repair__stub__replay-only.cassette.json
+++ b/packages/eval-harness/cassettes/split_entity_repair__stub__replay-only.cassette.json
@@ -1,0 +1,67 @@
+{
+  "meta": {
+    "format_version": 1,
+    "scenario_id": "split_entity_repair",
+    "provider": "stub",
+    "model": "replay-only",
+    "instruction_profile": "auto",
+    "recorded_at": "2026-06-22T00:00:00.000Z",
+    "cost_usd": 0
+  },
+  "user_prompt": "The task \"Split Source Task\" accidentally absorbed a later session's data (tagged session_tag=later-session). Split that out onto a new task entity.\n",
+  "system_prompt": "You are an assistant integrated with the Neotoma memory system. To repair an over-merged entity, use split_entity with a predicate selecting the observations to move onto a new_entity, plus an idempotency_key.\n",
+  "tool_calls": [
+    {
+      "name": "store",
+      "input": {
+        "idempotency_key": "split-later-obs",
+        "entities": [
+          {
+            "entity_type": "task",
+            "title": "Split Source Task",
+            "status": "todo",
+            "session_tag": "later-session"
+          }
+        ]
+      },
+      "sequence": 0
+    },
+    {
+      "name": "split_entity",
+      "input": {
+        "source_entity_id": "ent_7df9aa3bdd09a9ae1f8fec95",
+        "predicate": {
+          "observation_field_equals": { "field": "session_tag", "value": "later-session" }
+        },
+        "new_entity": { "entity_type": "task", "canonical_name": "split-target-task" },
+        "idempotency_key": "split-op-eval-1"
+      },
+      "sequence": 1
+    },
+    {
+      "name": "split_entity",
+      "input": {
+        "source_entity_id": "ent_7df9aa3bdd09a9ae1f8fec95",
+        "predicate": {
+          "observation_field_equals": { "field": "session_tag", "value": "later-session" }
+        },
+        "new_entity": { "entity_type": "task", "canonical_name": "split-target-task" },
+        "idempotency_key": "split-op-eval-1"
+      },
+      "sequence": 2
+    },
+    {
+      "name": "split_entity",
+      "input": {
+        "source_entity_id": "ent_7df9aa3bdd09a9ae1f8fec95",
+        "predicate": {
+          "observation_field_equals": { "field": "session_tag", "value": "NEVER_MATCHES" }
+        },
+        "new_entity": { "entity_type": "task", "canonical_name": "split-none-target" },
+        "idempotency_key": "split-op-eval-none"
+      },
+      "sequence": 3
+    }
+  ],
+  "assistant_text": "Split the later-session observation off \"Split Source Task\" onto a new task entity. Re-running the same split was a no-op (idempotent replay), and a predicate matching nothing returned an error, as expected."
+}

--- a/packages/eval-harness/scenarios/split_entity_repair.scenario.yaml
+++ b/packages/eval-harness/scenarios/split_entity_repair.scenario.yaml
@@ -1,0 +1,71 @@
+meta:
+  id: split_entity_repair
+  description: >
+    An over-merged task (one entity carrying observations from two sessions) is
+    repaired: the agent splits the later-session observations onto a new entity
+    via a field predicate. Validates split_entity (data-corruption class — a
+    mis-split silently strands observations on the wrong entity) which had zero
+    agentic coverage. Covers the happy path, idempotent replay (same key+
+    predicate -> same new_entity_id, replayed:true, no double-split), and the
+    matched-nothing guard. Asserts via #1703 tool_result.matches. Part of
+    neotoma#1707.
+  tags:
+    - tier2
+    - split
+    - lifecycle
+    - eval-coverage
+
+seed_strategy: generated
+source_pattern: "split_entity had only non-agentic dispatch coverage; no eval asserted observations actually move to the new entity, that replay is idempotent (replayed:true), or that matched-nothing/all guards fire."
+privacy_transform: "Fully synthetic task; no PII."
+
+seed_entities:
+  - entity_type: task
+    title: Split Source Task
+    status: todo
+
+system_prompt: >
+  You are an assistant integrated with the Neotoma memory system. To repair an
+  over-merged entity, use split_entity with a predicate selecting the
+  observations to move onto a new_entity, plus an idempotency_key.
+
+user_prompt: |
+  The task "Split Source Task" accidentally absorbed a later session's data
+  (tagged session_tag=later-session). Split that out onto a new task entity.
+
+host_tools: []
+
+models:
+  - provider: stub
+    model: replay-only
+
+expected:
+  # The split was issued and moved observations onto a new entity.
+  - type: mcp_tool.invocations
+    tool_name: split_entity
+    op: gte
+    value: 1
+  - type: tool_result.matches
+    tool_name: split_entity
+    which: 0
+    result_subset:
+      observations_moved: 1
+      replayed: false
+  # Replay with the same key+predicate is idempotent (same new entity, no re-split).
+  - type: tool_result.matches
+    tool_name: split_entity
+    which: 1
+    result_subset:
+      replayed: true
+  # The matched-nothing guard surfaces an error (no stray new entity).
+  - type: tool_result.matches
+    tool_name: split_entity
+    which: last
+    result_key: error
+    present: true
+  # The split returned a distinct new_entity_id (the repair target was created).
+  - type: tool_result.matches
+    tool_name: split_entity
+    which: 0
+    result_key: new_entity_id
+    present: true

--- a/packages/eval-harness/src/drivers/base.ts
+++ b/packages/eval-harness/src/drivers/base.ts
@@ -36,6 +36,8 @@ const TOOL_ENDPOINTS: Record<string, string> = {
   restore_entity: "/restore_entity",
   // Entity merge (#1706 eval-coverage backfill). Endpoint is /entities/merge.
   merge_entities: "/entities/merge",
+  // Entity split (#1707 eval-coverage backfill). Endpoint is /entities/split.
+  split_entity: "/entities/split",
   // Relationship lifecycle tools (#1708 eval-coverage backfill).
   create_relationships: "/create_relationships",
   delete_relationship: "/delete_relationship",


### PR DESCRIPTION
Adds an agentic eval for `split_entity` (data-corruption class — a mis-split silently strands observations on the wrong entity) which had zero agentic coverage. Part of the backfill (umbrella #230); runs in the `eval_scenarios` lane.

## Eval
Seeds a task, adds a later-session observation (`session_tag`), then splits that observation onto a new entity via an `observation_field_equals` predicate. Asserts via #1703 `tool_result.matches`:
- first split moves 1 observation (`replayed: false`) + returns a `new_entity_id`
- replay with the same key+predicate is **idempotent** (`replayed: true`, no double-split)
- a matched-nothing predicate surfaces an error

## Probe findings
Endpoint `/entities/split`; request `{source_entity_id, predicate (observed_at_gte | source_id_in | observation_field_equals), new_entity:{entity_type, canonical_name}, idempotency_key}`; matched-nothing/all → 400. Added `split_entity` to the unified `TOOL_ENDPOINTS` registry.

## Verification
Passing in replay; full suite **22 passed / 0 failed / 8 skipped**. No `.test.ts` → catalog unaffected. Closes #1707.

_Advisory review GHA erroring on an Anthropic-API auth issue (tracked); merging on `security_gates` + substantive lanes green._