### PR TITLE
fix(ops): apply rc-autodeploy review follow-ups (#1624)

### DIFF
--- a/docs/developer/npm_scripts.md
+++ b/docs/developer/npm_scripts.md
@@ -91,6 +91,7 @@ Keep these aliases for one minor release, update docs and automation to the cano
 |------------|----------|
 | `setup:launchd-dev` / `setup:launchd-dev-server` | `com.neotoma.dev-server` → `npm run dev:server` ([`launchd_dev_servers.md`](launchd_dev_servers.md)) |
 | `setup:launchd-prod-server` | `com.neotoma.prod-server` → `npm run start:server:prod` ([`launchd_prod_server.md`](launchd_prod_server.md)) |
+| `setup:launchd-rc-autodeploy` | `com.neotoma.rc-autodeploy` → polls `origin/main` every 120s and, when the RC checkout is behind, fast-forwards it, rebuilds dist (server + Inspector), and hard-restarts `com.neotoma.prod-server` ("rolling main = RC"; mechanical deploy only — Struthio still owns tagged releases) ([`launchd_dev_servers.md`](launchd_dev_servers.md)) |
 | `setup:launchd-cli-sync` | `com.neotoma.watch-build` → `npm link`, one `build:server`, then `dev:types` using the captured setup-time Node/npm toolchain (keeps global `neotoma` pointed at the checkout and aligned with `dist/`) |
 | `setup:launchd-watch-build` | Alias → `setup:launchd-cli-sync` |
 | `setup:launchd-watch-stacks` | Dev server agent + `setup:launchd-cli-sync` (compatibility wrapper) |

--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,17 +61,17 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **483**
-- Backend and repo Vitest files: **450**
+- Total automated test files: **485**
+- Backend and repo Vitest files: **452**
 - Frontend Vitest files: **9**
 - Playwright spec files: **24**
 
 ### Suite counts
 | Suite | Files |
 |---|---:|
-| Vitest unit tests | 128 |
+| Vitest unit tests | 129 |
 | Vitest service tests | 34 |
-| Source-adjacent tests | 58 |
+| Source-adjacent tests | 59 |
 | Vitest integration tests | 137 |
 | Vitest CLI tests | 65 |
 | Vitest contract tests | 14 |
@@ -109,7 +109,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/unit`
 **Requirements:** Basic `.env` if required by the module under test.
-**Files (128):**
+**Files (129):**
 - `tests/unit/aauth_admission.test.ts`
 - `tests/unit/aauth_attestation_apple_se.test.ts`
 - `tests/unit/aauth_attestation_revocation.test.ts`
@@ -120,6 +120,7 @@ flowchart TD
 - `tests/unit/aauth_authority_normalization.test.ts`
 - `tests/unit/aauth_operator_allowlist.test.ts`
 - `tests/unit/aauth_sdk_and_capability_flags.test.ts`
+- `tests/unit/aauth_signer_jwk_override.test.ts`
 - `tests/unit/aauth_tpm_structures.test.ts`
 - `tests/unit/aauth_verify_middleware.test.ts`
 - `tests/unit/action_schemas_observation_source.test.ts`
@@ -285,9 +286,10 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- src`
 **Requirements:** Basic `.env` if required by the module under test.
-**Files (58):**
+**Files (59):**
 - `src/cli/parse_cli_corrected_value.test.ts`
 - `src/crypto/crypto.test.ts`
+- `src/proxy/mcp_stdio_proxy.test.ts`
 - `src/record_types.test.ts`
 - `src/release_notes_enrichment.test.ts`
 - `src/repositories/sqlite/__tests__/local_db_adapter.test.ts`

--- a/scripts/com.neotoma.rc-autodeploy.plist.template
+++ b/scripts/com.neotoma.rc-autodeploy.plist.template
@@ -11,6 +11,7 @@
   Install via: node scripts/install_launchd_rc_autodeploy.js
   Placeholders (REPO_ROOT_PLACEHOLDER etc.) are substituted by the installer.
 -->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
   <key>Label</key>

--- a/scripts/redeploy_rc_from_main.sh
+++ b/scripts/redeploy_rc_from_main.sh
@@ -22,7 +22,17 @@
 
 set -uo pipefail
 
-RC_DIR="${RC_DIR:-/Users/markmhendrickson/neotoma-rc-src}"
+# Default RC_DIR to this script's own repo root (scripts/..), so the script is
+# portable to any RC checkout; the installer still sets RC_DIR explicitly in the
+# LaunchAgent env. Resolve the real path of the script even if symlinked.
+_SCRIPT_SRC="${BASH_SOURCE[0]}"
+while [ -h "$_SCRIPT_SRC" ]; do
+  _SCRIPT_DIR="$(cd -P "$(dirname "$_SCRIPT_SRC")" >/dev/null 2>&1 && pwd)"
+  _SCRIPT_SRC="$(readlink "$_SCRIPT_SRC")"
+  [ "${_SCRIPT_SRC#/}" = "$_SCRIPT_SRC" ] && _SCRIPT_SRC="$_SCRIPT_DIR/$_SCRIPT_SRC"
+done
+_SCRIPT_DIR="$(cd -P "$(dirname "$_SCRIPT_SRC")" >/dev/null 2>&1 && pwd)"
+RC_DIR="${RC_DIR:-$(cd "$_SCRIPT_DIR/.." && pwd)}"
 PROD_LABEL="${PROD_LABEL:-com.neotoma.prod-server}"
 HEALTH_URL="${HEALTH_URL:-https://neotoma.markmhendrickson.com/health}"
 BRANCH="${BRANCH:-main}"
@@ -90,15 +100,20 @@ fi
 if [ "$STASHED" -eq 1 ]; then
   if ! git stash pop --quiet; then
     log "WARNING: stash pop conflicted (likely main changed package.json vs the RC version bump)."
-    log "         Resolve manually in $RC_DIR; server NOT restarted to avoid shipping a conflicted tree."
+    log "         Resolve manually in $RC_DIR (git status / git checkout --theirs the version bump),"
+    log "         then run 'git stash drop'. The next poll (≤120s) will retry the deploy automatically."
+    log "         Only remove $LOCK_DIR by hand if a prior run crashed mid-deploy and left it behind."
+    log "         Server NOT restarted to avoid shipping a conflicted tree."
     exit 1
   fi
   log "restored local RC changes after fast-forward"
 fi
 
 log "RC now at $(git rev-parse --short HEAD); rebuilding dist…"
-if ! npm run build:server >/dev/null 2>&1; then
-  log "ERROR: build:server failed; server left on prior build."
+# Let stdout/stderr flow to launchd's StandardOut/ErrorPath so a build failure is
+# diagnosable from the log without re-running the build by hand.
+if ! npm run build:server; then
+  log "ERROR: build:server failed; server left on prior build. See the build output above."
   exit 1
 fi
 log "build:server complete."
@@ -109,8 +124,8 @@ log "build:server complete."
 # v0.16 RC, where the git pointer advanced but the served Inspector was 10
 # days stale because this step was missing. build:inspector:prod-target emits
 # the prod-targeted bundle into dist/inspector.
-if ! npm run build:inspector:prod-target >/dev/null 2>&1; then
-  log "ERROR: build:inspector:prod-target failed; server left on prior build."
+if ! npm run build:inspector:prod-target; then
+  log "ERROR: build:inspector:prod-target failed; server left on prior build. See the build output above."
   exit 1
 fi
 log "build:inspector complete."


### PR DESCRIPTION
Follow-up to #1624 (which merged APPROVED-WITH-NOTES). Applies the non-blocking review advisories. Ops scripts + docs only — no `src/`, schema, route, or error-envelope changes.

## Changes
- **`scripts/redeploy_rc_from_main.sh`**
  - Default `RC_DIR` to the script's own repo root (resolved via `BASH_SOURCE`, symlink-safe) instead of a hardcoded `/Users/markmhendrickson/...` path. The installer still sets `RC_DIR` explicitly in the LaunchAgent env, so behavior on the operator's machine is unchanged; the script just stops being personal-path-bound.
  - Stop silencing `npm run build:server` and `build:inspector:prod-target` (`>/dev/null 2>&1` removed) so build failures are diagnosable from launchd's `StandardErrorPath` without re-running by hand.
  - Make the stash-pop conflict hint actionable: how to resolve, that the next poll (≤120s) retries automatically, and when (not) to remove the lock dir.
- **`scripts/com.neotoma.rc-autodeploy.plist.template`** — add the `<!DOCTYPE plist …>` line to match the sibling `com.neotoma.prod-server.plist.template`. (`plutil -lint` passes.)
- **`docs/developer/npm_scripts.md`** — add the missing LaunchAgents-table row for `setup:launchd-rc-autodeploy`.

## Validation
- `bash -n` clean; `shellcheck` clean except a pre-existing intentional `SC2034` (countdown loop var) not introduced here.
- `RC_DIR` self-resolution verified to yield the repo root.
- `plutil -lint` OK on the substituted plist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)