### PR TITLE
ci(sandbox): deploy neotoma-sandbox on GitHub Release published

### DIFF
--- a/.github/workflows/deploy-sandbox.yml
+++ b/.github/workflows/deploy-sandbox.yml
@@ -1,0 +1,90 @@
+name: Deploy sandbox
+
+# Deploys the public sandbox (`neotoma-sandbox` on Fly) whenever a GitHub
+# Release is published, so the sandbox always tracks the latest shipped
+# release. Replaces the manual `flyctl deploy` step in the /release flow
+# (which is easy to skip — the sandbox silently drifts behind a release).
+#
+# Also runnable on demand via workflow_dispatch (manual redeploy / hotfix).
+#
+# Requires repository secret: FLY_API_TOKEN (deploy token scoped to the org).
+# The NEOTOMA_GIT_SHA build-arg only takes effect once the Dockerfile declares
+# it (see the git-SHA stamping PR); until then the verify step treats the
+# deployed git_sha as informational (Fly machine-version ULID) and gates only
+# on the version + sandbox header. Once the ARG is in, a real 40-hex git_sha
+# that mismatches the deployed commit fails the job.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref to deploy (defaults to the workflow ref)"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-sandbox
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+
+      - name: Setup flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Deploy to Fly (sandbox)
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: |
+          flyctl deploy -c fly.sandbox.toml --remote-only \
+            --build-arg NEOTOMA_GIT_SHA="${{ github.sha }}"
+
+      - name: Verify live sandbox
+        env:
+          EXPECTED_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          export EXPECTED_VERSION="$(node -p "require('./package.json').version")"
+          echo "Expecting version=$EXPECTED_VERSION, git_sha=$EXPECTED_SHA"
+
+          # Root JSON must report the release version and sandbox mode.
+          curl -fsS --retry 5 --retry-delay 5 --retry-all-errors \
+            -H "Accept: application/json" https://sandbox.neotoma.io/ -o /tmp/root.json
+          cat /tmp/root.json
+
+          node -e '
+            const fs = require("fs");
+            const j = JSON.parse(fs.readFileSync("/tmp/root.json", "utf8"));
+            const expVer = process.env.EXPECTED_VERSION;
+            const expSha = process.env.EXPECTED_SHA;
+            const fail = (m) => { console.error("FAIL: " + m); process.exit(1); };
+            if (j.version !== expVer) fail(`version ${j.version} != ${expVer}`);
+            if (j.mode !== "sandbox") fail(`mode ${j.mode} != sandbox`);
+            // git_sha: enforce only when it is a real 40-hex commit (Dockerfile
+            // ARG present). A 26-char ULID means the ARG is not wired yet — log
+            // and pass so this workflow does not depend on that PR landing first.
+            if (/^[0-9a-f]{40}$/.test(j.git_sha || "")) {
+              if (j.git_sha !== expSha) fail(`git_sha ${j.git_sha} != ${expSha}`);
+              console.log("git_sha verified:", j.git_sha);
+            } else {
+              console.log("git_sha not a commit (ARG not wired yet):", j.git_sha);
+            }
+            console.log("OK:", j.version, j.mode);
+          '
+
+      - name: Verify sandbox health header
+        run: |
+          set -euo pipefail
+          curl -fsSI --retry 5 --retry-delay 5 --retry-all-errors \
+            https://sandbox.neotoma.io/health | grep -i '^x-neotoma-sandbox: 1'

--- a/docs/developer/github_release_process.md
+++ b/docs/developer/github_release_process.md
@@ -151,6 +151,12 @@ The `/release` skill ([`.cursor/skills/release/SKILL.md`](../../.cursor/skills/r
 
 ## Deploy sandbox.neotoma.io
 
+> **Now automated.** Publishing the GitHub Release triggers
+> [`.github/workflows/deploy-sandbox.yml`](../../.github/workflows/deploy-sandbox.yml),
+> which deploys `neotoma-sandbox` on Fly and verifies the live version + sandbox
+> header. The manual steps below are the fallback (run `workflow_dispatch` on
+> that workflow, or the `flyctl` command directly) when CI is unavailable.
+
 A normal `/release` is also **not finished** until the public sandbox host is redeployed and verified. After npm publish succeeds and the registry reports the new version, deploy the Fly sandbox app:
 
 ```bash


### PR DESCRIPTION
## Why

The sandbox code deploy was a **manual** `flyctl deploy` step at the end of the `/release` flow — the only sandbox automation in CI was the weekly *data* reset. So a published release could silently leave `sandbox.neotoma.io` running an older build (the original "is it on the latest build?" report). The local `rc-autodeploy` LaunchAgent only runs when one specific Mac is awake.

## What

`.github/workflows/deploy-sandbox.yml`:
- **Triggers:** `release: published` (+ `workflow_dispatch` for manual redeploy/hotfix, with an optional `ref` input).
- **Deploy:** `flyctl deploy -c fly.sandbox.toml --remote-only --build-arg NEOTOMA_GIT_SHA=${{ github.sha }}`.
- **Verify (gates the job):** root JSON reports the release `version` and `mode: "sandbox"`, and `/health` returns `X-Neotoma-Sandbox: 1` (with curl retries for warm-up).
- Reuses the existing **`FLY_API_TOKEN`** repo secret (same as `sandbox-weekly-reset.yml`).

Updates the release-process doc to note the deploy is now automated, with the manual `flyctl`/`workflow_dispatch` path as fallback.

## Merge-order independence

The `git_sha` check is enforced **only** when the deployed value is a real 40-hex commit (i.e. the Dockerfile `NEOTOMA_GIT_SHA` ARG from [#1762](https://github.com/markmhendrickson/neotoma/pull/1762) is present). Until then it logs the Fly machine-version ULID and gates on version + sandbox header only — so this workflow can merge before or after #1762 without breaking.

## Note
I can't fully end-to-end test this without triggering a real release/deploy (and Fly auth isn't on this machine's CI context). The flyctl invocation and verify logic mirror the working manual commands and the existing weekly-reset workflow; YAML validated locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)