### PR TITLE
fix(identity): issue entities key on (github_number, repo), not mutable title (#1761)

### DIFF
--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,8 +61,8 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **487**
-- Backend and repo Vitest files: **454**
+- Total automated test files: **488**
+- Backend and repo Vitest files: **455**
 - Frontend Vitest files: **9**
 - Playwright spec files: **24**
 

--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,8 +61,8 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **486**
-- Backend and repo Vitest files: **453**
+- Total automated test files: **487**
+- Backend and repo Vitest files: **454**
 - Frontend Vitest files: **9**
 - Playwright spec files: **24**
 
@@ -71,7 +71,7 @@ flowchart TD
 |---|---:|
 | Vitest unit tests | 129 |
 | Vitest service tests | 34 |
-| Source-adjacent tests | 60 |
+| Source-adjacent tests | 61 |
 | Vitest integration tests | 137 |
 | Vitest CLI tests | 65 |
 | Vitest contract tests | 14 |
@@ -286,7 +286,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- src`
 **Requirements:** Basic `.env` if required by the module under test.
-**Files (60):**
+**Files (61):**
 - `src/cli/parse_cli_corrected_value.test.ts`
 - `src/crypto/crypto.test.ts`
 - `src/proxy/mcp_stdio_proxy.test.ts`
@@ -323,6 +323,7 @@ flowchart TD
 - `src/services/entity_submission/submission_service.test.ts`
 - `src/services/guest_access_token.test.ts`
 - `src/services/issues/body_newline_decode.test.ts`
+- `src/services/issues/issue_identity.test.ts`
 - `src/services/issues/issue_operations.test.ts`
 - `src/services/issues/neotoma_client.test.ts`
 - `src/services/issues/observer_import.test.ts`

--- a/src/services/entity_resolution.ts
+++ b/src/services/entity_resolution.ts
@@ -459,10 +459,27 @@ function deriveCanonicalNameFromSchemaRules(
 export function deriveCanonicalNameFromFieldsWithTrace(
   entityType: string,
   fields: Record<string, unknown>,
-  schema?: Pick<SchemaDefinition, "canonical_name_fields"> | null
+  schema?: Pick<SchemaDefinition, "canonical_name_fields" | "canonical_name_strict"> | null
 ): CanonicalNameDerivation {
   const schemaDerivation = deriveCanonicalNameFromSchemaRules(entityType, fields, schema);
   if (schemaDerivation) return schemaDerivation;
+
+  // Schema-authoritative identity: when the schema declares canonical_name_fields
+  // AND opts into strict identity, refuse the mutable heuristic fallbacks below.
+  // A write that misses every declared rule fails loudly instead of minting a
+  // divergent heuristic-keyed entity (e.g. a title-keyed issue that never
+  // coalesces with its (github_number, repo) twin — #1761).
+  if (
+    schema?.canonical_name_strict &&
+    Array.isArray(schema.canonical_name_fields) &&
+    schema.canonical_name_fields.length > 0
+  ) {
+    throw new CanonicalNameUnresolvedError({
+      entityType,
+      seenFields: Object.keys(fields),
+      attemptedValue: null,
+    });
+  }
 
   const preferredNameKeys = [
     "canonical_name",

--- a/src/services/issues/issue_identity.test.ts
+++ b/src/services/issues/issue_identity.test.ts
@@ -62,7 +62,11 @@ describe("issue identity (#1761)", () => {
     // A write carrying only a title (no composite, no local_issue_id) must throw
     // rather than silently create a divergent title-hashed `issue` entity.
     expect(() =>
-      deriveCanonicalNameFromFields("issue", { title: "orphan triage write", status: "open" }, schema)
+      deriveCanonicalNameFromFields(
+        "issue",
+        { title: "orphan triage write", status: "open" },
+        schema
+      )
     ).toThrow(CanonicalNameUnresolvedError);
   });
 

--- a/src/services/issues/issue_identity.test.ts
+++ b/src/services/issues/issue_identity.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  deriveCanonicalNameFromFields,
+  CanonicalNameUnresolvedError,
+} from "../entity_resolution.js";
+import { buildSchemaDefinition } from "./seed_schema.js";
+
+/**
+ * Regression coverage for #1761 — issue entities with the same logical identity
+ * (github_number, repo) must coalesce to one entity, and a write that misses the
+ * declared identity must fail loudly instead of minting a divergent title-keyed
+ * duplicate.
+ *
+ * Root cause: the issue schema used `title` as an identity fallback, and the
+ * resolver's heuristic fallback also keys on `title`. A triage write carrying
+ * only a title got a title-hashed entity_id; once it later gained
+ * github_number+repo its snapshot canonical_name recomputed to the composite
+ * form, so it *displayed* identical to the real issue yet never coalesced with
+ * it. Fix: drop `title` from `canonical_name_fields` AND mark the issue schema
+ * `canonical_name_strict` so the heuristic title fallback is refused.
+ */
+describe("issue identity (#1761)", () => {
+  const schema = buildSchemaDefinition();
+
+  it("does not use title as a declared identity rule", () => {
+    const flattened = JSON.stringify(schema.canonical_name_fields);
+    expect(flattened).not.toContain("title");
+  });
+
+  it("is canonical_name_strict (heuristic title fallback refused)", () => {
+    expect(schema.canonical_name_strict).toBe(true);
+  });
+
+  it("keys a GitHub-backed issue on (github_number, repo), independent of title", () => {
+    const a = deriveCanonicalNameFromFields(
+      "issue",
+      { github_number: 1755, repo: "markmhendrickson/neotoma", title: "first title" },
+      schema
+    );
+    const b = deriveCanonicalNameFromFields(
+      "issue",
+      { github_number: 1755, repo: "markmhendrickson/neotoma", title: "RENAMED later" },
+      schema
+    );
+    // Same composite identity → same canonical_name → same entity_id → coalesce.
+    expect(a).toBe(b);
+    expect(a).toContain("1755");
+    expect(a).toContain("markmhendrickson/neotoma");
+  });
+
+  it("falls back to local_issue_id for local-only issues", () => {
+    const c = deriveCanonicalNameFromFields(
+      "issue",
+      { local_issue_id: "local:markmhendrickson/neotoma:abc123", title: "local one" },
+      schema
+    );
+    expect(c).toContain("local:markmhendrickson/neotoma:abc123");
+  });
+
+  it("REFUSES to mint a title-keyed entity when identity fields are missing (the #1761 collision)", () => {
+    // A write carrying only a title (no composite, no local_issue_id) must throw
+    // rather than silently create a divergent title-hashed `issue` entity.
+    expect(() =>
+      deriveCanonicalNameFromFields("issue", { title: "orphan triage write", status: "open" }, schema)
+    ).toThrow(CanonicalNameUnresolvedError);
+  });
+
+  it("is opt-in: a non-strict schema still allows the heuristic title fallback (back-compat)", () => {
+    const lenient = {
+      canonical_name_fields: [{ composite: ["github_number", "repo"] as string[] }],
+      // canonical_name_strict omitted → legacy behavior
+    };
+    const v = deriveCanonicalNameFromFields("issue", { title: "heuristic ok here" }, lenient);
+    expect(v).toContain("heuristic ok here");
+  });
+});

--- a/src/services/issues/seed_schema.ts
+++ b/src/services/issues/seed_schema.ts
@@ -133,7 +133,7 @@ const ISSUE_FIELDS: FieldSpec = [
   },
 ];
 
-function buildSchemaDefinition(): SchemaDefinition {
+export function buildSchemaDefinition(): SchemaDefinition {
   const fields: Record<string, FieldDefinition> = {
     schema_version: { type: "string", required: true },
   };
@@ -146,7 +146,22 @@ function buildSchemaDefinition(): SchemaDefinition {
   }
   return {
     fields,
-    canonical_name_fields: [{ composite: ["github_number", "repo"] }, "local_issue_id", "title"],
+    // Identity precedence: GitHub-backed issues key on (github_number, repo);
+    // local-only issues key on local_issue_id. `title` is deliberately NOT an
+    // identity fallback — it is mutable and non-identifying, and as a fallback it
+    // mints a divergent entity_id when a write lands before/without the composite
+    // fields (e.g. a triage write carrying only a title). That row's id is frozen
+    // off the title hash; once it later gains github_number+repo its snapshot
+    // canonical_name recomputes to the composite form, so it *displays* identical
+    // to the real issue yet never coalesces with it — the #1761 collision. A write
+    // with neither the composite fields nor local_issue_id now fails loudly
+    // (CanonicalNameUnresolvedError) instead of silently creating a title-keyed
+    // duplicate.
+    canonical_name_fields: [{ composite: ["github_number", "repo"] }, "local_issue_id"],
+    // Authoritative identity: a write that satisfies none of the rules above
+    // must fail loudly rather than fall back to the heuristic title/name path
+    // (which is what minted the divergent title-keyed duplicate in #1761).
+    canonical_name_strict: true,
     temporal_fields: [
       { field: "created_at", event_type: "issue_created" },
       { field: "closed_at", event_type: "issue_closed" },
@@ -274,6 +289,7 @@ export async function seedIssueSchema(options?: {
       ...existing.schema_definition,
       fields: { ...definition.fields, ...existing.schema_definition.fields },
       canonical_name_fields: definition.canonical_name_fields,
+      canonical_name_strict: definition.canonical_name_strict,
       temporal_fields: definition.temporal_fields ?? existing.schema_definition.temporal_fields,
     };
     const mergedReducer: ReducerConfig = {

--- a/src/services/schema_registry.ts
+++ b/src/services/schema_registry.ts
@@ -239,6 +239,22 @@ export interface SchemaDefinition {
   name_collision_policy?: "merge" | "warn" | "reject";
 
   /**
+   * When `true`, the schema's `canonical_name_fields` are AUTHORITATIVE: if none
+   * of the declared rules resolve for a write, derivation fails loudly
+   * (`CanonicalNameUnresolvedError`) instead of falling back to the mutable
+   * heuristic fields (name/title/first-string). This prevents a write that
+   * misses the declared identity from silently minting a divergent entity that
+   * never coalesces with its real twin once enriched — e.g. an issue stored with
+   * only a `title` getting a title-keyed id that never merges with its
+   * `(github_number, repo)` row (#1761).
+   *
+   * Only meaningful alongside a non-empty `canonical_name_fields`. Opt-in:
+   * omitted/`false` preserves the legacy heuristic-fallback behavior for every
+   * existing schema.
+   */
+  canonical_name_strict?: boolean;
+
+  /**
    * Fields compared by the post-hoc duplicate detector (R5). When omitted,
    * the detector falls back to comparing canonical_name only, which is the
    * weakest possible signal. Declaring additional fields (e.g. ["email"],


### PR DESCRIPTION
## Root cause

Two `issue` rows with the same logical identity (`github_number`, `repo`) could exist as separate entities (e.g. #1755 had a GitHub-sync row and a gate-triage row). Coalescing is by `generateEntityId(entity_type, canonical_name)` — deterministic — so identical identity should collapse to one id. The divergence came from **identity derivation**:

- The issue schema's `canonical_name_fields` was `[composite(github_number, repo), local_issue_id, title]`. `title` was an identity fallback.
- The resolver's heuristic fallback *also* keys on `title` (among name-like fields) when no schema rule resolves.
- A triage write that arrived with **only a title** (no `github_number`/`repo`) got a **title-hashed** entity_id. An entity's row id is frozen at creation, but its snapshot `canonical_name` is **recomputed** from current fields — so once that row later gained `github_number`+`repo`, it *displayed* the composite canonical_name identical to the real issue, yet never coalesced with it.

## Fix (two parts)

1. **Drop `title`** from the issue `canonical_name_fields` → `[composite(github_number, repo), local_issue_id]`. Title is mutable and non-identifying.
2. **Add an opt-in `canonical_name_strict` schema flag** (`src/services/schema_registry.ts`): when a schema declares `canonical_name_fields` and sets this, a write that resolves *none* of the rules fails loudly with `CanonicalNameUnresolvedError` instead of falling back to the heuristic name/title path (`src/services/entity_resolution.ts`). Set it on the issue schema and propagate it through the seed repair/upgrade path (`src/services/issues/seed_schema.ts`).

`canonical_name_strict` is **opt-in** — omitted/false preserves the legacy heuristic-fallback behavior for every other schema, so blast radius is limited to `issue`.

### Result
A GitHub-backed issue write always coalesces on `(github_number, repo)` regardless of title; a write missing every identity rule fails loudly rather than silently minting a divergent duplicate.

## Tests
- New `src/services/issues/issue_identity.test.ts` — 6 cases: title excluded from rules; strict flag set; same `(github_number, repo)` with different titles → same canonical_name; local-only via `local_issue_id`; **the collision regression** (title-only write throws); opt-in back-compat (non-strict schema still allows heuristic title).
- Existing `issue_operations` (40) and `seed_schema` suites still pass; `npx tsc --noEmit` clean.

Closes #1761.
