### PR TITLE
feat(eval-harness): subscribe webhook-secret eval (#1715)

### DIFF
--- a/packages/eval-harness/cassettes/subscribe_webhook_secret__stub__replay-only.cassette.json
+++ b/packages/eval-harness/cassettes/subscribe_webhook_secret__stub__replay-only.cassette.json
@@ -1,0 +1,33 @@
+{
+  "meta": {
+    "format_version": 1,
+    "scenario_id": "subscribe_webhook_secret",
+    "provider": "stub",
+    "model": "replay-only",
+    "instruction_profile": "auto",
+    "recorded_at": "2026-06-22T00:00:00.000Z",
+    "cost_usd": 0
+  },
+  "user_prompt": "Subscribe to task events via a webhook at https://example.com/hook, and also open an SSE subscription to task events.\n",
+  "system_prompt": "You are an assistant integrated with the Neotoma memory system. Use subscribe with a delivery_method (\"webhook\" or \"sse\"); for webhooks provide a webhook_url and capture the returned webhook_secret.\n",
+  "tool_calls": [
+    {
+      "name": "subscribe",
+      "input": {
+        "delivery_method": "webhook",
+        "entity_types": ["task"],
+        "webhook_url": "https://example.com/hook"
+      },
+      "sequence": 0
+    },
+    {
+      "name": "subscribe",
+      "input": {
+        "delivery_method": "sse",
+        "entity_types": ["task"]
+      },
+      "sequence": 1
+    }
+  ],
+  "assistant_text": "Created a webhook subscription to task events (captured the returned webhook_secret for signature verification) and an SSE subscription to task events."
+}

--- a/packages/eval-harness/scenarios/subscribe_webhook_secret.scenario.yaml
+++ b/packages/eval-harness/scenarios/subscribe_webhook_secret.scenario.yaml
@@ -1,0 +1,57 @@
+meta:
+  id: subscribe_webhook_secret
+  description: >
+    The agent creates a webhook subscription and an SSE subscription. The
+    security-relevant contract: a webhook subscription MUST mint and return a
+    webhook_secret (agents depend on it to verify delivery signatures), and the
+    delivery_method is honored. subscribe had zero agentic coverage. Asserts via
+    #1703 tool_result.matches. Part of neotoma#1715.
+  tags:
+    - tier2
+    - subscriptions
+    - security
+    - eval-coverage
+
+seed_strategy: generated
+source_pattern: "subscribe (webhook_secret minting, delivery_method handling) had zero agentic coverage — a regression that dropped the minted secret or mishandled delivery_method would be invisible."
+privacy_transform: "Synthetic webhook URL; no PII."
+
+system_prompt: >
+  You are an assistant integrated with the Neotoma memory system. Use subscribe
+  with a delivery_method ("webhook" or "sse"); for webhooks provide a
+  webhook_url and capture the returned webhook_secret.
+
+user_prompt: |
+  Subscribe to task events via a webhook at https://example.com/hook, and also
+  open an SSE subscription to task events.
+
+host_tools: []
+
+models:
+  - provider: stub
+    model: replay-only
+
+expected:
+  # Two subscriptions were created.
+  - type: mcp_tool.invocations
+    tool_name: subscribe
+    op: gte
+    value: 2
+  # The webhook subscription minted + returned a webhook_secret (the security
+  # contract agents rely on for delivery-signature verification).
+  - type: tool_result.matches
+    tool_name: subscribe
+    which: 0
+    result_key: webhook_secret
+    present: true
+  - type: tool_result.matches
+    tool_name: subscribe
+    which: 0
+    result_key: subscription_id
+    present: true
+  # The SSE subscription was created (no webhook_secret needed/expected).
+  - type: tool_result.matches
+    tool_name: subscribe
+    which: last
+    result_key: subscription_id
+    present: true

--- a/packages/eval-harness/src/drivers/base.ts
+++ b/packages/eval-harness/src/drivers/base.ts
@@ -50,6 +50,8 @@ const TOOL_ENDPOINTS: Record<string, string> = {
   restore_relationship: "/restore_relationship",
   list_relationships: "/list_relationships",
   get_relationship_snapshot: "/relationships/snapshot",
+  // Subscriptions (#1715 eval-coverage backfill).
+  subscribe: "/subscribe",
 };
 
 /**


### PR DESCRIPTION
Adds an agentic eval for `subscribe` (security-relevant) which had zero agentic coverage. Part of the backfill (umbrella #230); runs in the `eval_scenarios` lane.

## Eval
The agent creates a webhook subscription + an SSE subscription. Asserts via #1703 `tool_result.matches`:
- the webhook subscription **mints + returns a `webhook_secret`** (the contract agents rely on for delivery-signature verification) and a `subscription_id`
- the SSE subscription returns a `subscription_id`

Added `subscribe` to the unified `TOOL_ENDPOINTS` registry.

## Scope note
The SSRF / HTTPS-allowlist guard is **not** asserted — the isolated replay server doesn't enforce it (a non-https/SSRF `webhook_url` returns 200 there), same isolated-server support-gap class as #1726. The secret-minting contract is the agent-observable security behavior and is covered.

## Verification
Passing in replay; full suite **24 passed / 0 failed / 8 skipped**. No `.test.ts` → catalog unaffected. Closes #1715.

_Advisory review GHA erroring on Anthropic-API auth (tracked); merging on `security_gates` + substantive lanes green._