### PR TITLE
ci: disable standalone Claude PR reviewer (swarm panel now owns review)

### DIFF
--- a/.github/workflows/claude_pr_review.yml
+++ b/.github/workflows/claude_pr_review.yml
@@ -1,30 +1,22 @@
 name: Claude PR Review
 
+# DISABLED for automatic PR review (2026-06-24).
+#
+# PR review is now owned by the Ateles swarm review panel (Anthus-dispatched
+# gates: pm/Pavo, ux/Accipiter, arch/Bombycilla, qa/Phoenicurus,
+# pr_review/Vanellus, legal/Buteo), governed by the neotoma|feature
+# workflow_definition and the `code_review` agent_policy "Swarm PR review: full
+# diff + role-based depth". The swarm reviews every PR in depth by role against
+# the full diff, so this standalone single-pass reviewer is no longer the
+# correctness backstop.
+#
+# The job below is hard-guarded with `if: ${{ false }}`, so it is inert even on
+# manual dispatch. To re-enable: restore the `pull_request` / `issue_comment`
+# triggers and the original job `if:` condition (preserved as a comment on the
+# job). The workflow_dispatch trigger is retained only so the file stays a valid,
+# discoverable workflow.
 on:
-  pull_request:
-    types:
-      - opened
-      - ready_for_review
-      - synchronize
-    # Run when code, contract, or agent-facing surfaces change. Agent instructions
-    # ship to every MCP client, so changes there are user-facing behavior even
-    # when no src/ file changed.
-    paths:
-      - "src/**"
-      - "packages/**"
-      - "openapi.yaml"
-      - "package.json"
-      - "tests/**"
-      - "docs/developer/mcp/instructions.md"
-      - "docs/developer/cli_agent_instructions.md"
-      - "docs/foundation/**"
-      - "docs/architecture/**"
-      - "docs/subsystems/**"
-      - ".claude/skills/**"
-      - ".claude/rules/**"
-  issue_comment:
-    types:
-      - created
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -44,16 +36,13 @@ concurrency:
 
 jobs:
   review:
-    if: |
-      (github.event_name == 'pull_request' &&
-       github.event.pull_request.draft == false &&
-       !(github.event.action == 'synchronize' && (
-         startsWith(github.event.pull_request.head.ref, 'claude/') ||
-         github.event.pull_request.user.login == 'castor-agent'
-       ))) ||
-      (github.event_name == 'issue_comment' &&
-       github.event.issue.pull_request != null &&
-       contains(github.event.comment.body, '@claude review'))
+    # DISABLED — the Ateles swarm review panel owns PR review (see header).
+    # This guard makes the job inert even if manually dispatched. To re-enable,
+    # restore the pull_request/issue_comment triggers above and the original
+    # condition below (preserved as a comment):
+    #   (github.event_name == 'pull_request' && pr.draft == false && !(synchronize on claude/* or castor-agent))
+    #   || (github.event_name == 'issue_comment' && issue.pull_request != null && contains(comment.body, '@claude review'))
+    if: ${{ false }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Why

PR review is now owned by the **Ateles swarm review panel** (Anthus-dispatched gates), not the standalone single-pass GHA reviewer. The swarm panel previously left shallow reviews while this GHA bot caught a real correctness bug — because (a) the `neotoma|feature` `workflow_definition` was malformed (string-encoded `gates` dict Anthus couldn't parse), so the **arch gate (Bombycilla)** never dispatched, and (b) the panelists that ran reviewed at PR-description altitude.

Both root causes are fixed in Neotoma (not in this PR):
- `workflow_definition:neotoma|feature` reshaped to the parseable gate array including **arch → Bombycilla** (required on every code PR), qa → Phoenicurus, etc.
- New `code_review` `agent_policy` "Swarm PR review: full diff + role-based depth" mandating every gate owner review the **full diff** (`gh pr diff`), not the PR body, with role-specific depth + file:line findings.

## What

- `.github/workflows/claude_pr_review.yml`: drop the automatic `pull_request` / `issue_comment` triggers (now `workflow_dispatch` only) and hard-guard the job with `if: ${{ false }}` so it's inert. Original triggers + condition preserved as comments for easy re-enable.

## Note
Disables the *automatic* reviewer only. The Loxia reviewer (separate, ateles-repo-focused) is unaffected. If you'd rather fully delete the workflow than leave it inert-but-present, say the word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)