### PR TITLE
feat(rendered-page): auto-anchor all headings in served pages

### DIFF
--- a/src/services/rendered_page/html_template.test.ts
+++ b/src/services/rendered_page/html_template.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { renderRenderedPageHtml } from "./html_template";
+
+describe("renderRenderedPageHtml heading anchors", () => {
+  it("injects the heading-anchor script over <main> headings", () => {
+    const out = renderRenderedPageHtml({ title: "T", htmlBody: "<h2>Hello World</h2>" });
+    // client script that assigns ids + appends permalink anchors to headings
+    expect(out).toContain(
+      'querySelectorAll("main h1, main h2, main h3, main h4, main h5, main h6")'
+    );
+    expect(out).toContain('a.className = "hanchor"');
+    // styling for the permalink affordance
+    expect(out).toContain("a.hanchor {");
+    expect(out).toContain("scroll-margin-top");
+  });
+
+  it("still renders the body verbatim and keeps the custom style tag", () => {
+    const out = renderRenderedPageHtml({
+      title: "T",
+      htmlBody: '<h1 id="keep">Kept</h1>',
+      customCss: "h1{color:red}",
+    });
+    expect(out).toContain('<h1 id="keep">Kept</h1>');
+    expect(out).toContain("<style>h1{color:red}</style>");
+  });
+});

--- a/src/services/rendered_page/html_template.ts
+++ b/src/services/rendered_page/html_template.ts
@@ -48,6 +48,10 @@ table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
 th, td { text-align: left; padding: 0.5rem 0.75rem; border-bottom: 1px solid #e3ddd2; }
 th { background: #f4f1ec; font-weight: 600; }
 .footer-meta { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid #e3ddd2; font-size: 0.85rem; color: #777; }
+h1, h2, h3, h4, h5, h6 { scroll-margin-top: 1.5rem; }
+a.hanchor { margin-left: 0.4em; font-weight: 400; font-size: 0.85em; text-decoration: none; opacity: 0; transition: opacity 0.12s ease; }
+h1:hover > a.hanchor, h2:hover > a.hanchor, h3:hover > a.hanchor, h4:hover > a.hanchor, h5:hover > a.hanchor, h6:hover > a.hanchor { opacity: 0.4; }
+a.hanchor:hover { opacity: 1; }
 `;
 
 function escapeHtmlAttribute(s: string): string {
@@ -90,6 +94,36 @@ ${customStyleTag}
 <main>
 ${input.htmlBody}
 </main>
+<script>
+(function () {
+  function slugify(t) {
+    return ((t || "").toLowerCase().trim()
+      .replace(/[^a-z0-9\\s-]/g, "")
+      .replace(/\\s+/g, "-")
+      .replace(/-+/g, "-")
+      .replace(/^-+|-+$/g, "")) || "section";
+  }
+  var heads = document.querySelectorAll("main h1, main h2, main h3, main h4, main h5, main h6");
+  for (var i = 0; i < heads.length; i++) {
+    var h = heads[i];
+    var id = h.id;
+    if (!id) {
+      var base = slugify(h.textContent), cand = base, n = 2;
+      while (document.getElementById(cand)) { cand = base + "-" + n++; }
+      id = cand;
+      h.id = id;
+    }
+    if (!h.querySelector("a.hanchor")) {
+      var a = document.createElement("a");
+      a.className = "hanchor";
+      a.href = "#" + id;
+      a.setAttribute("aria-label", "Permalink to this section");
+      a.textContent = "#";
+      h.appendChild(a);
+    }
+  }
+})();
+</script>
 </body>
 </html>`;
 }


### PR DESCRIPTION
## What

Every `rendered_page` served via `GET /entities/:id/html` now gets stable, linkable heading anchors, with no per-page edits.

A small client script in the page shell (`renderRenderedPageHtml`):
- slugifies each `<main>` heading's text into an `id` (only when one is not already set, so existing ids like `#actions` are preserved),
- de-duplicates collisions, and
- appends a hover-revealed permalink `#` to each heading.

CSS adds `scroll-margin-top` so anchored navigation clears the top, and a `.hanchor` affordance that is invisible until heading hover.

## Why

Headings across rendered pages were not linkable, so deep-linking to a section (e.g. an asset's "Recommended sprint") was not possible. This makes section anchors a default for all current and future rendered pages.

## Test

`src/services/rendered_page/html_template.test.ts` asserts the script + styles are present and that existing ids and the custom style tag are preserved. Existing `publish.test.ts` still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)