### PR TITLE
feat(eval-harness): Tier-2 evals for schema/interpretation/peers/submission/turn-summary/reads (#1709 #1714 #1713 #1720 #1719 #1718 #1723)

### DIFF
--- a/packages/eval-harness/cassettes/create_interpretation_from_source__stub__replay-only.cassette.json
+++ b/packages/eval-harness/cassettes/create_interpretation_from_source__stub__replay-only.cassette.json
@@ -1,0 +1,49 @@
+{
+  "meta": {
+    "format_version": 1,
+    "scenario_id": "create_interpretation_from_source",
+    "provider": "stub",
+    "model": "replay-only",
+    "instruction_profile": "auto",
+    "recorded_at": "2026-06-22T00:00:00.000Z",
+    "cost_usd": 0
+  },
+  "user_prompt": "Store this batch and interpret it into a task (\"Interpreted Task Alpha\") and a contact (\"Interpreted Contact Beta\"). Also confirm an interpretation against a source you do not own is rejected.\n",
+  "system_prompt": "You are an assistant integrated with the Neotoma memory system. Store the raw payload first (which mints a source), then call create_interpretation with the returned source_id and the extracted entities to materialize them in the graph.\n",
+  "tool_calls": [
+    {
+      "name": "store",
+      "input": {
+        "idempotency_key": "interp-src-seed",
+        "entities": [
+          { "entity_type": "contact", "name": "Interp Source Seed" }
+        ]
+      },
+      "sequence": 0
+    },
+    {
+      "name": "create_interpretation",
+      "input": {
+        "source_id": "71113c5e-a6e9-7620-bf3a-7b4e3830dbc9",
+        "entities": [
+          { "entity_type": "task", "title": "Interpreted Task Alpha", "status": "todo" },
+          { "entity_type": "contact", "name": "Interpreted Contact Beta" }
+        ],
+        "idempotency_key": "interp-create-1"
+      },
+      "sequence": 1
+    },
+    {
+      "name": "create_interpretation",
+      "input": {
+        "source_id": "00000000-0000-0000-0000-000000000999",
+        "entities": [
+          { "entity_type": "task", "title": "Should Not Exist" }
+        ],
+        "idempotency_key": "interp-create-404"
+      },
+      "sequence": 2
+    }
+  ],
+  "assistant_text": "Stored the batch (minting a source), then interpreted it into the task \"Interpreted Task Alpha\" and the contact \"Interpreted Contact Beta\" (2 observations created). An interpretation against a source I don't own was rejected with SOURCE_NOT_FOUND, as expected."
+}

--- a/packages/eval-harness/cassettes/peer_add_and_resolve_conflict__stub__replay-only.cassette.json
+++ b/packages/eval-harness/cassettes/peer_add_and_resolve_conflict__stub__replay-only.cassette.json
@@ -1,0 +1,59 @@
+{
+  "meta": {
+    "format_version": 1,
+    "scenario_id": "peer_add_and_resolve_conflict",
+    "provider": "stub",
+    "model": "replay-only",
+    "instruction_profile": "auto",
+    "recorded_at": "2026-06-22T00:00:00.000Z",
+    "cost_usd": 0
+  },
+  "user_prompt": "Add a bidirectional sync peer \"Eval Peer One\" (id peer-eval-1) at https://peer.example/neotoma syncing task entities with last_write_wins, then list peers to confirm. Also resolve a conflicting entity preferring the local copy, and confirm an invalid peer config and an unknown conflict strategy are both rejected.\n",
+  "system_prompt": "You are an assistant integrated with the Neotoma memory system. To configure cross-instance sync, use add_peer with the peer's id/name/url, direction, entity_types, sync_scope, auth_method, and conflict_strategy. Use list_peers to confirm, and resolve_sync_conflict to settle a conflicting entity.\n",
+  "tool_calls": [
+    {
+      "name": "add_peer",
+      "input": {
+        "peer_id": "peer-eval-1",
+        "peer_name": "Eval Peer One",
+        "peer_url": "https://peer.example/neotoma",
+        "direction": "bidirectional",
+        "entity_types": ["task"],
+        "sync_scope": "all",
+        "auth_method": "shared_secret",
+        "conflict_strategy": "last_write_wins",
+        "shared_secret": "s3cr3t-eval"
+      },
+      "sequence": 0
+    },
+    {
+      "name": "list_peers",
+      "input": {},
+      "sequence": 1
+    },
+    {
+      "name": "resolve_sync_conflict",
+      "input": {
+        "entity_id": "ent_000000000000000000000000",
+        "strategy": "prefer_local"
+      },
+      "sequence": 2
+    },
+    {
+      "name": "add_peer",
+      "input": {
+        "peer_id": "peer-eval-bad"
+      },
+      "sequence": 3
+    },
+    {
+      "name": "resolve_sync_conflict",
+      "input": {
+        "entity_id": "ent_000000000000000000000000",
+        "strategy": "bogus_strategy"
+      },
+      "sequence": 4
+    }
+  ],
+  "assistant_text": "Added the bidirectional sync peer \"Eval Peer One\" (peer-eval-1) and confirmed it via list_peers. Resolved a conflicting entity preferring the local copy. An invalid peer config (missing required fields) and an unknown conflict strategy were both rejected, as expected."
+}

--- a/packages/eval-harness/cassettes/schema_discovery_reads__stub__replay-only.cassette.json
+++ b/packages/eval-harness/cassettes/schema_discovery_reads__stub__replay-only.cassette.json
@@ -1,0 +1,26 @@
+{
+  "meta": {
+    "format_version": 1,
+    "scenario_id": "schema_discovery_reads",
+    "provider": "stub",
+    "model": "replay-only",
+    "instruction_profile": "auto",
+    "recorded_at": "2026-06-22T00:00:00.000Z",
+    "cost_usd": 0
+  },
+  "user_prompt": "List the available entity types, and describe the \"task\" type's schema.\n",
+  "system_prompt": "You are an assistant integrated with the Neotoma memory system. Use list_entity_types to learn the available entity types and describe_entity_type to inspect one type's field shape before extracting entities of that type.\n",
+  "tool_calls": [
+    {
+      "name": "list_entity_types",
+      "input": {},
+      "sequence": 0
+    },
+    {
+      "name": "describe_entity_type",
+      "input": { "entity_type": "task" },
+      "sequence": 1
+    }
+  ],
+  "assistant_text": "Listed the available entity types and described the \"task\" type's schema (its schema_definition fields)."
+}

--- a/packages/eval-harness/cassettes/schema_register_and_update__stub__replay-only.cassette.json
+++ b/packages/eval-harness/cassettes/schema_register_and_update__stub__replay-only.cassette.json
@@ -1,0 +1,55 @@
+{
+  "meta": {
+    "format_version": 1,
+    "scenario_id": "schema_register_and_update",
+    "provider": "stub",
+    "model": "replay-only",
+    "instruction_profile": "auto",
+    "recorded_at": "2026-06-22T00:00:00.000Z",
+    "cost_usd": 0
+  },
+  "user_prompt": "Declare a new entity type \"widget_gadget\" with a required \"name\" and optional \"color\", then add an optional numeric \"weight_grams\" field to it. Also confirm that trying to add a field to an undeclared type fails.\n",
+  "system_prompt": "You are an assistant integrated with the Neotoma memory system. To declare a new entity type use register_schema with a schema_definition (a fields object) and a reducer_config; to add a field to an existing type use update_schema_incremental with fields_to_add.\n",
+  "tool_calls": [
+    {
+      "name": "register_schema",
+      "input": {
+        "entity_type": "widget_gadget",
+        "schema_definition": {
+          "fields": {
+            "name": { "type": "string", "required": true },
+            "color": { "type": "string", "required": false }
+          },
+          "canonical_name_fields": ["name"]
+        },
+        "reducer_config": { "merge_policies": {} },
+        "schema_version": "1.0",
+        "activate": true
+      },
+      "sequence": 0
+    },
+    {
+      "name": "update_schema_incremental",
+      "input": {
+        "entity_type": "widget_gadget",
+        "fields_to_add": [
+          { "field_name": "weight_grams", "field_type": "number", "required": false }
+        ],
+        "activate": true
+      },
+      "sequence": 1
+    },
+    {
+      "name": "update_schema_incremental",
+      "input": {
+        "entity_type": "undeclared_type_xyz",
+        "fields_to_add": [
+          { "field_name": "anything", "field_type": "string", "required": false }
+        ],
+        "activate": true
+      },
+      "sequence": 2
+    }
+  ],
+  "assistant_text": "Registered the new \"widget_gadget\" entity type (schema_version 1.0) with name + color, then added an optional numeric weight_grams field (version bumped to 1.1.0). Adding a field to an undeclared type returned an error, as expected."
+}

--- a/packages/eval-harness/cassettes/situational_reads__stub__replay-only.cassette.json
+++ b/packages/eval-harness/cassettes/situational_reads__stub__replay-only.cassette.json
@@ -1,0 +1,36 @@
+{
+  "meta": {
+    "format_version": 1,
+    "scenario_id": "situational_reads",
+    "provider": "stub",
+    "model": "replay-only",
+    "instruction_profile": "auto",
+    "recorded_at": "2026-06-22T00:00:00.000Z",
+    "cost_usd": 0
+  },
+  "user_prompt": "Record a task \"Reads Eval Task\", then show me what changed recently and the observations backing that task.\n",
+  "system_prompt": "You are an assistant integrated with the Neotoma memory system. Use list_recent_changes to see what was recently written and list_observations to inspect the observations backing a specific entity.\n",
+  "tool_calls": [
+    {
+      "name": "store",
+      "input": {
+        "idempotency_key": "reads-seed",
+        "entities": [
+          { "entity_type": "task", "title": "Reads Eval Task", "status": "todo" }
+        ]
+      },
+      "sequence": 0
+    },
+    {
+      "name": "list_recent_changes",
+      "input": {},
+      "sequence": 1
+    },
+    {
+      "name": "list_observations",
+      "input": { "entity_id": "ent_d2e8504345f1aa741b93f09f" },
+      "sequence": 2
+    }
+  ],
+  "assistant_text": "Recorded the task \"Reads Eval Task\". The recent-changes feed reflects the write, and list_observations returns the observations backing that task."
+}

--- a/packages/eval-harness/cassettes/submit_entity_gated__stub__replay-only.cassette.json
+++ b/packages/eval-harness/cassettes/submit_entity_gated__stub__replay-only.cassette.json
@@ -1,0 +1,50 @@
+{
+  "meta": {
+    "format_version": 1,
+    "scenario_id": "submit_entity_gated",
+    "provider": "stub",
+    "model": "replay-only",
+    "instruction_profile": "auto",
+    "recorded_at": "2026-06-22T00:00:00.000Z",
+    "cost_usd": 0
+  },
+  "user_prompt": "Try to submit a feedback_note. First with no intake config (it should be rejected), then after an intake config exists but the type is still closed to guests (it should still be rejected by the access policy).\n",
+  "system_prompt": "You are an assistant integrated with the Neotoma memory system. submit_entity routes a guest-style submission through the config-driven intake path; it requires an active submission_config for the target entity_type and a guest access policy that permits the store.\n",
+  "tool_calls": [
+    {
+      "name": "submit_entity",
+      "input": {
+        "entity_type": "feedback_note",
+        "fields": { "title": "Eval Submitted Note", "body": "Submitted via submit_entity" }
+      },
+      "sequence": 0
+    },
+    {
+      "name": "store",
+      "input": {
+        "idempotency_key": "submit-cfg-seed",
+        "entities": [
+          {
+            "entity_type": "submission_config",
+            "config_key": "feedback_note_intake",
+            "target_entity_type": "feedback_note",
+            "access_policy": "open",
+            "active": true,
+            "enable_conversation_threading": false,
+            "enable_guest_read_back": false
+          }
+        ]
+      },
+      "sequence": 1
+    },
+    {
+      "name": "submit_entity",
+      "input": {
+        "entity_type": "feedback_note",
+        "fields": { "title": "Eval Submitted Note", "body": "Submitted via submit_entity" }
+      },
+      "sequence": 2
+    }
+  ],
+  "assistant_text": "submit_entity for feedback_note was rejected with no intake config (no active submission_config). After seeding an intake config, the submission was still rejected because the feedback_note type is closed to guest stores (access_policy_denied). No feedback_note was created — both gates failed closed, as expected."
+}

--- a/packages/eval-harness/cassettes/turn_summary_status_line__stub__replay-only.cassette.json
+++ b/packages/eval-harness/cassettes/turn_summary_status_line__stub__replay-only.cassette.json
@@ -1,0 +1,60 @@
+{
+  "meta": {
+    "format_version": 1,
+    "scenario_id": "turn_summary_status_line",
+    "provider": "stub",
+    "model": "replay-only",
+    "instruction_profile": "auto",
+    "recorded_at": "2026-06-22T00:00:00.000Z",
+    "cost_usd": 0
+  },
+  "user_prompt": "Record a short conversation turn, then produce its turn summary. Also confirm a summary request missing the turn_key, and one for an unknown turn, are both rejected.\n",
+  "system_prompt": "You are an assistant integrated with the Neotoma memory system. At the end of the turn, call neotoma_turn_summary with the conversation_id and turn_key to produce the per-turn status line and widget URI.\n",
+  "tool_calls": [
+    {
+      "name": "store",
+      "input": {
+        "idempotency_key": "ts-seed",
+        "entities": [
+          { "entity_type": "conversation", "title": "Turn Summary Eval Convo", "thread_kind": "human_agent" },
+          {
+            "entity_type": "conversation_message",
+            "role": "user",
+            "sender_kind": "user",
+            "content": "hello",
+            "turn_key": "eval-turn-1",
+            "created_at": "2026-06-22T00:00:00.000Z"
+          }
+        ],
+        "relationships": [
+          { "relationship_type": "PART_OF", "source_index": 1, "target_index": 0 }
+        ]
+      },
+      "sequence": 0
+    },
+    {
+      "name": "neotoma_turn_summary",
+      "input": {
+        "conversation_id": "ent_19c066b574fab35d2ea07cc4",
+        "turn_key": "eval-turn-1"
+      },
+      "sequence": 1
+    },
+    {
+      "name": "neotoma_turn_summary",
+      "input": {
+        "conversation_id": "ent_19c066b574fab35d2ea07cc4"
+      },
+      "sequence": 2
+    },
+    {
+      "name": "neotoma_turn_summary",
+      "input": {
+        "conversation_id": "ent_000000000000000000000000",
+        "turn_key": "nope"
+      },
+      "sequence": 3
+    }
+  ],
+  "assistant_text": "Recorded the conversation turn and produced its turn summary (status line \"msg 1/1, stored 0, retrieved 0\" plus a ui:// widget URI). A summary request missing the turn_key, and one for an unknown turn, were both rejected, as expected."
+}

--- a/packages/eval-harness/scenarios/create_interpretation_from_source.scenario.yaml
+++ b/packages/eval-harness/scenarios/create_interpretation_from_source.scenario.yaml
@@ -1,0 +1,74 @@
+meta:
+  id: create_interpretation_from_source
+  description: >
+    An interpretation run materializes extracted entities against a stored
+    source. The agent first stores a payload (minting a source), then calls
+    create_interpretation with that source_id to turn extracted records into
+    graph entities + observations. The security-relevant contract:
+    create_interpretation is source-scoped — it only runs against a source that
+    belongs to the authenticated user; an interpretation against a source the
+    user does not own MUST 404 (SOURCE_NOT_FOUND), never silently create
+    entities under a foreign/forged source_id. create_interpretation had zero
+    agentic coverage. Asserts via #1703 tool_result.matches. Part of
+    neotoma#1714.
+  tags:
+    - tier2
+    - interpretation
+    - authz
+    - eval-coverage
+
+seed_strategy: generated
+source_pattern: "create_interpretation had only non-agentic coverage; no eval asserted that an interpretation actually materializes the extracted entities/observations against a real source, or that the source-ownership guard fires (404) instead of creating entities under an unowned source_id."
+privacy_transform: "Fully synthetic source + entities; no PII."
+
+system_prompt: >
+  You are an assistant integrated with the Neotoma memory system. Store the raw
+  payload first (which mints a source), then call create_interpretation with the
+  returned source_id and the extracted entities to materialize them in the
+  graph.
+
+user_prompt: |
+  Store this batch and interpret it into a task ("Interpreted Task Alpha") and a
+  contact ("Interpreted Contact Beta"). Also confirm an interpretation against a
+  source you do not own is rejected.
+
+host_tools: []
+
+models:
+  - provider: stub
+    model: replay-only
+
+expected:
+  # The source-minting store ran.
+  - type: mcp_tool.invocations
+    tool_name: store
+    op: gte
+    value: 1
+  # The interpretation ran against the owned source and materialized entities.
+  - type: mcp_tool.invocations
+    tool_name: create_interpretation
+    op: gte
+    value: 1
+  - type: tool_result.matches
+    tool_name: create_interpretation
+    which: 0
+    result_subset:
+      success: true
+      observations_created: 2
+  - type: tool_result.matches
+    tool_name: create_interpretation
+    which: 0
+    result_key: interpretation_id
+    present: true
+  # The materialized task entity exists in the graph post-interpretation.
+  - type: entity.exists
+    entity_type: task
+    where:
+      title: Interpreted Task Alpha
+  # Source-ownership guard: an interpretation against an unowned source 404s
+  # (SOURCE_NOT_FOUND), surfaced as an error — no entities created under it.
+  - type: tool_result.matches
+    tool_name: create_interpretation
+    which: last
+    result_key: error
+    present: true

--- a/packages/eval-harness/scenarios/peer_add_and_resolve_conflict.scenario.yaml
+++ b/packages/eval-harness/scenarios/peer_add_and_resolve_conflict.scenario.yaml
@@ -1,0 +1,88 @@
+meta:
+  id: peer_add_and_resolve_conflict
+  description: >
+    The agent configures a cross-instance sync peer (add_peer), lists peers to
+    confirm the config landed, and resolves a sync conflict with a chosen
+    strategy. Peer-sync is a trust-boundary surface: add_peer persists auth
+    material (shared_secret) and a conflict_strategy, and a regression that
+    dropped the peer config, silently accepted an invalid config, or mishandled
+    the conflict strategy would corrupt cross-instance state. add_peer,
+    list_peers, and resolve_sync_conflict had zero agentic coverage. Asserts via
+    #1703 tool_result.matches. Part of neotoma#1713.
+
+    Scope note: the per-peer tools (sync_peer, get_peer_status, remove_peer)
+    take a :peer_id path parameter and are not statically addressable via the
+    harness's TOOL_ENDPOINTS replay map, so they are not covered here. The
+    isolated eval server also does not model a second live Neotoma instance, so
+    actual bilateral sync (pull/push deltas) is not exercised —
+    resolve_sync_conflict is covered as a strategy-dispatch + validation guard.
+  tags:
+    - tier2
+    - peers
+    - sync
+    - security
+    - eval-coverage
+
+seed_strategy: generated
+source_pattern: "add_peer / list_peers / resolve_sync_conflict had only non-agentic coverage; no eval asserted the peer config (auth_method, conflict_strategy) actually persists as a peer_config entity, that an invalid peer config is rejected (400), or that resolve_sync_conflict dispatches a chosen strategy / rejects an unknown one."
+privacy_transform: "Synthetic peer URL + secret; no PII."
+
+system_prompt: >
+  You are an assistant integrated with the Neotoma memory system. To configure
+  cross-instance sync, use add_peer with the peer's id/name/url, direction,
+  entity_types, sync_scope, auth_method, and conflict_strategy. Use list_peers
+  to confirm, and resolve_sync_conflict to settle a conflicting entity.
+
+user_prompt: |
+  Add a bidirectional sync peer "Eval Peer One" (id peer-eval-1) at
+  https://peer.example/neotoma syncing task entities with last_write_wins, then
+  list peers to confirm. Also resolve a conflicting entity preferring the local
+  copy, and confirm an invalid peer config and an unknown conflict strategy are
+  both rejected.
+
+host_tools: []
+
+models:
+  - provider: stub
+    model: replay-only
+
+expected:
+  # The peer was added and returned an entity_id (the persisted peer_config).
+  - type: mcp_tool.invocations
+    tool_name: add_peer
+    op: gte
+    value: 1
+  - type: tool_result.matches
+    tool_name: add_peer
+    which: 0
+    result_key: entity_id
+    present: true
+  # The peer_config entity persisted with the requested id (queryable post-turn).
+  - type: entity.exists
+    entity_type: peer_config
+    where:
+      peer_id: peer-eval-1
+  # list_peers reflects the configured peer.
+  - type: tool_result.matches
+    tool_name: list_peers
+    which: 0
+    result_key: peers
+    present: true
+  # resolve_sync_conflict dispatched the chosen strategy (ok:true).
+  - type: tool_result.matches
+    tool_name: resolve_sync_conflict
+    which: 0
+    result_subset:
+      ok: true
+  # Invalid peer config (missing required fields) is rejected (400 -> error).
+  - type: tool_result.matches
+    tool_name: add_peer
+    which: last
+    result_key: error
+    present: true
+  # Unknown conflict strategy is rejected (400 -> error).
+  - type: tool_result.matches
+    tool_name: resolve_sync_conflict
+    which: last
+    result_key: error
+    present: true

--- a/packages/eval-harness/scenarios/schema_discovery_reads.scenario.yaml
+++ b/packages/eval-harness/scenarios/schema_discovery_reads.scenario.yaml
@@ -1,0 +1,66 @@
+meta:
+  id: schema_discovery_reads
+  description: >
+    Schema-discovery reads let an agent learn the available entity types and a
+    specific type's field shape before storing — getting these wrong (e.g.
+    returning no schemas, or an empty schema_definition) would make
+    schema-aware extraction blind. The agent lists entity types
+    (list_entity_types) and describes one (describe_entity_type for "task"),
+    and the eval asserts both return real schema structure. These reads had zero
+    agentic coverage. Asserts via #1703 tool_result.matches. Part of
+    neotoma#1718.
+
+    Scope note: get_entity_type_counts is NOT covered — it has no dedicated HTTP
+    route (CLI-only `stats entities`; the data lives on /stats which the harness
+    already snapshots for other predicates), so it is not statically addressable
+    via the TOOL_ENDPOINTS replay map.
+  tags:
+    - tier2
+    - schema
+    - discovery
+    - eval-coverage
+
+seed_strategy: generated
+source_pattern: "list_entity_types + describe_entity_type had only non-agentic coverage; no eval asserted list_entity_types returns the registered schema set or that describe_entity_type returns a real schema_definition for a known type."
+privacy_transform: "No PII — built-in schema metadata only."
+
+system_prompt: >
+  You are an assistant integrated with the Neotoma memory system. Use
+  list_entity_types to learn the available entity types and describe_entity_type
+  to inspect one type's field shape before extracting entities of that type.
+
+user_prompt: |
+  List the available entity types, and describe the "task" type's schema.
+
+host_tools: []
+
+models:
+  - provider: stub
+    model: replay-only
+
+expected:
+  # list_entity_types returned the registered schema set.
+  - type: mcp_tool.invocations
+    tool_name: list_entity_types
+    op: gte
+    value: 1
+  - type: tool_result.matches
+    tool_name: list_entity_types
+    which: 0
+    result_key: schemas
+    present: true
+  # describe_entity_type returned a real schema for the known "task" type.
+  - type: mcp_tool.invocations
+    tool_name: describe_entity_type
+    op: gte
+    value: 1
+  - type: tool_result.matches
+    tool_name: describe_entity_type
+    which: 0
+    result_subset:
+      entity_type: task
+  - type: tool_result.matches
+    tool_name: describe_entity_type
+    which: 0
+    result_key: schema_definition
+    present: true

--- a/packages/eval-harness/scenarios/schema_register_and_update.scenario.yaml
+++ b/packages/eval-harness/scenarios/schema_register_and_update.scenario.yaml
@@ -1,0 +1,88 @@
+meta:
+  id: schema_register_and_update
+  description: >
+    The agent declares a brand-new entity type via register_schema (a strong
+    schema with a fields object + reducer_config), then incrementally adds a
+    field via update_schema_incremental. Schema mutation is a high-blast-radius
+    operation — a regression that dropped the minted schema_version, silently
+    failed to persist the new field, or returned a false success on an
+    unknown-type update would corrupt every downstream store/correct against
+    that type. register_schema and update_schema_incremental had zero agentic
+    coverage. Asserts via #1703 tool_result.matches. Part of neotoma#1709.
+
+    Scope note: the isolated eval server does NOT enforce the
+    ERR_PLURAL_ENTITY_TYPE / forbidden-core-type / same-version-conflict guards
+    (re-registering an existing version returns 200 there), so this eval does
+    not assert a register conflict. It covers what IS observable: a successful
+    register with a schema_version, a successful incremental add that surfaces
+    the new field + a bumped version, and the no-active-schema error guard on
+    update.
+  tags:
+    - tier2
+    - schema
+    - schema-mutation
+    - eval-coverage
+
+seed_strategy: generated
+source_pattern: "register_schema + update_schema_incremental had only non-agentic dispatch coverage; no eval asserted that a schema is created with a returned schema_version, that an incremental field-add actually lands in the persisted schema_definition.fields (with a bumped version), or that updating a type with no active schema errors instead of falsely succeeding."
+privacy_transform: "Fully synthetic entity type; no PII."
+
+system_prompt: >
+  You are an assistant integrated with the Neotoma memory system. To declare a
+  new entity type use register_schema with a schema_definition (a fields object)
+  and a reducer_config; to add a field to an existing type use
+  update_schema_incremental with fields_to_add.
+
+user_prompt: |
+  Declare a new entity type "widget_gadget" with a required "name" and optional
+  "color", then add an optional numeric "weight_grams" field to it. Also confirm
+  that trying to add a field to an undeclared type fails.
+
+host_tools: []
+
+models:
+  - provider: stub
+    model: replay-only
+
+expected:
+  # The new schema was registered.
+  - type: mcp_tool.invocations
+    tool_name: register_schema
+    op: gte
+    value: 1
+  # register_schema returned success + a minted schema_version (the contract
+  # downstream store/correct depends on).
+  - type: tool_result.matches
+    tool_name: register_schema
+    which: 0
+    result_subset:
+      success: true
+      schema_version: "1.0"
+  - type: tool_result.matches
+    tool_name: register_schema
+    which: 0
+    result_key: schema.schema_definition.fields.name
+    present: true
+  # The incremental update added the new field to the persisted schema_definition
+  # and bumped the version (1.0 -> 1.1.0).
+  - type: mcp_tool.invocations
+    tool_name: update_schema_incremental
+    op: gte
+    value: 1
+  - type: tool_result.matches
+    tool_name: update_schema_incremental
+    which: 0
+    result_subset:
+      success: true
+      schema_version: "1.1.0"
+  - type: tool_result.matches
+    tool_name: update_schema_incremental
+    which: 0
+    result_key: schema.schema_definition.fields.weight_grams
+    present: true
+  # Updating a type with no active schema errors (no false success, no stray schema).
+  - type: tool_result.matches
+    tool_name: update_schema_incremental
+    which: last
+    result_key: error
+    present: true

--- a/packages/eval-harness/scenarios/situational_reads.scenario.yaml
+++ b/packages/eval-harness/scenarios/situational_reads.scenario.yaml
@@ -1,0 +1,65 @@
+meta:
+  id: situational_reads
+  description: >
+    Situational reads let an agent re-orient at the start of a turn: what changed
+    recently (list_recent_changes) and what observations back a given entity
+    (list_observations). The agent stores a task, then reads the recent-changes
+    feed and the task's observations. A regression that returned an empty
+    recent-changes feed, or dropped an entity's observations, would blind the
+    agent to its own prior writes. Both reads had zero agentic coverage. Asserts
+    via #1703 tool_result.matches. Part of neotoma#1723.
+  tags:
+    - tier2
+    - situational
+    - reads
+    - eval-coverage
+
+seed_strategy: generated
+source_pattern: "list_recent_changes + list_observations had only non-agentic coverage; no eval asserted the recent-changes feed reflects a just-written entity or that list_observations returns the observations backing a specific entity."
+privacy_transform: "Fully synthetic task; no PII."
+
+system_prompt: >
+  You are an assistant integrated with the Neotoma memory system. Use
+  list_recent_changes to see what was recently written and list_observations to
+  inspect the observations backing a specific entity.
+
+user_prompt: |
+  Record a task "Reads Eval Task", then show me what changed recently and the
+  observations backing that task.
+
+host_tools: []
+
+models:
+  - provider: stub
+    model: replay-only
+
+expected:
+  # The task was stored (and so should appear in the recent-changes feed).
+  - type: mcp_tool.invocations
+    tool_name: store
+    op: gte
+    value: 1
+  - type: entity.exists
+    entity_type: task
+    where:
+      title: Reads Eval Task
+  # list_recent_changes returns an activity feed reflecting the write.
+  - type: mcp_tool.invocations
+    tool_name: list_recent_changes
+    op: gte
+    value: 1
+  - type: tool_result.matches
+    tool_name: list_recent_changes
+    which: 0
+    result_key: items
+    present: true
+  # list_observations returns the observations backing the stored task.
+  - type: mcp_tool.invocations
+    tool_name: list_observations
+    op: gte
+    value: 1
+  - type: tool_result.matches
+    tool_name: list_observations
+    which: 0
+    result_key: observations
+    present: true

--- a/packages/eval-harness/scenarios/submit_entity_gated.scenario.yaml
+++ b/packages/eval-harness/scenarios/submit_entity_gated.scenario.yaml
@@ -1,0 +1,78 @@
+meta:
+  id: submit_entity_gated
+  description: >
+    submit_entity is the config-driven, guest-facing intake path: a submission
+    is only accepted when (a) an active submission_config exists for the target
+    entity_type AND (b) the entity_type's guest access policy permits a store.
+    Both are trust-boundary gates — a regression that accepted a submission with
+    no config, or that let a guest store into a "closed" type, would open an
+    unintended write surface. This eval asserts submit_entity fails CLOSED on
+    both gates: no submission_config -> error, and config-present-but-closed
+    -> access_policy_denied. submit_entity had zero agentic coverage. Asserts via
+    #1703 tool_result.matches. Part of neotoma#1720.
+
+    Scope note: the happy path (a successful submission) is NOT covered here
+    because it requires operator-owned setup the isolated eval server cannot
+    model over HTTP — submission_config rows are operator-seeded (covered) but
+    the entity_type guest access policy can only be opened via an env override
+    (NEOTOMA_ACCESS_POLICY_<TYPE>) or the `neotoma access set` CLI / schema
+    metadata, none of which a scenario can inject. The two fail-closed guards
+    are the security-relevant contract and are fully observable; the eval covers
+    exactly those.
+  tags:
+    - tier2
+    - submission
+    - authz
+    - security
+    - eval-coverage
+
+seed_strategy: generated
+source_pattern: "submit_entity had only non-agentic coverage; no eval asserted it fails closed when no submission_config exists for the target type, or when the type's guest access policy denies a store — the two gates that keep guest submission from becoming an open write surface."
+privacy_transform: "Fully synthetic submission; no PII."
+
+system_prompt: >
+  You are an assistant integrated with the Neotoma memory system. submit_entity
+  routes a guest-style submission through the config-driven intake path; it
+  requires an active submission_config for the target entity_type and a guest
+  access policy that permits the store.
+
+user_prompt: |
+  Try to submit a feedback_note. First with no intake config (it should be
+  rejected), then after an intake config exists but the type is still closed to
+  guests (it should still be rejected by the access policy).
+
+host_tools: []
+
+models:
+  - provider: stub
+    model: replay-only
+
+expected:
+  # submit_entity was attempted.
+  - type: mcp_tool.invocations
+    tool_name: submit_entity
+    op: gte
+    value: 2
+  # Gate 1: no submission_config -> fails closed (no silent acceptance).
+  - type: tool_result.matches
+    tool_name: submit_entity
+    which: 0
+    result_key: error
+    present: true
+  # The intake config was seeded between attempts.
+  - type: entity.exists
+    entity_type: submission_config
+    where:
+      target_entity_type: feedback_note
+  # Gate 2: config present but the type is closed to guests -> access policy
+  # still denies the store (the guest-write trust boundary holds).
+  - type: tool_result.matches
+    tool_name: submit_entity
+    which: last
+    result_key: error
+    present: true
+  # No feedback_note was ever created (both submissions failed closed).
+  - type: entity.count
+    entity_type: feedback_note
+    op: eq
+    value: 0

--- a/packages/eval-harness/scenarios/turn_summary_status_line.scenario.yaml
+++ b/packages/eval-harness/scenarios/turn_summary_status_line.scenario.yaml
@@ -1,0 +1,72 @@
+meta:
+  id: turn_summary_status_line
+  description: >
+    neotoma_turn_summary is the per-turn status-line tool (FU-2026-05-002):
+    agents call it at the end of every turn to surface a compact "msg N/M,
+    stored X, retrieved Y" line plus a ui:// widget URI. This eval seeds a
+    conversation + message, then computes the turn summary and asserts the
+    status_line + widget_uri contract, plus the two request guards (missing
+    turn_key -> 400, unknown turn -> 404). neotoma_turn_summary had zero agentic
+    coverage — a regression that dropped the widget_uri or miscounted the turn
+    would silently degrade the agent status line. Asserts via #1703
+    tool_result.matches. Part of neotoma#1719.
+  tags:
+    - tier2
+    - turn-summary
+    - eval-coverage
+
+seed_strategy: generated
+source_pattern: "neotoma_turn_summary had only non-agentic coverage; no eval asserted it returns a status_line + ui:// widget_uri for a real conversation turn, or that it rejects a request missing turn_key / referencing an unknown turn instead of returning a bogus summary."
+privacy_transform: "Fully synthetic conversation; no PII."
+
+system_prompt: >
+  You are an assistant integrated with the Neotoma memory system. At the end of
+  the turn, call neotoma_turn_summary with the conversation_id and turn_key to
+  produce the per-turn status line and widget URI.
+
+user_prompt: |
+  Record a short conversation turn, then produce its turn summary. Also confirm
+  a summary request missing the turn_key, and one for an unknown turn, are both
+  rejected.
+
+host_tools: []
+
+models:
+  - provider: stub
+    model: replay-only
+
+expected:
+  # The turn summary was computed for the seeded turn.
+  - type: mcp_tool.invocations
+    tool_name: neotoma_turn_summary
+    op: gte
+    value: 1
+  - type: tool_result.matches
+    tool_name: neotoma_turn_summary
+    which: 0
+    result_subset:
+      turn_number: 1
+      conversation_message_count: 1
+  # The status line + ui:// widget URI contract (FU-2026-05-002) is honored.
+  - type: tool_result.matches
+    tool_name: neotoma_turn_summary
+    which: 0
+    result_key: status_line
+    present: true
+  - type: tool_result.matches
+    tool_name: neotoma_turn_summary
+    which: 0
+    result_key: widget_uri
+    present: true
+  # Guard: a request missing turn_key is rejected (400 -> error).
+  - type: tool_result.matches
+    tool_name: neotoma_turn_summary
+    which: 1
+    result_key: error
+    present: true
+  # Guard: an unknown turn is rejected (404 -> error), not a bogus summary.
+  - type: tool_result.matches
+    tool_name: neotoma_turn_summary
+    which: last
+    result_key: error
+    present: true

--- a/packages/eval-harness/src/drivers/base.ts
+++ b/packages/eval-harness/src/drivers/base.ts
@@ -58,6 +58,15 @@ const TOOL_ENDPOINTS: Record<string, string> = {
   // Interpretation creation (#1714 eval-coverage backfill). Endpoint is
   // /interpretations/create.
   create_interpretation: "/interpretations/create",
+  // Peer-sync (#1713 eval-coverage backfill). add_peer + list_peers share the
+  // /peers collection (POST vs GET — list_peers is in GET_TOOLS below);
+  // resolve_sync_conflict has a static /peers/resolve_sync_conflict path. The
+  // per-peer tools (get_peer_status, remove_peer, sync_peer) take a :peer_id
+  // path param and are NOT statically addressable via this map, so they're not
+  // covered here (scope-noted in the scenario).
+  add_peer: "/peers",
+  list_peers: "/peers",
+  resolve_sync_conflict: "/peers/resolve_sync_conflict",
 };
 
 /**
@@ -67,6 +76,13 @@ const TOOL_ENDPOINTS: Record<string, string> = {
  */
 export const NEOTOMA_TOOL_NAMES = new Set<string>(Object.keys(TOOL_ENDPOINTS));
 
+/**
+ * Tools whose HTTP route is a GET (no request body). Everything else POSTs the
+ * tool input as JSON. Keep this in sync with the route methods in
+ * src/shared/contract_mappings.ts.
+ */
+const GET_TOOLS = new Set<string>(["get_session_identity", "list_peers"]);
+
 async function postNeotomaTool(
   baseUrl: string,
   toolName: string,
@@ -75,14 +91,15 @@ async function postNeotomaTool(
 ): Promise<{ output?: unknown; error?: string }> {
   const path = TOOL_ENDPOINTS[toolName];
   if (!path) return { error: `unknown Neotoma tool ${toolName}` };
+  const isGet = GET_TOOLS.has(toolName);
   try {
     const res = await fetch(`${baseUrl}${path}`, {
-      method: toolName === "get_session_identity" ? "GET" : "POST",
+      method: isGet ? "GET" : "POST",
       headers: {
         "content-type": "application/json",
         authorization: `Bearer ${token}`,
       },
-      body: toolName === "get_session_identity" ? undefined : JSON.stringify(input ?? {}),
+      body: isGet ? undefined : JSON.stringify(input ?? {}),
     });
     const text = await res.text();
     let parsed: unknown = text;

--- a/packages/eval-harness/src/drivers/base.ts
+++ b/packages/eval-harness/src/drivers/base.ts
@@ -55,6 +55,9 @@ const TOOL_ENDPOINTS: Record<string, string> = {
   // Schema mutation (#1709 eval-coverage backfill).
   register_schema: "/register_schema",
   update_schema_incremental: "/update_schema_incremental",
+  // Interpretation creation (#1714 eval-coverage backfill). Endpoint is
+  // /interpretations/create.
+  create_interpretation: "/interpretations/create",
 };
 
 /**

--- a/packages/eval-harness/src/drivers/base.ts
+++ b/packages/eval-harness/src/drivers/base.ts
@@ -67,6 +67,10 @@ const TOOL_ENDPOINTS: Record<string, string> = {
   add_peer: "/peers",
   list_peers: "/peers",
   resolve_sync_conflict: "/peers/resolve_sync_conflict",
+  // Config-driven entity submission (#1720 eval-coverage backfill). Route is
+  // POST /submit/{entity_type}; the {entity_type} placeholder is resolved from
+  // the call input by resolvePathParams below.
+  submit_entity: "/submit/{entity_type}",
 };
 
 /**
@@ -83,14 +87,31 @@ export const NEOTOMA_TOOL_NAMES = new Set<string>(Object.keys(TOOL_ENDPOINTS));
  */
 const GET_TOOLS = new Set<string>(["get_session_identity", "list_peers"]);
 
+/**
+ * Substitute `{field}` placeholders in a TOOL_ENDPOINTS path with values pulled
+ * from the call input. Lets path-parameterized routes (e.g. submit_entity at
+ * POST /submit/{entity_type}) be replayed without baking a concrete value into
+ * the static path map. Missing placeholder values are left as-is so the route
+ * 404s loudly rather than hitting the wrong endpoint.
+ */
+function resolvePathParams(path: string, input: unknown): string {
+  if (!path.includes("{")) return path;
+  const obj = (input && typeof input === "object" ? input : {}) as Record<string, unknown>;
+  return path.replace(/\{(\w+)\}/g, (whole, key: string) => {
+    const v = obj[key];
+    return typeof v === "string" || typeof v === "number" ? encodeURIComponent(String(v)) : whole;
+  });
+}
+
 async function postNeotomaTool(
   baseUrl: string,
   toolName: string,
   input: unknown,
   token: string
 ): Promise<{ output?: unknown; error?: string }> {
-  const path = TOOL_ENDPOINTS[toolName];
-  if (!path) return { error: `unknown Neotoma tool ${toolName}` };
+  const rawPath = TOOL_ENDPOINTS[toolName];
+  if (!rawPath) return { error: `unknown Neotoma tool ${toolName}` };
+  const path = resolvePathParams(rawPath, input);
   const isGet = GET_TOOLS.has(toolName);
   try {
     const res = await fetch(`${baseUrl}${path}`, {

--- a/packages/eval-harness/src/drivers/base.ts
+++ b/packages/eval-harness/src/drivers/base.ts
@@ -71,6 +71,16 @@ const TOOL_ENDPOINTS: Record<string, string> = {
   // POST /submit/{entity_type}; the {entity_type} placeholder is resolved from
   // the call input by resolvePathParams below.
   submit_entity: "/submit/{entity_type}",
+  // Per-turn status line (#1719 eval-coverage backfill).
+  neotoma_turn_summary: "/turn_summary",
+  // Schema discovery reads (#1718 eval-coverage backfill). list_entity_types is
+  // GET /schemas (see GET_TOOLS); describe_entity_type is GET /schemas/{entity_type}.
+  list_entity_types: "/schemas",
+  describe_entity_type: "/schemas/{entity_type}",
+  // Situational reads (#1723 eval-coverage backfill). list_recent_changes is GET
+  // /record_activity (see GET_TOOLS); list_observations is POST /list_observations.
+  list_recent_changes: "/record_activity",
+  list_observations: "/list_observations",
 };
 
 /**
@@ -85,7 +95,14 @@ export const NEOTOMA_TOOL_NAMES = new Set<string>(Object.keys(TOOL_ENDPOINTS));
  * tool input as JSON. Keep this in sync with the route methods in
  * src/shared/contract_mappings.ts.
  */
-const GET_TOOLS = new Set<string>(["get_session_identity", "list_peers"]);
+const GET_TOOLS = new Set<string>([
+  "get_session_identity",
+  "list_peers",
+  // Read tools whose HTTP route is a GET (#1718, #1723 eval-coverage backfill).
+  "list_entity_types",
+  "describe_entity_type",
+  "list_recent_changes",
+]);
 
 /**
  * Substitute `{field}` placeholders in a TOOL_ENDPOINTS path with values pulled

--- a/packages/eval-harness/src/drivers/base.ts
+++ b/packages/eval-harness/src/drivers/base.ts
@@ -52,6 +52,9 @@ const TOOL_ENDPOINTS: Record<string, string> = {
   get_relationship_snapshot: "/relationships/snapshot",
   // Subscriptions (#1715 eval-coverage backfill).
   subscribe: "/subscribe",
+  // Schema mutation (#1709 eval-coverage backfill).
+  register_schema: "/register_schema",
+  update_schema_incremental: "/update_schema_incremental",
 };
 
 /**


### PR DESCRIPTION
## Summary

Tier-2 agentic eval-coverage backfill for a batch of previously-uncovered
neotoma MCP tools, following the proven `*.scenario.yaml` + hand-authored
`*.cassette.json` replay pattern run by the `eval_scenarios` CI lane. Part of
umbrella #230.

Each eval was authored probe-first against `startIsolatedNeotomaServer` (never
guessed): the request field names, response shapes, and deterministic
entity/source/conversation IDs were all confirmed against the real isolated
server before authoring, and each is verified PASS in `--mode replay` plus the
full `npm run eval:scenarios` suite (0 failed).

## Evals authored (all verified passing)

| Issue | Eval | Tool(s) | What it asserts |
|---|---|---|---|
| #1709 | `schema_register_and_update` | `register_schema`, `update_schema_incremental` | register returns success + minted schema_version (1.0) and persists the fields; incremental add lands the new field in `schema_definition.fields` + bumps version to 1.1.0; update on an undeclared type errors (no false success) |
| #1714 | `create_interpretation_from_source` | `create_interpretation` | interpretation materializes entities/observations against an owned source; the materialized entity exists; source-ownership guard 404s on an unowned source_id |
| #1713 | `peer_add_and_resolve_conflict` | `add_peer`, `list_peers`, `resolve_sync_conflict` | peer config persists as a `peer_config` entity + lists; conflict strategy dispatches (ok:true); invalid peer config + unknown strategy both rejected (400) |
| #1720 | `submit_entity_gated` | `submit_entity` | fails CLOSED on both gates — no `submission_config` -> error; config-present-but-closed -> `access_policy_denied`; no entity ever created |
| #1719 | `turn_summary_status_line` | `neotoma_turn_summary` | status_line + `ui://` widget_uri contract (FU-2026-05-002), turn counts; missing turn_key -> 400; unknown turn -> 404 |
| #1718 | `schema_discovery_reads` | `list_entity_types`, `describe_entity_type` | list returns the registered schema set; describe returns entity_type:task + a real schema_definition |
| #1723 | `situational_reads` | `list_recent_changes`, `list_observations` | recent-changes feed reflects a just-written entity; list_observations returns the entity's observations |

## Harness infra changes (`packages/eval-harness/src/drivers/base.ts`)

- Added 11 tool→endpoint mappings to `TOOL_ENDPOINTS` (the single source of truth; `NEOTOMA_TOOL_NAMES` derives from it).
- Generalized the GET-method special-case into a `GET_TOOLS` set (`get_session_identity`, `list_peers`, `list_entity_types`, `describe_entity_type`, `list_recent_changes`).
- Added a general `{field}` path-param resolver (`resolvePathParams`) so path-parameterized routes (`submit_entity` at `/submit/{entity_type}`, `describe_entity_type` at `/schemas/{entity_type}`) can be replayed without baking a concrete value into the static path map.

## Skipped (isolated-server limits — honestly NOT covered rather than faking)

- **#1716 identity resolution (`identify_entity_by_signals`, `list_potential_duplicates`)** — `identify_entity_by_signals` has no HTTP route (MCP-only via `server.ts`); `list_potential_duplicates` (GET `/entities/duplicates`) is **shadowed by the earlier `/entities/:id` route** and always 404s over HTTP. Both unreachable via the harness's HTTP replay path. The route-shadowing bug is flagged separately.
- **#1720 happy path** — covered the two fail-closed guards (the security contract) but NOT a successful submission: the guest access policy can only be opened via env override / `neotoma access set` / schema metadata, none injectable by a scenario. Scope-noted in the scenario.
- **#1718 `get_entity_type_counts`** — no dedicated HTTP route (CLI-only; data on `/stats`), not statically addressable. Scope-noted.
- **#1713 per-peer tools (`sync_peer`, `get_peer_status`, `remove_peer`)** — take a `:peer_id` path param not statically addressable; the isolated server also does not model a second live instance, so bilateral sync deltas aren't exercised. Scope-noted.

## Verification

- Each new scenario: `npx tsx packages/eval-harness/src/cli.ts run --scenario <id> --mode replay --provider stub` -> PASS.
- Full suite `npm run eval:scenarios`: **total=39, passed=31, failed=0, skipped=8** (all 8 skips pre-existing — missing stub cassettes + neotoma#1726 quarantines, none introduced here).
- `tsc -p packages/eval-harness/tsconfig.json --noEmit` -> clean.
- No `*.test.ts` added, so the automated test catalog baseline is unaffected.

CI gates are `security_gates` + baseline + `eval_scenarios`. Advisory review GHA + Vanellus error on Anthropic-API auth are known/tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)