### PR TITLE
feat(claude-code-plugin): capture agent_session + session_transcript in lifecycle hooks

### DIFF
--- a/packages/claude-code-plugin/README.md
+++ b/packages/claude-code-plugin/README.md
@@ -16,11 +16,13 @@ It pairs with the Neotoma MCP server for agent-driven structured storage — hoo
 
 | Hook | Purpose |
 | --- | --- |
-| `SessionStart` | Records the Claude Code session as a `conversation` entity. |
+| `SessionStart` | Records the Claude Code session as a `conversation` entity, and opens the `agent_session` runtime/resume record (harness + native session id, git env, `claude --resume` command). |
 | `UserPromptSubmit` | Injects retrieval context (recent timeline + `@identifier` matches) via `additionalContext`, and captures the user message as `agent_message`. |
 | `PostToolUse` | Logs a `tool_invocation` observation for every tool call — passive observability. |
 | `PreCompact` | Snapshots a `context_event` marker before Claude Code summarizes the context window. |
-| `Stop` | Persists the assistant's final reply as an `agent_message` safety net. |
+| `Stop` | Persists the assistant's final reply as an `agent_message` safety net, refreshes the `agent_session` (`last_activity_at`), and snapshots the transcript as a content-addressed `session_transcript` index entity. |
+
+`agent_session` and `session_transcript` are the runtime/resume layer: the `agent_session` records which harness produced the session, its native resume id, and the git env to reconstruct it; the `session_transcript` is the content-addressed (SHA-256) index of the raw JSONL transcript artifact. The harness value is always `claude-code` (hyphen), matching Neotoma's convention and the `agent_session` joint identity `["harness","native_session_id"]`. The Stop hook records the transcript index only; uploading the transcript bytes to the sources bucket is handled out-of-band by backfill tooling.
 
 The plugin deliberately does not do LLM-based entity extraction from chat or tool output. That stays in the agent's hands via MCP, preserving Neotoma's "no inference" guarantee.
 

--- a/packages/claude-code-plugin/hooks/_common.py
+++ b/packages/claude-code-plugin/hooks/_common.py
@@ -9,9 +9,11 @@ Code prints it in verbose mode but the turn still proceeds.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import re
+import subprocess
 import sys
 import time
 import uuid
@@ -188,6 +190,233 @@ def record_conversation_turn(
     except Exception as exc:
         log("debug", f"record_conversation_turn failed: {exc}")
         return None
+
+
+# ---------------------------------------------------------------------------
+# agent_session + session_transcript capture
+#
+# MCP owns structured turn storage (conversation / conversation_message). The
+# lifecycle hooks own the *runtime/resume* record that MCP cannot see: which
+# harness produced the session, its native resume id, the git env to
+# reconstruct, and the raw transcript artifact. These two helpers write the
+# `agent_session` and `session_transcript` entity types added in the
+# agent-session-capture work. Both are best-effort and identity-stable so
+# repeated calls across SessionStart / Stop coalesce rather than duplicate.
+# ---------------------------------------------------------------------------
+
+# Harness value MUST be the hyphenated Neotoma convention; it is part of the
+# agent_session joint identity ["harness","native_session_id"], so an
+# underscore variant would key a different (wrong) entity.
+HARNESS = "claude-code"
+
+
+def git_context(cwd: str | None = None) -> dict[str, Any]:
+    """Best-effort git repo/branch/sha for the working directory.
+
+    Returns only the keys we could resolve; never raises. Used to populate
+    the agent_session git-env fields needed to reconstruct a session on
+    another machine.
+    """
+    root = cwd or str(Path.cwd())
+
+    def _git(args: list[str]) -> str | None:
+        try:
+            res = subprocess.run(  # noqa: S603
+                ["git", *args],
+                cwd=root,
+                capture_output=True,
+                text=True,
+                timeout=2,
+            )
+        except Exception:
+            return None
+        if res.returncode != 0:
+            return None
+        value = res.stdout.strip()
+        return value or None
+
+    out: dict[str, Any] = {}
+    toplevel = _git(["rev-parse", "--show-toplevel"])
+    if toplevel:
+        out["repo"] = Path(toplevel).name
+        out["worktree_path"] = toplevel
+    branch = _git(["rev-parse", "--abbrev-ref", "HEAD"])
+    if branch and branch != "HEAD":
+        out["branch"] = branch
+    sha = _git(["rev-parse", "HEAD"])
+    if sha:
+        out["git_head_sha"] = sha
+    remote = _git(["config", "--get", "remote.origin.url"])
+    if remote:
+        out["repo_remote_url"] = remote
+    return out
+
+
+def build_agent_session_entity(
+    *,
+    native_session_id: str,
+    kind: str = "interactive",
+    model: str | None = None,
+    created_at: str | None = None,
+    last_activity_at: str | None = None,
+    message_count: int | None = None,
+    cwd: str | None = None,
+    git: dict[str, Any] | None = None,
+    trigger_kind: str | None = None,
+    parent_session_id: str | None = None,
+    resume_command: str | None = None,
+    hook_event: str | None = None,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build an agent_session entity payload (pure; no network)."""
+    entity: dict[str, Any] = {
+        "entity_type": "agent_session",
+        "harness": HARNESS,
+        "native_session_id": native_session_id,
+        **harness_provenance({"hook_event": hook_event} if hook_event else None),
+    }
+    if kind:
+        entity["kind"] = kind
+    if model:
+        entity["model"] = model
+    if created_at:
+        entity["created_at"] = created_at
+    if last_activity_at:
+        entity["last_activity_at"] = last_activity_at
+    if message_count is not None:
+        entity["message_count"] = message_count
+    if cwd:
+        entity["cwd"] = cwd
+    for key in ("repo", "branch", "git_head_sha", "worktree_path", "repo_remote_url"):
+        if git and git.get(key):
+            entity[key] = git[key]
+    if trigger_kind:
+        entity["trigger_kind"] = trigger_kind
+    if parent_session_id:
+        entity["parent_session_id"] = parent_session_id
+    if resume_command:
+        entity["resume_command"] = resume_command
+    if extra:
+        entity.update(extra)
+    return entity
+
+
+def record_agent_session(
+    client: Any | None,
+    *,
+    native_session_id: str,
+    hook_event: str | None = None,
+    **kwargs: Any,
+) -> dict[str, Any] | None:
+    """Upsert the agent_session entity for this session. Best-effort."""
+    if client is None or not native_session_id:
+        return None
+    entity = build_agent_session_entity(
+        native_session_id=native_session_id, hook_event=hook_event, **kwargs
+    )
+    idempotency_key = f"agent-session-{HARNESS}-{native_session_id}-{hook_event or 'update'}"
+    try:
+        client.store({"entities": [entity], "idempotency_key": idempotency_key})
+    except Exception as exc:
+        log("debug", f"record_agent_session failed: {exc}")
+        return None
+    return entity
+
+
+def hash_transcript_file(transcript_path: str) -> tuple[str, int, int] | None:
+    """Return (sha256_hex, byte_size, line_count) for a transcript file.
+
+    Streams the file so large JSONL transcripts do not load into memory.
+    Returns None if the path is missing or unreadable.
+    """
+    try:
+        path = Path(transcript_path)
+        if not path.is_file():
+            return None
+        digest = hashlib.sha256()
+        size = 0
+        lines = 0
+        with path.open("rb") as fh:
+            for chunk in iter(lambda: fh.read(65536), b""):
+                digest.update(chunk)
+                size += len(chunk)
+                lines += chunk.count(b"\n")
+        return digest.hexdigest(), size, lines
+    except Exception as exc:
+        log("debug", f"hash_transcript_file failed: {exc}")
+        return None
+
+
+def build_session_transcript_entity(
+    *,
+    content_hash: str,
+    agent_session_id: str | None = None,
+    file_size: int | None = None,
+    turn_count: int | None = None,
+    transcript_kind: str = "main",
+    fmt: str = "claude_code_jsonl",
+    mime_type: str = "application/jsonl",
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a session_transcript index entity (pure; no network).
+
+    Content-addressed by ``content_hash`` (identity), so re-recording an
+    unchanged transcript coalesces. This writes the index only; uploading the
+    transcript bytes to the sources bucket is handled out-of-band (backfill /
+    future enhancement), hence no ``source_id`` / ``storage_url`` here.
+    """
+    entity: dict[str, Any] = {
+        "entity_type": "session_transcript",
+        "content_hash": content_hash,
+        "harness": HARNESS,
+        "format": fmt,
+        "mime_type": mime_type,
+        "transcript_kind": transcript_kind,
+        **harness_provenance(),
+    }
+    if agent_session_id:
+        entity["agent_session_id"] = agent_session_id
+    if file_size is not None:
+        entity["file_size"] = file_size
+    if turn_count is not None:
+        entity["turn_count"] = turn_count
+    if extra:
+        entity.update(extra)
+    return entity
+
+
+def record_session_transcript(
+    client: Any | None,
+    *,
+    transcript_path: str | None,
+    agent_session_id: str | None = None,
+    transcript_kind: str = "main",
+) -> dict[str, Any] | None:
+    """Hash a transcript file and upsert its session_transcript index entity.
+
+    Best-effort: a missing path, unreadable file, or transport error is logged
+    and swallowed so the agent turn is never blocked.
+    """
+    if client is None or not transcript_path:
+        return None
+    hashed = hash_transcript_file(transcript_path)
+    if hashed is None:
+        return None
+    content_hash, file_size, line_count = hashed
+    entity = build_session_transcript_entity(
+        content_hash=content_hash,
+        agent_session_id=agent_session_id,
+        file_size=file_size,
+        turn_count=line_count or None,
+        transcript_kind=transcript_kind,
+    )
+    idempotency_key = f"session-transcript-{content_hash}"
+    try:
+        client.store({"entities": [entity], "idempotency_key": idempotency_key})
+    except Exception as exc:
+        log("debug", f"record_session_transcript failed: {exc}")
+        return None
+    return entity
 
 
 # ---------------------------------------------------------------------------

--- a/packages/claude-code-plugin/hooks/_common.py
+++ b/packages/claude-code-plugin/hooks/_common.py
@@ -209,13 +209,103 @@ def record_conversation_turn(
 # underscore variant would key a different (wrong) entity.
 HARNESS = "claude-code"
 
+# Query params whose values are treated as credentials (parity with
+# packages/cursor-hooks/hooks/_common.ts `redactRepositoryRemote`).
+_REMOTE_SECRET_QUERY_RE = re.compile(
+    r"([?&](?:access_token|auth|key|password|token)=)[^&]+", re.IGNORECASE
+)
+_REMOTE_USERINFO_RE = re.compile(r"://([^/@]+)@")
+
+
+def redact_repository_remote(remote: str | None) -> str | None:
+    """Scrub credential material from a git remote URL.
+
+    Faithful Python port of Cursor hooks ``redactRepositoryRemote``:
+    userinfo → ``<redacted>``; ``access_token`` / ``auth`` / ``key`` /
+    ``password`` / ``token`` query values → ``<redacted>``.
+    """
+    if not remote:
+        return None
+    scrubbed = _REMOTE_USERINFO_RE.sub("://<redacted>@", remote)
+    scrubbed = _REMOTE_SECRET_QUERY_RE.sub(r"\1<redacted>", scrubbed)
+    return scrubbed
+
+
+def _is_entity_id(value: Any) -> bool:
+    """True when ``value`` looks like a Neotoma entity id (``ent_*``)."""
+    return isinstance(value, str) and value.startswith("ent_")
+
+
+def _entity_id_from_store_result(result: Any) -> str | None:
+    """Pull the first ``entity_id`` from a store response (dual-shape)."""
+    try:
+        from neotoma_client.helpers import _extract_entities
+
+        entities_list = _extract_entities(result)
+    except Exception:
+        entities_list = (
+            (result or {}).get("entities")
+            or (result or {}).get("structured", {}).get("entities")
+            or []
+        )
+    if not entities_list:
+        return None
+    row = entities_list[0]
+    if not isinstance(row, dict):
+        return None
+    for key in ("entity_id", "id"):
+        eid = row.get(key)
+        if _is_entity_id(eid):
+            return eid
+    return None
+
+
+def _resolve_agent_session_entity_id(
+    client: Any,
+    *,
+    native_session_id: str,
+    store_result: Any,
+) -> str | None:
+    """Prefer store-response ``entity_id``; fall back to retrieve-by-identifier."""
+    eid = _entity_id_from_store_result(store_result)
+    if eid:
+        return eid
+    try:
+        found = client.retrieve_entity_by_identifier(
+            {"entity_type": "agent_session", "identifier": native_session_id}
+        )
+    except Exception as exc:
+        log("debug", f"agent_session retrieve fallback failed: {exc}")
+        return None
+    if not isinstance(found, dict):
+        return None
+    # Preferred: top-level entity_id (some client helpers normalize this way).
+    candidate = found.get("entity_id")
+    if _is_entity_id(candidate):
+        return candidate
+    nested = found.get("entity")
+    if isinstance(nested, dict):
+        for key in ("entity_id", "id"):
+            if _is_entity_id(nested.get(key)):
+                return nested[key]
+    # REST/MCP shape: { entities: [{ id: "ent_…" }], total, match_mode }.
+    entities = found.get("entities")
+    if isinstance(entities, list):
+        for row in entities:
+            if not isinstance(row, dict):
+                continue
+            for key in ("entity_id", "id"):
+                if _is_entity_id(row.get(key)):
+                    return row[key]
+    return None
+
 
 def git_context(cwd: str | None = None) -> dict[str, Any]:
     """Best-effort git repo/branch/sha for the working directory.
 
     Returns only the keys we could resolve; never raises. Used to populate
     the agent_session git-env fields needed to reconstruct a session on
-    another machine.
+    another machine. ``repo_remote_url`` is redacted before return.
     """
     root = cwd or str(Path.cwd())
 
@@ -246,7 +336,7 @@ def git_context(cwd: str | None = None) -> dict[str, Any]:
     sha = _git(["rev-parse", "HEAD"])
     if sha:
         out["git_head_sha"] = sha
-    remote = _git(["config", "--get", "remote.origin.url"])
+    remote = redact_repository_remote(_git(["config", "--get", "remote.origin.url"]))
     if remote:
         out["repo_remote_url"] = remote
     return out
@@ -289,7 +379,12 @@ def build_agent_session_entity(
         entity["cwd"] = cwd
     for key in ("repo", "branch", "git_head_sha", "worktree_path", "repo_remote_url"):
         if git and git.get(key):
-            entity[key] = git[key]
+            value = git[key]
+            if key == "repo_remote_url":
+                value = redact_repository_remote(value if isinstance(value, str) else None)
+                if not value:
+                    continue
+            entity[key] = value
     if trigger_kind:
         entity["trigger_kind"] = trigger_kind
     if parent_session_id:
@@ -308,7 +403,13 @@ def record_agent_session(
     hook_event: str | None = None,
     **kwargs: Any,
 ) -> dict[str, Any] | None:
-    """Upsert the agent_session entity for this session. Best-effort."""
+    """Upsert the agent_session entity for this session. Best-effort.
+
+    Returns the stored payload including ``entity_id`` when the store (or a
+    retrieve-by-identifier fallback) yields an ``ent_*`` id. Callers that
+    link ``session_transcript.agent_session_id`` MUST use that ``entity_id``,
+    never the harness native UUID.
+    """
     if client is None or not native_session_id:
         return None
     entity = build_agent_session_entity(
@@ -316,10 +417,15 @@ def record_agent_session(
     )
     idempotency_key = f"agent-session-{HARNESS}-{native_session_id}-{hook_event or 'update'}"
     try:
-        client.store({"entities": [entity], "idempotency_key": idempotency_key})
+        result = client.store({"entities": [entity], "idempotency_key": idempotency_key})
     except Exception as exc:
         log("debug", f"record_agent_session failed: {exc}")
         return None
+    entity_id = _resolve_agent_session_entity_id(
+        client, native_session_id=native_session_id, store_result=result
+    )
+    if entity_id:
+        return {**entity, "entity_id": entity_id}
     return entity
 
 
@@ -364,6 +470,10 @@ def build_session_transcript_entity(
     unchanged transcript coalesces. This writes the index only; uploading the
     transcript bytes to the sources bucket is handled out-of-band (backfill /
     future enhancement), hence no ``source_id`` / ``storage_url`` here.
+
+    ``agent_session_id`` MUST be the parent ``agent_session`` entity_id
+    (``ent_*``). Harness native UUIDs are rejected so the FK never fakes a
+    link (see #2195 / stacked schema reference_fields).
     """
     entity: dict[str, Any] = {
         "entity_type": "session_transcript",
@@ -374,7 +484,7 @@ def build_session_transcript_entity(
         "transcript_kind": transcript_kind,
         **harness_provenance(),
     }
-    if agent_session_id:
+    if _is_entity_id(agent_session_id):
         entity["agent_session_id"] = agent_session_id
     if file_size is not None:
         entity["file_size"] = file_size
@@ -394,6 +504,12 @@ def record_session_transcript(
 ) -> dict[str, Any] | None:
     """Hash a transcript file and upsert its session_transcript index entity.
 
+    When ``agent_session_id`` is an ``ent_*`` id, sets the denormalized FK and
+    emits a typed ``PART_OF`` edge (transcript → session), mirroring
+    ``scripts/lib/agent_session_store.ts`` ``buildTranscriptSessionFkEnvelope``.
+    Non-``ent_*`` values (including harness UUIDs) are omitted — honest empty
+    rather than a silent join miss.
+
     Best-effort: a missing path, unreadable file, or transport error is logged
     and swallowed so the agent turn is never blocked.
     """
@@ -403,19 +519,35 @@ def record_session_transcript(
     if hashed is None:
         return None
     content_hash, file_size, line_count = hashed
+    session_fk = agent_session_id if _is_entity_id(agent_session_id) else None
     entity = build_session_transcript_entity(
         content_hash=content_hash,
-        agent_session_id=agent_session_id,
+        agent_session_id=session_fk,
         file_size=file_size,
         turn_count=line_count or None,
         transcript_kind=transcript_kind,
     )
     idempotency_key = f"session-transcript-{content_hash}"
+    store_payload: dict[str, Any] = {
+        "entities": [entity],
+        "idempotency_key": idempotency_key,
+    }
+    if session_fk:
+        store_payload["relationships"] = [
+            {
+                "relationship_type": "PART_OF",
+                "source_index": 0,
+                "target_entity_id": session_fk,
+            }
+        ]
     try:
-        client.store({"entities": [entity], "idempotency_key": idempotency_key})
+        result = client.store(store_payload)
     except Exception as exc:
         log("debug", f"record_session_transcript failed: {exc}")
         return None
+    transcript_eid = _entity_id_from_store_result(result)
+    if transcript_eid:
+        return {**entity, "entity_id": transcript_eid}
     return entity
 
 

--- a/packages/claude-code-plugin/hooks/session_start.py
+++ b/packages/claude-code-plugin/hooks/session_start.py
@@ -28,10 +28,12 @@ sys.path.insert(0, str(Path(__file__).parent))
 from _common import (  # noqa: E402
     NEOTOMA_BASE_URL,
     get_client,
+    git_context,
     harness_provenance,
     log,
     make_idempotency_key,
     read_hook_input,
+    record_agent_session,
     record_conversation_turn,
     write_cached_mcp_instructions,
     write_hook_output,
@@ -104,6 +106,26 @@ def main() -> int:
         hook_event="SessionStart",
         started_at=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
     )
+
+    # Runtime/resume record: where the transcript lives and the git env to
+    # reconstruct. Only emitted for a real harness UUID (a synthesized
+    # fallback id is not resume-capable). Keyed by harness + native_session_id
+    # so the SessionStart and later Stop observations coalesce.
+    if raw_session_id:
+        cwd = payload.get("cwd") or str(Path.cwd())
+        record_agent_session(
+            client,
+            native_session_id=raw_session_id,
+            hook_event="SessionStart",
+            kind="interactive",
+            trigger_kind="interactive",
+            model=payload.get("model"),
+            created_at=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            last_activity_at=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            cwd=cwd,
+            git=git_context(cwd),
+            resume_command=f"claude --resume {raw_session_id}",
+        )
 
     try:
         client.close()

--- a/packages/claude-code-plugin/hooks/stop.py
+++ b/packages/claude-code-plugin/hooks/stop.py
@@ -16,11 +16,14 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent))
 from _common import (  # noqa: E402
     get_client,
+    git_context,
     harness_provenance,
     log,
     make_idempotency_key,
     read_hook_input,
+    record_agent_session,
     record_conversation_turn,
+    record_session_transcript,
     write_hook_output,
 )
 
@@ -35,6 +38,29 @@ def main() -> int:
     session_id = payload.get("session_id") or "claude-code-unknown"
     turn_id = payload.get("turn_id") or str(int(time.time() * 1000))
     final_text = payload.get("response") or payload.get("assistant_response") or ""
+
+    # Refresh the runtime/resume record and snapshot the transcript artifact.
+    # Done before the empty-reply short-circuit so a turn that produces no
+    # final text still advances last_activity_at and captures the transcript.
+    # Guarded on a real harness UUID (the resume id must be genuine).
+    raw_session_id = payload.get("session_id")
+    if raw_session_id:
+        cwd = payload.get("cwd") or str(Path.cwd())
+        record_agent_session(
+            client,
+            native_session_id=raw_session_id,
+            hook_event="Stop",
+            kind="interactive",
+            model=payload.get("model"),
+            last_activity_at=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            cwd=cwd,
+            git=git_context(cwd),
+        )
+        record_session_transcript(
+            client,
+            transcript_path=payload.get("transcript_path"),
+            agent_session_id=raw_session_id,
+        )
 
     if not final_text:
         write_hook_output({})

--- a/packages/claude-code-plugin/hooks/stop.py
+++ b/packages/claude-code-plugin/hooks/stop.py
@@ -46,7 +46,7 @@ def main() -> int:
     raw_session_id = payload.get("session_id")
     if raw_session_id:
         cwd = payload.get("cwd") or str(Path.cwd())
-        record_agent_session(
+        session_rec = record_agent_session(
             client,
             native_session_id=raw_session_id,
             hook_event="Stop",
@@ -56,10 +56,13 @@ def main() -> int:
             cwd=cwd,
             git=git_context(cwd),
         )
+        # FK must be agent_session.entity_id (ent_*), never the harness UUID.
+        # Omit when unresolved — honest empty beats a silent join miss (#2195).
+        session_entity_id = (session_rec or {}).get("entity_id")
         record_session_transcript(
             client,
             transcript_path=payload.get("transcript_path"),
-            agent_session_id=raw_session_id,
+            agent_session_id=session_entity_id if isinstance(session_entity_id, str) else None,
         )
 
     if not final_text:

--- a/packages/claude-code-plugin/tests/test_session_capture.py
+++ b/packages/claude-code-plugin/tests/test_session_capture.py
@@ -1,0 +1,186 @@
+"""Unit tests for agent_session + session_transcript hook capture.
+
+Exercises the pure builders and the best-effort record_* helpers in
+hooks/_common.py with a stub client (no server required). Runs under pytest
+or standalone via ``python3 test_session_capture.py``.
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+# Import the hook helpers from the sibling hooks/ directory.
+HOOKS_DIR = Path(__file__).resolve().parent.parent / "hooks"
+sys.path.insert(0, str(HOOKS_DIR))
+
+from _common import (  # noqa: E402
+    HARNESS,
+    build_agent_session_entity,
+    build_session_transcript_entity,
+    hash_transcript_file,
+    record_agent_session,
+    record_session_transcript,
+)
+
+
+class StubClient:
+    """Captures store() calls so tests can assert the entity payloads."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def store(self, input):  # noqa: A002 - mirror real client signature
+        self.calls.append(input)
+        return {"entities": [{"entity_id": "ent_stub"}]}
+
+
+def test_harness_is_hyphenated() -> None:
+    # The value is part of agent_session's joint identity; underscore would
+    # key a different entity. Lock the convention.
+    assert HARNESS == "claude-code"
+
+
+def test_build_agent_session_entity_identity_and_fields() -> None:
+    entity = build_agent_session_entity(
+        native_session_id="uuid-123",
+        kind="interactive",
+        model="claude-opus-4-8",
+        created_at="2026-06-22T00:00:00Z",
+        last_activity_at="2026-06-22T01:00:00Z",
+        cwd="/work/repo",
+        git={"repo": "neotoma", "branch": "main", "git_head_sha": "abc", "ignored": "x"},
+        trigger_kind="interactive",
+        resume_command="claude --resume uuid-123",
+        hook_event="SessionStart",
+    )
+    assert entity["entity_type"] == "agent_session"
+    assert entity["harness"] == "claude-code"
+    assert entity["native_session_id"] == "uuid-123"
+    assert entity["kind"] == "interactive"
+    assert entity["model"] == "claude-opus-4-8"
+    assert entity["repo"] == "neotoma"
+    assert entity["branch"] == "main"
+    assert entity["git_head_sha"] == "abc"
+    assert entity["resume_command"] == "claude --resume uuid-123"
+    assert entity["trigger_kind"] == "interactive"
+    # Only declared git keys are copied across.
+    assert "ignored" not in entity
+    # Provenance carries the hook event and hyphenated harness.
+    assert entity["hook_event"] == "SessionStart"
+    assert entity["data_source"] == "claude-code-hook"
+
+
+def test_build_session_transcript_entity_is_content_addressed() -> None:
+    entity = build_session_transcript_entity(
+        content_hash="deadbeef",
+        agent_session_id="uuid-123",
+        file_size=4096,
+        turn_count=12,
+    )
+    assert entity["entity_type"] == "session_transcript"
+    assert entity["content_hash"] == "deadbeef"
+    assert entity["harness"] == "claude-code"
+    assert entity["format"] == "claude_code_jsonl"
+    assert entity["mime_type"] == "application/jsonl"
+    assert entity["transcript_kind"] == "main"
+    assert entity["agent_session_id"] == "uuid-123"
+    assert entity["file_size"] == 4096
+    assert entity["turn_count"] == 12
+
+
+def test_hash_transcript_file_matches_sha256() -> None:
+    import hashlib
+
+    with tempfile.TemporaryDirectory() as d:
+        path = Path(d) / "transcript.jsonl"
+        body = b'{"a":1}\n{"b":2}\n{"c":3}\n'
+        path.write_bytes(body)
+        result = hash_transcript_file(str(path))
+        assert result is not None
+        content_hash, size, lines = result
+        assert content_hash == hashlib.sha256(body).hexdigest()
+        assert size == len(body)
+        assert lines == 3
+
+
+def test_hash_transcript_file_missing_returns_none() -> None:
+    assert hash_transcript_file("/no/such/file.jsonl") is None
+
+
+def test_record_agent_session_stores_with_stable_idempotency_key() -> None:
+    client = StubClient()
+    record_agent_session(
+        client,
+        native_session_id="uuid-123",
+        hook_event="SessionStart",
+        kind="interactive",
+    )
+    assert len(client.calls) == 1
+    call = client.calls[0]
+    assert call["idempotency_key"] == "agent-session-claude-code-uuid-123-SessionStart"
+    assert call["entities"][0]["native_session_id"] == "uuid-123"
+    assert call["entities"][0]["harness"] == "claude-code"
+
+
+def test_record_agent_session_noop_without_session_id() -> None:
+    client = StubClient()
+    assert record_agent_session(client, native_session_id="") is None
+    assert client.calls == []
+
+
+def test_record_session_transcript_hashes_and_links() -> None:
+    client = StubClient()
+    with tempfile.TemporaryDirectory() as d:
+        path = Path(d) / "t.jsonl"
+        path.write_bytes(b'{"x":1}\n')
+        entity = record_session_transcript(
+            client,
+            transcript_path=str(path),
+            agent_session_id="uuid-123",
+        )
+    assert entity is not None
+    assert len(client.calls) == 1
+    call = client.calls[0]
+    stored = call["entities"][0]
+    assert stored["entity_type"] == "session_transcript"
+    assert stored["agent_session_id"] == "uuid-123"
+    assert call["idempotency_key"] == f"session-transcript-{stored['content_hash']}"
+
+
+def test_record_session_transcript_noop_for_missing_path() -> None:
+    client = StubClient()
+    assert record_session_transcript(client, transcript_path=None) is None
+    assert record_session_transcript(client, transcript_path="/no/file") is None
+    assert client.calls == []
+
+
+def test_record_helpers_swallow_client_errors() -> None:
+    class BoomClient:
+        def store(self, input):  # noqa: A002
+            raise RuntimeError("transport down")
+
+    # Best-effort: a transport failure must never raise out of the hook.
+    assert record_agent_session(BoomClient(), native_session_id="uuid-9") is None
+    with tempfile.TemporaryDirectory() as d:
+        path = Path(d) / "t.jsonl"
+        path.write_bytes(b"x\n")
+        assert record_session_transcript(BoomClient(), transcript_path=str(path)) is None
+
+
+if __name__ == "__main__":
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print(f"ok   {name}")
+            except AssertionError as exc:
+                failures += 1
+                print(f"FAIL {name}: {exc}")
+            except Exception as exc:  # noqa: BLE001
+                failures += 1
+                print(f"ERR  {name}: {exc}")
+    print(f"\n{'PASS' if failures == 0 else 'FAIL'}: {failures} failure(s)")
+    sys.exit(1 if failures else 0)

--- a/packages/claude-code-plugin/tests/test_session_capture.py
+++ b/packages/claude-code-plugin/tests/test_session_capture.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import sys
 import tempfile
 from pathlib import Path
+from unittest.mock import patch
 
 # Import the hook helpers from the sibling hooks/ directory.
 HOOKS_DIR = Path(__file__).resolve().parent.parent / "hooks"
@@ -19,21 +20,24 @@ from _common import (  # noqa: E402
     HARNESS,
     build_agent_session_entity,
     build_session_transcript_entity,
+    git_context,
     hash_transcript_file,
     record_agent_session,
     record_session_transcript,
+    redact_repository_remote,
 )
 
 
 class StubClient:
     """Captures store() calls so tests can assert the entity payloads."""
 
-    def __init__(self) -> None:
+    def __init__(self, entity_id: str = "ent_stub") -> None:
         self.calls: list[dict] = []
+        self._entity_id = entity_id
 
     def store(self, input):  # noqa: A002 - mirror real client signature
         self.calls.append(input)
-        return {"entities": [{"entity_id": "ent_stub"}]}
+        return {"entities": [{"entity_id": self._entity_id}]}
 
 
 def test_harness_is_hyphenated() -> None:
@@ -72,22 +76,29 @@ def test_build_agent_session_entity_identity_and_fields() -> None:
     assert entity["data_source"] == "claude-code-hook"
 
 
-def test_build_session_transcript_entity_is_content_addressed() -> None:
-    entity = build_session_transcript_entity(
+def test_build_session_transcript_entity_requires_ent_fk() -> None:
+    linked = build_session_transcript_entity(
         content_hash="deadbeef",
-        agent_session_id="uuid-123",
+        agent_session_id="ent_stub",
         file_size=4096,
         turn_count=12,
     )
-    assert entity["entity_type"] == "session_transcript"
-    assert entity["content_hash"] == "deadbeef"
-    assert entity["harness"] == "claude-code"
-    assert entity["format"] == "claude_code_jsonl"
-    assert entity["mime_type"] == "application/jsonl"
-    assert entity["transcript_kind"] == "main"
-    assert entity["agent_session_id"] == "uuid-123"
-    assert entity["file_size"] == 4096
-    assert entity["turn_count"] == 12
+    assert linked["entity_type"] == "session_transcript"
+    assert linked["content_hash"] == "deadbeef"
+    assert linked["harness"] == "claude-code"
+    assert linked["format"] == "claude_code_jsonl"
+    assert linked["mime_type"] == "application/jsonl"
+    assert linked["transcript_kind"] == "main"
+    assert linked["agent_session_id"] == "ent_stub"
+    assert linked["file_size"] == 4096
+    assert linked["turn_count"] == 12
+
+    # Harness UUID must NOT be written as agent_session_id (silent join miss).
+    rejected = build_session_transcript_entity(
+        content_hash="deadbeef",
+        agent_session_id="uuid-123",
+    )
+    assert "agent_session_id" not in rejected
 
 
 def test_hash_transcript_file_matches_sha256() -> None:
@@ -109,19 +120,52 @@ def test_hash_transcript_file_missing_returns_none() -> None:
     assert hash_transcript_file("/no/such/file.jsonl") is None
 
 
-def test_record_agent_session_stores_with_stable_idempotency_key() -> None:
-    client = StubClient()
-    record_agent_session(
+def test_record_agent_session_returns_entity_id_from_store() -> None:
+    client = StubClient(entity_id="ent_session_abc")
+    result = record_agent_session(
         client,
         native_session_id="uuid-123",
         hook_event="SessionStart",
         kind="interactive",
     )
+    assert result is not None
+    assert result["entity_id"] == "ent_session_abc"
+    assert result["native_session_id"] == "uuid-123"
     assert len(client.calls) == 1
     call = client.calls[0]
     assert call["idempotency_key"] == "agent-session-claude-code-uuid-123-SessionStart"
     assert call["entities"][0]["native_session_id"] == "uuid-123"
     assert call["entities"][0]["harness"] == "claude-code"
+
+
+def test_record_agent_session_retrieve_fallback_uses_entities_id() -> None:
+    """When store omits entity_id, parse REST retrieve shape {entities:[{id}]}."""
+
+    class StoreThenRetrieveClient:
+        def __init__(self) -> None:
+            self.store_calls: list[dict] = []
+
+        def store(self, input):  # noqa: A002
+            self.store_calls.append(input)
+            # Dual-shape empty: no entity_id in response.
+            return {"entities": [{"action": "updated"}]}
+
+        def retrieve_entity_by_identifier(self, input):  # noqa: A002
+            assert input["entity_type"] == "agent_session"
+            assert input["identifier"] == "uuid-123"
+            return {
+                "entities": [{"id": "ent_from_retrieve"}],
+                "total": 1,
+                "match_mode": "snapshot_field",
+            }
+
+    result = record_agent_session(
+        StoreThenRetrieveClient(),
+        native_session_id="uuid-123",
+        hook_event="Stop",
+    )
+    assert result is not None
+    assert result["entity_id"] == "ent_from_retrieve"
 
 
 def test_record_agent_session_noop_without_session_id() -> None:
@@ -130,7 +174,33 @@ def test_record_agent_session_noop_without_session_id() -> None:
     assert client.calls == []
 
 
-def test_record_session_transcript_hashes_and_links() -> None:
+def test_record_session_transcript_hashes_and_links_ent_fk() -> None:
+    client = StubClient()
+    with tempfile.TemporaryDirectory() as d:
+        path = Path(d) / "t.jsonl"
+        path.write_bytes(b'{"x":1}\n')
+        entity = record_session_transcript(
+            client,
+            transcript_path=str(path),
+            agent_session_id="ent_stub",
+        )
+    assert entity is not None
+    assert len(client.calls) == 1
+    call = client.calls[0]
+    stored = call["entities"][0]
+    assert stored["entity_type"] == "session_transcript"
+    assert stored["agent_session_id"] == "ent_stub"
+    assert call["idempotency_key"] == f"session-transcript-{stored['content_hash']}"
+    assert call["relationships"] == [
+        {
+            "relationship_type": "PART_OF",
+            "source_index": 0,
+            "target_entity_id": "ent_stub",
+        }
+    ]
+
+
+def test_record_session_transcript_rejects_harness_uuid_fk() -> None:
     client = StubClient()
     with tempfile.TemporaryDirectory() as d:
         path = Path(d) / "t.jsonl"
@@ -141,12 +211,9 @@ def test_record_session_transcript_hashes_and_links() -> None:
             agent_session_id="uuid-123",
         )
     assert entity is not None
-    assert len(client.calls) == 1
-    call = client.calls[0]
-    stored = call["entities"][0]
-    assert stored["entity_type"] == "session_transcript"
-    assert stored["agent_session_id"] == "uuid-123"
-    assert call["idempotency_key"] == f"session-transcript-{stored['content_hash']}"
+    stored = client.calls[0]["entities"][0]
+    assert "agent_session_id" not in stored
+    assert "relationships" not in client.calls[0]
 
 
 def test_record_session_transcript_noop_for_missing_path() -> None:
@@ -167,6 +234,86 @@ def test_record_helpers_swallow_client_errors() -> None:
         path = Path(d) / "t.jsonl"
         path.write_bytes(b"x\n")
         assert record_session_transcript(BoomClient(), transcript_path=str(path)) is None
+
+
+def test_redact_repository_remote_userinfo() -> None:
+    # Placeholder credentials only — never real secrets in fixtures.
+    assert (
+        redact_repository_remote("https://oauth2:PLACEHOLDER_TOKEN@github.com/org/repo.git")
+        == "https://<redacted>@github.com/org/repo.git"
+    )
+    assert (
+        redact_repository_remote("https://user:PLACEHOLDER_PASS@github.com/org/repo.git")
+        == "https://<redacted>@github.com/org/repo.git"
+    )
+
+
+def test_redact_repository_remote_query_params() -> None:
+    assert (
+        redact_repository_remote(
+            "https://github.com/org/repo.git?access_token=PLACEHOLDER_AT&ref=main"
+        )
+        == "https://github.com/org/repo.git?access_token=<redacted>&ref=main"
+    )
+    assert (
+        redact_repository_remote(
+            "https://github.com/org/repo.git?token=PLACEHOLDER_T&auth=PLACEHOLDER_A"
+        )
+        == "https://github.com/org/repo.git?token=<redacted>&auth=<redacted>"
+    )
+    assert (
+        redact_repository_remote(
+            "https://github.com/org/repo.git?key=PLACEHOLDER_K&password=PLACEHOLDER_P"
+        )
+        == "https://github.com/org/repo.git?key=<redacted>&password=<redacted>"
+    )
+
+
+def test_redact_repository_remote_clean_and_empty() -> None:
+    clean = "https://github.com/org/repo.git"
+    assert redact_repository_remote(clean) == clean
+    assert redact_repository_remote("git@github.com:org/repo.git") == "git@github.com:org/repo.git"
+    assert redact_repository_remote(None) is None
+    assert redact_repository_remote("") is None
+
+
+def test_git_context_redacts_remote_origin_url() -> None:
+    with patch("subprocess.run") as run_mock:
+
+        def _run(cmd, **kwargs):  # noqa: ANN001
+            class Res:
+                returncode = 0
+                stdout = ""
+
+            # Mirror _git: it passes ["git", *args]
+            args = cmd[1:] if cmd and cmd[0] == "git" else cmd
+            joined = " ".join(args)
+            res = Res()
+            if "show-toplevel" in joined:
+                res.stdout = "/tmp/repo\n"
+            elif "abbrev-ref" in joined:
+                res.stdout = "main\n"
+            elif args == ["rev-parse", "HEAD"]:
+                res.stdout = "abc123\n"
+            elif "remote.origin.url" in joined:
+                res.stdout = "https://oauth2:PLACEHOLDER_TOKEN@github.com/org/repo.git\n"
+            return res
+
+        run_mock.side_effect = _run
+        ctx = git_context("/tmp/repo")
+
+    assert ctx["repo_remote_url"] == "https://<redacted>@github.com/org/repo.git"
+    assert "PLACEHOLDER_TOKEN" not in ctx["repo_remote_url"]
+
+
+def test_build_agent_session_entity_redacts_raw_git_remote() -> None:
+    entity = build_agent_session_entity(
+        native_session_id="uuid-123",
+        git={
+            "repo_remote_url": "https://user:PLACEHOLDER_PASS@github.com/org/repo.git",
+        },
+    )
+    assert entity["repo_remote_url"] == "https://<redacted>@github.com/org/repo.git"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Follow-up to #1743. Wires the `agent_session` + `session_transcript` runtime/resume layer into the Claude Code plugin lifecycle hooks, so the capture is **deterministic** (hook-driven) rather than dependent on the agent's non-deterministic MCP tool usage.

Stacked on `feat/agent-session-capture` (#1743), which adds the two schema types + backfill tooling.

## What it does

| Hook | Added capture |
| --- | --- |
| `SessionStart` | Opens the `agent_session` (harness `claude-code` + native session id, `kind=interactive`, git env via `git_context()`, `created_at`, `resume_command` = `claude --resume <id>`). Only for a real harness UUID. |
| `Stop` | Refreshes the `agent_session` (`last_activity_at`) and snapshots the transcript as a content-addressed `session_transcript` index entity — runs before the empty-reply short-circuit so it always fires. |

`_common.py` gains the pure builders (`build_agent_session_entity`, `build_session_transcript_entity`), the best-effort recorders (`record_agent_session`, `record_session_transcript`), `git_context()`, and a streaming `hash_transcript_file()` (SHA-256 + byte size + line count).

## Design notes

- **Harness value** is the `claude-code` (hyphen) constant. It is part of `agent_session`'s joint identity `["harness","native_session_id"]`, so an underscore would key a different (wrong) entity. A `HARNESS` constant + a test lock this.
- **Index only**: the Stop hook records the `session_transcript` index (content_hash / file_size / turn_count); uploading the transcript bytes to the sources bucket stays in backfill tooling (the vendored hook client has `store` only, no blob upload).
- **Best-effort**: every helper swallows transport/IO errors and logs at debug — a failure here never blocks the agent turn.
- **Idempotent**: `agent_session` upserts under a stable key per `(session_id, hook_event)`; `session_transcript` under `session-transcript-<content_hash>`, so an unchanged transcript coalesces.

## Tests

`packages/claude-code-plugin/tests/test_session_capture.py` — 10 unit tests (pure builders, streaming hash vs `hashlib`, stub-client store payloads + idempotency keys, missing-path no-ops, error swallowing). Runs under pytest or standalone (`python3 test_session_capture.py`). All pass.

## Verification

Harness value already reconciled in production via #1743's tooling: `agent_session` 1876 and `session_transcript` 1886 now on `claude-code`; 0 remain on `claude_code`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)