### PR TITLE
chore(npm): authenticate publish via NODE_AUTH_TOKEN in .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,10 @@
 # Suppress "packages are looking for funding" / "npm fund" message
 fund=false
+
+# Authenticate publishes via the NODE_AUTH_TOKEN env var (npm's standard name).
+# The token is provisioned out-of-band from the SOPS secrets snapshot
+# (ateles-private -> ~/.config/neotoma/.env, key NODE_AUTH_TOKEN). Before
+# publishing, load it into the environment, e.g.:
+#   set -a; . ~/.config/neotoma/.env; set +a
+# This file contains no secret — only an env-var reference npm interpolates.
+//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}


### PR DESCRIPTION
## Why
The v0.16.0 release publish stalled on `npm whoami → 401 Unauthorized`: nothing wired an npm auth token into the publish flow. (The legacy path tried a live `op read` of a 1Password item whose reference was doubly broken — wrong vault `Personal` and an en-dash field label `op` rejects.)

## What
Add the standard line to `.npmrc`:
```
//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
```
No secret is committed — only an env-var reference npm interpolates at publish time.

## Token provisioning
`NODE_AUTH_TOKEN` now ships in the SOPS secrets snapshot (`ateles-private` → materializes to `~/.config/neotoma/.env`), referenced by stable 1Password **field id** so the en-dash label can't break it again. Before publishing:
```
set -a; . ~/.config/neotoma/.env; set +a
npm publish
```

## Verification
`NODE_AUTH_TOKEN=… npm whoami` → `markmhendrickson` (the publishing account). The prior 401 is resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)