### PR TITLE
feat(agent_session): agent_session + session_transcript types and ingest tooling

### DIFF
--- a/docs/subsystems/agent_session_architecture.md
+++ b/docs/subsystems/agent_session_architecture.md
@@ -1,0 +1,69 @@
+# Subsystem: agent_session
+
+Runtime and resume record for a coding-agent session, across harnesses (Claude Code, Codex, Cursor) and across devices. An `agent_session` captures where a session's transcript lives, the git environment needed to reconstruct it, and (for autonomous swarm runs) the trigger and AAuth attribution. It is the resume-oriented sibling of the semantic `conversation`: `conversation` answers "what was discussed", `agent_session` answers "where is the transcript and how do I resume it".
+
+Neotoma owns the State Layer parts of this subsystem (the entity types, deterministic capture, durable transcript storage). The resume orchestration (materialize transcript, fetch git, recreate worktree, launch or re-dispatch) is Operational Layer work and lives in ateles, not here.
+
+## Entity model
+
+### `agent_session` (`category: agent_runtime`)
+
+- **Identity**: joint `canonical_name_fields: ["harness", "native_session_id"]` with `name_collision_policy: "reject"`. A native session id is only unique within its harness.
+- **`kind`**: `interactive` | `autonomous` | `subagent`.
+- **Runtime / git fields**: `cwd`, `repo`, `repo_remote_url`, `source_branch`, `branch`, `git_head_sha`, `worktree_path`, `origin_device`, `parent_session_id`. Paths and host are context only and are excluded from identity because they move and embed usernames.
+- **Activity**: `title`, `summary`, `model`, `status`, `message_count`, `created_at`, `last_activity_at`.
+- **Per-device app state**: `is_archived`, `auto_archive_exempt`, `is_pinned`, `is_bridged`, `bridge_session_ids`.
+- **Autonomous trigger and attribution block**: `trigger_kind`, `trigger_ref`, `dispatch_parent`, `aauth_sub`, `workflow_definition_ref`, `gate_name`. These are denormalized for discovery and filtering; the authoritative record stays in the linked orchestration entities (see below).
+- **`resume_command`**: literal harness-specific command to resume.
+
+### `session_transcript` (`category: agent_runtime`)
+
+The raw, lossless transcript artifact. Specialized asset type, modeled like `image_asset` and `audio_asset`: content-addressed bytes in the `sources` bucket at `{user_id}/{content_hash}`, surfaced via `retrieve_file_url`.
+
+- **Identity**: `canonical_name_fields: ["content_hash"]` (SHA-256 of the transcript bytes).
+- **Fields**: `source_id`, `mime_type`, `file_size`, `storage_url`, `harness`, `format` (`claude_code_jsonl` | `codex_rollout` | `cursor_sqlite`), `format_version`, `turn_count`, `transcript_kind` (`main` | `subagent`), `agent_session_id`.
+
+The raw transcript is the byte-exact resume artifact and the durable backup. The structured turns of the same session live separately in `conversation_message`. The two fidelities are complementary, not alternatives.
+
+## Relationship to existing entities
+
+`agent_session` links, it does not duplicate.
+
+- `agent_session` is `PART_OF` linked from a `conversation` (the semantic record already carries `session_id`, `client_name`/`harness`, and `repository_*`).
+- `agent_session` relates to its `session_transcript` (raw bytes) and to the `conversation_message` rows (structured turns).
+- For autonomous swarm runs, `agent_session` relates to the existing ateles orchestration entities rather than re-deriving them: `harness_event` (lifecycle plus `agent_sub` AAuth identity and `task_entity_id`), `participation_record` (gate dispatch and satisfaction), and the `agent_task` to `agent_attempt` to `agent_outcome` chain. The `agent_attempt` type already claims the alias `agent_run`, so `agent_session` deliberately does not introduce a competing run type; it is the per-session unifying record that the orchestration entities lacked.
+
+## Deterministic capture
+
+Capture does not depend on the model calling the MCP `store` tool. Neotoma already runs deterministic harness hooks (`claude-code-plugin`, `cursor-hooks`, `codex-hooks`, `opencode-plugin`, `claude-agent-sdk-adapter`) that record structured turns. This subsystem extends that path with:
+
+1. A raw-transcript tail in the Stop and SessionEnd hooks that reads transcript lines appended since a per-session offset cursor and appends the delta to a durable local queue, then exits fast with no synchronous Neotoma call.
+2. An async drainer that ships queued deltas to Neotoma: `storeRawContent` for the `session_transcript` blob plus the structured `conversation_message` rows. Idempotent via the JSONL `uuid` and `parentUuid` natural keys plus the offset cursor.
+3. A filesystem-watcher backstop for sessions whose harness has no hooks installed, or that die before Stop fires.
+
+A backfill scanner provides historical coverage and repair. The scanner reads `cwd` and `gitBranch` from the message lines of the transcript, not from line one (line one is a hook or summary event without `cwd`). Validation across 1288 desktop sessions showed reading only line one left `cwd` null on 91 percent of sessions; reading the message lines raised resolution to 99.5 percent.
+
+## Autonomous and swarm sessions
+
+The ateles swarm runs T2, T3, and T4 agents headlessly through `claude --print` subprocesses, with no interactive UI harness. These are still Claude Code sessions: they write standard JSONL transcripts under `~/.claude/projects` and fire the same hooks, because the daemon sets no `CLAUDE_CONFIG_DIR` override.
+
+Empirical hook firing under `--print` (60 sampled swarm sessions): `SessionStart` 60 of 60, `PostToolUse` 60 of 60, `Stop` 59 of 60 (the miss was a run killed mid-execution), `PreCompact` 1 of 60 (only on compaction), `UserPromptSubmit` 15 of 60. `UserPromptSubmit` is unreliable headlessly because the prompt is piped rather than interactively submitted, so capture reads the prompt and turns from the transcript, not from that hook. The roughly 2 percent of runs that die before `Stop`, plus daemon timeouts, are covered by the watcher and scanner backstops.
+
+Sub-agent runs spawned by the Task tool write their own nested `~/.claude/projects/<session>/subagents/*.jsonl` transcripts. These are modeled as child `agent_session` rows with `kind: subagent` and `parent_session_id` set, each with its own `session_transcript`.
+
+## Layer boundaries and invariants
+
+- State Layer only. No resume orchestration, dispatch logic, or scheduled runs live in Neotoma. Resume and re-dispatch live in ateles.
+- Immutability. The drainer writes via observations; corrections create new observations. Content-addressed transcript storage makes re-ingest of identical bytes a no-op.
+- Determinism. Entity and event ids are reproducible; the offset cursor and content hash make capture idempotent.
+- Schema-first. Behavior that varies by type is declared on the schema, not branched in code.
+
+## Resume fidelity ladder (ateles, Operational Layer)
+
+The `/resume-session` flow auto-selects the highest available tier; `--mode` can force one.
+
+1. **Native**: materialize the transcript from the `session_transcript` blob (or a reachable peer device), then `claude --resume` or `codex resume`. Exact fidelity, same session id.
+2. **Context injection**: start a fresh session in any harness and inject a reconstructed context block (summary plus the last N turns verbatim plus key entities), restoring model and effort from the `agent_session`. Portable, new session id.
+3. **Re-dispatch** (autonomous): re-fire the trigger or re-run the skill with the same task entity. Used for swarm runs, which have no UI to reopen. Builds on the existing ateles idempotent re-dispatch and gate-state recovery.
+
+Cross-harness transcript translation is intentionally not built.

--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,8 +61,8 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **593**
-- Backend and repo Vitest files: **558**
+- Total automated test files: **594**
+- Backend and repo Vitest files: **559**
 - Frontend Vitest files: **9**
 - Playwright spec files: **26**
 
@@ -73,7 +73,7 @@ flowchart TD
 | Vitest service tests | 44 |
 | Source-adjacent tests | 66 |
 | Vitest integration tests | 167 |
-| Vitest CLI tests | 77 |
+| Vitest CLI tests | 78 |
 | Vitest contract tests | 18 |
 | Vitest security tests | 7 |
 | Vitest subscription tests | 6 |
@@ -578,7 +578,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/cli`
 **Requirements:** Basic `.env`; some tests provision temp config homes automatically.
-**Files (77):**
+**Files (78):**
 - `tests/cli/api_client_offline_fallback.test.ts`
 - `tests/cli/backup_verify.test.ts`
 - `tests/cli/cli_access_commands.test.ts`
@@ -634,6 +634,7 @@ flowchart TD
 - `tests/cli/discovery_codex_sessions.test.ts`
 - `tests/cli/discovery_harness.test.ts`
 - `tests/cli/extract_user_cli_args.test.ts`
+- `tests/cli/ingest_agent_sessions.test.ts`
 - `tests/cli/instance_scripts.test.ts`
 - `tests/cli/instance_skills_client.test.ts`
 - `tests/cli/instance_skills.test.ts`

--- a/scripts/delete_by_harness.ts
+++ b/scripts/delete_by_harness.ts
@@ -1,0 +1,95 @@
+#!/usr/bin/env tsx
+/**
+ * Delete agent_session entities with a given harness value, via AAuth signing.
+ *
+ * Used to clean up the stale `claude_code` (underscore) agent_session entities
+ * after re-storing them under the standardized `claude-code` (hyphen) harness.
+ * agent_session identity is ["harness","native_session_id"], so the harness
+ * value is part of the canonical name — changing it creates NEW entities and
+ * leaves the old ones behind. This removes the old ones.
+ *
+ * Enumerates via POST /entities/query (snapshot_filters on harness) and deletes
+ * each via POST /delete_entity (reversible deletion observation). Both requests
+ * are AAuth-signed with the local keypair via cliSignedFetch, the same path as
+ * store_via_aauth.ts.
+ *
+ * Usage:
+ *   tsx scripts/delete_by_harness.ts [--harness claude_code] [--entity-type agent_session] [--base-url URL] [--dry-run]
+ */
+
+import { cliSignedFetch } from "../src/cli/aauth_signer.js";
+
+const args = process.argv.slice(2);
+const arg = (k: string, d?: string) => (args.includes(k) ? args[args.indexOf(k) + 1] : d);
+const baseUrl = arg("--base-url", "https://neotoma.markmhendrickson.com")!;
+const entityType = arg("--entity-type", "agent_session")!;
+const harness = arg("--harness", "claude_code")!;
+const dryRun = args.includes("--dry-run");
+
+async function queryPage(offset: number, limit: number): Promise<Array<{ entity_id: string }>> {
+  const res = await cliSignedFetch(`${baseUrl}/entities/query`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      entity_type: entityType,
+      snapshot_filters: { harness: { op: "eq", value: harness } },
+      include_snapshots: false,
+      include_merged: false,
+      limit,
+      offset,
+    }),
+  });
+  if (!res.ok) {
+    throw new Error(`query @${offset} failed ${res.status}: ${(await res.text()).slice(0, 300)}`);
+  }
+  const data = (await res.json()) as { entities?: Array<{ entity_id: string }> };
+  return data.entities ?? [];
+}
+
+// Enumerate all matching entity ids. Re-query from offset 0 each round is not
+// needed here because we read before deleting; collect everything first.
+const limit = 500;
+const ids: string[] = [];
+let offset = 0;
+for (;;) {
+  const page = await queryPage(offset, limit);
+  for (const e of page) ids.push(e.entity_id);
+  if (page.length < limit) break;
+  offset += limit;
+}
+console.log(
+  `${ids.length} ${entityType} entities with harness=${harness} -> ${baseUrl}/delete_entity${dryRun ? " (dry-run)" : ""}`,
+);
+
+let ok = 0;
+let fail = 0;
+for (const id of ids) {
+  if (dryRun) {
+    ok++;
+    continue;
+  }
+  let res: Response;
+  try {
+    res = await cliSignedFetch(`${baseUrl}/delete_entity`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        entity_id: id,
+        entity_type: entityType,
+        reason: `harness value standardization ${harness} -> claude-code`,
+      }),
+    });
+  } catch (err) {
+    fail++;
+    console.error(`\n  delete ${id} threw:`, (err as Error).message);
+    continue;
+  }
+  if (res.ok) {
+    ok++;
+  } else {
+    fail++;
+    if (fail <= 5) console.error(`\n  delete ${id} failed ${res.status}: ${(await res.text()).slice(0, 200)}`);
+  }
+  if ((ok + fail) % 100 === 0) process.stdout.write(`\r  ${ok + fail}/${ids.length}`);
+}
+console.log(`\ndelete complete: ${ok} ok, ${fail} failed${dryRun ? " (dry-run)" : ""}`);

--- a/scripts/ingest_agent_sessions.ts
+++ b/scripts/ingest_agent_sessions.ts
@@ -1,0 +1,285 @@
+#!/usr/bin/env tsx
+/**
+ * Ingest agent_session index entities from Claude Code transcripts.
+ *
+ * Walks ~/.claude/projects, extracts the runtime/resume metadata the existing
+ * transcript parser does not surface (cwd, git branch, model, kind), and stores
+ * one agent_session per session via the `neotoma store` CLI (same idempotent path
+ * as backfill_harness_transcripts.ts). Top-level sessions and Task sub-agent
+ * transcripts are both ingested; sub-agents are linked via parent_session_id.
+ *
+ * Each session emits an agent_session plus a session_transcript (linked by
+ * content_hash) and stores the raw transcript bytes content-addressed via
+ * `neotoma upload --local`.
+ *
+ * Usage:
+ *   tsx scripts/ingest_agent_sessions.ts [--dry-run] [--limit N] [--base-url URL] [--verbose]
+ */
+
+import fs from "node:fs/promises";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { createHash } from "node:crypto";
+import { execFileSync } from "node:child_process";
+
+const args = process.argv.slice(2);
+const dryRun = args.includes("--dry-run");
+const verbose = args.includes("--verbose");
+const limitArg = args.includes("--limit") ? parseInt(args[args.indexOf("--limit") + 1], 10) : null;
+const baseUrl =
+  (args.includes("--base-url") ? args[args.indexOf("--base-url") + 1] : null) ??
+  process.env.NEOTOMA_BASE_URL ??
+  "http://localhost:3180";
+
+const REPO_ROOT = path.join(import.meta.dirname ?? path.dirname(new URL(import.meta.url).pathname), "..");
+const TSX = path.join(REPO_ROOT, "node_modules", ".bin", "tsx");
+const CLI = path.join(REPO_ROOT, "src", "cli", "index.ts");
+const PROJECTS_DIR = path.join(os.homedir(), ".claude", "projects");
+const READ_BYTES = 500_000; // head window for metadata; enough for cwd + swarm marker
+
+function loadEnvFile(envPath: string): Record<string, string> {
+  const vars: Record<string, string> = {};
+  try {
+    for (const line of readFileSync(envPath, "utf-8").split("\n")) {
+      const t = line.trim();
+      if (!t || t.startsWith("#")) continue;
+      const eq = t.indexOf("=");
+      if (eq === -1) continue;
+      vars[t.slice(0, eq).trim()] = t.slice(eq + 1).trim().replace(/^["']|["']$/g, "");
+    }
+  } catch {
+    /* env file optional */
+  }
+  return vars;
+}
+
+const prodEnv = loadEnvFile(path.join(REPO_ROOT, ".env.production"));
+const childEnv: Record<string, string> = {
+  ...(process.env as Record<string, string>),
+  ...(prodEnv.NEOTOMA_BEARER_TOKEN ? { NEOTOMA_BEARER_TOKEN: prodEnv.NEOTOMA_BEARER_TOKEN } : {}),
+};
+
+interface SessionRecord {
+  entity_type: "agent_session";
+  harness: string;
+  native_session_id: string;
+  kind: string;
+  cwd: string | null;
+  repo: string | null;
+  source_branch: string | null;
+  branch: string | null;
+  worktree_path: string | null;
+  model: string | null;
+  message_count: number;
+  created_at: string | null;
+  last_activity_at: string | null;
+  parent_session_id: string | null;
+  _contentHash: string; // internal: idempotency + transcript content link, not stored
+  _filePath: string; // internal: source path for blob upload, not stored
+  _fileSize: number; // internal, not stored
+}
+
+/** Recursively collect transcript files: top-level sessions and nested sub-agents. */
+async function collectTranscripts(): Promise<{ topLevel: string[]; subAgents: string[] }> {
+  const topLevel: string[] = [];
+  const subAgents: string[] = [];
+  let projectDirs: string[];
+  try {
+    projectDirs = (await fs.readdir(PROJECTS_DIR, { withFileTypes: true }))
+      .filter((d) => d.isDirectory())
+      .map((d) => path.join(PROJECTS_DIR, d.name));
+  } catch {
+    return { topLevel, subAgents };
+  }
+  for (const dir of projectDirs) {
+    let entries;
+    try {
+      entries = await fs.readdir(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const e of entries) {
+      const full = path.join(dir, e.name);
+      if (e.isFile() && e.name.endsWith(".jsonl")) {
+        topLevel.push(full);
+      } else if (e.isDirectory()) {
+        const subDir = path.join(full, "subagents");
+        try {
+          for (const s of await fs.readdir(subDir)) {
+            if (s.endsWith(".jsonl")) subAgents.push(path.join(subDir, s));
+          }
+        } catch {
+          /* no subagents dir */
+        }
+      }
+    }
+  }
+  return { topLevel, subAgents };
+}
+
+function extractMetadata(
+  filePath: string,
+  kind: string,
+  parentSessionId: string | null,
+): SessionRecord {
+  const buf = readFileSync(filePath);
+  const contentHash = createHash("sha256").update(buf).digest("hex");
+  const head = buf.subarray(0, READ_BYTES).toString("utf-8");
+  const isSwarm = head.includes("ateles-swarm");
+
+  let cwd: string | null = null;
+  let created: string | null = null;
+  let gitBranch: string | null = null;
+  let model: string | null = null;
+  let messageCount = 0;
+
+  // Read message lines, not line one: cwd/gitBranch live on message rows, not the
+  // leading hook/summary event. Validated: line-one-only leaves cwd null on ~91%.
+  for (const line of head.split("\n")) {
+    if (!line) continue;
+    let o: any;
+    try {
+      o = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (!created && o.timestamp) created = o.timestamp;
+    if (!cwd && o.cwd) cwd = o.cwd;
+    if (!gitBranch && o.gitBranch) gitBranch = o.gitBranch;
+    if (!model && o.message?.model) model = o.message.model;
+    if (o.type === "user" || o.type === "assistant") messageCount++;
+  }
+
+  const worktree = cwd && cwd.includes("/.claude/worktrees/") ? cwd : null;
+  const repo = cwd && cwd.includes("/repos/") ? cwd.split("/repos/")[1].split("/")[0] : null;
+  const resolvedKind = kind === "subagent" ? "subagent" : isSwarm ? "autonomous" : "interactive";
+
+  return {
+    entity_type: "agent_session",
+    harness: "claude_code",
+    native_session_id: path.basename(filePath, ".jsonl"),
+    kind: resolvedKind,
+    cwd,
+    repo,
+    source_branch: null,
+    branch: gitBranch,
+    worktree_path: worktree,
+    model,
+    message_count: messageCount,
+    created_at: created,
+    last_activity_at: null, // set from mtime below
+    parent_session_id: parentSessionId,
+    _contentHash: contentHash,
+    _filePath: filePath,
+    _fileSize: buf.length,
+  };
+}
+
+function idempotencyKey(rec: SessionRecord): string {
+  // Same content -> same key (server skips); changed content -> new observation
+  // that merges onto the entity via its [harness, native_session_id] identity.
+  return `agent-session-${rec.native_session_id}-${rec._contentHash.slice(0, 12)}`;
+}
+
+/**
+ * Store the raw transcript bytes content-addressed in the sources bucket via the
+ * in-process storeRawContent path (`neotoma upload --local`). Best-effort: the
+ * session_transcript entity links to the bytes by content_hash, so a failed
+ * upload still leaves a valid (if blob-less) index entry to retry later.
+ */
+function uploadTranscriptBlob(rec: SessionRecord): boolean {
+  try {
+    execFileSync(
+      TSX,
+      [CLI, "upload", rec._filePath, "--local",
+        "--idempotency-key", `transcript-${rec._contentHash.slice(0, 16)}`,
+        "--mime-type", "application/jsonl"],
+      { stdio: verbose ? "inherit" : "pipe", encoding: "utf-8", env: childEnv },
+    );
+    return true;
+  } catch (err: any) {
+    if (verbose) console.error(`  blob upload failed ${rec.native_session_id}:`, err.stderr ?? err.message ?? err);
+    return false;
+  }
+}
+
+async function storeOne(rec: SessionRecord): Promise<"ok" | "failed"> {
+  const { _contentHash, _filePath, _fileSize, ...session } = rec;
+  // session_transcript links to the stored bytes by content_hash (same SHA-256
+  // that storeRawContent computes), so source_id/storage_url need not be parsed.
+  const transcript = {
+    entity_type: "session_transcript",
+    content_hash: _contentHash,
+    file_size: _fileSize,
+    mime_type: "application/jsonl",
+    harness: "claude_code",
+    format: "claude_code_jsonl",
+    transcript_kind: rec.kind === "subagent" ? "subagent" : "main",
+    agent_session_id: rec.native_session_id,
+  };
+  const tmp = path.join(os.tmpdir(), `neotoma-agent-session-${rec.native_session_id}.json`);
+  try {
+    await fs.writeFile(tmp, JSON.stringify([session, transcript], null, 2));
+    if (dryRun) return "ok";
+    uploadTranscriptBlob(rec); // best-effort: stores raw bytes keyed by content_hash
+    execFileSync(
+      TSX,
+      [CLI, "store", "--file", tmp, "--observation-source", "import",
+        "--idempotency-key", idempotencyKey(rec), "--base-url", baseUrl, "--no-log-file"],
+      { stdio: verbose ? "inherit" : "pipe", encoding: "utf-8", env: childEnv },
+    );
+    return "ok";
+  } catch (err: any) {
+    if (verbose) console.error(`  store failed ${rec.native_session_id}:`, err.stderr ?? err.message ?? err);
+    return "failed";
+  } finally {
+    await fs.unlink(tmp).catch(() => {});
+  }
+}
+
+async function main() {
+  const { topLevel, subAgents } = await collectTranscripts();
+  const parentOf = (subPath: string) => path.basename(path.dirname(path.dirname(subPath)));
+
+  let items: Array<{ file: string; kind: string; parent: string | null }> = [
+    ...topLevel.map((f) => ({ file: f, kind: "auto", parent: null })),
+    ...subAgents.map((f) => ({ file: f, kind: "subagent", parent: parentOf(f) })),
+  ];
+  if (limitArg) items = items.slice(0, limitArg);
+
+  console.log(
+    `Found ${topLevel.length} sessions + ${subAgents.length} sub-agents. ` +
+      `Ingesting ${items.length}${dryRun ? " (dry-run)" : ""} -> ${baseUrl}`,
+  );
+
+  const counts = { ok: 0, failed: 0 };
+  const byKind: Record<string, number> = {};
+  for (let i = 0; i < items.length; i++) {
+    const { file, kind, parent } = items[i];
+    let rec: SessionRecord;
+    try {
+      rec = extractMetadata(file, kind, parent);
+      rec.last_activity_at = (await fs.stat(file)).mtime.toISOString();
+    } catch (err: any) {
+      counts.failed++;
+      if (verbose) console.error(`  read failed ${file}:`, err.message ?? err);
+      continue;
+    }
+    byKind[rec.kind] = (byKind[rec.kind] ?? 0) + 1;
+    const res = await storeOne(rec);
+    counts[res]++;
+    if (verbose || (i + 1) % 100 === 0) {
+      console.log(`  [${i + 1}/${items.length}] ${rec.native_session_id} kind=${rec.kind} repo=${rec.repo ?? "-"}`);
+    }
+  }
+
+  console.log(`\n${"-".repeat(60)}`);
+  console.log(`Ingest complete: ${counts.ok} ok, ${counts.failed} failed. By kind:`, byKind);
+  if (dryRun) console.log("(dry-run - nothing stored)");
+}
+
+main().catch((err) => {
+  console.error("Fatal:", err);
+  process.exit(1);
+});

--- a/scripts/ingest_agent_sessions.ts
+++ b/scripts/ingest_agent_sessions.ts
@@ -157,7 +157,7 @@ function extractMetadata(
 
   return {
     entity_type: "agent_session",
-    harness: "claude_code",
+    harness: "claude-code",
     native_session_id: path.basename(filePath, ".jsonl"),
     kind: resolvedKind,
     cwd,
@@ -213,7 +213,7 @@ async function storeOne(rec: SessionRecord): Promise<"ok" | "failed"> {
     content_hash: _contentHash,
     file_size: _fileSize,
     mime_type: "application/jsonl",
-    harness: "claude_code",
+    harness: "claude-code",
     format: "claude_code_jsonl",
     transcript_kind: rec.kind === "subagent" ? "subagent" : "main",
     agent_session_id: rec.native_session_id,

--- a/scripts/ingest_agent_sessions.ts
+++ b/scripts/ingest_agent_sessions.ts
@@ -12,12 +12,23 @@
  * content_hash) and stores the raw transcript bytes content-addressed via
  * `neotoma upload --local`.
  *
+ * Parent / transcript linking (arch review PR #1743):
+ * Two-pass ingestion — store all top-level sessions first, build a
+ * `native_session_id → entity_id` map from store JSON responses, then store
+ * sub-agents with `parent_session_id` set to the parent's **entity_id** and a
+ * typed PART_OF relationship (`source_index` → `target_entity_id`). Within a
+ * single session store, `[session, transcript]` is written together with
+ * `relationships: [{ PART_OF, source_index: 1, target_index: 0 }]`; after the
+ * store response yields the session entity_id, a follow-up observation sets
+ * `session_transcript.agent_session_id` to that entity_id (FK is entity_id,
+ * not the harness-scoped native id — joint identity is [harness, native_session_id]).
+ *
  * Usage:
  *   tsx scripts/ingest_agent_sessions.ts [--dry-run] [--limit N] [--base-url URL] [--verbose]
  */
 
 import fs from "node:fs/promises";
-import { readFileSync } from "node:fs";
+import { readFileSync, writeFileSync, unlinkSync } from "node:fs";
 import path from "node:path";
 import os from "node:os";
 import { createHash } from "node:crypto";
@@ -32,11 +43,15 @@ const baseUrl =
   process.env.NEOTOMA_BASE_URL ??
   "http://localhost:3180";
 
-const REPO_ROOT = path.join(import.meta.dirname ?? path.dirname(new URL(import.meta.url).pathname), "..");
+const REPO_ROOT = path.join(
+  import.meta.dirname ?? path.dirname(new URL(import.meta.url).pathname),
+  ".."
+);
 const TSX = path.join(REPO_ROOT, "node_modules", ".bin", "tsx");
 const CLI = path.join(REPO_ROOT, "src", "cli", "index.ts");
 const PROJECTS_DIR = path.join(os.homedir(), ".claude", "projects");
 const READ_BYTES = 500_000; // head window for metadata; enough for cwd + swarm marker
+const HARNESS = "claude-code";
 
 function loadEnvFile(envPath: string): Record<string, string> {
   const vars: Record<string, string> = {};
@@ -46,7 +61,10 @@ function loadEnvFile(envPath: string): Record<string, string> {
       if (!t || t.startsWith("#")) continue;
       const eq = t.indexOf("=");
       if (eq === -1) continue;
-      vars[t.slice(0, eq).trim()] = t.slice(eq + 1).trim().replace(/^["']|["']$/g, "");
+      vars[t.slice(0, eq).trim()] = t
+        .slice(eq + 1)
+        .trim()
+        .replace(/^["']|["']$/g, "");
     }
   } catch {
     /* env file optional */
@@ -60,7 +78,7 @@ const childEnv: Record<string, string> = {
   ...(prodEnv.NEOTOMA_BEARER_TOKEN ? { NEOTOMA_BEARER_TOKEN: prodEnv.NEOTOMA_BEARER_TOKEN } : {}),
 };
 
-interface SessionRecord {
+export interface SessionRecord {
   entity_type: "agent_session";
   harness: string;
   native_session_id: string;
@@ -74,21 +92,31 @@ interface SessionRecord {
   message_count: number;
   created_at: string | null;
   last_activity_at: string | null;
+  /** Parent agent_session entity_id once resolved; null for top-level. */
   parent_session_id: string | null;
+  /** Internal: parent native id before entity_id resolution (not stored). */
+  _parentNativeSessionId: string | null;
   _contentHash: string; // internal: idempotency + transcript content link, not stored
   _filePath: string; // internal: source path for blob upload, not stored
   _fileSize: number; // internal, not stored
 }
 
+export interface StoreEnvelope {
+  entities: Array<Record<string, unknown>>;
+  relationships: Array<Record<string, unknown>>;
+}
+
 /** Recursively collect transcript files: top-level sessions and nested sub-agents. */
-async function collectTranscripts(): Promise<{ topLevel: string[]; subAgents: string[] }> {
+export async function collectTranscripts(
+  projectsDir: string = PROJECTS_DIR
+): Promise<{ topLevel: string[]; subAgents: string[] }> {
   const topLevel: string[] = [];
   const subAgents: string[] = [];
   let projectDirs: string[];
   try {
-    projectDirs = (await fs.readdir(PROJECTS_DIR, { withFileTypes: true }))
+    projectDirs = (await fs.readdir(projectsDir, { withFileTypes: true }))
       .filter((d) => d.isDirectory())
-      .map((d) => path.join(PROJECTS_DIR, d.name));
+      .map((d) => path.join(projectsDir, d.name));
   } catch {
     return { topLevel, subAgents };
   }
@@ -118,13 +146,23 @@ async function collectTranscripts(): Promise<{ topLevel: string[]; subAgents: st
   return { topLevel, subAgents };
 }
 
-function extractMetadata(
+export function contentHashOf(buf: Buffer): string {
+  return createHash("sha256").update(buf).digest("hex");
+}
+
+/**
+ * Extract runtime/resume metadata from a transcript. cwd / gitBranch / model
+ * live on message rows, not the leading hook/summary event — reading only
+ * line 1 leaves cwd null on ~91% of real transcripts.
+ */
+export function extractMetadata(
   filePath: string,
   kind: string,
-  parentSessionId: string | null,
+  parentNativeSessionId: string | null,
+  fileContents?: Buffer
 ): SessionRecord {
-  const buf = readFileSync(filePath);
-  const contentHash = createHash("sha256").update(buf).digest("hex");
+  const buf = fileContents ?? readFileSync(filePath);
+  const contentHash = contentHashOf(buf);
   const head = buf.subarray(0, READ_BYTES).toString("utf-8");
   const isSwarm = head.includes("ateles-swarm");
 
@@ -134,20 +172,19 @@ function extractMetadata(
   let model: string | null = null;
   let messageCount = 0;
 
-  // Read message lines, not line one: cwd/gitBranch live on message rows, not the
-  // leading hook/summary event. Validated: line-one-only leaves cwd null on ~91%.
   for (const line of head.split("\n")) {
     if (!line) continue;
-    let o: any;
+    let o: Record<string, unknown>;
     try {
-      o = JSON.parse(line);
+      o = JSON.parse(line) as Record<string, unknown>;
     } catch {
       continue;
     }
-    if (!created && o.timestamp) created = o.timestamp;
-    if (!cwd && o.cwd) cwd = o.cwd;
-    if (!gitBranch && o.gitBranch) gitBranch = o.gitBranch;
-    if (!model && o.message?.model) model = o.message.model;
+    if (!created && typeof o.timestamp === "string") created = o.timestamp;
+    if (!cwd && typeof o.cwd === "string") cwd = o.cwd;
+    if (!gitBranch && typeof o.gitBranch === "string") gitBranch = o.gitBranch;
+    const message = o.message as { model?: string } | undefined;
+    if (!model && message?.model) model = message.model;
     if (o.type === "user" || o.type === "assistant") messageCount++;
   }
 
@@ -157,7 +194,7 @@ function extractMetadata(
 
   return {
     entity_type: "agent_session",
-    harness: "claude-code",
+    harness: HARNESS,
     native_session_id: path.basename(filePath, ".jsonl"),
     kind: resolvedKind,
     cwd,
@@ -168,18 +205,93 @@ function extractMetadata(
     model,
     message_count: messageCount,
     created_at: created,
-    last_activity_at: null, // set from mtime below
-    parent_session_id: parentSessionId,
+    last_activity_at: null,
+    parent_session_id: null, // filled with entity_id after parent pass
+    _parentNativeSessionId: parentNativeSessionId,
     _contentHash: contentHash,
     _filePath: filePath,
     _fileSize: buf.length,
   };
 }
 
-function idempotencyKey(rec: SessionRecord): string {
-  // Same content -> same key (server skips); changed content -> new observation
-  // that merges onto the entity via its [harness, native_session_id] identity.
-  return `agent-session-${rec.native_session_id}-${rec._contentHash.slice(0, 12)}`;
+export function idempotencyKey(rec: SessionRecord): string {
+  // v2: payload now includes entity_id FKs + PART_OF relationships. Bumping the
+  // key namespace avoids ERR_IDEMPOTENCY_MISMATCH against pre-fix v1 ingests
+  // that used the same content hash but a different entity/relationship shape.
+  return `agent-session-v2-${rec.native_session_id}-${rec._contentHash.slice(0, 12)}`;
+}
+
+export function transcriptIdempotencyKey(contentHash: string): string {
+  return `transcript-${contentHash.slice(0, 16)}`;
+}
+
+/**
+ * Build the store envelope for [session, transcript].
+ * `sessionEntityId` — when known (re-ingest), set as transcript.agent_session_id.
+ * `parentEntityId` — parent agent_session entity_id for sub-agents.
+ */
+export function buildStoreEnvelope(
+  rec: SessionRecord,
+  opts: { sessionEntityId?: string | null; parentEntityId?: string | null } = {}
+): StoreEnvelope {
+  const {
+    _contentHash,
+    _filePath: _fp,
+    _fileSize,
+    _parentNativeSessionId: _p,
+    ...sessionFields
+  } = rec;
+  const session: Record<string, unknown> = {
+    ...sessionFields,
+    parent_session_id: opts.parentEntityId ?? null,
+  };
+
+  const transcript: Record<string, unknown> = {
+    entity_type: "session_transcript",
+    content_hash: _contentHash,
+    file_size: _fileSize,
+    mime_type: "application/jsonl",
+    harness: HARNESS,
+    format: "claude_code_jsonl",
+    transcript_kind: rec.kind === "subagent" ? "subagent" : "main",
+    // Prefer entity_id when known; null on first write until follow-up fill.
+    agent_session_id: opts.sessionEntityId ?? null,
+  };
+
+  const relationships: Array<Record<string, unknown>> = [
+    // transcript PART_OF session (same-request index pair)
+    { relationship_type: "PART_OF", source_index: 1, target_index: 0 },
+  ];
+  if (opts.parentEntityId) {
+    // sub-agent session PART_OF parent session (cross-request target id)
+    relationships.push({
+      relationship_type: "PART_OF",
+      source_index: 0,
+      target_entity_id: opts.parentEntityId,
+    });
+  }
+
+  return { entities: [session, transcript], relationships };
+}
+
+/** Parse `neotoma store --json` stdout for the agent_session entity_id. */
+export function parseSessionEntityIdFromStoreOutput(stdout: string): string | null {
+  try {
+    const data = JSON.parse(stdout) as {
+      entities?: Array<{ entity_id?: string; id?: string; entity_type?: string }>;
+      entities_created?: Array<{ id?: string }>;
+    };
+    const typed = (data.entities ?? []).find((e) => e.entity_type === "agent_session");
+    if (typed?.entity_id) return typed.entity_id;
+    if (typed?.id) return typed.id;
+    const first =
+      data.entities_created?.[0]?.id ?? data.entities?.[0]?.entity_id ?? data.entities?.[0]?.id;
+    return typeof first === "string" && first.length > 0 ? first : null;
+  } catch {
+    // Pretty mode or mixed stderr: scan for ent_ tokens near agent_session.
+    const m = stdout.match(/ent_[a-f0-9]{16,}/);
+    return m ? m[0] : null;
+  }
 }
 
 /**
@@ -188,90 +300,200 @@ function idempotencyKey(rec: SessionRecord): string {
  * session_transcript entity links to the bytes by content_hash, so a failed
  * upload still leaves a valid (if blob-less) index entry to retry later.
  */
-function uploadTranscriptBlob(rec: SessionRecord): boolean {
+export function uploadTranscriptBlob(rec: SessionRecord): boolean {
   try {
     execFileSync(
       TSX,
-      [CLI, "upload", rec._filePath, "--local",
-        "--idempotency-key", `transcript-${rec._contentHash.slice(0, 16)}`,
-        "--mime-type", "application/jsonl"],
-      { stdio: verbose ? "inherit" : "pipe", encoding: "utf-8", env: childEnv },
+      [
+        CLI,
+        "upload",
+        rec._filePath,
+        "--local",
+        "--idempotency-key",
+        transcriptIdempotencyKey(rec._contentHash),
+        "--mime-type",
+        "application/jsonl",
+        "--json",
+      ],
+      { stdio: verbose ? "inherit" : "pipe", encoding: "utf-8", env: childEnv }
     );
     return true;
-  } catch (err: any) {
-    if (verbose) console.error(`  blob upload failed ${rec.native_session_id}:`, err.stderr ?? err.message ?? err);
+  } catch (err: unknown) {
+    const e = err as { stderr?: string; message?: string };
+    if (verbose)
+      console.error(`  blob upload failed ${rec.native_session_id}:`, e.stderr ?? e.message ?? err);
     return false;
   }
 }
 
-async function storeOne(rec: SessionRecord): Promise<"ok" | "failed"> {
-  const { _contentHash, _filePath, _fileSize, ...session } = rec;
-  // session_transcript links to the stored bytes by content_hash (same SHA-256
-  // that storeRawContent computes), so source_id/storage_url need not be parsed.
-  const transcript = {
-    entity_type: "session_transcript",
-    content_hash: _contentHash,
-    file_size: _fileSize,
-    mime_type: "application/jsonl",
-    harness: "claude-code",
-    format: "claude_code_jsonl",
-    transcript_kind: rec.kind === "subagent" ? "subagent" : "main",
-    agent_session_id: rec.native_session_id,
-  };
-  const tmp = path.join(os.tmpdir(), `neotoma-agent-session-${rec.native_session_id}.json`);
+function runStore(envelope: StoreEnvelope, key: string): { ok: boolean; stdout: string } {
+  const tmp = path.join(os.tmpdir(), `neotoma-agent-session-${key}.json`);
   try {
-    await fs.writeFile(tmp, JSON.stringify([session, transcript], null, 2));
-    if (dryRun) return "ok";
-    uploadTranscriptBlob(rec); // best-effort: stores raw bytes keyed by content_hash
-    execFileSync(
+    writeFileSync(tmp, JSON.stringify(envelope, null, 2));
+    if (dryRun) return { ok: true, stdout: "{}" };
+    const stdout = execFileSync(
       TSX,
-      [CLI, "store", "--file", tmp, "--observation-source", "import",
-        "--idempotency-key", idempotencyKey(rec), "--base-url", baseUrl, "--no-log-file"],
-      { stdio: verbose ? "inherit" : "pipe", encoding: "utf-8", env: childEnv },
+      [
+        CLI,
+        "store",
+        "--file",
+        tmp,
+        "--observation-source",
+        "import",
+        "--idempotency-key",
+        key,
+        "--base-url",
+        baseUrl,
+        "--no-log-file",
+        "--json",
+      ],
+      { stdio: ["pipe", "pipe", verbose ? "inherit" : "pipe"], encoding: "utf-8", env: childEnv }
     );
-    return "ok";
-  } catch (err: any) {
-    if (verbose) console.error(`  store failed ${rec.native_session_id}:`, err.stderr ?? err.message ?? err);
-    return "failed";
+    return { ok: true, stdout: typeof stdout === "string" ? stdout : String(stdout) };
+  } catch (err: unknown) {
+    const e = err as { stderr?: string; message?: string; stdout?: string };
+    if (verbose) console.error(`  store failed ${key}:`, e.stderr ?? e.message ?? err);
+    return { ok: false, stdout: e.stdout ?? "" };
   } finally {
-    await fs.unlink(tmp).catch(() => {});
+    try {
+      unlinkSync(tmp);
+    } catch {
+      /* ignore */
+    }
   }
+}
+
+/**
+ * Fill session_transcript.agent_session_id with the session entity_id after the
+ * initial store (same content_hash identity → merges onto the transcript row).
+ * Returns false if the follow-up store fails (caller should treat as failed).
+ */
+function fillTranscriptSessionFk(contentHash: string, sessionEntityId: string): boolean {
+  if (dryRun) return true;
+  const envelope: StoreEnvelope = {
+    entities: [
+      {
+        entity_type: "session_transcript",
+        content_hash: contentHash,
+        agent_session_id: sessionEntityId,
+      },
+    ],
+    relationships: [
+      {
+        relationship_type: "PART_OF",
+        source_index: 0,
+        target_entity_id: sessionEntityId,
+      },
+    ],
+  };
+  return runStore(envelope, `agent-session-fk-v2-${contentHash.slice(0, 12)}`).ok;
+}
+
+export async function storeOne(
+  rec: SessionRecord,
+  sessionEntityIds: Map<string, string>
+): Promise<"ok" | "failed"> {
+  const parentEntityId =
+    rec._parentNativeSessionId != null
+      ? (sessionEntityIds.get(rec._parentNativeSessionId) ?? null)
+      : null;
+
+  if (rec._parentNativeSessionId && !parentEntityId && verbose) {
+    console.error(
+      `  parent entity_id unresolved for native_session_id=${rec._parentNativeSessionId} ` +
+        `(harness=${HARNESS}); storing sub-agent without parent PART_OF edge`
+    );
+  }
+
+  const envelope = buildStoreEnvelope(rec, {
+    parentEntityId,
+    sessionEntityId: sessionEntityIds.get(rec.native_session_id) ?? null,
+  });
+
+  if (dryRun) return "ok";
+  uploadTranscriptBlob(rec);
+  const { ok, stdout } = runStore(envelope, idempotencyKey(rec));
+  if (!ok) return "failed";
+
+  const sessionEntityId = parseSessionEntityIdFromStoreOutput(stdout);
+  if (sessionEntityId) {
+    sessionEntityIds.set(rec.native_session_id, sessionEntityId);
+    // Ensure denormalized FK holds entity_id (not native id).
+    if (!envelope.entities[1]?.agent_session_id) {
+      if (!fillTranscriptSessionFk(rec._contentHash, sessionEntityId)) {
+        if (verbose) {
+          console.error(
+            `  FK fill failed for transcript content_hash=${rec._contentHash.slice(0, 12)} ` +
+              `session=${sessionEntityId}`
+          );
+        }
+        return "failed";
+      }
+    }
+  } else if (verbose) {
+    console.error(
+      `  could not parse session entity_id from store output for ${rec.native_session_id}`
+    );
+  }
+  return "ok";
 }
 
 async function main() {
   const { topLevel, subAgents } = await collectTranscripts();
   const parentOf = (subPath: string) => path.basename(path.dirname(path.dirname(subPath)));
 
-  let items: Array<{ file: string; kind: string; parent: string | null }> = [
-    ...topLevel.map((f) => ({ file: f, kind: "auto", parent: null })),
-    ...subAgents.map((f) => ({ file: f, kind: "subagent", parent: parentOf(f) })),
-  ];
-  if (limitArg) items = items.slice(0, limitArg);
+  // Two-pass: top-level first so sub-agent parent entity_ids resolve.
+  let topItems = topLevel.map((f) => ({ file: f, kind: "auto", parent: null as string | null }));
+  let subItems = subAgents.map((f) => ({
+    file: f,
+    kind: "subagent",
+    parent: parentOf(f) as string | null,
+  }));
+  if (limitArg) {
+    const combined = [...topItems, ...subItems].slice(0, limitArg);
+    topItems = combined.filter((i) => i.kind !== "subagent");
+    subItems = combined.filter((i) => i.kind === "subagent");
+  }
 
+  const total = topItems.length + subItems.length;
   console.log(
     `Found ${topLevel.length} sessions + ${subAgents.length} sub-agents. ` +
-      `Ingesting ${items.length}${dryRun ? " (dry-run)" : ""} -> ${baseUrl}`,
+      `Ingesting ${total}${dryRun ? " (dry-run)" : ""} -> ${baseUrl} (two-pass parent linking)`
   );
 
+  const sessionEntityIds = new Map<string, string>();
   const counts = { ok: 0, failed: 0 };
   const byKind: Record<string, number> = {};
-  for (let i = 0; i < items.length; i++) {
-    const { file, kind, parent } = items[i];
+
+  async function ingestItem(
+    item: { file: string; kind: string; parent: string | null },
+    index: number
+  ) {
     let rec: SessionRecord;
     try {
-      rec = extractMetadata(file, kind, parent);
-      rec.last_activity_at = (await fs.stat(file)).mtime.toISOString();
-    } catch (err: any) {
+      rec = extractMetadata(item.file, item.kind, item.parent);
+      rec.last_activity_at = (await fs.stat(item.file)).mtime.toISOString();
+    } catch (err: unknown) {
       counts.failed++;
-      if (verbose) console.error(`  read failed ${file}:`, err.message ?? err);
-      continue;
+      if (verbose) console.error(`  read failed ${item.file}:`, (err as Error).message ?? err);
+      return;
     }
     byKind[rec.kind] = (byKind[rec.kind] ?? 0) + 1;
-    const res = await storeOne(rec);
+    const res = await storeOne(rec, sessionEntityIds);
     counts[res]++;
-    if (verbose || (i + 1) % 100 === 0) {
-      console.log(`  [${i + 1}/${items.length}] ${rec.native_session_id} kind=${rec.kind} repo=${rec.repo ?? "-"}`);
+    if (verbose || (index + 1) % 100 === 0) {
+      console.log(
+        `  [${index + 1}/${total}] ${rec.native_session_id} kind=${rec.kind} repo=${rec.repo ?? "-"}`
+      );
     }
+  }
+
+  let i = 0;
+  for (const item of topItems) {
+    await ingestItem(item, i++);
+  }
+  for (const item of subItems) {
+    await ingestItem(item, i++);
   }
 
   console.log(`\n${"-".repeat(60)}`);
@@ -279,7 +501,14 @@ async function main() {
   if (dryRun) console.log("(dry-run - nothing stored)");
 }
 
-main().catch((err) => {
-  console.error("Fatal:", err);
-  process.exit(1);
-});
+const isDirectRun =
+  process.argv[1] != null &&
+  (process.argv[1].endsWith("ingest_agent_sessions.ts") ||
+    process.argv[1].endsWith("ingest_agent_sessions.js"));
+
+if (isDirectRun) {
+  main().catch((err) => {
+    console.error("Fatal:", err);
+    process.exit(1);
+  });
+}

--- a/scripts/ingest_agent_sessions.ts
+++ b/scripts/ingest_agent_sessions.ts
@@ -33,6 +33,17 @@ import path from "node:path";
 import os from "node:os";
 import { createHash } from "node:crypto";
 import { execFileSync } from "node:child_process";
+import {
+  buildSessionTranscriptEnvelope,
+  buildTranscriptSessionFkEnvelope,
+  type SessionStoreRecord,
+  type StoreEnvelope,
+} from "./lib/agent_session_store.js";
+
+export type { StoreEnvelope, SessionStoreRecord };
+export { buildSessionTranscriptEnvelope, buildTranscriptSessionFkEnvelope };
+/** @deprecated Prefer buildSessionTranscriptEnvelope — kept for existing imports/tests. */
+export const buildStoreEnvelope = buildSessionTranscriptEnvelope;
 
 const args = process.argv.slice(2);
 const dryRun = args.includes("--dry-run");
@@ -78,33 +89,7 @@ const childEnv: Record<string, string> = {
   ...(prodEnv.NEOTOMA_BEARER_TOKEN ? { NEOTOMA_BEARER_TOKEN: prodEnv.NEOTOMA_BEARER_TOKEN } : {}),
 };
 
-export interface SessionRecord {
-  entity_type: "agent_session";
-  harness: string;
-  native_session_id: string;
-  kind: string;
-  cwd: string | null;
-  repo: string | null;
-  source_branch: string | null;
-  branch: string | null;
-  worktree_path: string | null;
-  model: string | null;
-  message_count: number;
-  created_at: string | null;
-  last_activity_at: string | null;
-  /** Parent agent_session entity_id once resolved; null for top-level. */
-  parent_session_id: string | null;
-  /** Internal: parent native id before entity_id resolution (not stored). */
-  _parentNativeSessionId: string | null;
-  _contentHash: string; // internal: idempotency + transcript content link, not stored
-  _filePath: string; // internal: source path for blob upload, not stored
-  _fileSize: number; // internal, not stored
-}
-
-export interface StoreEnvelope {
-  entities: Array<Record<string, unknown>>;
-  relationships: Array<Record<string, unknown>>;
-}
+export type SessionRecord = SessionStoreRecord;
 
 /** Recursively collect transcript files: top-level sessions and nested sub-agents. */
 export async function collectTranscripts(
@@ -225,55 +210,6 @@ export function transcriptIdempotencyKey(contentHash: string): string {
   return `transcript-${contentHash.slice(0, 16)}`;
 }
 
-/**
- * Build the store envelope for [session, transcript].
- * `sessionEntityId` — when known (re-ingest), set as transcript.agent_session_id.
- * `parentEntityId` — parent agent_session entity_id for sub-agents.
- */
-export function buildStoreEnvelope(
-  rec: SessionRecord,
-  opts: { sessionEntityId?: string | null; parentEntityId?: string | null } = {}
-): StoreEnvelope {
-  const {
-    _contentHash,
-    _filePath: _fp,
-    _fileSize,
-    _parentNativeSessionId: _p,
-    ...sessionFields
-  } = rec;
-  const session: Record<string, unknown> = {
-    ...sessionFields,
-    parent_session_id: opts.parentEntityId ?? null,
-  };
-
-  const transcript: Record<string, unknown> = {
-    entity_type: "session_transcript",
-    content_hash: _contentHash,
-    file_size: _fileSize,
-    mime_type: "application/jsonl",
-    harness: HARNESS,
-    format: "claude_code_jsonl",
-    transcript_kind: rec.kind === "subagent" ? "subagent" : "main",
-    // Prefer entity_id when known; null on first write until follow-up fill.
-    agent_session_id: opts.sessionEntityId ?? null,
-  };
-
-  const relationships: Array<Record<string, unknown>> = [
-    // transcript PART_OF session (same-request index pair)
-    { relationship_type: "PART_OF", source_index: 1, target_index: 0 },
-  ];
-  if (opts.parentEntityId) {
-    // sub-agent session PART_OF parent session (cross-request target id)
-    relationships.push({
-      relationship_type: "PART_OF",
-      source_index: 0,
-      target_entity_id: opts.parentEntityId,
-    });
-  }
-
-  return { entities: [session, transcript], relationships };
-}
-
 /** Parse `neotoma store --json` stdout for the agent_session entity_id. */
 export function parseSessionEntityIdFromStoreOutput(stdout: string): string | null {
   try {
@@ -370,22 +306,7 @@ function runStore(envelope: StoreEnvelope, key: string): { ok: boolean; stdout: 
  */
 function fillTranscriptSessionFk(contentHash: string, sessionEntityId: string): boolean {
   if (dryRun) return true;
-  const envelope: StoreEnvelope = {
-    entities: [
-      {
-        entity_type: "session_transcript",
-        content_hash: contentHash,
-        agent_session_id: sessionEntityId,
-      },
-    ],
-    relationships: [
-      {
-        relationship_type: "PART_OF",
-        source_index: 0,
-        target_entity_id: sessionEntityId,
-      },
-    ],
-  };
+  const envelope = buildTranscriptSessionFkEnvelope(contentHash, sessionEntityId);
   return runStore(envelope, `agent-session-fk-v2-${contentHash.slice(0, 12)}`).ok;
 }
 

--- a/scripts/lib/agent_session_store.ts
+++ b/scripts/lib/agent_session_store.ts
@@ -1,0 +1,164 @@
+/**
+ * Shared agent_session + session_transcript store envelope construction.
+ *
+ * Used by both the Bearer CLI ingest path (`ingest_agent_sessions.ts`) and the
+ * AAuth bulk path (`store_via_aauth.ts`) so PART_OF relationship shape stays
+ * identical across surfaces (cross_surface_contract_parity_tested_all_surfaces).
+ */
+
+export interface SessionStoreRecord {
+  entity_type: "agent_session";
+  harness: string;
+  native_session_id: string;
+  kind: string;
+  cwd: string | null;
+  repo: string | null;
+  source_branch: string | null;
+  branch: string | null;
+  worktree_path: string | null;
+  model: string | null;
+  message_count: number;
+  created_at: string | null;
+  last_activity_at: string | null;
+  /** Parent agent_session entity_id once resolved; null for top-level. */
+  parent_session_id: string | null;
+  /** Internal: parent native id before entity_id resolution (not stored). */
+  _parentNativeSessionId: string | null;
+  _contentHash: string;
+  _filePath: string;
+  _fileSize: number;
+}
+
+export interface StoreEnvelope {
+  entities: Array<Record<string, unknown>>;
+  relationships: Array<Record<string, unknown>>;
+}
+
+/**
+ * PART_OF edges for a same-request [session, transcript] pair (indexes relative
+ * to the entities array that will be POSTed together).
+ */
+export function buildSessionTranscriptRelationships(
+  opts: {
+    sessionIndex?: number;
+    transcriptIndex?: number;
+    parentEntityId?: string | null;
+  } = {}
+): Array<Record<string, unknown>> {
+  const sessionIndex = opts.sessionIndex ?? 0;
+  const transcriptIndex = opts.transcriptIndex ?? 1;
+  const relationships: Array<Record<string, unknown>> = [
+    {
+      relationship_type: "PART_OF",
+      source_index: transcriptIndex,
+      target_index: sessionIndex,
+    },
+  ];
+  if (opts.parentEntityId) {
+    relationships.push({
+      relationship_type: "PART_OF",
+      source_index: sessionIndex,
+      target_entity_id: opts.parentEntityId,
+    });
+  }
+  return relationships;
+}
+
+/**
+ * Build the store envelope for [session, transcript].
+ * `sessionEntityId` — when known (re-ingest), set as transcript.agent_session_id.
+ * `parentEntityId` — parent agent_session entity_id for sub-agents.
+ */
+export function buildSessionTranscriptEnvelope(
+  rec: SessionStoreRecord,
+  opts: { sessionEntityId?: string | null; parentEntityId?: string | null } = {}
+): StoreEnvelope {
+  const {
+    _contentHash,
+    _filePath: _fp,
+    _fileSize,
+    _parentNativeSessionId: _p,
+    ...sessionFields
+  } = rec;
+  const session: Record<string, unknown> = {
+    ...sessionFields,
+    parent_session_id: opts.parentEntityId ?? null,
+  };
+
+  const transcript: Record<string, unknown> = {
+    entity_type: "session_transcript",
+    content_hash: _contentHash,
+    file_size: _fileSize,
+    mime_type: "application/jsonl",
+    harness: rec.harness,
+    format: "claude_code_jsonl",
+    transcript_kind: rec.kind === "subagent" ? "subagent" : "main",
+    // Prefer entity_id when known; null on first write until follow-up fill.
+    agent_session_id: opts.sessionEntityId ?? null,
+  };
+
+  return {
+    entities: [session, transcript],
+    relationships: buildSessionTranscriptRelationships({
+      parentEntityId: opts.parentEntityId,
+    }),
+  };
+}
+
+/** Alias used by ingest_agent_sessions (and its tests). */
+export const buildStoreEnvelope = buildSessionTranscriptEnvelope;
+
+/**
+ * Follow-up envelope: set session_transcript.agent_session_id to the session
+ * entity_id and emit a cross-request PART_OF edge.
+ */
+export function buildTranscriptSessionFkEnvelope(
+  contentHash: string,
+  sessionEntityId: string
+): StoreEnvelope {
+  return {
+    entities: [
+      {
+        entity_type: "session_transcript",
+        content_hash: contentHash,
+        agent_session_id: sessionEntityId,
+      },
+    ],
+    relationships: [
+      {
+        relationship_type: "PART_OF",
+        source_index: 0,
+        target_entity_id: sessionEntityId,
+      },
+    ],
+  };
+}
+
+/**
+ * Infer PART_OF relationships for a flat entity batch that contains consecutive
+ * [agent_session, session_transcript] pairs (ingest dump order). Used by the
+ * AAuth bulk path so flat entity files still get the same edges as envelopes.
+ */
+export function inferSessionTranscriptRelationships(
+  entities: Array<Record<string, unknown>>
+): Array<Record<string, unknown>> {
+  const relationships: Array<Record<string, unknown>> = [];
+  for (let i = 0; i < entities.length - 1; i++) {
+    if (
+      entities[i]?.entity_type === "agent_session" &&
+      entities[i + 1]?.entity_type === "session_transcript"
+    ) {
+      relationships.push(
+        ...buildSessionTranscriptRelationships({
+          sessionIndex: i,
+          transcriptIndex: i + 1,
+          parentEntityId:
+            typeof entities[i].parent_session_id === "string"
+              ? (entities[i].parent_session_id as string)
+              : null,
+        })
+      );
+    }
+  }
+  return relationships;
+}

--- a/scripts/store_via_aauth.ts
+++ b/scripts/store_via_aauth.ts
@@ -1,0 +1,77 @@
+#!/usr/bin/env tsx
+/**
+ * Bulk-store entities to a Neotoma instance with AAuth request signing.
+ *
+ * The CLI `store` command authenticates via Bearer only; this script signs each
+ * /store POST with the local AAuth keypair (~/.neotoma/aauth/) via cliSignedFetch,
+ * so it authenticates to an AAuth-gated endpoint (e.g. neotoma.markmhendrickson.com)
+ * the same way `neotoma mcp proxy --aauth` does. Used to bulk-ingest agent_session
+ * + session_transcript index entities that don't fit the inline MCP store path.
+ *
+ * Usage:
+ *   tsx scripts/store_via_aauth.ts --file entities.json [--base-url URL] [--batch N] [--dry-run]
+ *
+ * `entities.json` is a JSON array of entity objects ({entity_type, ...fields}).
+ */
+
+import { readFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { cliSignedFetch } from "../src/cli/aauth_signer.js";
+
+const args = process.argv.slice(2);
+const arg = (k: string, d?: string) => (args.includes(k) ? args[args.indexOf(k) + 1] : d);
+const file = arg("--file");
+const baseUrl = arg("--base-url", "https://neotoma.markmhendrickson.com")!;
+const batchSize = parseInt(arg("--batch", "50")!, 10);
+const dryRun = args.includes("--dry-run");
+
+if (!file) {
+  console.error("Missing --file <entities.json>");
+  process.exit(1);
+}
+
+const entities = JSON.parse(readFileSync(file, "utf-8")) as Array<Record<string, unknown>>;
+console.log(
+  `${entities.length} entities, batch ${batchSize} -> ${baseUrl}/store${dryRun ? " (dry-run)" : ""}`,
+);
+
+function batchKey(batch: Array<Record<string, unknown>>): string {
+  // Content-derived so re-runs with identical content reuse the key (idempotent),
+  // and changed content produces a new observation rather than a key-reuse error.
+  return "aauth-bulk-" + createHash("sha256").update(JSON.stringify(batch)).digest("hex").slice(0, 24);
+}
+
+let ok = 0;
+let fail = 0;
+for (let i = 0; i < entities.length; i += batchSize) {
+  const batch = entities.slice(i, i + batchSize);
+  if (!dryRun) {
+    let res: Response;
+    try {
+      res = await cliSignedFetch(`${baseUrl}/store`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          entities: batch,
+          idempotency_key: batchKey(batch),
+          observation_source: "import",
+        }),
+      });
+    } catch (err) {
+      fail += batch.length;
+      console.error(`\n  batch @${i} threw:`, (err as Error).message);
+      continue;
+    }
+    if (res.ok) {
+      ok += batch.length;
+    } else {
+      fail += batch.length;
+      const text = await res.text().catch(() => "");
+      console.error(`\n  batch @${i} failed ${res.status}: ${text.slice(0, 300)}`);
+    }
+  } else {
+    ok += batch.length;
+  }
+  process.stdout.write(`\r  ${Math.min(i + batchSize, entities.length)}/${entities.length}`);
+}
+console.log(`\nstore complete: ${ok} ok, ${fail} failed${dryRun ? " (dry-run)" : ""}`);

--- a/scripts/store_via_aauth.ts
+++ b/scripts/store_via_aauth.ts
@@ -8,18 +8,44 @@
  * the same way `neotoma mcp proxy --aauth` does. Used to bulk-ingest agent_session
  * + session_transcript index entities that don't fit the inline MCP store path.
  *
+ * Accepts either:
+ *   - a JSON array of entities (flat) — consecutive [agent_session, session_transcript]
+ *     pairs get PART_OF relationships inferred via the shared helper
+ *   - a single store envelope `{ entities, relationships }`
+ *   - an array of store envelopes
+ *
  * Usage:
  *   tsx scripts/store_via_aauth.ts --file entities.json [--base-url URL] [--batch N] [--dry-run]
- *
- * `entities.json` is a JSON array of entity objects ({entity_type, ...fields}).
  */
 
 import { readFileSync } from "node:fs";
 import { createHash } from "node:crypto";
 import { cliSignedFetch } from "../src/cli/aauth_signer.js";
+import {
+  inferSessionTranscriptRelationships,
+  type StoreEnvelope,
+} from "./lib/agent_session_store.js";
 
 export interface StoreViaAauthOptions {
-  entities: Array<Record<string, unknown>>;
+  /** Flat entity list (legacy / dump format). Mutually exclusive with `envelopes`. */
+  entities?: Array<Record<string, unknown>>;
+  /**
+   * When posting a flat `entities` list without envelopes, optional relationships
+   * for the whole list. Prefer envelopes for index-relative PART_OF edges.
+   */
+  relationships?: Array<Record<string, unknown>>;
+  /**
+   * Prefer this for agent_session + session_transcript pairs built by
+   * `buildSessionTranscriptEnvelope` — each envelope is one /store POST so
+   * relationship indexes stay correct.
+   */
+  envelopes?: StoreEnvelope[];
+  /**
+   * When true (default) and posting a flat entity batch, attach PART_OF edges
+   * for consecutive [agent_session, session_transcript] pairs via the shared
+   * helper. Set false to preserve legacy entity-only posts.
+   */
+  inferRelationships?: boolean;
   baseUrl: string;
   batchSize: number;
   dryRun: boolean;
@@ -27,77 +53,199 @@ export interface StoreViaAauthOptions {
   signedFetch?: typeof cliSignedFetch;
 }
 
+export interface StoreViaAauthPostedBody {
+  entities: Array<Record<string, unknown>>;
+  relationships?: Array<Record<string, unknown>>;
+  idempotency_key: string;
+  observation_source: string;
+}
+
 export interface StoreViaAauthResult {
   ok: number;
   fail: number;
   batches: number;
   /** Per-batch request bodies that would be / were POSTed (for effect assertions). */
-  postedBodies: Array<{
-    entities: Array<Record<string, unknown>>;
-    idempotency_key: string;
-    observation_source: string;
-  }>;
+  postedBodies: StoreViaAauthPostedBody[];
 }
 
-export function batchKey(batch: Array<Record<string, unknown>>): string {
+export function batchKey(
+  batch: Array<Record<string, unknown>>,
+  relationships?: Array<Record<string, unknown>>
+): string {
   // Content-derived so re-runs with identical content reuse the key (idempotent),
-  // and changed content produces a new observation rather than a key-reuse error.
+  // and changed content (including relationship shape) produces a new key.
+  const payload =
+    relationships && relationships.length > 0 ? { entities: batch, relationships } : batch;
   return (
-    "aauth-bulk-" + createHash("sha256").update(JSON.stringify(batch)).digest("hex").slice(0, 24)
+    "aauth-bulk-" + createHash("sha256").update(JSON.stringify(payload)).digest("hex").slice(0, 24)
   );
 }
 
+function buildPostedBody(
+  entities: Array<Record<string, unknown>>,
+  relationships: Array<Record<string, unknown>> | undefined
+): StoreViaAauthPostedBody {
+  const body: StoreViaAauthPostedBody = {
+    entities,
+    idempotency_key: batchKey(entities, relationships),
+    observation_source: "import",
+  };
+  if (relationships && relationships.length > 0) {
+    body.relationships = relationships;
+  }
+  return body;
+}
+
 /**
- * Signed bulk /store. Effect: each batch is POSTed to `{baseUrl}/store` with
- * AAuth signing, `observation_source: "import"`, and a content-derived
- * idempotency_key. Re-running identical batches reuses the same key.
+ * Signed bulk /store. Effect: each batch/envelope is POSTed to `{baseUrl}/store`
+ * with AAuth signing, `observation_source: "import"`, content-derived
+ * idempotency_key, and (for session/transcript pairs) the same PART_OF
+ * `relationships` the Bearer ingest path emits.
  */
 export async function storeViaAauth(opts: StoreViaAauthOptions): Promise<StoreViaAauthResult> {
   const fetchFn = opts.signedFetch ?? cliSignedFetch;
   let ok = 0;
   let fail = 0;
   let batches = 0;
-  const postedBodies: StoreViaAauthResult["postedBodies"] = [];
+  const postedBodies: StoreViaAauthPostedBody[] = [];
 
-  for (let i = 0; i < opts.entities.length; i += opts.batchSize) {
-    const batch = opts.entities.slice(i, i + opts.batchSize);
-    const body = {
-      entities: batch,
-      idempotency_key: batchKey(batch),
-      observation_source: "import",
-    };
+  const postOne = async (body: StoreViaAauthPostedBody, entityCount: number): Promise<void> => {
     postedBodies.push(body);
     batches++;
-
-    if (!opts.dryRun) {
-      let res: Response;
-      try {
-        res = await fetchFn(`${opts.baseUrl}/store`, {
-          method: "POST",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify(body),
-        });
-      } catch (err) {
-        fail += batch.length;
-        console.error(`\n  batch @${i} threw:`, (err as Error).message);
-        continue;
-      }
-      if (res.ok) {
-        ok += batch.length;
-      } else {
-        fail += batch.length;
-        const text = await res.text().catch(() => "");
-        console.error(`\n  batch @${i} failed ${res.status}: ${text.slice(0, 300)}`);
-      }
-    } else {
-      ok += batch.length;
+    if (opts.dryRun) {
+      ok += entityCount;
+      return;
     }
-    process.stdout.write(
-      `\r  ${Math.min(i + opts.batchSize, opts.entities.length)}/${opts.entities.length}`
-    );
+    let res: Response;
+    try {
+      res = await fetchFn(`${opts.baseUrl}/store`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+      });
+    } catch (err) {
+      fail += entityCount;
+      console.error(`\n  batch threw:`, (err as Error).message);
+      return;
+    }
+    if (res.ok) {
+      ok += entityCount;
+    } else {
+      fail += entityCount;
+      const text = await res.text().catch(() => "");
+      console.error(`\n  batch failed ${res.status}: ${text.slice(0, 300)}`);
+    }
+  };
+
+  if (opts.envelopes && opts.envelopes.length > 0) {
+    for (const envelope of opts.envelopes) {
+      await postOne(
+        buildPostedBody(envelope.entities, envelope.relationships),
+        envelope.entities.length
+      );
+      process.stdout.write(`\r  ${postedBodies.length}/${opts.envelopes.length} envelopes`);
+    }
+    return { ok, fail, batches, postedBodies };
+  }
+
+  const entities = opts.entities ?? [];
+  const infer = opts.inferRelationships !== false;
+
+  // When inferring PART_OF for session+transcript pairs, post each consecutive
+  // pair as its own envelope so batchSize cannot split indexes mid-pair.
+  if (infer && (!opts.relationships || opts.relationships.length === 0)) {
+    let i = 0;
+    const total = entities.length;
+    while (i < entities.length) {
+      if (
+        i + 1 < entities.length &&
+        entities[i]?.entity_type === "agent_session" &&
+        entities[i + 1]?.entity_type === "session_transcript"
+      ) {
+        const pair = [entities[i], entities[i + 1]];
+        const relationships = inferSessionTranscriptRelationships(pair);
+        await postOne(buildPostedBody(pair, relationships), 2);
+        i += 2;
+      } else {
+        // Accumulate non-pair entities up to batchSize.
+        const batch: Array<Record<string, unknown>> = [];
+        while (
+          i < entities.length &&
+          batch.length < opts.batchSize &&
+          !(
+            i + 1 < entities.length &&
+            entities[i]?.entity_type === "agent_session" &&
+            entities[i + 1]?.entity_type === "session_transcript"
+          )
+        ) {
+          batch.push(entities[i]);
+          i++;
+        }
+        if (batch.length > 0) {
+          await postOne(buildPostedBody(batch, undefined), batch.length);
+        }
+      }
+      process.stdout.write(`\r  ${i}/${total}`);
+    }
+    return { ok, fail, batches, postedBodies };
+  }
+
+  for (let i = 0; i < entities.length; i += opts.batchSize) {
+    const batch = entities.slice(i, i + opts.batchSize);
+    // Index-relative relationships are only valid for a single unsplit POST.
+    if (opts.relationships && opts.relationships.length > 0 && entities.length > opts.batchSize) {
+      throw new Error(
+        "storeViaAauth: explicit relationships require batchSize >= entities.length " +
+          "(or pass envelopes so each pair is its own POST)"
+      );
+    }
+    await postOne(buildPostedBody(batch, opts.relationships), batch.length);
+    process.stdout.write(`\r  ${Math.min(i + opts.batchSize, entities.length)}/${entities.length}`);
   }
 
   return { ok, fail, batches, postedBodies };
+}
+
+/** Parse --file JSON into either flat entities or envelopes. */
+export function parseStoreViaAauthFile(raw: unknown): {
+  entities?: Array<Record<string, unknown>>;
+  envelopes?: StoreEnvelope[];
+} {
+  if (Array.isArray(raw)) {
+    if (
+      raw.length > 0 &&
+      raw.every(
+        (item) =>
+          item != null &&
+          typeof item === "object" &&
+          Array.isArray((item as StoreEnvelope).entities)
+      )
+    ) {
+      return { envelopes: raw as StoreEnvelope[] };
+    }
+    return { entities: raw as Array<Record<string, unknown>> };
+  }
+  if (raw != null && typeof raw === "object") {
+    const obj = raw as Record<string, unknown>;
+    if (Array.isArray(obj.envelopes)) {
+      return { envelopes: obj.envelopes as StoreEnvelope[] };
+    }
+    if (Array.isArray(obj.entities)) {
+      return {
+        envelopes: [
+          {
+            entities: obj.entities as Array<Record<string, unknown>>,
+            relationships: Array.isArray(obj.relationships)
+              ? (obj.relationships as Array<Record<string, unknown>>)
+              : [],
+          },
+        ],
+      };
+    }
+  }
+  throw new Error(
+    "Expected JSON array of entities, a {entities, relationships} envelope, or an envelopes array"
+  );
 }
 
 const isDirectRun =
@@ -118,12 +266,21 @@ if (isDirectRun) {
     process.exit(1);
   }
 
-  const entities = JSON.parse(readFileSync(file, "utf-8")) as Array<Record<string, unknown>>;
+  const parsed = parseStoreViaAauthFile(JSON.parse(readFileSync(file, "utf-8")));
+  const count = parsed.envelopes
+    ? parsed.envelopes.reduce((n, e) => n + e.entities.length, 0)
+    : (parsed.entities?.length ?? 0);
   console.log(
-    `${entities.length} entities, batch ${batchSize} -> ${baseUrl}/store${dryRun ? " (dry-run)" : ""}`
+    `${count} entities${parsed.envelopes ? ` in ${parsed.envelopes.length} envelopes` : ""}, batch ${batchSize} -> ${baseUrl}/store${dryRun ? " (dry-run)" : ""}`
   );
 
-  const result = await storeViaAauth({ entities, baseUrl, batchSize, dryRun });
+  const result = await storeViaAauth({
+    entities: parsed.entities,
+    envelopes: parsed.envelopes,
+    baseUrl,
+    batchSize,
+    dryRun,
+  });
   console.log(
     `\nstore complete: ${result.ok} ok, ${result.fail} failed${dryRun ? " (dry-run)" : ""}`
   );

--- a/scripts/store_via_aauth.ts
+++ b/scripts/store_via_aauth.ts
@@ -18,60 +18,114 @@ import { readFileSync } from "node:fs";
 import { createHash } from "node:crypto";
 import { cliSignedFetch } from "../src/cli/aauth_signer.js";
 
-const args = process.argv.slice(2);
-const arg = (k: string, d?: string) => (args.includes(k) ? args[args.indexOf(k) + 1] : d);
-const file = arg("--file");
-const baseUrl = arg("--base-url", "https://neotoma.markmhendrickson.com")!;
-const batchSize = parseInt(arg("--batch", "50")!, 10);
-const dryRun = args.includes("--dry-run");
-
-if (!file) {
-  console.error("Missing --file <entities.json>");
-  process.exit(1);
+export interface StoreViaAauthOptions {
+  entities: Array<Record<string, unknown>>;
+  baseUrl: string;
+  batchSize: number;
+  dryRun: boolean;
+  /** Injectable fetch for tests; defaults to cliSignedFetch. */
+  signedFetch?: typeof cliSignedFetch;
 }
 
-const entities = JSON.parse(readFileSync(file, "utf-8")) as Array<Record<string, unknown>>;
-console.log(
-  `${entities.length} entities, batch ${batchSize} -> ${baseUrl}/store${dryRun ? " (dry-run)" : ""}`,
-);
+export interface StoreViaAauthResult {
+  ok: number;
+  fail: number;
+  batches: number;
+  /** Per-batch request bodies that would be / were POSTed (for effect assertions). */
+  postedBodies: Array<{
+    entities: Array<Record<string, unknown>>;
+    idempotency_key: string;
+    observation_source: string;
+  }>;
+}
 
-function batchKey(batch: Array<Record<string, unknown>>): string {
+export function batchKey(batch: Array<Record<string, unknown>>): string {
   // Content-derived so re-runs with identical content reuse the key (idempotent),
   // and changed content produces a new observation rather than a key-reuse error.
-  return "aauth-bulk-" + createHash("sha256").update(JSON.stringify(batch)).digest("hex").slice(0, 24);
+  return (
+    "aauth-bulk-" + createHash("sha256").update(JSON.stringify(batch)).digest("hex").slice(0, 24)
+  );
 }
 
-let ok = 0;
-let fail = 0;
-for (let i = 0; i < entities.length; i += batchSize) {
-  const batch = entities.slice(i, i + batchSize);
-  if (!dryRun) {
-    let res: Response;
-    try {
-      res = await cliSignedFetch(`${baseUrl}/store`, {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({
-          entities: batch,
-          idempotency_key: batchKey(batch),
-          observation_source: "import",
-        }),
-      });
-    } catch (err) {
-      fail += batch.length;
-      console.error(`\n  batch @${i} threw:`, (err as Error).message);
-      continue;
-    }
-    if (res.ok) {
-      ok += batch.length;
+/**
+ * Signed bulk /store. Effect: each batch is POSTed to `{baseUrl}/store` with
+ * AAuth signing, `observation_source: "import"`, and a content-derived
+ * idempotency_key. Re-running identical batches reuses the same key.
+ */
+export async function storeViaAauth(opts: StoreViaAauthOptions): Promise<StoreViaAauthResult> {
+  const fetchFn = opts.signedFetch ?? cliSignedFetch;
+  let ok = 0;
+  let fail = 0;
+  let batches = 0;
+  const postedBodies: StoreViaAauthResult["postedBodies"] = [];
+
+  for (let i = 0; i < opts.entities.length; i += opts.batchSize) {
+    const batch = opts.entities.slice(i, i + opts.batchSize);
+    const body = {
+      entities: batch,
+      idempotency_key: batchKey(batch),
+      observation_source: "import",
+    };
+    postedBodies.push(body);
+    batches++;
+
+    if (!opts.dryRun) {
+      let res: Response;
+      try {
+        res = await fetchFn(`${opts.baseUrl}/store`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(body),
+        });
+      } catch (err) {
+        fail += batch.length;
+        console.error(`\n  batch @${i} threw:`, (err as Error).message);
+        continue;
+      }
+      if (res.ok) {
+        ok += batch.length;
+      } else {
+        fail += batch.length;
+        const text = await res.text().catch(() => "");
+        console.error(`\n  batch @${i} failed ${res.status}: ${text.slice(0, 300)}`);
+      }
     } else {
-      fail += batch.length;
-      const text = await res.text().catch(() => "");
-      console.error(`\n  batch @${i} failed ${res.status}: ${text.slice(0, 300)}`);
+      ok += batch.length;
     }
-  } else {
-    ok += batch.length;
+    process.stdout.write(
+      `\r  ${Math.min(i + opts.batchSize, opts.entities.length)}/${opts.entities.length}`
+    );
   }
-  process.stdout.write(`\r  ${Math.min(i + batchSize, entities.length)}/${entities.length}`);
+
+  return { ok, fail, batches, postedBodies };
 }
-console.log(`\nstore complete: ${ok} ok, ${fail} failed${dryRun ? " (dry-run)" : ""}`);
+
+const isDirectRun =
+  process.argv[1] != null &&
+  (process.argv[1].endsWith("store_via_aauth.ts") ||
+    process.argv[1].endsWith("store_via_aauth.js"));
+
+if (isDirectRun) {
+  const args = process.argv.slice(2);
+  const arg = (k: string, d?: string) => (args.includes(k) ? args[args.indexOf(k) + 1] : d);
+  const file = arg("--file");
+  const baseUrl = arg("--base-url", "https://neotoma.markmhendrickson.com")!;
+  const batchSize = parseInt(arg("--batch", "50")!, 10);
+  const dryRun = args.includes("--dry-run");
+
+  if (!file) {
+    console.error("Missing --file <entities.json>");
+    process.exit(1);
+  }
+
+  const entities = JSON.parse(readFileSync(file, "utf-8")) as Array<Record<string, unknown>>;
+  console.log(
+    `${entities.length} entities, batch ${batchSize} -> ${baseUrl}/store${dryRun ? " (dry-run)" : ""}`
+  );
+
+  const result = await storeViaAauth({ entities, baseUrl, batchSize, dryRun });
+  console.log(
+    `\nstore complete: ${result.ok} ok, ${result.fail} failed${dryRun ? " (dry-run)" : ""}`
+  );
+  if (result.fail > 0) process.exit(1);
+}

--- a/src/services/schema_definitions.ts
+++ b/src/services/schema_definitions.ts
@@ -2632,6 +2632,158 @@ export const ENTITY_SCHEMAS: Record<string, EntitySchema> = {
     },
   },
 
+  agent_session: {
+    entity_type: "agent_session",
+    schema_version: "0.1.0",
+    metadata: {
+      label: "Agent session",
+      description:
+        "A coding-agent session (interactive or autonomous) keyed by harness + native session id. The runtime/resume record: where the transcript lives, the git env to reconstruct, and (for autonomous swarm runs) the trigger + AAuth attribution. Links PART_OF a conversation and to a session_transcript; relates to harness_event / participation_record / agent_attempt for full orchestration provenance (linked, not duplicated).",
+      category: "agent_runtime",
+      aliases: ["coding_session", "claude_code_session"],
+    },
+    schema_definition: {
+      fields: {
+        // Identity: which harness produced the session and its native,
+        // resume-capable id (Claude Code: cli_session_id / JSONL stem).
+        harness: { type: "string", required: true },
+        native_session_id: { type: "string", required: true },
+        // interactive | autonomous | subagent
+        kind: { type: "string", required: false },
+        title: { type: "string", required: false, preserveCase: true },
+        summary: { type: "string", required: false, preserveCase: true },
+        model: { type: "string", required: false },
+        status: { type: "string", required: false },
+        message_count: { type: "number", required: false },
+        created_at: { type: "date", required: false },
+        last_activity_at: { type: "date", required: false },
+        // Git env to reconstruct for resume. Path/host kept as context only
+        // (excluded from identity: paths move and embed usernames).
+        cwd: { type: "string", required: false },
+        repo: { type: "string", required: false },
+        repo_remote_url: { type: "string", required: false },
+        source_branch: { type: "string", required: false },
+        branch: { type: "string", required: false },
+        git_head_sha: { type: "string", required: false },
+        worktree_path: { type: "string", required: false },
+        // Stable handle of the device that produced the session (resolved to a
+        // device entity when one exists). Sub-agent sessions reference parent.
+        origin_device: { type: "string", required: false },
+        parent_session_id: { type: "string", required: false },
+        // Desktop-app UI state (per device).
+        is_archived: { type: "boolean", required: false },
+        auto_archive_exempt: { type: "boolean", required: false },
+        is_pinned: { type: "boolean", required: false },
+        is_bridged: { type: "boolean", required: false },
+        bridge_session_ids: { type: "array", required: false },
+        // Autonomous/swarm trigger + attribution block. Denormalized for
+        // discovery/filtering; authoritative provenance stays in the linked
+        // harness_event / participation_record / agent_attempt entities.
+        trigger_kind: { type: "string", required: false },
+        trigger_ref: { type: "string", required: false },
+        dispatch_parent: { type: "string", required: false },
+        aauth_sub: { type: "string", required: false },
+        workflow_definition_ref: { type: "string", required: false },
+        gate_name: { type: "string", required: false },
+        // Literal command to resume (harness-specific).
+        resume_command: { type: "string", required: false, preserveCase: true },
+      },
+      // Joint identity: a native session id is only unique within its harness.
+      canonical_name_fields: ["harness", "native_session_id"],
+      name_collision_policy: "reject",
+      temporal_fields: [
+        { field: "created_at", event_type: "AgentSessionStarted" },
+      ],
+      agent_instructions:
+        "An agent_session is the runtime/resume record for one coding-agent session. " +
+        "Always supply harness and native_session_id so the entity resolves deterministically. " +
+        "Set kind to interactive, autonomous, or subagent. " +
+        "For autonomous swarm runs, populate the trigger block (trigger_kind, trigger_ref, aauth_sub, " +
+        "workflow_definition_ref, gate_name) and relate to the authoritative harness_event / " +
+        "participation_record / agent_attempt rather than duplicating their data. " +
+        "Link the session PART_OF its conversation and to its session_transcript.",
+    },
+    reducer_config: {
+      merge_policies: {
+        kind: { strategy: "last_write" },
+        title: { strategy: "highest_priority", tie_breaker: "source_priority" },
+        summary: { strategy: "highest_priority", tie_breaker: "source_priority" },
+        model: { strategy: "last_write" },
+        status: { strategy: "last_write" },
+        message_count: { strategy: "last_write" },
+        created_at: { strategy: "last_write" },
+        last_activity_at: { strategy: "last_write" },
+        cwd: { strategy: "last_write" },
+        repo: { strategy: "last_write" },
+        repo_remote_url: { strategy: "last_write" },
+        source_branch: { strategy: "last_write" },
+        branch: { strategy: "last_write" },
+        git_head_sha: { strategy: "last_write" },
+        worktree_path: { strategy: "last_write" },
+        origin_device: { strategy: "last_write" },
+        parent_session_id: { strategy: "last_write" },
+        is_archived: { strategy: "last_write" },
+        auto_archive_exempt: { strategy: "last_write" },
+        is_pinned: { strategy: "last_write" },
+        is_bridged: { strategy: "last_write" },
+        bridge_session_ids: { strategy: "merge_array" },
+        trigger_kind: { strategy: "last_write" },
+        trigger_ref: { strategy: "last_write" },
+        dispatch_parent: { strategy: "last_write" },
+        aauth_sub: { strategy: "last_write" },
+        workflow_definition_ref: { strategy: "last_write" },
+        gate_name: { strategy: "last_write" },
+        resume_command: { strategy: "last_write" },
+      },
+    },
+  },
+
+  session_transcript: {
+    entity_type: "session_transcript",
+    schema_version: "0.1.0",
+    metadata: {
+      label: "Session transcript",
+      description:
+        "The raw, lossless transcript artifact of an agent_session (Claude Code JSONL, Codex rollout, Cursor SQLite export), stored content-addressed in the sources bucket like image_asset/audio_asset. The byte-exact resume artifact and durable backup; structured turns live separately in conversation_message.",
+      category: "agent_runtime",
+      aliases: ["agent_transcript"],
+    },
+    schema_definition: {
+      fields: {
+        // Content-addressed identity (SHA-256 of the transcript bytes), shared
+        // with the sources blob path {user_id}/{content_hash}.
+        content_hash: { type: "string", required: true },
+        source_id: { type: "string", required: false },
+        mime_type: { type: "string", required: false },
+        file_size: { type: "number", required: false },
+        storage_url: { type: "string", required: false },
+        harness: { type: "string", required: false },
+        // claude_code_jsonl | codex_rollout | cursor_sqlite
+        format: { type: "string", required: false },
+        format_version: { type: "string", required: false },
+        turn_count: { type: "number", required: false },
+        // main | subagent
+        transcript_kind: { type: "string", required: false },
+        agent_session_id: { type: "string", required: false },
+      },
+      canonical_name_fields: ["content_hash"],
+    },
+    reducer_config: {
+      merge_policies: {
+        source_id: { strategy: "last_write" },
+        mime_type: { strategy: "last_write" },
+        file_size: { strategy: "last_write" },
+        storage_url: { strategy: "last_write" },
+        harness: { strategy: "last_write" },
+        format: { strategy: "last_write" },
+        format_version: { strategy: "last_write" },
+        turn_count: { strategy: "last_write" },
+        transcript_kind: { strategy: "last_write" },
+        agent_session_id: { strategy: "last_write" },
+      },
+    },
+  },
+
   agent_artifact: {
     entity_type: "agent_artifact",
     schema_version: "0.1.0",

--- a/src/services/schema_definitions.ts
+++ b/src/services/schema_definitions.ts
@@ -2638,7 +2638,7 @@ export const ENTITY_SCHEMAS: Record<string, EntitySchema> = {
     metadata: {
       label: "Agent session",
       description:
-        "A coding-agent session (interactive or autonomous) keyed by harness + native session id. The runtime/resume record: where the transcript lives, the git env to reconstruct, and (for autonomous swarm runs) the trigger + AAuth attribution. Links PART_OF a conversation and to a session_transcript; relates to harness_event / participation_record / agent_attempt for full orchestration provenance (linked, not duplicated).",
+        "A coding-agent session (interactive or autonomous) keyed by harness + native session id. The runtime/resume record: where the transcript lives, the git env to reconstruct, and (for autonomous swarm runs) the trigger + AAuth attribution. Sub-agent sessions PART_OF their parent agent_session; session_transcript PART_OF this session. Relates to harness_event / participation_record / agent_attempt for full orchestration provenance (linked, not duplicated).",
       category: "agent_runtime",
       aliases: ["coding_session", "claude_code_session"],
     },
@@ -2691,8 +2691,17 @@ export const ENTITY_SCHEMAS: Record<string, EntitySchema> = {
       // Joint identity: a native session id is only unique within its harness.
       canonical_name_fields: ["harness", "native_session_id"],
       name_collision_policy: "reject",
-      temporal_fields: [
-        { field: "created_at", event_type: "AgentSessionStarted" },
+      temporal_fields: [{ field: "created_at", event_type: "AgentSessionStarted" }],
+      // parent_session_id holds the parent agent_session's entity_id (not the
+      // harness-scoped native id). Auto-resolution is not wired for this target
+      // type today — callers must emit an explicit PART_OF relationship (see
+      // scripts/ingest_agent_sessions.ts). resolve_target is intentionally omitted.
+      reference_fields: [
+        {
+          field: "parent_session_id",
+          target_entity_type: "agent_session",
+          relationship_type: "PART_OF",
+        },
       ],
       agent_instructions:
         "An agent_session is the runtime/resume record for one coding-agent session. " +
@@ -2701,7 +2710,12 @@ export const ENTITY_SCHEMAS: Record<string, EntitySchema> = {
         "For autonomous swarm runs, populate the trigger block (trigger_kind, trigger_ref, aauth_sub, " +
         "workflow_definition_ref, gate_name) and relate to the authoritative harness_event / " +
         "participation_record / agent_attempt rather than duplicating their data. " +
-        "Link the session PART_OF its conversation and to its session_transcript.",
+        "For sub-agent sessions set parent_session_id to the parent agent_session entity_id and " +
+        "emit a typed PART_OF relationship (source=this session, target=parent). " +
+        "Link the session to its session_transcript via PART_OF (transcript PART_OF session) " +
+        "with agent_session_id set to this session's entity_id. " +
+        "Conversation PART_OF linking requires a conversation_id field (not yet declared) — " +
+        "do not invent an untyped conversation edge from this schema alone.",
     },
     reducer_config: {
       merge_policies: {
@@ -2764,9 +2778,19 @@ export const ENTITY_SCHEMAS: Record<string, EntitySchema> = {
         turn_count: { type: "number", required: false },
         // main | subagent
         transcript_kind: { type: "string", required: false },
+        // agent_session entity_id (not harness-scoped native_session_id).
         agent_session_id: { type: "string", required: false },
       },
       canonical_name_fields: ["content_hash"],
+      // Declares the FK shape; auto-resolution is not wired for agent_session
+      // targets — ingest must emit an explicit PART_OF relationship.
+      reference_fields: [
+        {
+          field: "agent_session_id",
+          target_entity_type: "agent_session",
+          relationship_type: "PART_OF",
+        },
+      ],
     },
     reducer_config: {
       merge_policies: {

--- a/tests/cli/ingest_agent_sessions.test.ts
+++ b/tests/cli/ingest_agent_sessions.test.ts
@@ -1,0 +1,276 @@
+/**
+ * Effect-level tests for agent_session ingest + AAuth bulk-store scripts.
+ *
+ * Asserts observable outcomes (metadata extraction from non-first message
+ * lines, content_hash / idempotency-key stability for re-ingest, blob upload
+ * key shape, PART_OF relationship emission, signed /store batch bodies) —
+ * not merely that schemas accept the fields.
+ */
+
+import { createHash } from "node:crypto";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  buildStoreEnvelope,
+  contentHashOf,
+  extractMetadata,
+  idempotencyKey,
+  parseSessionEntityIdFromStoreOutput,
+  transcriptIdempotencyKey,
+} from "../../scripts/ingest_agent_sessions.js";
+import { batchKey, storeViaAauth } from "../../scripts/store_via_aauth.js";
+import { getSchemaDefinition } from "../../src/services/schema_definitions.js";
+
+/** Fixture: hook/summary on line 1; cwd/branch/model only on a later message. */
+function fixtureJsonl(opts: {
+  cwd: string;
+  gitBranch: string;
+  model: string;
+  swarm?: boolean;
+}): string {
+  const line0 = JSON.stringify({
+    type: "file-history-snapshot",
+    timestamp: "2026-06-01T10:00:00.000Z",
+  });
+  const line1 = JSON.stringify({
+    type: "user",
+    timestamp: "2026-06-01T10:00:01.000Z",
+    cwd: opts.cwd,
+    gitBranch: opts.gitBranch,
+    message: { role: "user", content: opts.swarm ? "ateles-swarm dispatch" : "hello" },
+  });
+  const line2 = JSON.stringify({
+    type: "assistant",
+    timestamp: "2026-06-01T10:00:02.000Z",
+    cwd: opts.cwd,
+    gitBranch: opts.gitBranch,
+    message: { role: "assistant", model: opts.model, content: "hi" },
+  });
+  // Swarm marker must appear in the head window; put it in a system line too.
+  const lineSwarm = opts.swarm
+    ? JSON.stringify({ type: "system", content: "ateles-swarm agent cicada" }) + "\n"
+    : "";
+  return `${line0}\n${lineSwarm}${line1}\n${line2}\n`;
+}
+
+describe("ingest_agent_sessions extractMetadata (effect)", () => {
+  it("extracts cwd, branch, model, and kind from non-first message lines", () => {
+    const dir = mkdtempSync(join(tmpdir(), "agent-session-fx-"));
+    const file = join(dir, "sess-abc.jsonl");
+    const body = fixtureJsonl({
+      cwd: "/Users/me/repos/neotoma",
+      gitBranch: "feat/agent-session-capture",
+      model: "claude-opus-4-20250514",
+    });
+    writeFileSync(file, body);
+
+    const rec = extractMetadata(file, "auto", null, Buffer.from(body));
+
+    expect(rec.cwd).toBe("/Users/me/repos/neotoma");
+    expect(rec.branch).toBe("feat/agent-session-capture");
+    expect(rec.model).toBe("claude-opus-4-20250514");
+    expect(rec.repo).toBe("neotoma");
+    expect(rec.kind).toBe("interactive");
+    expect(rec.harness).toBe("claude-code");
+    expect(rec.native_session_id).toBe("sess-abc");
+    expect(rec.message_count).toBe(2);
+    // Line-0-only would leave these null — assert we did not fall into that trap.
+    expect(rec.cwd).not.toBeNull();
+    expect(rec.branch).not.toBeNull();
+    expect(rec.model).not.toBeNull();
+  });
+
+  it("marks swarm transcripts autonomous when ateles-swarm appears after line 1", () => {
+    const dir = mkdtempSync(join(tmpdir(), "agent-session-fx-"));
+    const file = join(dir, "swarm-1.jsonl");
+    const body = fixtureJsonl({
+      cwd: "/Users/me/repos/ateles",
+      gitBranch: "main",
+      model: "claude-opus-4-20250514",
+      swarm: true,
+    });
+    writeFileSync(file, body);
+    const rec = extractMetadata(file, "auto", null, Buffer.from(body));
+    expect(rec.kind).toBe("autonomous");
+  });
+
+  it("uses identical content_hash + idempotency key on re-ingest of the same bytes", () => {
+    const body = fixtureJsonl({
+      cwd: "/tmp/repos/x",
+      gitBranch: "main",
+      model: "m",
+    });
+    const buf = Buffer.from(body);
+    const hash1 = contentHashOf(buf);
+    const hash2 = contentHashOf(Buffer.from(body));
+    expect(hash1).toBe(hash2);
+    expect(hash1).toBe(createHash("sha256").update(buf).digest("hex"));
+
+    const dir = mkdtempSync(join(tmpdir(), "agent-session-fx-"));
+    const file = join(dir, "dup.jsonl");
+    writeFileSync(file, body);
+    const a = extractMetadata(file, "auto", null, buf);
+    const b = extractMetadata(file, "auto", null, Buffer.from(body));
+    expect(a._contentHash).toBe(b._contentHash);
+    expect(idempotencyKey(a)).toBe(idempotencyKey(b));
+    expect(idempotencyKey(a)).toContain(a._contentHash.slice(0, 12));
+  });
+
+  it("blob upload idempotency key is content-addressed (retrievable by content_hash)", () => {
+    const hash = "abcdef0123456789deadbeef0000111122223333444455556666777788889999";
+    const key = transcriptIdempotencyKey(hash);
+    expect(key).toBe(`transcript-${hash.slice(0, 16)}`);
+    // Same hash → same key (dedupe / retrievability contract for sources blob).
+    expect(transcriptIdempotencyKey(hash)).toBe(key);
+  });
+});
+
+describe("ingest_agent_sessions buildStoreEnvelope (relationships)", () => {
+  it("emits transcript PART_OF session via source_index/target_index", () => {
+    const dir = mkdtempSync(join(tmpdir(), "agent-session-fx-"));
+    const file = join(dir, "rel.jsonl");
+    const body = fixtureJsonl({
+      cwd: "/Users/me/repos/neotoma",
+      gitBranch: "main",
+      model: "m",
+    });
+    writeFileSync(file, body);
+    const rec = extractMetadata(file, "auto", null, Buffer.from(body));
+    const envelope = buildStoreEnvelope(rec);
+
+    expect(envelope.entities).toHaveLength(2);
+    expect(envelope.entities[0].entity_type).toBe("agent_session");
+    expect(envelope.entities[1].entity_type).toBe("session_transcript");
+    expect(envelope.relationships).toContainEqual({
+      relationship_type: "PART_OF",
+      source_index: 1,
+      target_index: 0,
+    });
+    // FK starts null until entity_id is known (not bare native id).
+    expect(envelope.entities[1].agent_session_id).toBeNull();
+  });
+
+  it("emits sub-agent PART_OF parent via target_entity_id and stores parent entity_id", () => {
+    const dir = mkdtempSync(join(tmpdir(), "agent-session-fx-"));
+    const file = join(dir, "agent-sub.jsonl");
+    const body = fixtureJsonl({
+      cwd: "/Users/me/repos/neotoma",
+      gitBranch: "main",
+      model: "m",
+    });
+    writeFileSync(file, body);
+    const rec = extractMetadata(file, "subagent", "parent-native", Buffer.from(body));
+    const parentEntityId = "ent_parentdeadbeef0001";
+    const envelope = buildStoreEnvelope(rec, {
+      parentEntityId,
+      sessionEntityId: "ent_sessiondeadbeef02",
+    });
+
+    expect(envelope.entities[0].parent_session_id).toBe(parentEntityId);
+    expect(envelope.entities[1].agent_session_id).toBe("ent_sessiondeadbeef02");
+    expect(envelope.relationships).toContainEqual({
+      relationship_type: "PART_OF",
+      source_index: 0,
+      target_entity_id: parentEntityId,
+    });
+  });
+
+  it("parses session entity_id from store --json output", () => {
+    const stdout = JSON.stringify({
+      entities_created: [{ id: "ent_aaa111" }],
+      entities: [
+        { entity_type: "agent_session", entity_id: "ent_session99" },
+        { entity_type: "session_transcript", entity_id: "ent_tx99" },
+      ],
+    });
+    expect(parseSessionEntityIdFromStoreOutput(stdout)).toBe("ent_session99");
+  });
+});
+
+describe("agent_session / session_transcript reference_fields (schema)", () => {
+  it("declares PART_OF reference_fields for parent_session_id and agent_session_id", () => {
+    const session = getSchemaDefinition("agent_session")!;
+    const transcript = getSchemaDefinition("session_transcript")!;
+    expect(session.schema_definition.reference_fields).toEqual([
+      {
+        field: "parent_session_id",
+        target_entity_type: "agent_session",
+        relationship_type: "PART_OF",
+      },
+    ]);
+    expect(transcript.schema_definition.reference_fields).toEqual([
+      {
+        field: "agent_session_id",
+        target_entity_type: "agent_session",
+        relationship_type: "PART_OF",
+      },
+    ]);
+    expect(session.schema_definition.agent_instructions).toContain("PART_OF");
+    expect(session.schema_definition.agent_instructions).toContain("entity_id");
+    expect(session.schema_definition.agent_instructions).not.toMatch(
+      /Link the session PART_OF its conversation and to its session_transcript\.?$/
+    );
+  });
+});
+
+describe("store_via_aauth signed bulk /store (effect)", () => {
+  it("POSTs each batch to /store with AAuth fetch, import source, and stable idempotency key", async () => {
+    const entities = [
+      { entity_type: "agent_session", harness: "claude-code", native_session_id: "a" },
+      { entity_type: "agent_session", harness: "claude-code", native_session_id: "b" },
+      { entity_type: "session_transcript", content_hash: "abc" },
+    ];
+    const calls: Array<{ url: string; init: RequestInit }> = [];
+    const signedFetch = vi.fn(async (url: string, init?: RequestInit) => {
+      calls.push({ url, init: init ?? {} });
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    });
+
+    const result = await storeViaAauth({
+      entities,
+      baseUrl: "https://neotoma.example.test",
+      batchSize: 2,
+      dryRun: false,
+      signedFetch:
+        signedFetch as unknown as typeof import("../../src/cli/aauth_signer.js").cliSignedFetch,
+    });
+
+    expect(result.ok).toBe(3);
+    expect(result.fail).toBe(0);
+    expect(result.batches).toBe(2);
+    expect(calls).toHaveLength(2);
+    expect(calls[0].url).toBe("https://neotoma.example.test/store");
+    expect(calls[0].init.method).toBe("POST");
+
+    const body1 = JSON.parse(String(calls[0].init.body)) as {
+      entities: unknown[];
+      idempotency_key: string;
+      observation_source: string;
+    };
+    expect(body1.observation_source).toBe("import");
+    expect(body1.entities).toHaveLength(2);
+    expect(body1.idempotency_key).toBe(batchKey(entities.slice(0, 2)));
+
+    // Re-run identical batch → same idempotency key (dedupe effect).
+    expect(batchKey(entities.slice(0, 2))).toBe(body1.idempotency_key);
+    expect(batchKey(entities.slice(0, 2))).not.toBe(batchKey(entities.slice(2)));
+  });
+
+  it("dry-run does not call signed fetch but still builds batch bodies", async () => {
+    const signedFetch = vi.fn();
+    const result = await storeViaAauth({
+      entities: [{ entity_type: "agent_session", harness: "claude-code", native_session_id: "z" }],
+      baseUrl: "https://neotoma.example.test",
+      batchSize: 50,
+      dryRun: true,
+      signedFetch:
+        signedFetch as unknown as typeof import("../../src/cli/aauth_signer.js").cliSignedFetch,
+    });
+    expect(signedFetch).not.toHaveBeenCalled();
+    expect(result.ok).toBe(1);
+    expect(result.postedBodies[0].observation_source).toBe("import");
+  });
+});

--- a/tests/cli/ingest_agent_sessions.test.ts
+++ b/tests/cli/ingest_agent_sessions.test.ts
@@ -15,6 +15,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   buildStoreEnvelope,
+  buildTranscriptSessionFkEnvelope,
   contentHashOf,
   extractMetadata,
   idempotencyKey,
@@ -234,6 +235,8 @@ describe("store_via_aauth signed bulk /store (effect)", () => {
       baseUrl: "https://neotoma.example.test",
       batchSize: 2,
       dryRun: false,
+      // Explicit: this case exercises raw batching, not pair inference.
+      inferRelationships: false,
       signedFetch:
         signedFetch as unknown as typeof import("../../src/cli/aauth_signer.js").cliSignedFetch,
     });
@@ -266,11 +269,104 @@ describe("store_via_aauth signed bulk /store (effect)", () => {
       baseUrl: "https://neotoma.example.test",
       batchSize: 50,
       dryRun: true,
+      inferRelationships: false,
       signedFetch:
         signedFetch as unknown as typeof import("../../src/cli/aauth_signer.js").cliSignedFetch,
     });
     expect(signedFetch).not.toHaveBeenCalled();
     expect(result.ok).toBe(1);
     expect(result.postedBodies[0].observation_source).toBe("import");
+  });
+});
+
+describe("cross-surface parity: Bearer ingest envelope vs AAuth store (PART_OF)", () => {
+  it("posts identical relationships from shared envelope via both call shapes", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "agent-session-fx-"));
+    const file = join(dir, "parity.jsonl");
+    const body = fixtureJsonl({
+      cwd: "/Users/me/repos/neotoma",
+      gitBranch: "feat/agent-session-capture",
+      model: "claude-opus-4-20250514",
+    });
+    writeFileSync(file, body);
+    const rec = extractMetadata(file, "subagent", "parent-native", Buffer.from(body));
+    const parentEntityId = "ent_parentdeadbeef0001";
+    const sessionEntityId = "ent_sessiondeadbeef02";
+
+    // Shared construction (single source of truth for both surfaces).
+    const bearerEnvelope = buildStoreEnvelope(rec, { parentEntityId, sessionEntityId });
+
+    const calls: Array<{ url: string; init: RequestInit }> = [];
+    const signedFetch = vi.fn(async (url: string, init?: RequestInit) => {
+      calls.push({ url, init: init ?? {} });
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    });
+
+    // AAuth call shape: envelopes from the shared helper.
+    const aauthFromEnvelopes = await storeViaAauth({
+      envelopes: [bearerEnvelope],
+      baseUrl: "https://neotoma.example.test",
+      batchSize: 50,
+      dryRun: false,
+      signedFetch:
+        signedFetch as unknown as typeof import("../../src/cli/aauth_signer.js").cliSignedFetch,
+    });
+
+    expect(aauthFromEnvelopes.postedBodies).toHaveLength(1);
+    const aauthBody = aauthFromEnvelopes.postedBodies[0];
+    expect(aauthBody.entities).toEqual(bearerEnvelope.entities);
+    expect(aauthBody.relationships).toEqual(bearerEnvelope.relationships);
+    expect(aauthBody.relationships).toEqual([
+      { relationship_type: "PART_OF", source_index: 1, target_index: 0 },
+      {
+        relationship_type: "PART_OF",
+        source_index: 0,
+        target_entity_id: parentEntityId,
+      },
+    ]);
+
+    const posted = JSON.parse(String(calls[0].init.body)) as {
+      entities: unknown[];
+      relationships: unknown[];
+    };
+    expect(posted.relationships).toEqual(bearerEnvelope.relationships);
+    expect(posted.entities).toEqual(bearerEnvelope.entities);
+  });
+
+  it("flat AAuth entity list of [session, transcript] pairs infers the same PART_OF shape", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "agent-session-fx-"));
+    const file = join(dir, "flat-parity.jsonl");
+    const body = fixtureJsonl({
+      cwd: "/tmp/repos/x",
+      gitBranch: "main",
+      model: "m",
+    });
+    writeFileSync(file, body);
+    const rec = extractMetadata(file, "auto", null, Buffer.from(body));
+    const envelope = buildStoreEnvelope(rec);
+
+    const result = await storeViaAauth({
+      entities: envelope.entities,
+      baseUrl: "https://neotoma.example.test",
+      batchSize: 50,
+      dryRun: true,
+      // default inferRelationships: true
+    });
+
+    expect(result.postedBodies).toHaveLength(1);
+    expect(result.postedBodies[0].relationships).toEqual(envelope.relationships);
+    expect(result.postedBodies[0].entities).toEqual(envelope.entities);
+  });
+
+  it("FK follow-up envelope matches across shared helper consumers", () => {
+    const fk = buildTranscriptSessionFkEnvelope("abc123hash", "ent_session99");
+    expect(fk.relationships).toEqual([
+      {
+        relationship_type: "PART_OF",
+        source_index: 0,
+        target_entity_id: "ent_session99",
+      },
+    ]);
+    expect(fk.entities[0].agent_session_id).toBe("ent_session99");
   });
 });

--- a/tests/services/schema_definitions_agent_runtime.test.ts
+++ b/tests/services/schema_definitions_agent_runtime.test.ts
@@ -107,3 +107,49 @@ describe("fleet-general agent_* schemas v0.1", () => {
     }
   });
 });
+
+describe("agent_session + session_transcript schemas v0.1", () => {
+  it("registers agent_session and session_transcript", () => {
+    const registered = getRegisteredEntityTypes();
+    expect(registered).toContain("agent_session");
+    expect(registered).toContain("session_transcript");
+  });
+
+  it("agent_session uses joint identity on harness + native_session_id with reject collision policy", () => {
+    const s = getSchemaDefinition("agent_session");
+    expect(s, "agent_session schema missing").not.toBeNull();
+    expect(s!.entity_type).toBe("agent_session");
+    expect(s!.schema_version).toBe("0.1.0");
+    expect(s!.metadata?.category).toBe("agent_runtime");
+    expect(s!.schema_definition.fields.harness?.required).toBe(true);
+    expect(s!.schema_definition.fields.native_session_id?.required).toBe(true);
+    expect(s!.schema_definition.canonical_name_fields).toEqual([
+      "harness",
+      "native_session_id",
+    ]);
+    expect(s!.schema_definition.name_collision_policy).toBe("reject");
+  });
+
+  it("session_transcript is content-addressed (identity on content_hash)", () => {
+    const s = getSchemaDefinition("session_transcript");
+    expect(s, "session_transcript schema missing").not.toBeNull();
+    expect(s!.entity_type).toBe("session_transcript");
+    expect(s!.schema_version).toBe("0.1.0");
+    expect(s!.metadata?.category).toBe("agent_runtime");
+    expect(s!.schema_definition.fields.content_hash?.required).toBe(true);
+    expect(s!.schema_definition.canonical_name_fields).toEqual(["content_hash"]);
+  });
+
+  it("agent_session DOES carry denormalized aauth_sub + trigger provenance, unlike the fleet LCD types", () => {
+    // The fleet types (agent_task/attempt/outcome) keep agent identity in
+    // provenance via AAuth and forbid an agent_sub field. agent_session is a
+    // session-level record where aauth_sub is a denormalized *content* field
+    // (which agent produced the session) used for discovery/filtering; the
+    // authoritative provenance still lives in the linked harness_event /
+    // participation_record / agent_attempt entities.
+    const fields = getSchemaDefinition("agent_session")!.schema_definition.fields;
+    expect(Object.keys(fields)).toContain("aauth_sub");
+    expect(Object.keys(fields)).toContain("trigger_kind");
+    expect(Object.keys(fields)).toContain("kind");
+  });
+});

--- a/tests/services/schema_definitions_agent_runtime.test.ts
+++ b/tests/services/schema_definitions_agent_runtime.test.ts
@@ -44,10 +44,7 @@ describe("fleet-general agent_* schemas v0.1", () => {
   it("registers all six entity types", () => {
     const registered = getRegisteredEntityTypes();
     for (const entityType of AGENT_RUNTIME_TYPES) {
-      expect(
-        registered,
-        `expected ${entityType} to be registered`,
-      ).toContain(entityType);
+      expect(registered, `expected ${entityType} to be registered`).toContain(entityType);
     }
   });
 
@@ -65,15 +62,15 @@ describe("fleet-general agent_* schemas v0.1", () => {
       const fieldDef = schema!.schema_definition.fields[identityField];
       expect(
         fieldDef,
-        `${entityType} is missing required identity field ${identityField}`,
+        `${entityType} is missing required identity field ${identityField}`
       ).toBeDefined();
       expect(fieldDef!.required).toBe(true);
 
       expect(
         schema!.schema_definition.canonical_name_fields,
-        `${entityType} must declare canonical_name_fields`,
+        `${entityType} must declare canonical_name_fields`
       ).toBeDefined();
-    },
+    }
   );
 
   it("agent_attempt.task_id and agent_outcome.attempt_id are declared as required link fields", () => {
@@ -123,10 +120,7 @@ describe("agent_session + session_transcript schemas v0.1", () => {
     expect(s!.metadata?.category).toBe("agent_runtime");
     expect(s!.schema_definition.fields.harness?.required).toBe(true);
     expect(s!.schema_definition.fields.native_session_id?.required).toBe(true);
-    expect(s!.schema_definition.canonical_name_fields).toEqual([
-      "harness",
-      "native_session_id",
-    ]);
+    expect(s!.schema_definition.canonical_name_fields).toEqual(["harness", "native_session_id"]);
     expect(s!.schema_definition.name_collision_policy).toBe("reject");
   });
 
@@ -151,5 +145,24 @@ describe("agent_session + session_transcript schemas v0.1", () => {
     expect(Object.keys(fields)).toContain("aauth_sub");
     expect(Object.keys(fields)).toContain("trigger_kind");
     expect(Object.keys(fields)).toContain("kind");
+  });
+
+  it("declares reference_fields for parent_session_id and session_transcript.agent_session_id", () => {
+    const session = getSchemaDefinition("agent_session")!;
+    const transcript = getSchemaDefinition("session_transcript")!;
+    expect(session.schema_definition.reference_fields).toEqual([
+      {
+        field: "parent_session_id",
+        target_entity_type: "agent_session",
+        relationship_type: "PART_OF",
+      },
+    ]);
+    expect(transcript.schema_definition.reference_fields).toEqual([
+      {
+        field: "agent_session_id",
+        target_entity_type: "agent_session",
+        relationship_type: "PART_OF",
+      },
+    ]);
   });
 });


### PR DESCRIPTION
## Problems

- No durable, queryable record of coding-agent sessions across harnesses and machines: transcripts live only as local JSONL files, are invisible to remote control once unregistered, and have no resume metadata in Neotoma.
- Autonomous Ateles swarm runs (`claude --print`) write transcripts but their session/attribution context is dropped.
- The CLI `store` command can only Bearer-authenticate, so it cannot push to an AAuth-gated Neotoma (e.g. `neotoma.markmhendrickson.com`) the way `mcp proxy --aauth` does.

## Solutions

- **`agent_session`** entity type (`agent_runtime`): joint identity `[harness, native_session_id]`; runtime/resume fields; autonomous trigger + AAuth block that links to existing harness_event / participation_record / agent_attempt. `reference_fields` declare `parent_session_id` → `agent_session` PART_OF.
- **`session_transcript`** entity type: identity by `content_hash`; content-addressed sources blob path. `reference_fields` declare `agent_session_id` → `agent_session` PART_OF.
- **`docs/subsystems/agent_session_architecture.md`**: subsystem design.
- **`scripts/ingest_agent_sessions.ts`**: scans `~/.claude/projects`, extracts cwd/gitBranch/model/kind from message lines, stores both entities with typed PART_OF relationships, resolves FK fields to **entity_id** (two-pass parent map), uploads raw transcript blob.
- **`scripts/store_via_aauth.ts`**: bulk `/store` with AAuth request signing via `cliSignedFetch`.

## Parent issue

Closes #2195

## Test plan

- [x] `tests/services/schema_definitions_agent_runtime.test.ts`: registration, joint identity, content-addressed transcript, denormalized aauth/trigger fields, `reference_fields`.
- [x] `tests/cli/ingest_agent_sessions.test.ts`: cwd/branch/model/kind from non-first message line; content_hash / idempotency dedupe; PART_OF envelope emission; signed bulk-store effect on stubbed `/store`.
- [x] `npm run type-check` / `npm run format:check` clean; catalog regenerated.

## Breaking changes

No breaking changes. Two additive entity types; no changes to existing schemas, endpoints, or contracts.

## Note

Adding entity types is a schema change (risk hold point). Register on each instance via `npm run schema:init` (or `register_schema`).