### PR TITLE
feat(cli): --aauth flag for request to make AAuth-attributed calls

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -15840,6 +15840,13 @@ program
   .option("--query <json>", "JSON query override")
   .option("--path <json>", "JSON path override")
   .option("--skip-auth", "Skip auth token for public endpoints")
+  .option(
+    "--aauth",
+    "Authenticate via AAuth request signature instead of a bearer token. " +
+      "Sends no Authorization header so the per-agent signature (configured via " +
+      "NEOTOMA_AAUTH_PRIVATE_JWK_PATH + NEOTOMA_AAUTH_SUB/KID) is the credential, " +
+      "letting the server attribute the request to that agent."
+  )
   .action(async (opts) => {
     const outputMode = resolveOutputMode();
     const config = await readConfig();
@@ -15849,8 +15856,17 @@ program
     }
 
     const baseUrl = await resolveBaseUrl(program.opts().baseUrl, config);
-    const token = opts.skipAuth ? undefined : await getCliToken();
-    const api = createApiClient({ baseUrl, token });
+    // --aauth: drop the bearer so the AAuth request signature is the sole
+    // credential. A bearer Authorization header otherwise takes precedence and
+    // the request lands under the bearer's identity rather than the agent's.
+    const token = opts.skipAuth || opts.aauth ? undefined : await getCliToken();
+    const api = createApiClient({
+      baseUrl,
+      token,
+      // AAuth signing rides the HTTP transport, so force it over the in-process
+      // local transport (which would bypass the signature).
+      ...(opts.aauth ? { signWithCliAAuth: true, forceHttpTransport: true } : {}),
+    });
 
     const params = parseOptionalJson(opts.params);
     const body = parseOptionalJson(opts.body);

--- a/src/shared/api_client.ts
+++ b/src/shared/api_client.ts
@@ -14,6 +14,14 @@ export interface ApiClientOptions {
    * contexts and false in test / offline contexts.
    */
   signWithCliAAuth?: boolean;
+  /**
+   * Force the HTTP transport even when `NEOTOMA_FORCE_LOCAL_TRANSPORT=true`.
+   * The in-process local transport never makes an HTTP request, so RFC 9421
+   * request signing has nothing to sign — AAuth-attributed calls MUST go over
+   * HTTP. Setting this also disables the offline→local fallback (which would
+   * likewise bypass signing). Pairs with `signWithCliAAuth`.
+   */
+  forceHttpTransport?: boolean;
 }
 
 /**
@@ -90,8 +98,11 @@ export function createApiClient(options: ApiClientOptions = {}) {
       ? false
       : process.env.NEOTOMA_ENABLE_OFFLINE_FALLBACK === "true" &&
         process.env.NEOTOMA_DISABLE_OFFLINE_FALLBACK !== "true";
-  const shouldFallback = options.useOfflineFallback ?? defaultFallback;
-  const forceLocal = process.env.NEOTOMA_FORCE_LOCAL_TRANSPORT === "true";
+  const shouldFallback = options.forceHttpTransport
+    ? false
+    : (options.useOfflineFallback ?? defaultFallback);
+  const forceLocal =
+    !options.forceHttpTransport && process.env.NEOTOMA_FORCE_LOCAL_TRANSPORT === "true";
 
   const canFallbackForPath = (path: string): boolean => path !== "/health";
   const isNetworkError = (err: unknown): boolean => {

--- a/tests/cli/api_client_offline_fallback.test.ts
+++ b/tests/cli/api_client_offline_fallback.test.ts
@@ -124,4 +124,35 @@ describe("api_client transport modes", () => {
     expect(remoteClient.POST).not.toHaveBeenCalled();
     delete process.env.NEOTOMA_ENV;
   });
+
+  it("forceHttpTransport overrides NEOTOMA_FORCE_LOCAL_TRANSPORT so AAuth signing applies", async () => {
+    // The in-process local transport makes no HTTP request, so RFC 9421 request
+    // signing has nothing to sign. AAuth-attributed calls must ride HTTP even
+    // when the env forces local transport.
+    process.env.NEOTOMA_FORCE_LOCAL_TRANSPORT = "true";
+    remoteClient.GET.mockResolvedValueOnce({ data: { status: "ok" }, error: undefined });
+
+    const { createApiClient } = await import("../../src/shared/api_client.ts");
+    const api = createApiClient({ baseUrl: "http://localhost:3080", forceHttpTransport: true });
+    const result = await api.GET("/session", {} as never);
+
+    expect(result).toEqual({ data: { status: "ok" }, error: undefined });
+    expect(remoteClient.GET).toHaveBeenCalledWith("/session", {} as never);
+    expect(getLocalTransportClientMock).not.toHaveBeenCalled();
+  });
+
+  it("forceHttpTransport disables the offline->local fallback (which would bypass signing)", async () => {
+    const networkErr = new Error("fetch failed", { cause: { code: "ECONNREFUSED" } as Error });
+    remoteClient.POST.mockRejectedValueOnce(networkErr);
+
+    const { createApiClient } = await import("../../src/shared/api_client.ts");
+    const api = createApiClient({
+      baseUrl: "http://localhost:3080",
+      forceHttpTransport: true,
+      useOfflineFallback: true, // would normally fall back, but forceHttpTransport wins
+    });
+
+    await expect(api.POST("/store", { body: {} as never })).rejects.toThrow("fetch failed");
+    expect(getLocalTransportClientMock).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
Cherry-pick of `366cd6f9c` onto main (clean, 3 files / +62-4) — unblocks the Ateles per-agent AAuth daemon migration.

## What
`neotoma request` always sent a bearer and rode the in-process local transport, so per-agent AAuth requests landed anonymous. `--aauth` now:
- drops the bearer (the AAuth **signature** is the sole credential),
- forces CLI AAuth signing,
- forces HTTP transport via a new `createApiClient` `forceHttpTransport` option (the local transport makes no HTTP request, so RFC 9421 signing has nothing to sign; also disables the offline→local fallback that would bypass signing).

## Why it's needed
The Ateles swarm daemons will shell out to `neotoma request --aauth` to write **as their own agent identity** (per-agent JWK via `NEOTOMA_AAUTH_PRIVATE_JWK_PATH` + `SUB`/`KID`/`ISS`), so observations attribute to the agent and the shared `NEOTOMA_BEARER_TOKEN` can be retired. The matching CLI key-path override (#1744) is already on main.

## Verification
Author-verified e2e: `request --operation getSessionInfo --aauth` → server attributes to the agent sub (tier `software`, `signature_verified: true`). Adds 2 transport unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
