### PR TITLE
fix(proxy): recover MCP sessions across backend restarts/replicas (#1667, #1472)

### DIFF
--- a/src/proxy/mcp_stdio_proxy.test.ts
+++ b/src/proxy/mcp_stdio_proxy.test.ts
@@ -21,10 +21,7 @@ const baseConfig: ProxyConfig = {
   autostart: false,
 };
 
-function jsonResponse(
-  obj: unknown,
-  opts: { status?: number; sessionId?: string } = {}
-): Response {
+function jsonResponse(obj: unknown, opts: { status?: number; sessionId?: string } = {}): Response {
   const headers: Record<string, string> = { "content-type": "application/json" };
   if (opts.sessionId) headers["mcp-session-id"] = opts.sessionId;
   return new Response(JSON.stringify(obj), { status: opts.status ?? 200, headers });
@@ -84,7 +81,10 @@ describe("isRecoverableMcpSessionLostError", () => {
       isRecoverableMcpSessionLostError(503, "MCP session is unknown on this API instance")
     ).toBe(true);
     expect(
-      isRecoverableMcpSessionLostError(503, "service unavailable: session is unknown on this api instance")
+      isRecoverableMcpSessionLostError(
+        503,
+        "service unavailable: session is unknown on this api instance"
+      )
     ).toBe(true);
   });
   it("ignores non-503 statuses and unrelated bodies", () => {

--- a/src/proxy/mcp_stdio_proxy.test.ts
+++ b/src/proxy/mcp_stdio_proxy.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  backoffMs,
+  createLoopState,
+  dispatchCore,
+  isRecoverableMcpSessionLostError,
+  withTimeout,
+  type DispatchDeps,
+  type ProxyConfig,
+} from "./mcp_stdio_proxy.js";
+
+const baseConfig: ProxyConfig = {
+  downstreamUrl: "http://downstream.test/mcp",
+  clientName: "test-proxy",
+  clientVersion: "1.0.0",
+  sessionPreflight: false,
+  failClosed: false,
+  extraHeaders: {},
+  aauthEnabled: false,
+  autostart: false,
+};
+
+function jsonResponse(
+  obj: unknown,
+  opts: { status?: number; sessionId?: string } = {}
+): Response {
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  if (opts.sessionId) headers["mcp-session-id"] = opts.sessionId;
+  return new Response(JSON.stringify(obj), { status: opts.status ?? 200, headers });
+}
+
+/** Mirrors the `503 … session is unknown on this API instance` body from src/actions.ts. */
+function sessionLostResponse(): Response {
+  return jsonResponse(
+    {
+      jsonrpc: "2.0",
+      id: null,
+      error: {
+        code: -32001,
+        message: "Service Unavailable: MCP session is unknown on this API instance.",
+      },
+    },
+    { status: 503 }
+  );
+}
+
+type SendStep = (headers: Record<string, string>, body: string) => Response | Promise<Response>;
+
+function makeDeps(
+  send: DispatchDeps["send"],
+  opts: { maxAttempts?: number; timeoutMs?: number } = {}
+): { deps: DispatchDeps; emitted: unknown[] } {
+  const emitted: unknown[] = [];
+  return {
+    emitted,
+    deps: {
+      send,
+      emit: (payload) => emitted.push(payload),
+      sleep: () => Promise.resolve(), // no real backoff delay in tests
+      timeoutMs: opts.timeoutMs ?? 50,
+      maxAttempts: opts.maxAttempts ?? 4,
+    },
+  };
+}
+
+/** Consume a fixed script of responses, one per downstream call. */
+function scriptedSend(steps: SendStep[]): DispatchDeps["send"] {
+  let i = 0;
+  return async (headers, body) => {
+    const step = steps[i++];
+    if (!step) throw new Error(`unexpected extra downstream call #${i}`);
+    return step(headers, body);
+  };
+}
+
+function methodOf(body: string): string {
+  return (JSON.parse(body) as { method?: string }).method ?? "";
+}
+
+describe("isRecoverableMcpSessionLostError", () => {
+  it("matches the 503 session-unknown body", () => {
+    expect(
+      isRecoverableMcpSessionLostError(503, "MCP session is unknown on this API instance")
+    ).toBe(true);
+    expect(
+      isRecoverableMcpSessionLostError(503, "service unavailable: session is unknown on this api instance")
+    ).toBe(true);
+  });
+  it("ignores non-503 statuses and unrelated bodies", () => {
+    expect(isRecoverableMcpSessionLostError(500, "session is unknown on this api instance")).toBe(
+      false
+    );
+    expect(isRecoverableMcpSessionLostError(503, "rate limited")).toBe(false);
+  });
+});
+
+describe("backoffMs", () => {
+  it("grows exponentially and caps at 2s", () => {
+    expect(backoffMs(1)).toBe(300);
+    expect(backoffMs(2)).toBe(600);
+    expect(backoffMs(3)).toBe(1200);
+    expect(backoffMs(4)).toBe(2000);
+    expect(backoffMs(10)).toBe(2000);
+  });
+});
+
+describe("withTimeout", () => {
+  it("resolves a fast promise", async () => {
+    await expect(withTimeout(Promise.resolve("ok"), 50)).resolves.toBe("ok");
+  });
+  it("rejects when the promise hangs past the deadline", async () => {
+    await expect(withTimeout(new Promise<never>(() => {}), 10)).rejects.toThrow(/timeout/);
+  });
+  it("passes through when disabled (ms <= 0)", async () => {
+    await expect(withTimeout(Promise.resolve(42), 0)).resolves.toBe(42);
+  });
+});
+
+describe("dispatchCore", () => {
+  it("forwards a successful initialize and captures the session id", async () => {
+    const loop = createLoopState();
+    const { deps, emitted } = makeDeps(
+      scriptedSend([() => jsonResponse({ jsonrpc: "2.0", id: 1, result: {} }, { sessionId: "S1" })])
+    );
+
+    await dispatchCore(deps, loop, baseConfig, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {},
+    });
+
+    expect(loop.session.sessionId).toBe("S1");
+    expect(loop.lastInitializeBody).toContain("initialize");
+    expect(emitted).toEqual([{ jsonrpc: "2.0", id: 1, result: {} }]);
+  });
+
+  it("recovers from a lost session: re-initializes and retries, emitting only the final result", async () => {
+    const loop = createLoopState();
+    loop.session.sessionId = "S1";
+    loop.lastInitializeBody = JSON.stringify({
+      jsonrpc: "2.0",
+      id: 0,
+      method: "initialize",
+      params: { clientInfo: { name: "test-proxy", version: "1.0.0" } },
+    });
+
+    const calls: string[] = [];
+    const send: DispatchDeps["send"] = async (_headers, body) => {
+      const method = methodOf(body);
+      calls.push(method);
+      if (method === "initialize") return jsonResponse({ result: {} }, { sessionId: "S2" });
+      // first tool/call sees a dead session, second (after reinit) succeeds
+      return calls.filter((m) => m === "tools/call").length === 1
+        ? sessionLostResponse()
+        : jsonResponse({ jsonrpc: "2.0", id: 7, result: { ok: true } });
+    };
+
+    const { deps, emitted } = makeDeps(send);
+    await dispatchCore(deps, loop, baseConfig, {
+      jsonrpc: "2.0",
+      id: 7,
+      method: "tools/call",
+      params: {},
+    });
+
+    expect(calls).toEqual(["tools/call", "initialize", "tools/call"]);
+    expect(loop.session.sessionId).toBe("S2");
+    expect(emitted).toEqual([{ jsonrpc: "2.0", id: 7, result: { ok: true } }]); // no error leaked to client
+  });
+
+  it("recovers from a transport error/timeout window (restart) by re-handshaking", async () => {
+    const loop = createLoopState();
+    loop.session.sessionId = "S1";
+    loop.lastInitializeBody = JSON.stringify({ jsonrpc: "2.0", id: 0, method: "initialize" });
+
+    const { deps, emitted } = makeDeps(
+      scriptedSend([
+        () => {
+          throw new Error("fetch failed");
+        }, // attempt 1: connection refused mid-restart
+        () => jsonResponse({ result: {} }, { sessionId: "S2" }), // reinit
+        () => jsonResponse({ jsonrpc: "2.0", id: 9, result: { ok: 1 } }), // retry succeeds
+      ])
+    );
+
+    await dispatchCore(deps, loop, baseConfig, {
+      jsonrpc: "2.0",
+      id: 9,
+      method: "tools/call",
+      params: {},
+    });
+
+    expect(loop.session.sessionId).toBe("S2");
+    expect(emitted).toEqual([{ jsonrpc: "2.0", id: 9, result: { ok: 1 } }]);
+  });
+
+  it("emits a JSON-RPC error (never hangs) when recovery is exhausted", async () => {
+    const loop = createLoopState();
+    loop.session.sessionId = "S1";
+    loop.lastInitializeBody = JSON.stringify({ jsonrpc: "2.0", id: 0, method: "initialize" });
+
+    // reinit always succeeds, but every tool/call keeps hitting a dead session
+    const send: DispatchDeps["send"] = async (_headers, body) =>
+      methodOf(body) === "initialize"
+        ? jsonResponse({ result: {} }, { sessionId: "S2" })
+        : sessionLostResponse();
+
+    const { deps, emitted } = makeDeps(send, { maxAttempts: 3 });
+    await dispatchCore(deps, loop, baseConfig, {
+      jsonrpc: "2.0",
+      id: 11,
+      method: "tools/call",
+      params: {},
+    });
+
+    expect(emitted).toHaveLength(1);
+    const err = emitted[0] as { id: number; error: { code: number; message: string } };
+    expect(err.id).toBe(11);
+    expect(err.error.message).toMatch(/recovery exhausted after 3 attempts/);
+  });
+
+  it("does not retry a failed initialize (the client owns the handshake)", async () => {
+    const loop = createLoopState();
+    let calls = 0;
+    const { deps, emitted } = makeDeps(
+      scriptedSend([
+        () => {
+          calls++;
+          return sessionLostResponse();
+        },
+      ])
+    );
+
+    await dispatchCore(deps, loop, baseConfig, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {},
+    });
+
+    expect(calls).toBe(1); // no retry/replay for initialize itself
+    expect(emitted).toHaveLength(1);
+    expect((emitted[0] as { error?: unknown }).error).toBeDefined();
+  });
+});

--- a/src/proxy/mcp_stdio_proxy.ts
+++ b/src/proxy/mcp_stdio_proxy.ts
@@ -35,6 +35,19 @@ export interface ProxyConfig {
   aauthEnabled: boolean;
   aauthSigner?: AAuthSignerConfig;
   autostart: boolean;
+  /**
+   * Per-request downstream timeout (ms). A hung request rejects after this
+   * and enters the retry path instead of stalling until the harness's own
+   * MCP timeout. 0 disables. Falls back to NEOTOMA_MCP_PROXY_TIMEOUT_MS env,
+   * then DEFAULT_REQUEST_TIMEOUT_MS.
+   */
+  requestTimeoutMs?: number;
+  /**
+   * Max attempts (initial + retries) for recovering a lost MCP session.
+   * Falls back to NEOTOMA_MCP_PROXY_MAX_ATTEMPTS env, then
+   * DEFAULT_MAX_ATTEMPTS.
+   */
+  maxRetries?: number;
 }
 
 function effectiveClientName(config: ProxyConfig): string {
@@ -99,7 +112,7 @@ function injectClientInfo(message: Record<string, unknown>, config: ProxyConfig)
   );
 }
 
-class SessionState {
+export class SessionState {
   sessionId: string | null = null;
 
   attach(headers: Record<string, string>): void {
@@ -128,10 +141,15 @@ export function isRecoverableMcpSessionLostError(status: number, bodyText: strin
   );
 }
 
-interface ProxyLoopState {
+export interface ProxyLoopState {
   session: SessionState;
   /** Last downstream initialize body (JSON), after clientInfo injection — replayed on session loss. */
   lastInitializeBody: string | null;
+}
+
+/** Fresh proxy loop state — exported so callers/tests construct a clean session. */
+export function createLoopState(): ProxyLoopState {
+  return { session: new SessionState(), lastInitializeBody: null };
 }
 
 async function sendDownstream(
@@ -178,14 +196,17 @@ export function formatDownstreamErrorMessage(status: number, detail: string): st
   return `neotoma-mcp-proxy downstream error (${status}): ${trimmed.slice(0, 200)}`;
 }
 
+type EmitFn = (payload: unknown) => void;
+
 function emitErrorResponse(
   originalMessage: Record<string, unknown>,
   status: number,
-  detail: string
+  detail: string,
+  emit: EmitFn = emitJson
 ): void {
   const requestId = originalMessage.id;
   if (requestId === undefined) return;
-  emitJson({
+  emit({
     jsonrpc: "2.0",
     id: requestId,
     error: {
@@ -196,18 +217,18 @@ function emitErrorResponse(
   });
 }
 
-async function forwardJsonResponse(response: Response): Promise<void> {
+async function forwardJsonResponse(response: Response, emit: EmitFn = emitJson): Promise<void> {
   const body = await response.text();
   if (!body) return;
   try {
     const payload = JSON.parse(body);
-    emitJson(payload);
+    emit(payload);
   } catch (err) {
     log(`Failed to decode JSON response: ${String(err)}`);
   }
 }
 
-async function forwardSseResponse(response: Response): Promise<void> {
+async function forwardSseResponse(response: Response, emit: EmitFn = emitJson): Promise<void> {
   const reader = response.body?.getReader();
   if (!reader) return;
   const decoder = new TextDecoder();
@@ -237,7 +258,7 @@ async function forwardSseResponse(response: Response): Promise<void> {
           if (currentEvent !== "message") continue;
           try {
             const payload = JSON.parse(data);
-            emitJson(payload);
+            emit(payload);
           } catch {
             log(`SSE data frame is not JSON: ${data.slice(0, 200)}`);
           }
@@ -249,83 +270,211 @@ async function forwardSseResponse(response: Response): Promise<void> {
   }
 }
 
-async function dispatchMessage(
+async function forwardResponse(response: Response, emit: EmitFn): Promise<void> {
+  const contentType = response.headers.get("content-type") ?? "";
+  if (contentType.includes("text/event-stream")) {
+    await forwardSseResponse(response, emit);
+  } else {
+    await forwardJsonResponse(response, emit);
+  }
+}
+
+/** Default per-request downstream timeout (ms) — below typical harness MCP timeouts so a hang retries rather than surfacing as "unavailable". */
+export const DEFAULT_REQUEST_TIMEOUT_MS = 15_000;
+/** Default total attempts (initial + retries) to recover a lost MCP session. */
+export const DEFAULT_MAX_ATTEMPTS = 4;
+
+function envPositiveInt(name: string): number | undefined {
+  const raw = process.env[name];
+  if (!raw) return undefined;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : undefined;
+}
+
+function resolveTimeoutMs(config: ProxyConfig): number {
+  return (
+    config.requestTimeoutMs ??
+    envPositiveInt("NEOTOMA_MCP_PROXY_TIMEOUT_MS") ??
+    DEFAULT_REQUEST_TIMEOUT_MS
+  );
+}
+
+function resolveMaxAttempts(config: ProxyConfig): number {
+  return (
+    config.maxRetries ?? envPositiveInt("NEOTOMA_MCP_PROXY_MAX_ATTEMPTS") ?? DEFAULT_MAX_ATTEMPTS
+  );
+}
+
+/** Exponential backoff capped at 2s: 300, 600, 1200, 2000, … ms. */
+export function backoffMs(attempt: number): number {
+  return Math.min(300 * 2 ** (attempt - 1), 2000);
+}
+
+function sleep(ms: number): Promise<void> {
+  if (ms <= 0) return Promise.resolve();
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    if (typeof timer.unref === "function") timer.unref();
+  });
+}
+
+/**
+ * Reject if `p` does not settle within `ms` (0/negative disables). The
+ * underlying fetch is left to settle on its own — the caller has already
+ * moved on to a retry, and a late success is harmless.
+ */
+export function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
+  if (!ms || ms <= 0) return p;
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`downstream timeout after ${ms}ms`)), ms);
+    if (typeof timer.unref === "function") timer.unref();
+    p.then(
+      (v) => {
+        clearTimeout(timer);
+        resolve(v);
+      },
+      (e) => {
+        clearTimeout(timer);
+        reject(e);
+      }
+    );
+  });
+}
+
+/** Injected transport for {@link dispatchCore}: real impl wraps sendDownstream; tests pass a fake. */
+export interface DispatchDeps {
+  send: (headers: Record<string, string>, body: string) => Promise<Response>;
+  emit: EmitFn;
+  sleep: (ms: number) => Promise<void>;
+  timeoutMs: number;
+  maxAttempts: number;
+}
+
+/**
+ * Forward one JSON-RPC message downstream, recovering automatically from a
+ * lost/expired MCP session — the failure mode behind neotoma#1472/#1667,
+ * where a single-instance restart (or a non-sticky replica) drops the
+ * in-memory session and the server replies `503 … session is unknown on
+ * this API instance`, or the request hangs through the restart window.
+ *
+ * On that 503 OR a transport error/timeout for a non-initialize method, the
+ * cached `initialize` is replayed downstream and the message retried, up to
+ * `maxAttempts` with exponential backoff. The client's stdout only ever sees
+ * the final result, so backend restarts become invisible instead of failing
+ * the whole session. `initialize` itself is never retried here — the client
+ * owns the handshake.
+ */
+export async function dispatchCore(
+  deps: DispatchDeps,
   loopState: ProxyLoopState,
   config: ProxyConfig,
   message: Record<string, unknown>
 ): Promise<void> {
   injectClientInfo(message, config);
   const body = JSON.stringify(message);
-  if (message.method === "initialize") {
-    loopState.lastInitializeBody = body;
-  }
+  const isInit = message.method === "initialize";
+  if (isInit) loopState.lastInitializeBody = body;
 
-  const postOriginal = async (): Promise<Response> => {
+  const post = (payload: string): Promise<Response> => {
     const headers = buildBaseHeaders(config);
     loopState.session.attach(headers);
-    return sendDownstream(config, headers, body);
+    return withTimeout(deps.send(headers, payload), deps.timeoutMs);
   };
 
-  try {
-    let resp = await postOriginal();
+  const reinitialize = async (): Promise<void> => {
+    const initBody = loopState.lastInitializeBody;
+    if (!initBody) throw new Error("no cached initialize body to replay");
+    loopState.session.clearSession();
+    const headers = buildBaseHeaders(config);
+    const resp = await withTimeout(deps.send(headers, initBody), deps.timeoutMs);
     loopState.session.capture(resp.headers);
-
+    const text = await resp.text();
     if (resp.status >= 400) {
+      throw new Error(`re-initialize failed status=${resp.status} body=${text.slice(0, 300)}`);
+    }
+  };
+
+  let lastDetail = "";
+  for (let attempt = 1; attempt <= deps.maxAttempts; attempt++) {
+    try {
+      // A non-initialize message with no live session (lost on a prior
+      // attempt, or the downstream restarted) must re-handshake first.
+      if (!isInit && !loopState.session.sessionId && loopState.lastInitializeBody) {
+        await reinitialize();
+      }
+
+      const resp = await post(body);
+      loopState.session.capture(resp.headers);
+
+      if (resp.status < 400) {
+        await forwardResponse(resp, deps.emit);
+        return;
+      }
+
       const errText = await resp.text();
-      const method = message.method;
       if (
         isRecoverableMcpSessionLostError(resp.status, errText) &&
-        method !== "initialize" &&
+        !isInit &&
         loopState.lastInitializeBody
       ) {
-        log(
-          "Downstream MCP session unknown on this instance — replaying initialize to downstream, then retrying this JSON-RPC message once (client stdout unchanged)"
-        );
+        lastDetail = errText;
         loopState.session.clearSession();
-        const reinitHeaders = buildBaseHeaders(config);
-        const reinitResp = await sendDownstream(
-          config,
-          reinitHeaders,
-          loopState.lastInitializeBody
-        );
-        loopState.session.capture(reinitResp.headers);
-        const reinitBodyText = await reinitResp.text();
-        if (reinitResp.status >= 400) {
+        if (attempt < deps.maxAttempts) {
           log(
-            `Re-initialize after session loss failed: status=${reinitResp.status} body=${reinitBodyText.slice(0, 500)}`
+            `Downstream MCP session unknown (attempt ${attempt}/${deps.maxAttempts}) — re-initializing and retrying`
           );
-          emitErrorResponse(message, reinitResp.status, reinitBodyText);
-          return;
-        }
-        resp = await postOriginal();
-        loopState.session.capture(resp.headers);
-        if (resp.status >= 400) {
-          const retryErr = await resp.text();
-          log(
-            `Downstream error after session recovery: status=${resp.status} body=${retryErr.slice(0, 500)}`
-          );
-          emitErrorResponse(message, resp.status, retryErr);
-          return;
+          await deps.sleep(backoffMs(attempt));
+          continue;
         }
       } else {
         log(
           `Downstream error status=${resp.status} content_type=${resp.headers.get("content-type") ?? ""} body=${errText.slice(0, 500)}`
         );
-        emitErrorResponse(message, resp.status, errText);
+        emitErrorResponse(message, resp.status, errText, deps.emit);
         return;
       }
+    } catch (err) {
+      lastDetail = describeNetworkError(err);
+      // A transport error or timeout on a non-initialize call is treated as
+      // a downstream restart window: drop the session, back off, re-handshake.
+      if (!isInit && attempt < deps.maxAttempts) {
+        log(
+          `Downstream transport error (attempt ${attempt}/${deps.maxAttempts}): ${lastDetail} — clearing session and retrying`
+        );
+        loopState.session.clearSession();
+        await deps.sleep(backoffMs(attempt));
+        continue;
+      }
+      emitErrorResponse(message, 502, lastDetail, deps.emit);
+      return;
     }
-
-    const contentType = resp.headers.get("content-type") ?? "";
-    if (contentType.includes("text/event-stream")) {
-      await forwardSseResponse(resp);
-    } else {
-      await forwardJsonResponse(resp);
-    }
-  } catch (err) {
-    log(`Downstream transport error: ${describeNetworkError(err)}`);
-    emitErrorResponse(message, 502, describeNetworkError(err));
   }
+
+  emitErrorResponse(
+    message,
+    503,
+    `MCP session recovery exhausted after ${deps.maxAttempts} attempts: ${lastDetail}`,
+    deps.emit
+  );
+}
+
+async function dispatchMessage(
+  loopState: ProxyLoopState,
+  config: ProxyConfig,
+  message: Record<string, unknown>
+): Promise<void> {
+  await dispatchCore(
+    {
+      send: (headers, b) => sendDownstream(config, headers, b),
+      emit: emitJson,
+      sleep,
+      timeoutMs: resolveTimeoutMs(config),
+      maxAttempts: resolveMaxAttempts(config),
+    },
+    loopState,
+    config,
+    message
+  );
 }
 
 export async function runProxy(config: ProxyConfig): Promise<void> {
@@ -337,10 +486,7 @@ export async function runProxy(config: ProxyConfig): Promise<void> {
     await runPreflight(config);
   }
 
-  const loopState: ProxyLoopState = {
-    session: new SessionState(),
-    lastInitializeBody: null,
-  };
+  const loopState = createLoopState();
   const rl = createInterface({ input: process.stdin, crlfDelay: Infinity });
 
   for await (const rawLine of rl) {


### PR DESCRIPTION
## Problem

The stdio MCP proxy (`neotoma mcp proxy`) drops the **entire client session** when the downstream `/mcp` backend restarts (single instance) or a request routes to a non-sticky replica. The server replies `503 … session is unknown on this API instance`, or the request hangs through the restart window. Once it hits the hard state, the harness marks the server `unavailable` and does not reconnect for the rest of the session.

This is the failure tracked by #1667 and #1472. It was observed **still reproducing on v0.17.0** (post the v0.16.0 `resolved-in-release` note), across multiple concurrent client sessions, including a `store failed after 19s` timeout signature.

The previous recovery (added earlier) re-initialized and retried **once**, and **only** on the 503 — so:
- a retry that lands on *another* fresh instance failed with no further attempt, and
- the **timeout / connection-refused** window during a restart was never recovered (it surfaced as a generic 502 / a hang).

## Fix

Hardens the proxy dispatch so a backend restart becomes invisible to the client:

- **Bounded re-initialize + retry loop** (`DEFAULT_MAX_ATTEMPTS=4`) with exponential backoff (`backoffMs`: 300/600/1200/2000 ms) — a retry landing on another fresh instance re-handshakes again.
- **Transport errors *and* timeouts** (not just the 503) are treated as a restart window: drop the session, back off, replay the cached `initialize`, retry.
- **Per-request timeout** (`DEFAULT_REQUEST_TIMEOUT_MS=15s`) so a hang fails fast into a retry instead of stalling past the harness's own MCP timeout (the observed 19s).
- **`initialize` is never auto-retried** — the client owns the handshake.

Tunable via `requestTimeoutMs` / `maxRetries` on `ProxyConfig`, or env `NEOTOMA_MCP_PROXY_TIMEOUT_MS` / `NEOTOMA_MCP_PROXY_MAX_ATTEMPTS`.

Dispatch logic is extracted into `dispatchCore(deps, …)` with an injected transport for testability; the production `dispatchMessage` wraps it with `sendDownstream`.

## Tests

New `src/proxy/mcp_stdio_proxy.test.ts` (11 cases): `isRecoverableMcpSessionLostError`, `backoffMs`, `withTimeout`, and `dispatchCore` scenarios — session-loss recovery, restart/timeout recovery, **exhaustion emits a JSON-RPC error (never hangs)**, and the no-retry-for-initialize contract. `vitest` green, `tsc --noEmit` clean, `eslint` clean.

## Note (defense-in-depth, not a substitute)

This makes clients resilient to restarts but does not stop the restarts. In the operator deployment the root cause is separate: the public `/mcp` backend is served by a **file-watching auto-restart dev runner**, so incidental file changes restart it and wipe the in-memory session maps (`mcpTransports` / `mcpServerInstances` in `src/actions.ts`). That deployment fix is being handled operationally; this PR ensures a restart no longer takes the client session down with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
