### PR TITLE
chore(skills): reconcile on-disk mirrors with Neotoma canonical

### DIFF
--- a/skills/end/SKILL.md
+++ b/skills/end/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: end
-description: Session-end audit. Files remaining work as task entities and lists them as bullets, verifies all data intended for Neotoma storage from this session is actually stored, and persists what's missing. Invoke at the natural close of a working session, before context is lost.
+description: Session-end audit. Files remaining work as task entities and lists them as bullets, verifies all data intended for Neotoma storage from this session is actually stored, persists what's missing without a confirmation gate, and reviews the whole session (transcript JSONL when context is partial) for human-in-the-loop work that could be automated — filing automation proposals as tasks with autonomy-readiness classification. User-level skill (~/.claude/skills/end/), available in every repo.
 triggers:
   - /end
   - end session
@@ -18,13 +18,13 @@ entity_id: ent_af748d985b7bfa4f636eea70
 
 ## Purpose
 
-Run a session-close audit so nothing intended for follow-up or for Neotoma storage falls through the cracks. Distinct from `store-data` (single per-record persistence) and `store-neotoma` (full chat-transcript persistence): `/end` is the meta-step that decides which of those to invoke, files trackable work as task entities, and verifies storage.
+Run a session-close audit so nothing intended for follow-up or for Neotoma storage falls through the cracks. Distinct from `store-data` (single per-record persistence) and `store-neotoma` (full chat-transcript persistence): `/end` is the meta-step that decides which of those to invoke, files trackable work as task entities, and verifies storage. It also closes the automation loop: every session is reviewed for work conducted with a human in the loop (HITL) that agents could execute autonomously next time, and those opportunities are filed as automation-proposal tasks (Phase 3). When writing was crafted in the session, it additionally closes the **voice loop** — generalizing the operator's own edits to agent drafts into a durable voice/style guide so future generation needs less HITL editing, and routing rendered-page design/structure edits back into the page-drafting skill (Phase 3b).
 
 This skill is **user-level** (`~/.claude/skills/end/`), so it is available in every repo automatically.
 
 ## Scope
 
-Applies once per session, at user request. Does not modify code. Files Neotoma entities (tasks, sources, plan updates), persists missing entities, and delegates to `store-neotoma` for chat persistence.
+Applies once per session, at user request. Does not modify code. Files Neotoma entities (tasks, sources, plan updates), persists missing entities, and delegates to `store-neotoma` for chat persistence. Automation proposals are filed as tasks — `/end` does not itself create skills, hooks, daemons, or execution policies. The one durable artifact `/end` MAY write directly is the voice/style guide entity (Phase 3b), because it is the operator's own corrections captured verbatim, not a generated automation.
 
 ## Execution policy (no confirmation gate)
 
@@ -35,9 +35,27 @@ Applies once per session, at user request. Does not modify code. Files Neotoma e
 - The only thing it never auto-executes is `do-now` code work unless the user explicitly asked for it in-session; those are filed as tasks like any other `track` item.
 - PII MUST still be stripped from any filed issues per the `feedback_issue_pii` memory, and standing constraints (Neotoma prod, never mark yoga/therapy done, etc.) still apply.
 
+## Phase 0: Whole-session coverage (read the transcript when context is partial)
+
+`/end` must audit the **whole session**, not just the portion currently in context. This matters more here than for `/status`: a partial scan silently *fails to file* trackable work, *misses storage gaps*, and *misses HITL patterns* from the earlier session, defeating the skill's purpose.
+
+Before Phase 1, decide whether context is whole-session or partial. Treat it as **partial** whenever any of these hold:
+
+- A compaction/summary boundary is present in context (a "This session is being continued…" summary block, or an injected session-summary).
+- The session spans multiple days or many turns.
+- The user signals earlier work was missed.
+
+When partial, reconstruct the full arc from the transcript **before** auditing:
+
+1. **Locate the transcript JSONL.** It lives under `~/.claude/projects/<project-slug>/<session-id>.jsonl`. The compaction summary names the exact path; otherwise pick the most recently modified `.jsonl` in that project dir.
+2. **Do not read the whole file into context** — it can be multiple MB. Extract a skeleton with a small script: pull genuine user messages (filter out `tool_result` payloads, `<system-reminder>` / `<command-*>` / `<local-command-*>` blocks, and "Continue from where you left off."), plus the assistant's short summary lines, any entity IDs / PR numbers mentioned, and markers of HITL moments — operator approvals/confirmations, manual steps the user performed, corrections the user issued (needed by Phase 3), and **operator edits to agent-drafted writing OR rendered pages** — places where the agent produced prose (an email, post, message, doc) or a `rendered_page` and the operator rewrote, retoned, restructured, restyled, or replaced any of it before it shipped (needed by Phase 3b). This recovers the full request arc, the entities surfaced, the HITL pattern set, and the writing/page-edit set, cheaply.
+3. **Feed that whole-session skeleton into Phases 1–3b** — the remaining-work audit, the storage audit, the automation-opportunity audit, and the voice-loop audit must all cover the entire session, not just the in-context tail.
+
+If the transcript can't be found or read, proceed from context but state in the final report that coverage may be tail-only, so the user knows earlier work might be unaudited. When context is already whole-session (short, no compaction boundary), skip the transcript read.
+
 ## Phase 1: Remaining-work audit
 
-Scan the current conversation and identify every follow-up under these headings:
+Scan the whole session (per Phase 0 — the transcript skeleton when context is partial, otherwise the in-context conversation) and identify every follow-up under these headings:
 
 1. **Open work** — TODOs the assistant introduced, partial implementations, files modified but not verified, tests not run, lint/type-check skipped, PRs/commits not made.
 2. **Decisions or proposals not acted on** — recommendations the user accepted that have not been executed; designs sketched but not implemented.
@@ -51,30 +69,74 @@ For each item, classify: `do-now` (trivially finishable inline only if the user 
 
 Determine what should be in Neotoma from this session and what already is.
 
-1. **Per-turn lifecycle compliance** — confirm each turn this session followed the Neotoma turn lifecycle (user message + assistant message stored, PART_OF + REFERS_TO edges). If any turn was skipped (which is forbidden), note it for repair.
+1. **Per-turn lifecycle compliance** — confirm each turn this session followed the Neotoma turn lifecycle (user message + assistant message stored, PART_OF + REFERS_TO edges). Use the Phase 0 transcript skeleton to enumerate turns when context is partial, so turns from before a compaction boundary are checked too. If any turn was skipped (which is forbidden), note it for repair.
 2. **Substantive entities surfaced** — list every concrete entity discussed or produced this session: plans, decisions, skills, rules, bugs, contacts, transactions, events, code artifacts, etc. For each, check via `retrieve_entity_by_identifier` or `retrieve_entities` whether it is already stored.
 3. **Files or attachments** — any files the user pasted, screenshots, transcripts, or external URLs fetched. Check whether each has a corresponding `source_id` / content-addressed source row.
 4. **Memory-worthy facts** — items that should be written to the auto-memory directory (`~/.claude/projects/.../memory/`) per the auto-memory protocol.
 
-## Phase 3: Execute (file tasks first, then everything else)
+## Phase 3: Automation-opportunity audit (HITL → autonomous)
+
+Review the whole session (per Phase 0) for work conducted with a human in the loop and propose how tasks of the same nature could run with minimal or no HITL in the future.
+
+1. **Identify HITL patterns** — scan for: operator approvals/confirmations mid-flow; manual steps the user performed (running commands, pasting data, clicking through UIs, supplying credentials); repeated tool sequences the assistant executed step-by-step; corrections or preferences the user issued that imply a missing rule or skill; recurring task shapes (triage, syncs, drafting, filing, reporting).
+2. **Propose the cheapest adequate mechanism** for each pattern:
+   - **Rule or hook** — when the fix is "always do X when Y" (creation delegated to `/learn`).
+   - **Skill update or new skill** — when the workflow is multi-step and reusable (creation delegated to `/learn` / `skill-creator`).
+   - **Scheduled task, cron, or daemon/agent assignment** — when the work is time- or event-driven and an existing agent owns the domain.
+   - **`execution_policy` entity** (swarm governance layer) — when a whole plan's worth of work needs autonomy calibration: permission scopes, quality criteria, blocking checkpoints, and fallback instructions.
+3. **Classify autonomy readiness** per proposal: `full-auto` (safe to run unattended), `checkpoint-gated` (autonomous with blocking `checkpoint_brief` reviews), or `hitl-required` (judgment-heavy or irreversible/external-facing; automate only the preparation). Standing constraints (PII stripping, payment rules, Neotoma prod only, never-complete yoga/therapy) carry into every proposal — an automation that would violate them is `hitl-required` by definition.
+4. **Apply a repeatability threshold** — propose only for work that recurred this session or is known-recurring across sessions (check Neotoma for prior tasks/conversations of the same shape). Genuine one-offs are dropped with a one-line reason.
+5. **File, don't build** — each surviving proposal becomes a `task` entity in Phase 4 (PART_OF the active plan, REFERS_TO the relevant entities/skills/agents), with fields capturing the HITL pattern, proposed mechanism, and autonomy readiness. Creating the actual rule/skill/hook/policy happens later via `/learn` or explicit user request, never inside `/end`.
+
+## Phase 3b: Voice-loop audit (HITL writing/page edits → durable guidance)
+
+Run this phase **only when writing or a rendered page was crafted in the session** — any agent-drafted prose meant for a human audience (emails, messages, social posts, blog/long-form, recaps, docs) or any `rendered_page`. Its goal is to make the operator's own edits self-eliminating: every time the operator rewrites or restyles an agent draft, that delta is generalized into standing guidance so the *next* draft starts right and needs no edit. This is the inverse of Phase 3 — there the human approves a *process*; here the human corrects a *draft*, and the correction is the asset.
+
+1. **Detect agent-drafted artifacts + operator edits.** From the Phase 0 skeleton (or in-context tail), find each piece the agent produced for a human audience — prose AND rendered pages — and whether the operator changed it before it shipped. Signals of an edit: the operator pasted back a revised version, asked for a reword/retone/trim/expansion/restyle/relayout, said "make it more/less X", swapped specific words, phrasings, colors, or sections, cut or moved a block, changed the sign-off, fixed a theming/contrast/mobile issue, or rejected a draft and supplied their own. A draft sent **verbatim** is also signal — it confirms the draft was already right; note what worked so the guidance reinforces it, not just corrects.
+2. **Diff draft → final and name the delta — classifying each as VOICE or PAGE-CRAFT.** For each edited artifact, compare what the agent produced against what the operator made it, and split the deltas by type:
+   - **Voice deltas** (apply to prose *and* to the copy on a page): *lexical* (words/phrases the operator removes — hype, filler, AI-generic patterns — or substitutes); *tonal/register* (warmer/drier, more/less formal, more direct, less hedged); *structural* (length, paragraphing, where the claim goes, single-post vs thread, links inline vs separate, sign-off form); *content discipline* (what they always cut — meta-commentary, obligating CTAs, unverifiable superlatives — or always require — a worked example, the scheduler link, an author tag).
+   - **Page-craft deltas** (rendered pages only — design, layout, accessibility, structure, host-template behavior): theming (light/dark, CSS variables, palette), contrast/WCAG fixes, mobile responsiveness, SVG/diagram handling, container nesting / HTML structure, host-template style overrides (e.g. `pre{}`/`code{}`/`th{}`/`a{}` colors leaking through), section ordering / which sections to include or omit, CTA/hero conventions, the entities-vs-flat-strings modeling preference. These are the design-and-structure lessons the `draft-rendered-page` skill already accumulates.
+3. **Generalize past the instance.** Ask: would this edit recur on *other* artifacts of the same kind? Keep universal rules; discard recipient-specific or one-off content choices (a particular name, a particular scenario, this recipient's brand palette) — those are not reusable guidance. Cross-check against existing voice memories and content-rule feedback (e.g. `feedback_no_ai_generic_patterns`, `feedback_oxford_comma`, `feedback_single_post_vs_thread`, `feedback_social_links_inline`, `feedback_family_email_signoff`, `feedback_email_html_formatting`, `feedback_rendered_page_standards`) AND against the rules already in the `draft-rendered-page` skill's `content`, so you extend rather than duplicate — if an edit is already covered, the lesson is that the rule wasn't applied, which is a Phase 3 process gap, not new guidance.
+4. **Route each delta to its correct home:**
+   - **Voice deltas → the durable voice/style guide** (the one artifact `/end` writes directly — see Scope). Two homes, write to both:
+     - **Neotoma**: a canonical `style_guide` entity (retrieve the operator's existing one by identifier first — e.g. `operator-voice-guide` — and `correct`/extend it; create it only if none exists). Organize rules by writing channel (email, social, long-form, page-copy, message) plus a universal section. Each rule carries a one-line principle, a before→after example drawn from this session's edit, and provenance back to the piece it came from.
+     - **Auto-memory**: a `feedback`-type memory file per durable rule (or extend an existing one), with the `**Why:**` / `**How to apply:**` lines, so it surfaces in future sessions' context. Update `MEMORY.md`.
+   - **Page-craft deltas → the `draft-rendered-page` skill, via a `/learn` task.** That skill already owns a "Learn from revision feedback" loop that folds generalized revisions into its own `content` field — so `/end` does NOT author the skill edit itself (it never authors skills inline). Instead, **file a `track` task** (Phase 4, classified `hitl-required` since it changes outward-facing page design) that names each generalized page-craft rule with its before→after example and provenance, REFERS_TO the `draft-rendered-page` skill (`ent_20d1e8a0419632311ac3c88d`) and the edited `rendered_page` entity, and instructs `/learn` to fold the rule into that skill's `content` via `correct`. This catches page edits made *outside* a formal `draft-rendered-page` invocation (e.g. by an agent, or ad-hoc), which would otherwise never reach the skill's own loop. If the page edit happened *inside* a `draft-rendered-page` run that already folded the lesson in, note it as already-captured and skip the task.
+5. **Make voice consumable by the generators.** Drafting skills (`write`, `write-blog-post`, `social`, `draft-rendered-page`, `email-triage` drafts, agent personas like Corvus) should pull the voice guide on the way *in*, not after. Where a generalized voice rule clearly belongs in a specific drafting skill, file a `track` task (Phase 4) proposing the skill/`/learn` update that has it read the `style_guide` entity, classified `hitl-required` if it changes outward-facing voice. Do not rewrite those skills inside `/end`; `/end` captures the voice, `/learn` wires it in.
+
+If no writing or page was crafted this session, state that in one line and skip the phase. If an artifact was crafted but the operator made no edits, record the verbatim-send as positive confirmation (light touch) and note it.
+
+## Phase 4: Execute (file tasks first, then everything else)
 
 Run in this order, without confirmation:
 
-1. **File `task` entities for every `track` item from Phase 1.** Create them via the `store` MCP tool (Neotoma prod) with `REFERS_TO` edges to the relevant entities, and `PART_OF` the active plan when one applies (e.g. the Ateles plan `ent_99ace4dd6673aa36ed08b1fe`). Follow the `update-tasks` skill for field values and priority mapping. Capture the returned task entity IDs.
+1. **File `task` entities for every `track` item from Phase 1 and every automation/voice/page-craft proposal from Phases 3 and 3b.** Create them via the `store` MCP tool (Neotoma prod) with `REFERS_TO` edges to the relevant entities (for page-craft tasks: the `draft-rendered-page` skill `ent_20d1e8a0419632311ac3c88d` and the edited `rendered_page`), and `PART_OF` the active plan when one applies (e.g. the Ateles plan ent_99ace4dd6673aa36ed08b1fe). Follow the `update-tasks` skill for field values and priority mapping. Capture the returned task entity IDs.
 2. **Store missing entities or sources flagged in Phase 2** via the `store` MCP tool.
-3. **If the conversation itself has not been persisted** as a `conversation` + dual `conversation_message` shape end-to-end, invoke `store-neotoma` to do the full transcript sweep — **without confirmation** (pass through the no-confirm intent).
-4. **Write any memory files** per the auto-memory protocol and update the `MEMORY.md` index.
-5. **Repair any skipped-turn lifecycle gaps** found in Phase 2.1.
+3. **Write/extend the voice/style guide from Phase 3b** — `correct`/extend (or create) the `style_guide` entity and write the per-rule memory files. Do this even though it is not a "task": it is the operator's own corrections, captured verbatim. (Page-craft deltas are NOT written here — they go to the `/learn` task filed in step 1, since `/end` does not author skills inline.)
+4. **If the conversation itself has not been persisted** as a `conversation` + dual `conversation_message` shape end-to-end, invoke `store-neotoma` to do the full transcript sweep — **without confirmation** (pass through the no-confirm intent).
+5. **Write any memory files** per the auto-memory protocol and update the `MEMORY.md` index.
+6. **Repair any skipped-turn lifecycle gaps** found in Phase 2.1.
 
-## Phase 4: Final report (bullets reflect what was actually stored)
+## Phase 5: Final report (bullets reflect what was actually stored)
 
 Because tasks are filed **before** reporting, the bulleted list reflects committed state, not intentions.
 
-Render two sections:
+Render these sections:
 
 ### Remaining work (now tracked)
 
 A bullet list of every `track` item, each as: `- <one-line description> — task [<entity_id>](<origin>/inspector/entities/<entity_id>)`. Then a short `do-now` list (done inline or filed) and a `dropped` list with one-line reasons.
+
+### Automation opportunities (proposed)
+
+A bullet per proposal: `- <HITL pattern> → <proposed mechanism> (<autonomy readiness>) — task [<entity_id>](<origin>/inspector/entities/<entity_id>)`. Then dropped one-offs with one-line reasons. If no HITL patterns met the repeatability threshold, say so in one line.
+
+### Voice & page-craft learnings (guidance updated)
+
+Only when writing or a page was crafted this session. Two subsections:
+- **Voice** (style guide updated directly): a bullet per durable voice rule captured: `- <principle> (<channel>) — e.g. "<before>" → "<after>"`, linking the updated `style_guide` entity and any memory file.
+- **Page-craft** (routed to draft-rendered-page via /learn): a bullet per durable page-craft rule: `- <principle> — e.g. "<before>" → "<after>" — task [<id>](<origin>/inspector/entities/<id>) (→ draft-rendered-page)`.
+Note any rule already covered by existing guidance (a process gap, not new guidance), and any verbatim-send confirmations. If an artifact was crafted but produced no generalizable delta, say so in one line.
 
 ### Storage
 
@@ -82,7 +144,7 @@ A bullet list of every `track` item, each as: `- <one-line description> — task
 - Memory files written.
 - Whether `store-neotoma` was invoked, and its affected-records summary.
 
-Then render the mandatory `🧠 Neotoma` turn report covering all entities created across Phases 3–4 (Created / Updated / Retrieved groups with linked entity IDs).
+Then render the mandatory `🧠 Neotoma` turn report covering all entities created/updated across Phases 4–5 (Created / Updated / Retrieved groups with linked entity IDs).
 
 ## Affected-records output (shared with store-neotoma)
 
@@ -92,15 +154,24 @@ Both `/end` and `store-neotoma` MUST emit a **succinct affected-records list** i
 
 - **`store-data`** — per-entity/per-file store primitive. `/end` calls the underlying `store` MCP tool for each gap in Phase 2.
 - **`store-neotoma`** — full chat-transcript persistence. `/end` delegates to it when the conversation is not yet fully persisted, and (per user preference) invokes it **without a confirmation gate**, expecting it to emit the succinct affected-records list above.
-- **`update-tasks`** — field/priority guidance for the task entities `/end` files in Phase 3.1.
+- **`update-tasks`** — field/priority guidance for the task entities `/end` files in Phase 4.1.
+- **`learn`** — converts accepted automation proposals into durable rules, skills, and hooks. `/end` proposes and files (Phase 3); `/learn` builds. For Phase 3b, `/end` captures voice into the `style_guide` entity + memory directly, and routes page-craft deltas to `/learn` as tasks so `/learn` folds them into the `draft-rendered-page` skill's `content`.
+- **`draft-rendered-page`** — the page-drafting skill that already accumulates design/structure/accessibility rules in its own `content` via its "Learn from revision feedback" loop. `/end`'s Phase 3b is the safety net for page edits made *outside* a formal invocation of that skill: it detects the edit, generalizes the page-craft rule, and files a `/learn` task to fold it into `draft-rendered-page` (`ent_20d1e8a0419632311ac3c88d`). The voice/copy on a page still routes to the `style_guide` like any prose.
+- **Drafting skills** (`write`, `write-blog-post`, `social`, `draft-rendered-page`, email/recap drafters, agent personas like Corvus) — the consumers of the Phase 3b voice/style guide. They should retrieve the `style_guide` entity before generating so the operator's voice is applied from the first draft, not patched in by HITL afterward.
 
 ## Constraints
 
-- MUST file `track` items as task entities **before** rendering the remaining-work bullets, so the bullets reflect stored state.
-- MUST NOT request confirmation before filing tasks, storing entities, or invoking `store-neotoma`.
+- MUST audit the whole session: when context is partial (a compaction boundary is present, the session is multi-day / many-turn, or the user flags missed work), reconstruct the full arc from the transcript JSONL (Phase 0) before Phases 1–3b, so trackable work, storage gaps, HITL patterns, and writing/page edits from before the boundary are not missed. If the transcript is unreadable, proceed but state in the final report that coverage may be tail-only.
+- MUST file `track` items and automation proposals as task entities **before** rendering the report bullets, so the bullets reflect stored state.
+- MUST NOT request confirmation before filing tasks, storing entities, writing the voice/style guide, or invoking `store-neotoma`.
 - MUST NOT skip the storage audit even if the user only asks about remaining work, and vice versa.
+- MUST run the automation-opportunity audit (Phase 3) on every invocation, classify each proposal's autonomy readiness, and apply the repeatability threshold; one-offs are dropped with a reason, not silently omitted.
+- MUST run the voice-loop audit (Phase 3b) whenever writing OR a rendered page was crafted in the session: detect operator edits, classify each delta as VOICE or PAGE-CRAFT, generalize past the instance, and route — voice rules written to the `style_guide` entity + auto-memory directly in the same `/end` pass; page-craft rules filed as a `/learn` task to fold into the `draft-rendered-page` skill. When nothing was crafted, state so and skip. MUST cross-check existing voice memories AND the `draft-rendered-page` skill's content to extend rather than duplicate; an edit already covered is a process gap (the rule wasn't applied), not new guidance.
+- MUST keep recipient-specific or one-off content choices (a name, a scenario, a recipient's brand palette) OUT of both the voice guide and the page-craft rules; only universal/channel-level voice, tone, structure, design, and accessibility rules are durable guidance.
+- MUST NOT author the `draft-rendered-page` skill edit inside `/end`: page-craft lessons are filed as `/learn` tasks, never folded into the skill by `/end` directly. The `style_guide` entity + voice memory files remain the sole durable artifacts `/end` writes directly, because they are the operator's own corrections captured verbatim.
+- MUST file automation proposals (and any drafting-skill voice/page-craft wiring) as task entities only; MUST NOT create skills, hooks, daemons, scheduled tasks, or execution policies inside `/end` unless the user explicitly asked in-session.
 - MUST classify every surfaced item; no unclassified entries.
-- MUST check existing Neotoma state via retrieval before declaring an item "not stored."
+- MUST check existing Neotoma state via retrieval before declaring an item "not stored" or before creating a new `style_guide` entity (extend the operator's existing one if present).
 - MUST defer chat-transcript storage to `store-neotoma`, not re-implement it.
 - MUST strip PII from any filed issues per the `feedback_issue_pii` memory; use `visibility: private` for session-derived issues.
 - MUST use Neotoma prod, never the dev instance.

--- a/skills/remember-calendar/SKILL.md
+++ b/skills/remember-calendar/SKILL.md
@@ -12,74 +12,89 @@ triggers:
   - import google calendar
 ---
 
-# Remember Calendar
+# remember-calendar — Neotoma ↔ Google Calendar Sync
 
-Import calendar events into Neotoma memory — either from a live calendar MCP or from ICS file exports. Extracts scheduling commitments, attendees, and recurring patterns.
+## Purpose
 
-## When to use
+Keep Neotoma `event` entities and Google Calendar in sync. The canonical record is Neotoma; Google Calendar is the display layer. Each event routes to a calendar based on its type, following the operator's routing config (retrieved at runtime — see below).
 
-When the user wants to persist calendar events, scheduling commitments, and associated contacts into durable memory.
+## Calendar routing (retrieve at runtime, never hardcode)
 
-## Prerequisites
+Calendar IDs and the personal routing rules are operator-specific, so they are **not** in this skill. At runtime, retrieve the `calendar_routing_config` entity named `operator-calendar-routing` from Neotoma and follow its `routing` table: each entry gives a `calendar_id` and the `use_when` conditions that select it, with one entry flagged `is_default` for the uncertain case. Use the `is_default` calendar when classification is ambiguous. After creating or updating an event, write back the fields named in the config's `writeback_fields` using its `writeback_idempotency_pattern`.
 
-Run the `ensure-neotoma` skill first if Neotoma is not yet installed or configured in your current harness.
+If the config entity is missing, stop and surface that rather than guessing a calendar.
 
-## Supported sources
+## Trigger conditions (proactive)
 
-| Source | Format | Method |
-|--------|--------|--------|
-| Google Calendar | Live API | Google Calendar MCP |
-| Apple Calendar | ICS export | File read |
-| Outlook | ICS export | File read |
-| Any calendar | `.ics` files | File read |
+Apply this skill **without being asked** whenever:
 
-## Workflow
+1. A new `event` entity is stored in Neotoma and it lacks a `google_event_id` field
+2. An event entity is corrected (date/time/location changed) and it has a `google_event_id` — update the GCal event
+3. The user shares a message, screenshot, or invitation containing event details
+4. A task is created with a due_date and a clear venue/meeting (create a calendar block)
 
-### Phase 0: Verify Neotoma
+## Execution steps
 
-Confirm Neotoma MCP is connected (call `get_session_identity`).
+### Step 1 — Classify the event
 
-### Phase 1: Identify source
+Read the event `name`, `description`, `location`, and any linked `contact` entities. Match them against the `use_when` conditions in the routing config to select the target calendar. When no entry clearly matches, use the `is_default` calendar.
 
-1. Check if a calendar MCP is configured (e.g. `list_events` tool available).
-2. If no MCP, ask the user for an ICS file path.
-3. For MCP: ask for a time range (default: past 30 days + next 30 days).
-4. For ICS: read the file to determine the date range available.
+### Step 2 — Determine status
 
-### Phase 2: Retrieve and preview
+- If the event is confirmed: `status: confirmed`
+- If pending an RSVP, decision, or discussion: `status: tentative`
+- Default to `tentative` when uncertain
 
-1. **Calendar MCP**: use `list_events` to retrieve events in the specified range.
-2. **ICS file**: parse the iCalendar format to extract events.
-3. Present a preview: event count, date range, recurring vs one-time, top attendees.
-4. Ask for confirmation.
+### Step 3 — Create or update the GCal event
 
-### Phase 3: Extract entities
+**Create:**
+```bash
+gws calendar events insert \
+  --params '{"calendarId":"<calendar_id>"}' \
+  --json '{
+    "summary": "<event name>",
+    "description": "<full description with price, RSVP info, contacts>",
+    "location": "<venue>",
+    "start": {"dateTime": "<ISO8601>", "timeZone": "Europe/Madrid"},
+    "end": {"dateTime": "<ISO8601>", "timeZone": "Europe/Madrid"},
+    "status": "<confirmed|tentative>"
+  }'
+```
 
-For each event:
+If only a date is known (no time): use `"date": "YYYY-MM-DD"` instead of `dateTime`.
 
-1. **Event**: create an `event` entity with `title`, `start_time`, `end_time`, `location`, `description`, `recurrence`.
-2. **Contacts**: extract attendees as `contact` entities (deduplicate against existing contacts).
-3. **Tasks**: for events with action-oriented titles or descriptions, create associated tasks.
-4. **Places**: extract locations as `place` entities when they are specific venues.
+**Update existing event:**
+```bash
+gws calendar events patch \
+  --params '{"calendarId":"<calendar_id>","eventId":"<google_event_id>"}' \
+  --json '{ ...changed fields only... }'
+```
 
-For MCP sources, hydrate via the detail endpoint (`get_event`) before persisting, and set `data_source` per event with the event ID.
+**Default time estimates when not specified:**
+- Lunch/dinner event with no end time → add 3 hours
+- Conference/talk → add 2 hours
+- All-day cultural event → use `date` (all-day)
 
-### Phase 4: Store with provenance
+### Step 4 — Store GCal IDs back to Neotoma
 
-- For MCP-sourced events: set `data_source` per entity with the calendar event ID.
-- For ICS files: use the combined store path (entities + file_path) to preserve the raw ICS.
-- Batch REFERS_TO relationships from events to attendee contacts.
+After creating the event, correct the Neotoma entity with the config's `writeback_fields` (typically `google_event_id`, `google_calendar_id` used, and `google_event_url` from the GCal `htmlLink`). Use the config's `writeback_idempotency_pattern` (e.g. `gcal-link-<entity_id>-<YYYY-MM-DD>`).
 
-### Phase 5: Report results
+### Step 5 — Report
 
-Summarize:
-- Events imported (count, date range)
-- Contacts extracted
-- Upcoming commitments highlighted
-- Offer to set up recurring sync or import a different date range.
+> 📅 Added to **<calendar>**: *[Event name]* — [Date], [Time], [Location] ([confirmed|tentative])
 
-## Do not
+## Idempotency
 
-- Import without user confirmation.
-- Create duplicate events — check by title + start_time before storing.
-- Create duplicate contacts — deduplicate by email first.
+Before creating a new GCal event, check whether the Neotoma event entity already has a `google_event_id`. If it does, skip creation and offer to update instead.
+
+## Timezone
+
+Always use `Europe/Madrid`. Never UTC.
+
+## Joint-decision events
+
+When an event requires a joint decision with another person, set status to `tentative` and note in the GCal description that it needs confirmation before it is final.
+
+## Bulk sync
+
+When invoked as `/remember-calendar` with no arguments, scan Neotoma for `event` entities missing `google_event_id` created in the last 30 days and process each in order. Report a summary table at the end.

--- a/skills/status/SKILL.md
+++ b/skills/status/SKILL.md
@@ -17,101 +17,56 @@ supported_harnesses:
 
 ## Purpose
 
-Give the user a quick, readable read-out of the session so far: what's been accomplished and what's still outstanding. This is a **stock-taking** skill, not a closing skill. It is the lightweight counterpart to `/end`.
+Give the user a quick, readable read-out of the session so far: what's been accomplished and what's still outstanding. A stock-taking skill, not a closing skill — the lightweight counterpart to `/end`. User-level (`~/.claude/skills/status/`), available in every repo.
 
-This skill is **user-level** (`~/.claude/skills/status/`), so it is available in every repo automatically.
+## How it differs from /end
 
-## How it differs from `/end`
+`/status` is READ-ONLY: it does NOT store entities, file tasks, write memory, invoke store-neotoma, or render the 🧠 Neotoma turn report. It just reports. (Read-only retrieval of an existing plan is allowed in project mode, but it never writes.) `/end` is the closing audit that files and persists. Use /status any time mid-session; use /end at the natural close.
 
-- **`/status` is read-only.** It does NOT store entities, file tasks, write memory, invoke `store-neotoma`, or render the `🧠 Neotoma` turn report. It just reports. (Read-only retrieval of an existing plan is allowed — see Project-aware mode — but it never writes.)
-- **`/end` is the closing audit** — it files and persists. Reach for `/end` at the natural close of a session; reach for `/status` any time mid-session to check in.
+## Whole-session coverage (read the transcript when context is partial)
 
-## Modes
+`/status` must report on the WHOLE session, not just the portion currently in context. Long sessions get compacted: the active context window may hold only a recent slice (e.g. a pre-compaction summary plus the last few turns), so reporting from context alone silently under-represents earlier work.
 
-`/status` has one default behavior and two optional modifiers, which compose:
+Before composing the report, decide whether context is whole-session or partial. Treat it as PARTIAL whenever any of these hold: a compaction/summary boundary is present in context (a "This session is being continued…" summary block, or an injected session-summary), the session spans multiple days or many turns, or the user signals the read-out missed earlier work. When partial, reconstruct the full arc from the transcript BEFORE reporting:
 
-- **`/status`** — the default: a quick, session-only read-out (the lightweight version below).
-- **`/status verbose`** (also `--full`, `full`, `detailed`) — a longer read-out with more detail per item. See *Verbose variant*.
-- **`/status project`** (also `plan`) — fold in the active plan's remaining work. See *Project-aware mode*. This is also applied automatically when an active plan is obvious from context (see that section), unless the user passed `session` / `--session-only`.
+1. Locate the session transcript JSONL. It lives under `~/.claude/projects/<project-slug>/<session-id>.jsonl` (the compaction summary names the exact path; otherwise pick the most recently modified `.jsonl` in that project dir).
+2. Do NOT read the whole file into context — it can be multiple MB. Instead extract a skeleton with a small script: pull genuine user messages (filter out tool_result payloads, `<system-reminder>`/`<command-*>`/`<local-command-*>` blocks, and "Continue from where you left off."), and optionally the assistant's short summary lines. This yields the session's request arc cheaply.
+3. Compose Achieved/Remaining from that whole-session skeleton, not just the in-context tail.
 
-Modifiers stack: `/status verbose project` gives the detailed, plan-aware read-out.
+If the transcript can't be found or read, say so in one line and report from context with an explicit caveat that coverage may be tail-only — don't present a partial read-out as complete. When context is already whole-session (short, no compaction boundary), skip the transcript read.
+
+## Modes (compose)
+
+- `/status` — default: quick read-out (whole-session per above).
+- `/status verbose` (also `--full`, `full`, `detailed`) — longer read-out with more context per item. See Verbose variant.
+- `/status project` (also `plan`) — fold in the active plan's remaining work (read-only). Also applied automatically when an active plan is obvious from context, unless the user passed `session` / `--session-only`.
+- Modifiers stack: `/status verbose project`.
 
 ## What to report
 
-Scan the conversation so far and produce a tight report with two parts.
-
-### Achieved this session
-
-A short qualitative summary of what's actually been completed and verified — framed in plain outcomes, not a tool-by-tool log. Lead with a one- or two-sentence prose overview of the session's arc, then a bullet list of concrete wins. Each bullet is one outcome in plain language (e.g. "Made `/end` a user-level skill available in every repo"), with at most a light technical anchor (a file path, entity ID, or PR number) where it genuinely helps the user locate the work. Only count things that are done — not things attempted or in flight.
-
-### Remaining
-
-What's still open, as the user would think about it — not an exhaustive TODO dump. Bullet list, each item phrased as the outstanding outcome, optionally tagged with where it stands:
-
-- **In progress** — started but not finished this session.
-- **Next up** — agreed/obvious next steps not yet begun.
-- **Blocked / waiting** — anything depending on CI, a remote agent, a scheduled task, the operator, or a third party (name the blocker in a few words).
-
-If something was explicitly dropped or deferred, note it in one line so the user knows it wasn't forgotten.
+Two parts. ACHIEVED THIS SESSION: a short qualitative summary of what's actually completed and verified, framed as plain outcomes not a tool-by-tool log. Lead with a 1–2 sentence overview, then outcome bullets — one win each in plain language, with at most a light technical anchor (file path, entity ID, PR number) where it helps locate the work. Only count things that are done. REMAINING: what's still open as the user would think about it (not an exhaustive TODO dump). Bullets tagged where they stand: in progress / next up / blocked-or-waiting (name the blocker). Note anything explicitly dropped in one line.
 
 ## Format and tone rules
 
-- **Succinct.** Aim for something scannable in well under a minute. Prefer fewer, higher-signal bullets over completeness.
-- **Qualitative prose and/or bullets.** A short lead paragraph per section is welcome; long nested checklists are not.
-- **Light technical detail only.** Include a file path, entity ID, or PR number only when it helps the user *find* the work — never raw tool output, diffs, command logs, or schema chatter.
-- **Outcomes, not mechanics.** Describe what changed for the user, not which tools were called to do it.
-- **No new work.** Do not start tasks, store data, or propose a long plan; if the user wants to close out and persist, point them at `/end`.
-
-## Suggested shape
-
-```
-**Session so far**
-
-<1–2 sentence overview of what this session has been about.>
-
-Achieved
-- <outcome> (<optional light anchor>)
-- <outcome>
-
-Remaining
-- <outcome> — in progress
-- <outcome> — next up
-- <outcome> — blocked on <thing>
-```
-
-Adapt freely: if the session has achieved a lot and has little remaining (or vice versa), let the sections breathe accordingly. If almost nothing has happened yet, say so in a sentence rather than padding.
+- Succinct: scannable in well under a minute; fewer high-signal bullets over completeness.
+- Qualitative prose and/or bullets; short lead paragraph per section welcome, long nested checklists not.
+- Light technical detail only — anchors for navigation only, never raw tool output, diffs, command logs, or schema chatter.
+- Outcomes, not mechanics.
+- No new work: don't start tasks, store data, or propose a long plan; point at /end to close out and persist.
 
 ## Project-aware mode
 
-When the session is tied to a tracked plan, `/status` can cross-reference it so "Remaining" reflects not just this session but where the broader project stands.
-
-**When to engage it:**
-
-- The user passed `project` / `plan`, OR
-- An active plan is obvious from context — e.g. CLAUDE.md names a plan entity (the Ateles plan is `ent_99ace4dd6673aa36ed08b1fe`), or the session has been working against one. When obvious, engage it by default; skip if the user passed `session` / `--session-only`.
-
-**How (read-only):**
-
-1. Retrieve the plan entity via `retrieve_entity_by_identifier` / `retrieve_entity_snapshot` (Neotoma prod). Read its `todos`, `next_steps`, `decisions`, and `body`. **Never correct or write the plan** — that's `/update-plan`'s job; `/status` only reads.
-2. In **Achieved**, mark any session outcomes that close a plan todo, e.g. "Made `/end` user-level — closes plan todo *distribute end skill*."
-3. In **Remaining**, add a short **Plan** sub-group: the plan's still-open todos and `next_steps` not touched this session, each one line. Surface current `next_steps` blockers verbatim-ish but trimmed.
-4. Keep it light: summarize the plan's open items, don't dump the whole todo array. If the plan has many open todos, show the top few by priority and note the count of the rest (e.g. "+6 more open todos").
-
-If no plan is found, silently fall back to the session-only report — do not announce the absence unless the user explicitly asked for `project` mode.
+When the session is tied to a tracked plan, cross-reference it so Remaining reflects where the broader project stands, not just this session. Engage when the user passed `project`/`plan`, OR an active plan is obvious from context (e.g. CLAUDE.md names a plan entity — the Ateles plan is ent_99ace4dd6673aa36ed08b1fe); skip if the user passed `session`/`--session-only`. How (read-only): (1) retrieve the plan via retrieve_entity_by_identifier / retrieve_entity_snapshot (Neotoma prod); read todos, next_steps, decisions, body — NEVER correct or write it (that's /update-plan). (2) In Achieved, mark session outcomes that close a plan todo. (3) In Remaining, add a short Plan sub-group: still-open todos and next_steps not touched this session, one line each. (4) Keep it light — summarize open items, show top few by priority and note the count of the rest; don't dump the whole array. If no plan is found, silently fall back to session-only unless the user explicitly asked for project mode.
 
 ## Verbose variant
 
-`/status verbose` produces a fuller read-out while keeping the same structure and the same read-only, outcomes-first discipline. Relative to the default:
-
-- Each **Achieved** bullet may carry a second clause of context — *why* it mattered or what it unblocks — and may include the navigation anchor inline.
-- **Remaining** items may note the dependency or the reason they're still open, not just the tag.
-- Add a brief **Decisions made this session** sub-section (one line each) when the session settled anything worth recording — so the user can eyeball what might warrant `/end` persistence.
-- Still no raw logs, diffs, or tool-by-tool narration. "Verbose" means more *context*, not more *mechanics*. Target a comfortable read in a couple of minutes, not an exhaustive audit.
+`/status verbose` is a fuller read-out, same structure and same read-only outcomes-first discipline. Each Achieved bullet may carry a second clause of context (why it mattered / what it unblocks) and an inline anchor; Remaining items may note the dependency or reason they're open; add a brief 'Decisions made this session' sub-section (one line each) when the session settled anything worth recording. Still no raw logs, diffs, or tool-by-tool narration — verbose means more context, not more mechanics. Target a couple-minute read, not an audit.
 
 ## Constraints
 
-- MUST be read-only: no `store`, no task filing, no memory writes, no `store-neotoma`, no `🧠 Neotoma` turn report. Project-aware mode may *read* a plan but MUST NOT correct or write it (that's `/update-plan`).
-- MUST keep technical detail light — anchors for navigation only, never logs or diffs — in both default and verbose modes.
+- MUST report on the whole session: when context is partial (compaction boundary present, multi-day/many-turn session, or the user flags missed work), reconstruct the full arc from the transcript JSONL before reporting; never present a tail-only read-out as complete. If the transcript is unreadable, report from context with an explicit coverage caveat.
+- MUST be read-only: no store, no task filing, no memory writes, no store-neotoma, no 🧠 Neotoma turn report. Project-aware mode may read a plan but MUST NOT write it (that's /update-plan). Reading the transcript JSONL is a read and is allowed.
+- MUST keep technical detail light — navigation anchors only, never logs or diffs — in both default and verbose modes.
 - MUST separate genuinely-completed work from outstanding/in-progress work; do not report attempts as achievements.
-- Default `/status` MUST stay succinct; resist turning the report into a full audit (that's `/end`). `verbose` adds context, never mechanics.
+- Default /status MUST stay succinct; resist turning into a full audit (that's /end). verbose adds context, never mechanics.
 - Project-aware mode MUST summarize the plan's open items, not dump the full todo array.


### PR DESCRIPTION
Reconcile on-disk SKILL.md mirrors with their canonical Neotoma skill entities (entity_id drift fix + entity-only skills materialized). Generated by execution/scripts/sync_skills.py; content is Neotoma-canonical, no hand edits.