### PR TITLE
feat(cli): per-agent AAuth JWK path override (NEOTOMA_AAUTH_PRIVATE_JWK_PATH)

### DIFF
--- a/src/cli/aauth_signer.ts
+++ b/src/cli/aauth_signer.ts
@@ -40,6 +40,21 @@ export const AAUTH_PRIVATE_JWK_PATH = path.join(AAUTH_CONFIG_DIR, "private.jwk")
 export const AAUTH_PUBLIC_JWK_PATH = path.join(AAUTH_CONFIG_DIR, "public.jwk");
 export const AAUTH_CONFIG_PATH = path.join(AAUTH_CONFIG_DIR, "config.json");
 
+/**
+ * Resolve the private JWK path for CLI signing.
+ *
+ * Honors `NEOTOMA_AAUTH_PRIVATE_JWK_PATH` so a per-agent caller (e.g. a daemon
+ * signing as its own swarm identity) can point at its own key instead of the
+ * shared `~/.neotoma/aauth/private.jwk`. This matches the override the proxy
+ * signer already supports (`src/proxy/aauth_client_signer.ts`). Pair it with the
+ * `NEOTOMA_AAUTH_SUB` / `NEOTOMA_AAUTH_KID` claim overrides to fully assume a
+ * per-agent identity. Relative paths resolve against the current working dir.
+ */
+export function resolveCliPrivateJwkPath(): string {
+  const explicit = process.env.NEOTOMA_AAUTH_PRIVATE_JWK_PATH;
+  return explicit ? path.resolve(explicit) : AAUTH_PRIVATE_JWK_PATH;
+}
+
 export type SupportedAlg = "ES256" | "EdDSA";
 
 export interface SignerFileConfig {
@@ -148,7 +163,7 @@ export async function generateAndStoreKeypair(options?: {
  * that never have a keypair.
  */
 export async function hasCliAAuthKeypair(): Promise<boolean> {
-  return fileExists(AAUTH_PRIVATE_JWK_PATH);
+  return fileExists(resolveCliPrivateJwkPath());
 }
 
 /**
@@ -159,16 +174,17 @@ export async function hasCliAAuthKeypair(): Promise<boolean> {
  * configuration is corrupt (e.g. malformed JSON).
  */
 export async function loadCliSignerConfig(): Promise<LoadedSignerConfig | null> {
-  if (!(await fileExists(AAUTH_PRIVATE_JWK_PATH))) {
+  const privateJwkPath = resolveCliPrivateJwkPath();
+  if (!(await fileExists(privateJwkPath))) {
     return null;
   }
   let privateJwk: Record<string, unknown>;
   try {
-    const raw = await fs.readFile(AAUTH_PRIVATE_JWK_PATH, "utf-8");
+    const raw = await fs.readFile(privateJwkPath, "utf-8");
     privateJwk = JSON.parse(raw) as Record<string, unknown>;
   } catch (err) {
     throw new CliSignerConfigError(
-      `Failed to read AAuth private key at ${AAUTH_PRIVATE_JWK_PATH}: ${(err as Error).message}`
+      `Failed to read AAuth private key at ${privateJwkPath}: ${(err as Error).message}`
     );
   }
 

--- a/tests/unit/aauth_signer_jwk_override.test.ts
+++ b/tests/unit/aauth_signer_jwk_override.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Unit tests for the per-agent JWK path override on the CLI AAuth signer.
+ *
+ * `NEOTOMA_AAUTH_PRIVATE_JWK_PATH` lets a per-agent caller (e.g. a swarm daemon)
+ * sign as its own identity instead of the shared `~/.neotoma/aauth/private.jwk`.
+ * Mirrors the override the proxy signer already supports.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdirSync, writeFileSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+
+const ENV_KEY = "NEOTOMA_AAUTH_PRIVATE_JWK_PATH";
+
+describe("CLI AAuth per-agent JWK override", () => {
+  const tmpDir = path.join(os.tmpdir(), `neotoma-aauth-override-${randomUUID()}`);
+  const agentKeyPath = path.join(tmpDir, "apus.private.jwk");
+  let savedEnv: string | undefined;
+
+  beforeEach(() => {
+    savedEnv = process.env[ENV_KEY];
+    mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (savedEnv === undefined) delete process.env[ENV_KEY];
+    else process.env[ENV_KEY] = savedEnv;
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("defaults to the shared keypair path when the env var is unset", async () => {
+    delete process.env[ENV_KEY];
+    const { resolveCliPrivateJwkPath, AAUTH_PRIVATE_JWK_PATH } = await import(
+      "../../src/cli/aauth_signer.js"
+    );
+    expect(resolveCliPrivateJwkPath()).toBe(AAUTH_PRIVATE_JWK_PATH);
+  });
+
+  it("honors an absolute override path", async () => {
+    process.env[ENV_KEY] = agentKeyPath;
+    const { resolveCliPrivateJwkPath } = await import("../../src/cli/aauth_signer.js");
+    expect(resolveCliPrivateJwkPath()).toBe(agentKeyPath);
+  });
+
+  it("resolves a relative override against the cwd", async () => {
+    process.env[ENV_KEY] = "keys/apus.private.jwk";
+    const { resolveCliPrivateJwkPath } = await import("../../src/cli/aauth_signer.js");
+    expect(resolveCliPrivateJwkPath()).toBe(path.resolve(process.cwd(), "keys/apus.private.jwk"));
+  });
+
+  it("loadCliSignerConfig + hasCliAAuthKeypair read the overridden key", async () => {
+    const { generateKeyPair, exportJWK } = await import("jose");
+    const { privateKey } = await generateKeyPair("ES256", { extractable: true });
+    const jwk = (await exportJWK(privateKey)) as Record<string, unknown>;
+    jwk.alg = "ES256";
+    jwk.kid = "apus-test-kid";
+    writeFileSync(agentKeyPath, JSON.stringify(jwk), { mode: 0o600 });
+
+    // A per-agent caller sets the path override + the claim overrides together,
+    // so its identity does not inherit the default ~/.neotoma/aauth/config.json.
+    process.env[ENV_KEY] = agentKeyPath;
+    process.env.NEOTOMA_AAUTH_SUB = "apus@ateles-swarm";
+    process.env.NEOTOMA_AAUTH_KID = "apus-test-kid";
+    const mod = await import("../../src/cli/aauth_signer.js");
+    try {
+      expect(await mod.hasCliAAuthKeypair()).toBe(true);
+      const cfg = await mod.loadCliSignerConfig();
+      expect(cfg).not.toBeNull();
+      expect(cfg!.sub).toBe("apus@ateles-swarm");
+      expect(cfg!.kid).toBe("apus-test-kid");
+      // privateJwk comes straight from the overridden key file — proves the
+      // override (not the shared key) was loaded.
+      expect(cfg!.privateJwk.kid).toBe("apus-test-kid");
+    } finally {
+      delete process.env.NEOTOMA_AAUTH_SUB;
+      delete process.env.NEOTOMA_AAUTH_KID;
+    }
+  });
+
+  it("returns null (signing disabled) when the overridden key is absent", async () => {
+    process.env[ENV_KEY] = path.join(tmpDir, "does-not-exist.jwk");
+    const { loadCliSignerConfig, hasCliAAuthKeypair } = await import("../../src/cli/aauth_signer.js");
+    expect(await hasCliAAuthKeypair()).toBe(false);
+    expect(await loadCliSignerConfig()).toBeNull();
+  });
+});


### PR DESCRIPTION
## Why
The CLI signer (`loadCliSignerConfig` / `hasCliAAuthKeypair`) loaded the private key **only** from the shared `~/.neotoma/aauth/private.jwk`, so every caller on a host signed as **one** identity. This blocks per-agent AAuth for a multi-daemon swarm — each agent needs to sign as itself.

## What
Honor **`NEOTOMA_AAUTH_PRIVATE_JWK_PATH`** in the CLI signer so a per-agent caller can point at its own key. This is the **same env var the proxy signer already supports** (`src/proxy/aauth_client_signer.ts:138`) — closing an inconsistency, not adding a new knob.

- New `resolveCliPrivateJwkPath()` (env override → resolved path, else the default).
- Used in `loadCliSignerConfig` + `hasCliAAuthKeypair`.
- Pair with the existing `NEOTOMA_AAUTH_SUB` / `NEOTOMA_AAUTH_KID` claim overrides to fully assume a per-agent identity.
- Unit tests (5): default, absolute/relative override, full load via override, absent-key → signing-disabled.

## Notes
- No behavior change for the default case (env unset → same path).
- `keygen` still writes to the default location; the override is read-side (the signing path), which is what the swarm daemons need.
- Local checks: eslint clean, `tsc --noEmit` clean for changed files, the 5 unit tests pass.

Unblocks the Ateles per-agent AAuth migration (the shared-identity limitation found while scoping it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
