### PR TITLE
fix(eval-combined): await WRIT loader + fail closed on WRIT error (#1738)

### DIFF
--- a/packages/eval-combined/src/cli.ts
+++ b/packages/eval-combined/src/cli.ts
@@ -63,7 +63,15 @@ async function main() {
   const report = renderCombinedReport(result, opts.output);
   process.stdout.write(report + "\n");
 
+  // Fail closed: a requested WRIT run that errored out (no report) is a hard
+  // failure, not a silent pass with an empty matrix (#1738).
+  if (result.writError) {
+    process.stderr.write(
+      `[eval-combined] WRIT run failed: ${result.writError}\n`,
+    );
+  }
   const exitCode =
+    result.writError ? 1 :
     result.tier2Summary && result.tier2Summary.failed > 0 ? 1 :
     result.writReport && result.writReport.aggregate.recall_accuracy < 0.5 ? 1 :
     0;

--- a/packages/eval-combined/src/runner.ts
+++ b/packages/eval-combined/src/runner.ts
@@ -26,6 +26,12 @@ export interface CombinedResult {
   writReport: WritReportShape | null;
   tier2Summary: Tier2SummaryShape | null;
   layeredMatrix: LayeredMatrixRow[];
+  /**
+   * Set when a requested WRIT run failed to produce a report (e.g. loader/API
+   * error). The CLI treats this as a hard failure so the combined runner does
+   * NOT fail open when WRIT is broken (#1738).
+   */
+  writError?: string;
 }
 
 export interface WritReportShape {
@@ -169,6 +175,7 @@ export async function runCombined(opts: CombinedOptions): Promise<CombinedResult
   const log = opts.log ?? (() => undefined);
   let writReport: WritReportShape | null = null;
   let tier2Summary: Tier2SummaryShape | null = null;
+  let writError: string | undefined;
 
   const evalHarnessPath = join(opts.repoRoot, "packages", "eval-harness");
   const writPath = join(opts.repoRoot, "writ");
@@ -177,8 +184,11 @@ export async function runCombined(opts: CombinedOptions): Promise<CombinedResult
     log("[eval-combined] running WRIT benchmark...");
     try {
       const writ = await import(join(writPath, "src", "index.js"));
-      const scenarios = writ.loadAllScenarios
-        ? writ.loadAllScenarios(join(writPath, "scenarios"))
+      // loadAllScenarios is async (returns Promise<Scenario[]>) — must await,
+      // else `.filter` is called on a Promise and throws "scenarios.filter is
+      // not a function" (the WRIT integration was silently broken; #1738).
+      const scenarios: Array<{ category: string }> = writ.loadAllScenarios
+        ? await writ.loadAllScenarios(join(writPath, "scenarios"))
         : [];
 
       const filteredScenarios = opts.writCategories
@@ -209,7 +219,8 @@ export async function runCombined(opts: CombinedOptions): Promise<CombinedResult
         log("[eval-combined] no WRIT scenarios found or all filtered out");
       }
     } catch (err) {
-      log(`[eval-combined] WRIT failed: ${(err as Error).message}`);
+      writError = (err as Error).message;
+      log(`[eval-combined] WRIT failed: ${writError}`);
     }
   }
 
@@ -233,5 +244,5 @@ export async function runCombined(opts: CombinedOptions): Promise<CombinedResult
   }
 
   const layeredMatrix = buildLayeredMatrix(writReport, tier2Summary);
-  return { writReport, tier2Summary, layeredMatrix };
+  return { writReport, tier2Summary, layeredMatrix, writError };
 }


### PR DESCRIPTION
Fixes the combined WRIT+Tier-2 runner, which was **silently broken** against the current WRIT and **failing open** — blocking it from ever being a trustworthy qa-gate (QA-evals QE2 intent, umbrella #230). Closes #1738.

## Two bugs fixed
1. **Un-awaited async loader.** `runner.ts` called `scenarios.filter(...)` on the un-awaited Promise from WRIT's `async loadAllScenarios()` → `scenarios.filter is not a function`. Now awaited; **WRIT runs again** (verified: `WRIT complete: 5 scenarios` on `--writ-only --categories drift`).
2. **Failed open.** The CLI caught the WRIT error, rendered an empty matrix, and exited **0**. Now a `writError` is threaded through `CombinedResult` and the CLI **exits 1** when a requested WRIT run produced no report (fail closed).

## Sequencing (important)
This unblocks wiring the combined layered matrix as the qa-gate, but the **CI lane should land AFTER #1737**: the WRIT neotoma adapter currently only drives `/store`, so WRIT scores ~0% recall against neotoma (e.g. a `drift` employer-change applied via plain store doesn't round-trip in the snapshot). Gating now would fail every PR. Order: **this fix → #1737 adapter enrichment → combined CI lane.**

## Verification
`--writ-only --categories drift` now executes (5 scenarios); `--tier2-only` runs clean (exit 0, 26/43 passed). Typecheck clean. No `.test.ts` → catalog unaffected.

_Advisory review GHA erroring on Anthropic-API auth (tracked); merge on `security_gates` + substantive lanes green._