### PR TITLE
fix(cli): issues sync signs with AAuth when configured (env-gated)

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -9311,10 +9311,19 @@ issuesCommand
   .action(async (opts) => {
     const { issuesSync } = await import("./issues.js");
     const config = await readConfig();
-    const token = await getCliToken();
+    // Prefer per-agent AAuth signing when a CLI AAuth key is configured via env
+    // (NEOTOMA_AAUTH_PRIVATE_JWK_PATH). This lets the issues-sync LaunchAgent /
+    // neotoma-agent daemon authenticate with a signed request instead of a
+    // bearer token (bearer-token retirement). Drop the bearer so the signature
+    // is the sole credential, and force the HTTP transport — the in-process
+    // local transport bypasses signing (and also avoids the dev/prod local
+    // transport env-mismatch). Falls back to bearer when AAuth is not configured.
+    const useAAuth = Boolean(process.env.NEOTOMA_AAUTH_PRIVATE_JWK_PATH);
+    const token = useAAuth ? undefined : await getCliToken();
     const api = createApiClient({
       baseUrl: await resolveBaseUrl(program.opts().baseUrl, config),
       token,
+      ...(useAAuth ? { signWithCliAAuth: true, forceHttpTransport: true } : {}),
     });
     await issuesSync({ ...opts, json: Boolean((program.opts() as { json?: boolean }).json) }, api);
   });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -9318,12 +9318,28 @@ issuesCommand
     // is the sole credential, and force the HTTP transport — the in-process
     // local transport bypasses signing (and also avoids the dev/prod local
     // transport env-mismatch). Falls back to bearer when AAuth is not configured.
+    // When the env gate is set, fail loud if the key is missing/unusable —
+    // silent unsigned fallback would leave the unattended daemon syncing as
+    // anonymous (REQUEST_CHANGES on #1764 / phoenicurus).
     const useAAuth = Boolean(process.env.NEOTOMA_AAUTH_PRIVATE_JWK_PATH);
+    if (useAAuth) {
+      const { loadCliSignerConfig } = await import("./aauth_signer.js");
+      const signerConfig = await loadCliSignerConfig();
+      if (!signerConfig) {
+        throw new Error(
+          `NEOTOMA_AAUTH_PRIVATE_JWK_PATH is set (${process.env.NEOTOMA_AAUTH_PRIVATE_JWK_PATH}) ` +
+            "but no usable AAuth CLI keypair was found there. Fix the path or run `neotoma auth keygen`. " +
+            "Unattended issues sync must not fall back to an unsigned request."
+        );
+      }
+    }
     const token = useAAuth ? undefined : await getCliToken();
     const api = createApiClient({
       baseUrl: await resolveBaseUrl(program.opts().baseUrl, config),
       token,
-      ...(useAAuth ? { signWithCliAAuth: true, forceHttpTransport: true } : {}),
+      ...(useAAuth
+        ? { signWithCliAAuth: true, forceHttpTransport: true, requireCliAAuth: true }
+        : {}),
     });
     await issuesSync({ ...opts, json: Boolean((program.opts() as { json?: boolean }).json) }, api);
   });
@@ -15868,13 +15884,25 @@ program
     // --aauth: drop the bearer so the AAuth request signature is the sole
     // credential. A bearer Authorization header otherwise takes precedence and
     // the request lands under the bearer's identity rather than the agent's.
+    if (opts.aauth) {
+      const { loadCliSignerConfig } = await import("./aauth_signer.js");
+      const signerConfig = await loadCliSignerConfig();
+      if (!signerConfig) {
+        throw new Error(
+          "No AAuth CLI keypair found (~/.neotoma/aauth/private.jwk or NEOTOMA_AAUTH_PRIVATE_JWK_PATH). " +
+            "Run `neotoma auth keygen` once, then retry. `--aauth` must not fall back to an unsigned request."
+        );
+      }
+    }
     const token = opts.skipAuth || opts.aauth ? undefined : await getCliToken();
     const api = createApiClient({
       baseUrl,
       token,
       // AAuth signing rides the HTTP transport, so force it over the in-process
       // local transport (which would bypass the signature).
-      ...(opts.aauth ? { signWithCliAAuth: true, forceHttpTransport: true } : {}),
+      ...(opts.aauth
+        ? { signWithCliAAuth: true, forceHttpTransport: true, requireCliAAuth: true }
+        : {}),
     });
 
     const params = parseOptionalJson(opts.params);

--- a/src/shared/api_client.ts
+++ b/src/shared/api_client.ts
@@ -15,6 +15,14 @@ export interface ApiClientOptions {
    */
   signWithCliAAuth?: boolean;
   /**
+   * When true with `signWithCliAAuth`, do not fall back to unsigned `fetch`
+   * on missing/unusable keys or signing errors. Intended for unattended
+   * paths (`issues sync` env-gated AAuth, `api --aauth`) where silent
+   * anonymous requests would mask misconfiguration. Optional interactive
+   * signing keeps the default silent fallback.
+   */
+  requireCliAAuth?: boolean;
+  /**
    * Force the HTTP transport even when `NEOTOMA_FORCE_LOCAL_TRANSPORT=true`.
    * The in-process local transport never makes an HTTP request, so RFC 9421
    * request signing has nothing to sign — AAuth-attributed calls MUST go over
@@ -31,12 +39,12 @@ export interface ApiClientOptions {
  * indirection keeps Node-only `fs`/`jose` imports out of the browser
  * bundle via a dynamic import.
  */
-function buildMaybeSignedFetch(enabled: boolean): typeof fetch {
+function buildMaybeSignedFetch(enabled: boolean, requireCliAAuth = false): typeof fetch {
   if (!enabled) return fetch;
   return (async (input: RequestInfo | URL, init?: RequestInit) => {
     const request = input instanceof Request ? input : null;
     const url = request ? request.url : typeof input === "string" ? input : input.toString();
-    const { cliSignedFetch } = await import("../cli/aauth_signer.js");
+    const { cliSignedFetch, loadCliSignerConfig } = await import("../cli/aauth_signer.js");
     const method = (init?.method ?? request?.method ?? "GET").toUpperCase();
     const headers: Record<string, string> = {};
     const sourceHeaders = new Headers(request?.headers);
@@ -57,13 +65,23 @@ function buildMaybeSignedFetch(enabled: boolean): typeof fetch {
       body = await request.clone().text();
     }
     try {
+      if (requireCliAAuth) {
+        const signerConfig = await loadCliSignerConfig();
+        if (!signerConfig) {
+          throw new Error(
+            "AAuth signing is required but no usable CLI keypair was found. " +
+              "Set NEOTOMA_AAUTH_PRIVATE_JWK_PATH to a valid private JWK, or run `neotoma auth keygen`."
+          );
+        }
+      }
       return await cliSignedFetch(url, {
         method,
         headers,
         body,
         signal: init?.signal ?? undefined,
       });
-    } catch {
+    } catch (err) {
+      if (requireCliAAuth) throw err;
       // Never surface signing misconfiguration as a hard failure from the
       // API client — the caller should still reach the server and land
       // as `unverified_client` / `anonymous` tier.
@@ -85,7 +103,7 @@ export function createApiClient(options: ApiClientOptions = {}) {
     (process.env.NODE_ENV !== "test" &&
       process.env.NEOTOMA_CLI_AAUTH_DISABLE !== "1" &&
       process.env.NEOTOMA_CLI_AAUTH_ENABLE !== "0");
-  const fetchImpl = buildMaybeSignedFetch(signingEnabled);
+  const fetchImpl = buildMaybeSignedFetch(signingEnabled, Boolean(options.requireCliAAuth));
 
   const client = createClient<paths>({
     baseUrl: options.baseUrl,

--- a/tests/cli/cli_issues_commands.test.ts
+++ b/tests/cli/cli_issues_commands.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 type CliModule = { runCli: (argv: string[]) => Promise<void> };
 
@@ -64,11 +64,41 @@ function capturedBodyForPath(
   return Object.entries(capturedBodies).find(([url]) => url.includes(pathFragment))?.[1];
 }
 
+function requestUrl(input: RequestInfo | URL): string {
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return input.toString();
+  if (input instanceof Request) return input.url;
+  return String(input);
+}
+
+function fetchCalledForPath(fetchMock: ReturnType<typeof vi.fn>, pathFragment: string): boolean {
+  return fetchMock.mock.calls.some(([input]) => requestUrl(input as RequestInfo | URL).includes(pathFragment));
+}
+
 describe("CLI issues commands", () => {
+  const savedAauthEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of [
+      "NEOTOMA_AAUTH_PRIVATE_JWK_PATH",
+      "NEOTOMA_AAUTH_SUB",
+      "NEOTOMA_AAUTH_ISS",
+      "NEOTOMA_AAUTH_KID",
+      "NEOTOMA_BEARER_TOKEN",
+    ]) {
+      savedAauthEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
   afterEach(() => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
     process.exitCode = undefined;
+    for (const [key, value] of Object.entries(savedAauthEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
   });
 
   it("maps hidden issues create --advisory to private and emits a deprecation warning", async () => {
@@ -312,6 +342,117 @@ describe("CLI issues commands", () => {
         labels: ["neotoma", "bug"],
         since: "2026-05-01T00:00:00Z",
       });
+    });
+  });
+
+  it("issues sync uses bearer Authorization when NEOTOMA_AAUTH_PRIVATE_JWK_PATH is unset", async () => {
+    await withTempHome(async () => {
+      delete process.env.NEOTOMA_AAUTH_PRIVATE_JWK_PATH;
+      const syncAuthHeaders: string[] = [];
+      const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const request = input instanceof Request ? input : null;
+        const url = request?.url ?? String(input);
+        if (url.includes("/issues/sync")) {
+          const headers = new Headers(request?.headers);
+          if (init?.headers) {
+            new Headers(init.headers).forEach((value, key) => headers.set(key, value));
+          }
+          syncAuthHeaders.push(headers.get("authorization") ?? "");
+        }
+        return new Response(JSON.stringify({ issues_synced: 0, errors: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      const { runCli } = await loadCli();
+      const stdout = captureStdout();
+      try {
+        await runCli(["node", "cli", "issues", "sync", "--json"]);
+      } finally {
+        stdout.restore();
+      }
+
+      expect(syncAuthHeaders).toEqual(["Bearer token-test"]);
+      expect(fetchCalledForPath(fetchMock, "/issues/sync")).toBe(true);
+    });
+  });
+
+  it("issues sync drops bearer and still calls sync when env points at a valid temp JWK", async () => {
+    await withTempHome(async () => {
+      const jwkPath = path.join(process.env.HOME!, "agent.private.jwk");
+      const { generateKeyPair, exportJWK } = await import("jose");
+      const { privateKey } = await generateKeyPair("ES256", { extractable: true });
+      const jwk = (await exportJWK(privateKey)) as Record<string, unknown>;
+      jwk.alg = "ES256";
+      jwk.kid = "issues-sync-test-kid";
+      await fs.writeFile(jwkPath, JSON.stringify(jwk), { mode: 0o600 });
+
+      process.env.NEOTOMA_AAUTH_PRIVATE_JWK_PATH = jwkPath;
+      process.env.NEOTOMA_AAUTH_SUB = "cicada@ateles-swarm";
+      process.env.NEOTOMA_AAUTH_ISS = "https://neotoma.test";
+
+      const syncAuthHeaders: Array<string | null> = [];
+      const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const request = input instanceof Request ? input : null;
+        const url = request?.url ?? String(input);
+        if (url.includes("/issues/sync")) {
+          const headers = new Headers(request?.headers);
+          if (init?.headers) {
+            new Headers(init.headers).forEach((value, key) => headers.set(key, value));
+          }
+          syncAuthHeaders.push(headers.get("authorization"));
+        }
+        return new Response(JSON.stringify({ issues_synced: 1, errors: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      try {
+        const { runCli } = await loadCli();
+        const stdout = captureStdout();
+        try {
+          await runCli(["node", "cli", "issues", "sync", "--json"]);
+        } finally {
+          stdout.restore();
+        }
+
+        expect(syncAuthHeaders.length).toBeGreaterThan(0);
+        expect(syncAuthHeaders.every((h) => h === null || h === "")).toBe(true);
+        expect(fetchCalledForPath(fetchMock, "/issues/sync")).toBe(true);
+      } finally {
+        delete process.env.NEOTOMA_AAUTH_PRIVATE_JWK_PATH;
+        delete process.env.NEOTOMA_AAUTH_SUB;
+        delete process.env.NEOTOMA_AAUTH_ISS;
+      }
+    });
+  });
+
+  it("issues sync fails loud and never hits /issues/sync when env JWK path is missing", async () => {
+    await withTempHome(async () => {
+      const missingPath = path.join(process.env.HOME!, "missing-agent.private.jwk");
+      process.env.NEOTOMA_AAUTH_PRIVATE_JWK_PATH = missingPath;
+
+      const fetchMock = vi.fn(async () => {
+        return new Response(JSON.stringify({ issues_synced: 0, errors: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      try {
+        const { runCli } = await loadCli();
+        await expect(runCli(["node", "cli", "issues", "sync", "--json"])).rejects.toThrow(
+          /NEOTOMA_AAUTH_PRIVATE_JWK_PATH is set/,
+        );
+        expect(fetchCalledForPath(fetchMock, "/issues/sync")).toBe(false);
+      } finally {
+        delete process.env.NEOTOMA_AAUTH_PRIVATE_JWK_PATH;
+      }
     });
   });
 });


### PR DESCRIPTION
## Problem

`neotoma issues sync` is hardcoded to **bearer auth** (`getCliToken()` at `src/cli/index.ts`), with no AAuth path — only the generic `api --aauth` passthrough supports signing. So the issues-sync LaunchAgent / `neotoma-agent` daemon that drives the swarm gate pipeline cannot authenticate once bearer tokens are retired. Observed failure (laptop host): `issues sync failed: {"error_code":"AUTH_REQUIRED","message":"Missing Bearer token", ...}`, with the pipeline frozen as a result.

## Change

Env-gate per-agent AAuth signing in the issues-sync action, mirroring the proven `api --aauth` block:

```js
const useAAuth = Boolean(process.env.NEOTOMA_AAUTH_PRIVATE_JWK_PATH);
const token = useAAuth ? undefined : await getCliToken();
const api = createApiClient({
  baseUrl, token,
  ...(useAAuth ? { signWithCliAAuth: true, forceHttpTransport: true } : {}),
});
```

- When `NEOTOMA_AAUTH_PRIVATE_JWK_PATH` is set: drop the bearer, sign the request, force HTTP transport.
- `forceHttpTransport` also sidesteps the **dev/prod local-transport env mismatch** (`:3080` collision, #244 class), which was the second failure on the affected host.
- When AAuth is **not** configured: unchanged (bearer fallback) — zero impact on existing setups.

## Deploy target

The operational sync + `neotoma-agent` daemon run on **mac-studio** (via `rc-autodeploy`), so this lands there once merged. Once deployed, set in the sync's env file:

```
NEOTOMA_AAUTH_PRIVATE_JWK_PATH=$HOME/.neotoma/aauth/private.jwk
NEOTOMA_AAUTH_SUB=<agent sub>
NEOTOMA_AAUTH_ISS=<issuer>
```

## Known follow-ups (not in this PR)

- **Identity:** the host CLI keys are `agent@air.local` / `cross-instance-issues-signed-remote@test`, not a `neotoma-agent` identity. A grant for `neotoma-agent@ateles-swarm` was pre-created; a dedicated key (without `--force`-clobbering the shared one) or an identity decision is still needed.
- **Grant admission:** sub+iss vs thumbprint binding is unverified end-to-end.
- Consider extending the same env-gate to the other `issues` subcommands for consistency.

## Test

Mirrors the verbatim, already-tested `--aauth` client-construction pattern; no new test seam added (the wiring is inline in the Commander action). Bearer fallback path is unchanged.
