### PR TITLE
release(v0.17.0): supplement Highlights + Security hardening + security review

### DIFF
--- a/docs/releases/in_progress/v0.17.0/github_release_supplement.md
+++ b/docs/releases/in_progress/v0.17.0/github_release_supplement.md
@@ -1,27 +1,140 @@
 # v0.17.0 Release Supplement
 
-## Summary
+v0.17.0 ships four agent-facing capabilities surfaced from a high-volume production integration — a single-call entity-identity resolver, machine-readable per-release capability delta, discard-by-default high-velocity intake with read-time sightings aggregation, and an embeddable (chrome-less) Inspector graph — alongside auth parity for AAuth-admitted MCP sessions, proxy session resilience, multi-user data isolation fixes, and a large expansion of the agentic eval harness. All new data surfaces are additive and backward-compatible.
 
-v0.17.0 ships four agent-facing capabilities surfaced from a high-volume production integration: a single-call entity-identity resolver, a machine-readable per-release capability delta, discard-by-default high-velocity intake with read-time sightings aggregation, and an embeddable (chrome-less) Inspector graph. All four are additive and backward-compatible — existing callers that pass no new fields behave exactly as before.
+## Highlights
 
-1. **`identify_entity_by_signals` — single-call multi-signal resolver (#1603, #1670)** — resolve "is this the same person/company I already have?" in one MCP call. Accepts a set of identity signals (`name`, `email`, `company`, `domain`, `phone`, …) plus optional `entity_type`, and returns the best-match entity (id + medium-density snapshot) with an identity score and `matched_signals`, plus top-N disambiguation candidates. No LLM-invented ids — unknown inputs stay unresolved rather than creating orphans. Lets an agent auto-merge on a high score, ask a human on a medium score, and create-new on a low score without chaining `retrieve_entity_by_identifier` → `list_potential_duplicates` → `retrieve_entity_snapshot`.
+- **Resolve entity identity from any combination of signals in one call.** `identify_entity_by_signals` accepts a bundle of name, email, company, domain, phone, and open-ended properties and returns a best-match entity with an identity score, resolution band (`high`/`medium`/`low`/`unresolved`), and top-N candidates — so an agent can auto-merge on high confidence, ask a human on medium, and create-new on low, without chaining three separate retrieve calls.
+- **Know which tools an upgrade adds or removes before touching production.** `npm_check_update` gains an opt-in `include_capability_delta: true` flag that returns `new_tools` and `removed_tools` arrays alongside a one-line `capability_delta_recommendation`, letting auto-upgrading agents enumerate newly available MCP tools in the same update-check call.
+- **Keep high-velocity sources out of the graph without losing data.** `store` accepts `intake: { mode: "overflow" }` to append raw payloads to a configurable JSONL sink (`NEOTOMA_OVERFLOW_SINK`) instead of creating entities; a new `canonical_key` + `collapse_by` mechanism deduplicates sightings at read time without merging or deleting stored rows.
+- **Embed the Inspector graph anywhere via iframe.** The new chrome-less `/embed/graph?apiBase=<url>&node=<id>` route renders the graph explorer with no sidebar or header, inherits CSS-variable skin tokens, and emits `postMessage` on node double-click so a host page can react — zero behavior change for the existing in-app `/graph` route.
+- **AAuth-admitted agents can now use MCP tools directly.** An agent with a valid `agent_grant` (AAuth-signed requests) can now authenticate an MCP session without a Bearer token, at exact parity with the REST direct-write endpoints. Capability scope (`(op, entity_type)` ceiling) is enforced per tool call, identical to the REST path.
+- **Enforce allowed values, numeric bounds, and patterns at write time.** `register_schema` now accepts per-field `constraints` (`min`/`max`, `enum`, `pattern`, `banned`) and a schema-level `constraint_violation_policy` (`"reject"` aborts the write; `"warn"` stores a non-blocking advisory). Schemas with no constraints are completely unaffected. (#1756)
 
-2. **Machine-readable per-release capability delta (#1605, #1693, #1694)** — `npm_check_update` gains an opt-in `include_capability_delta` boolean. When true, the response carries `new_tools` / `removed_tools` (string arrays) and a one-line `capability_delta_recommendation` ("upgrade then extend your integration to use: …"), plus a `capability_delta_note` that is present **only** when the delta degraded (unparseable versions or a missing manifest). Sourced from a generated `src/shared/capability_manifest.json` (built by `scripts/generate-capability-manifest.ts`, which walks `vX.Y.Z` release tags — no hand-maintained list). An auto-upgrading agent can enumerate newly added tools after an upgrade in one call. Complements the real-server-version-in-`initialize` work already shipped in #1689.
+## What changed for npm package users
 
-3. **Discard-by-default intake + `canonical_key` sightings (#1604, #1697)** — two disciplines for high-velocity sources (news/social/firehose) made first-class:
-   - **Overflow sink:** `store` accepts an optional `intake: { mode: "graph" | "overflow", reason? }`. Default `"graph"` is today's behavior. `mode: "overflow"` appends the raw payload as a JSONL line to a configured sink (`NEOTOMA_OVERFLOW_SINK`, daily `overflow-YYYY-MM-DD.jsonl`) and returns `{ overflowed: true, sink_path, line_offset }` **without** creating entities/observations — so a firehose never pollutes the graph. If `mode: "overflow"` is used with the env unset, a structured hint is returned (never a silent write or uncaught throw).
-   - **Sightings + read-time aggregation:** new indexed `canonical_key` + `sighting_source_id` columns on observations (additive migration via the existing `addColumnIfMissing` pattern). Each sighting is an idempotent row keyed by `{source_id}:{canonical_key}`. `retrieve_entities` gains `collapse_by: "canonical_key"`, which groups rows sharing a key at **read time** into one synthesized result (union of sources, max caller-supplied `significance`, `sightings[]`). Underlying rows are never merged or deleted — dedup is a view, not a write-path merge, so dedup bugs can't corrupt stored data. CI enforces manifest/catalog freshness.
+**CLI (`neotoma`, `neotoma request`, …)**
 
-4. **Embeddable Inspector graph — phases 1–2 (#1606, #1698)** — white-label the Inspector graph inside another product:
-   - **Phase 1 — `apiBase`-parameterized API client:** an `ApiBaseProvider` / `useApiBase` context and `*WithBase` helpers let Inspector views target an arbitrary API origin instead of assuming same-origin (TanStack Query cache keyed by `apiBase` so multiple origins stay isolated). Zero behavior change when no provider is mounted.
-   - **Phase 2 — chrome-less `/embed/graph` route:** renders the graph explorer with no app shell (no sidebar/header), accepts `?apiBase=<url>` and `?node=<id>`, inherits the existing CSS-variable skin tokens (`NEOTOMA_INSPECTOR_SKIN`), and emits `postMessage` on node double-click so a host iframe can react. The normal in-app `/graph` route is unchanged. Entity-list embed and the multi-instance aggregate view remain as later phases of #1606.
+- `neotoma request` gains a `--aauth` flag (#1748, #1752). Pass it to authenticate via AAuth request signature instead of a bearer token — the CLI sends no `Authorization` header so the per-agent JWK signature is the credential. Requires `NEOTOMA_AAUTH_PRIVATE_JWK_PATH` + `NEOTOMA_AAUTH_SUB`/`NEOTOMA_AAUTH_KID`. Useful for testing agent attribution from the CLI.
+- Per-agent AAuth JWK path override (`NEOTOMA_AAUTH_PRIVATE_JWK_PATH`) lets the CLI signer resolve the private JWK from an env-configured path rather than the global default (#1744). Useful when running multiple agent identities from the same machine.
+- `neotoma digest import --from-ndjson` is the consuming counterpart to the observer NDJSON feed (#1777). Reads an NDJSON file and imports entities into the local database.
 
-## Upgrade notes
+**Runtime / data layer**
 
-- **Fully backward-compatible.** Every new surface is opt-in: `include_capability_delta`, `intake`, `canonical_key`/`sighting_source_id`, and `collapse_by` all default to prior behavior when omitted. The `canonical_key` columns are nullable additive columns — existing rows stay `NULL`.
-- **New env var:** `NEOTOMA_OVERFLOW_SINK` (absolute path or directory). Only consulted when a `store` call passes `intake.mode: "overflow"`; unset = overflow disabled (a hint is returned if overflow is requested without it).
-- **Embedders:** point an iframe at `/embed/graph?apiBase=<your-api-origin>`; theme via the existing `NEOTOMA_INSPECTOR_SKIN` / `NEOTOMA_INSPECTOR_SKIN_CONFIG` mechanism from v0.16.0.
-- **New env var:** `NEOTOMA_TENANT_SCOPED_ENTITY_IDS` (truthy `1`/`true`/`yes`) — see the Sandbox section below. Auto-enabled in sandbox mode; off in single-tenant prod (no behavior change).
+- **Proxy resilience:** the stdio MCP proxy (`src/proxy/mcp_stdio_proxy.ts`) now recovers MCP sessions across backend restarts and non-sticky replica routing (#1750). A bounded re-initialize + retry loop (`DEFAULT_MAX_ATTEMPTS=4`, exponential backoff) replaces the single-shot 503 recovery; per-request timeouts (`DEFAULT_REQUEST_TIMEOUT_MS=15s`) fail fast into a retry instead of stalling. Configurable via `NEOTOMA_MCP_PROXY_TIMEOUT_MS` and `NEOTOMA_MCP_PROXY_MAX_ATTEMPTS`.
+- **Multi-user data isolation fix:** observation existence checks and snapshot computation queries in `store` are now scoped by `user_id` (#1753). Previously, a content-addressed observation from a different user with the same ID could silently suppress the current user's insert; snapshot computation could bleed cross-user observations into a snapshot. Both are fixed.
+- **Prod server non-watch default:** `neotoma api start` in production now defaults to non-watch mode (#1751), matching how most operators run the server and avoiding accidental file-watcher overhead on `--env prod`.
+- **rc-autodeploy follow-ups:** `fix(ops)` tidies the autodeploy flow after the v0.16.0 rc-autodeploy feature review (#1754).
+- **`SOURCE_PRIORITY_IGNORED` store warning (#1774):** when an observation carries a non-default `source_priority` but every field on the entity type uses a merge strategy that ignores it (`last_write`, `merge_array`, or `most_specific` without `tie_breaker: source_priority`), the priority value is now surfaced as a non-blocking advisory warning in the store response instead of being silently discarded.
+
+**Shipped artifacts**
+
+- `openapi.yaml` is updated with a new `POST /identify_entity_by_signals` operation and updated `store` / `npm_check_update` schemas. See API surface section below.
+- `src/shared/capability_manifest.json` is a new generated artifact (built by `scripts/generate-capability-manifest.ts`). It is included in the npm package and is the source of truth for `npm_check_update` capability delta computation.
+
+## API surface & contracts
+
+**New endpoints**
+
+- `POST /identify_entity_by_signals` (MCP: `identify_entity_by_signals`) — multi-signal entity resolver. Requires bearer auth; `sandbox_allowed: none`. Request body: `{ signals: { name?, email?, company?, domain?, phone?, additional_signals? }, entity_type?, top_n? }`. Response: `{ best_match: { entity, identity_score, resolution_band, matched_signals } | null, candidates: [...] }`.
+
+**Updated endpoints / tools**
+
+- `POST /store` (MCP: `store`) — new optional `intake` field: `{ mode: "graph" | "overflow", reason? }`. Default `"graph"` is unchanged. `mode: "overflow"` skips graph writes and appends to the JSONL sink; response shape changes to `{ overflowed: true, sink_path, line_offset }`. New `canonical_key` and `sighting_source_id` fields on observation inputs are accepted and indexed. New `SOURCE_PRIORITY_IGNORED` advisory warning when `source_priority` is set but has no effect under the schema's merge strategies (#1774).
+- `GET /entities` (MCP: `retrieve_entities`) — new optional `collapse_by: "canonical_key"` parameter. When set, groups observations sharing a `canonical_key` at read time; response carries a `sightings[]` array on each synthesized result.
+- `npm_check_update` (MCP tool) — new optional `include_capability_delta: boolean` (default `false`). When true, response gains `new_tools`, `removed_tools`, `capability_delta_recommendation`, and (on degraded computation) `capability_delta_note`.
+- `POST /register_schema` (MCP: `register_schema`) — new optional per-field `constraints` object (`min`, `max`, `enum`, `pattern`, `banned`) and schema-level `constraint_violation_policy` (`"reject"` | `"warn"`, default `"reject"`). Schema registration validates constraint fields at registration time. Schemas without constraints are unaffected (#1756).
+- `GET /retrieve_entity_snapshot` (MCP: `retrieve_entity_snapshot`) — new optional `at_ingested` parameter: ingestion-time cutoff ("what did we know by T"), excluding observations whose `created_at` is after the cutoff even if their `observed_at` predates it (#1777). Supplying both `at` and `at_ingested` ANDs the bounds.
+
+**OpenAPI security**
+
+`/identify_entity_by_signals` has `security: [bearerAuth: []]` and is present in `scripts/security/protected_routes_manifest.json` with `requires_auth: true`. The manifest has been regenerated and is in sync with `openapi.yaml`.
+
+**MCP `initialize` version fix**
+
+The `serverInfo.version` field in the MCP `initialize` response now reports the real server package version (e.g. `0.17.0`) instead of the hardcoded `"1.0.0"` (#1689). Clients that inspect `serverInfo.version` for drift detection now get accurate data.
+
+## Behavior changes
+
+- **AAuth MCP authentication parity:** AAuth-admitted agents (active `agent_grant`, verified signature) can authenticate an MCP session without a Bearer token. The tool-call `(op, entity_type)` capability ceiling and governance-type guard apply identically to the REST path. Existing Bearer/OAuth callers are unaffected.
+- **`--strict` merge gate expanded:** `store` with `--strict` now permits merges via `canonical_name`, `email`, and stable internal/external ID fields (`message_id`, `turn_key`, `thread_id`, etc.), in addition to schema-declared `canonical_name_fields`. Heuristic fallbacks (`name`, `title`, fuzzy matches) are still refused. The updated error message explains all allowed paths (#1753).
+- **Prod server watch mode:** `neotoma api start --env prod` now defaults to non-watch mode.
+- **Proxy retry semantics:** MCP proxy sessions that previously fell permanently "unavailable" after a backend restart or replica routing event now recover transparently with bounded retries. The observable change is that tool calls succeed (with a short delay) across restarts rather than failing with a 503 or timeout.
+- **Ingestion-time snapshot cutoff (`at_ingested`):** `retrieve_entity_snapshot` gains an `at_ingested` parameter (ingestion-time cutoff: "what did we know by T", excluding observations whose `created_at` is after the cutoff even if their `observed_at` predates it) (#1777). Supplying both `at` and `at_ingested` ANDs the bounds for the most conservative view.
+- **Write-time value constraints:** `store` enforces per-field `constraints` declared in the schema. Default policy `"reject"` aborts the write and returns `ERR_CONSTRAINT_VIOLATION`; `"warn"` policy stores a `CONSTRAINT_VIOLATION` warning and proceeds. Schemas with no `constraints` declared are entirely unaffected (#1756).
+- **`issue` entity keying on `(github_number, repo)`:** issue entities now key on the immutable `(github_number, repo)` pair instead of the mutable title. Existing duplicate `issue` entities may coalesce on upgrade via the seed-repair path — see Upgrade notes (#1778).
+
+## Agent-facing instruction changes (shipped to every client)
+
+`docs/developer/mcp/instructions.md` changed in multiple places (shipped to every connected MCP client on server upgrade):
+
+1. **`retrieve_entity_snapshot` tool reference updated** — the `at` / `at_ingested` parameter distinction is now described: `at` is event-time cutoff ("what had happened by T"), `at_ingested` is ingestion-time cutoff ("what did we know by T"). Agents should use both parameters when they need the most conservative view.
+2. **`npm_check_update` update-check rule updated** — agents are now instructed to pass `include_capability_delta: true` when the session needs to enumerate newly available MCP tools after an upgrade, and to omit the flag when only the version check matters (to avoid unnecessary manifest I/O).
+3. **`register_schema` conflict-resolution config and `as_of` on `retrieve_entity_snapshot` now named on the tool surface** (#1785) — `register_schema` description explicitly names per-field conflict resolution via `reducer_config` and that `source_priority` only takes effect under `highest_priority`; `retrieve_entity_snapshot` description adds the `as-of` synonym for findability. Description-only; no behavior change.
+
+## Security hardening
+
+This release is security-sensitive (`npm run security:classify-diff -- --base v0.16.0 --head HEAD` → `sensitive=true`). The diff touches `src/actions.ts` (auth-middleware surface), `openapi.yaml` (openapi-security), and `scripts/security/protected_routes_manifest.json` (protected-routes-manifest + security-gates).
+
+The full AI security review is at [`docs/releases/in_progress/v0.17.0/security_review.md`](security_review.md).
+
+Post-deploy security probes are pending execution after sandbox deployment (Step 5 of the release process); the report will be written to `docs/releases/in_progress/v0.17.0/post_deploy_security_probes.md`.
+
+No security advisories were opened for this release. All changes are fail-safe by construction (see review).
+
+### Material security changes
+
+**1. AAuth admission as `/mcp` authentication path — session-admission race fixed (PR #1731, #1788)**
+
+- **Surface:** `src/actions.ts` (threads admission via per-request AsyncLocalStorage), `src/server.ts` (reads admission from ALS context, not shared field).
+- **What was fixed by #1788:** The prior implementation stored admission in a shared `NeotomaServer.sessionAdmission` field. Under concurrent admitted `/mcp` requests from different grant owners, request B could overwrite A's admission before A's `initialize` read it — a potential owner-pivot race. PR #1788 removes the shared field and threads admission through per-request AsyncLocalStorage (`runWithRequestContext`), eliminating the race. Regression test: `tests/integration/aauth_mcp_session_admission_race.test.ts` (red-before, green-after proof).
+- **Exposure if a regression had landed:** A mis-implemented admission thread could authenticate an unadmitted session (no valid grant) or allow an owner pivot (a signer selecting a different user's data). Either would be a privilege escalation on the MCP surface. The race was the residual risk flagged in the prior supplement draft — it is now resolved.
+- **Why it is safe as shipped:** `admitted: true` is set only for a verified signature (`signature_verified: true`) matched to an `active` grant; `user_id` is taken from the grant owner's record, never from request input; OAuth/Bearer check precedence is preserved; capability scope enforced per tool call. Regression tests: `aauth_mcp_initialize_admission.test.ts`, `aauth_mcp_capability_parity.test.ts`, `aauth_mcp_session_admission_race.test.ts`.
+- **Gate:** G1 (classify-diff `auth-middleware`), G3 (`test:security:auth-matrix`, protected routes manifest), G4 (security review).
+- **Operator action:** Upgrade to v0.17.0. AAuth-admitted agents now work with MCP tools directly, concurrency-safe. No bearer token rotation required.
+
+**2. `user_id`-scoped observation queries — multi-user data isolation fix (PR #1753)**
+
+- **Surface:** `src/server.ts` `storeStructuredInternal` (observation existence check, snapshot computation).
+- **Exposure if a regression had landed:** A content-addressed observation collision across users could cause a user's write to be silently skipped (write/read gap); snapshot computation could bleed another user's observation data into the current user's snapshot.
+- **Why it is safe as shipped:** Both queries now carry `.eq('user_id', userId)`. The `userId` is the server-authenticated identity, not a caller-supplied value. Unit tests: `store_strict_and_consistency.test.ts` (10 tests).
+- **Gate:** G4 (this security review). Unit test coverage in `tests/unit/store_strict_and_consistency.test.ts`.
+- **Operator action:** Upgrade to v0.17.0. Multi-user deployments that experienced silent observation drops or cross-user snapshot contamination will see correct write/read consistency after upgrade.
+
+**3. New `/identify_entity_by_signals` endpoint — manifest entry (PR #1603, #1670)**
+
+- **Surface:** `openapi.yaml` (new operation), `scripts/security/protected_routes_manifest.json` (new row).
+- **Exposure if a regression had landed:** An unauthenticated route would expose entity identity resolution to anonymous callers, leaking whether a given name/email/domain is stored in the graph.
+- **Why it is safe as shipped:** The route has `requires_auth: true` and `sandbox_allowed: none` in the manifest; `openapi.yaml` has `security: [bearerAuth: []]`. The manifest is in sync with `openapi.yaml` (verified by `npm run security:manifest:check`). G3 (`test:security:auth-matrix`) enforces 401 responses for no-auth and invalid-auth requests.
+- **Gate:** G1 (classify-diff `openapi-security`, `protected-routes-manifest`), G3 (`test:security:auth-matrix`), G5 (post-deploy probes will exercise the 401 row).
+- **Operator action:** Upgrade to v0.17.0. The endpoint is available to authenticated callers.
+
+## Breaking changes
+
+None. This release is additive.
+
+The `--strict` merge gate expansion (PR #1753) is not a breaking change: it widens the set of inputs that succeed under `--strict` (previously these returned an error). Callers that passed `--strict` with `canonical_name`, `email`, or stable ID fields will now get a merge result rather than a refusal. Callers that did not pass `--strict` are unaffected.
+
+The write-time field constraints feature (PR #1756) is opt-in: no built-in schema declares constraints, and the enforcement path is only entered when a schema explicitly declares `constraints`. Existing schemas and existing store calls are completely unaffected.
+
+Validation tightening: no request shapes were tightened in this release. No `additionalProperties: false` blocks added to previously open schemas; no fields promoted from optional to required; no enum narrowing.
+
+## Documentation
+
+Pre-staged site pages for each feature (discharges #1760 coverage for these tools):
+
+- [Identity resolver](/identify-entity-by-signals) — `identify_entity_by_signals` multi-signal bundle, scoring, resolution bands, example call
+- [Capability delta](/capability-delta) — `npm_check_update` with `include_capability_delta`, `new_tools`/`removed_tools` response, agent integration pattern
+- [High-velocity intake](/high-velocity-intake) — overflow sink (`intake.mode='overflow'`, `NEOTOMA_OVERFLOW_SINK`), `canonical_key` sightings, `collapse_by` read-time aggregation
+- [Embeddable graph](/embed-graph) — chrome-less `/embed/graph` iframe route, `?apiBase=`/`?node=` params, `postMessage` on node double-click
+- [Inspector skinning guide](/inspector-skinning) — CSS-variable theming, `NEOTOMA_INSPECTOR_SKIN` / `NEOTOMA_INSPECTOR_SKIN_CONFIG` (closes #1680)
+- [Observer / batch JSONL issue import guide](/issues-guide) — consuming the observer NDJSON feed, `neotoma digest import --from-ndjson` (#1765)
+
+Subsystem docs updated:
+- `docs/subsystems/agent_attribution_integration.md` — AAuth transport parity + MCP session threading
+- `docs/subsystems/agent_capabilities.md` — MCP enforcement points for admitted sessions
+- `docs/security/threat_model.md` — AAuth-admission `/mcp` auth path + fail-safe conditions
+- `docs/subsystems/conflict_resolution.md` — conflict resolution — merge policies, LWW default, omit-don't-zero (#1773)
 
 ## Sandbox (sandbox.neotoma.io)
 
@@ -33,15 +146,40 @@ Operator-facing fixes to the public sandbox; none affect single-tenant installs.
 - **Inspector served at the sandbox root.** `GET /` (HTML) now serves the Inspector SPA in sandbox mode too (as it already did in local/personal/prod); the pack picker moved into the Inspector home. Agents/`curl` still get the JSON/Markdown discovery payload at `/`. The legacy `/inspector#session=<code>` hash handoff still works.
 - **CI-driven sandbox deploy.** Publishing a GitHub Release now deploys `neotoma-sandbox` via `.github/workflows/deploy-sandbox.yml` (was a manual, easy-to-skip `flyctl` step), and the build stamps the real commit SHA so the root JSON `git_sha` is a verifiable 40-char commit instead of a Fly machine-version ULID.
 
-## Breaking changes
+## Docs site & CI / tooling
 
-None. This release is additive.
+- **Agentic eval harness — major expansion (#1703–#1735, #1737–#1741):** `packages/eval-harness` now covers entity delete/restore, merge dedup, split repair, relationship lifecycle, retrieve filters + snapshot + provenance, match_mode, schema/interpretation/peers/submission/turn-summary/reads, subscribe webhook-secret, and a combined WRIT+Tier-2 QA gate lane (`packages/eval-combined`). These are the authoritative regression evals for the tool-behavior contract.
+- **CI lane — `ci_test_lanes.yml`** updated to include the new eval harness lanes (`baseline`, `frontend`, `site_export`, `security_gates`).
 
-## Documentation
+## Internal changes
 
-Pre-staged site pages for each feature (discharges #1760 coverage for these tools):
+- `src/shared/package_version.ts` — new shared utility for reading the package version at runtime, used by `initialize` and the server card.
+- `src/services/entity_signal_resolver.ts` — new service backing `identify_entity_by_signals`.
+- `src/services/capability_delta.ts` — new service for computing the tool capability delta from the manifest.
+- `scripts/generate-capability-manifest.ts` — build-time script that walks `vX.Y.Z` release tags and emits `src/shared/capability_manifest.json`.
+- `src/services/field_constraints.ts` — new pure module implementing `FieldConstraints` evaluation (min/max, enum, pattern, banned); enforced in both MCP and HTTP store paths (#1756).
+- `src/services/source_priority_warning.ts` — pure helpers for detecting when `source_priority` has no effect under the entity type's merge strategies (#1774).
+- Inspector: `inspector/src/contexts/api_base_context.tsx`, `*WithBase` helpers, `inspector/src/pages/embed_graph.tsx` — new API-base context and embed route.
+- Eval harness cassettes — large set of stub/replay cassettes for the new eval scenarios.
 
-- [Identity resolver](/identify-entity-by-signals) — `identify_entity_by_signals` multi-signal bundle, scoring, resolution bands, example call
-- [Capability delta](/capability-delta) — `npm_check_update` with `include_capability_delta`, `new_tools`/`removed_tools` response, agent integration pattern
-- [High-velocity intake](/high-velocity-intake) — overflow sink (`intake.mode='overflow'`, `NEOTOMA_OVERFLOW_SINK`), `canonical_key` sightings, `collapse_by` read-time aggregation
-- [Embeddable graph](/embed-graph) — chrome-less `/embed/graph` iframe route, `?apiBase=`/`?node=` params, `postMessage` on node double-click
+## Fixes
+
+- **Proxy session recovery** — MCP proxy sessions no longer fall permanently "unavailable" after a backend restart or non-sticky replica routing. The fix handles transport errors, 503s, and per-request timeouts uniformly (#1750).
+- **MCP `initialize` version** — `serverInfo.version` now reports the real package version instead of hardcoded `"1.0.0"`. Clients using version checks for drift detection will get accurate data after upgrading (#1689).
+- **Multi-user observation isolation** — content-addressed observation ID collisions no longer silently suppress one user's insert, and snapshot computation no longer bleeds cross-user observations (#1753).
+- **Prod server non-watch default** — `neotoma api start --env prod` no longer starts with file-watching enabled by default (#1751).
+- **AAuth MCP session admission race** — concurrent admitted `/mcp` requests from different grant owners can no longer contaminate each other's session admission via the prior shared `sessionAdmission` field (#1788).
+- **`issue` entity deduplication** — issue entities now key on immutable `(github_number, repo)` instead of mutable title, eliminating duplicate issue entities that arose when a triage write carrying only a title received a title-hashed entity ID that diverged from the later `(github_number, repo)` composite (#1778).
+
+## Upgrade notes
+
+- **Fully backward-compatible.** Every new surface is opt-in: `include_capability_delta`, `intake`, `canonical_key`/`sighting_source_id`, `collapse_by`, `constraints`, `constraint_violation_policy`, and `at_ingested` all default to prior behavior when omitted. The `canonical_key` columns are nullable additive columns — existing rows stay `NULL`.
+- **`issue` entity coalescing (#1778):** existing duplicate `issue` entities (one title-keyed, one `(github_number, repo)`-keyed) may coalesce on upgrade via the seed-repair path. Review your issue entities before upgrading if you rely on specific entity IDs for `issue` type records.
+- **New env vars:**
+  - `NEOTOMA_OVERFLOW_SINK` (absolute path or directory). Only consulted when a `store` call passes `intake.mode: "overflow"`; unset = overflow disabled (a structured hint is returned if overflow is requested without it).
+  - `NEOTOMA_MCP_PROXY_TIMEOUT_MS` (integer, milliseconds, default `15000`). Per-request timeout for the stdio MCP proxy.
+  - `NEOTOMA_MCP_PROXY_MAX_ATTEMPTS` (integer, default `4`). Maximum retry attempts before the proxy emits a structured JSON-RPC error.
+  - `NEOTOMA_AAUTH_PRIVATE_JWK_PATH` (path). Overrides the default global AAuth private JWK path for CLI signing.
+  - `NEOTOMA_TENANT_SCOPED_ENTITY_IDS` (truthy `1`/`true`/`yes`). Enables tenant-scoped entity ID generation (sandbox: auto-enabled; single-tenant prod: off; set once per deployment — toggling on a persistent store strands existing rows).
+- **Embedders:** point an iframe at `/embed/graph?apiBase=<your-api-origin>`; theme via the existing `NEOTOMA_INSPECTOR_SKIN` / `NEOTOMA_INSPECTOR_SKIN_CONFIG` mechanism from v0.16.0.
+- **`initialize` version field:** clients that previously relied on `serverInfo.version === "1.0.0"` as a wildcard will now see the real version. No expected compatibility impact.

--- a/docs/releases/in_progress/v0.17.0/security_review.md
+++ b/docs/releases/in_progress/v0.17.0/security_review.md
@@ -1,0 +1,154 @@
+# Security Review — v0.17.0
+
+**Classification:** `sensitive=true` (output of `npm run security:classify-diff -- --base v0.16.0 --head HEAD`)
+
+**Surfaces flagged by classify-diff:**
+- `openapi-security` — `openapi.yaml`
+- `protected-routes-manifest` — `scripts/security/protected_routes_manifest.json`
+- `security-gates` — `scripts/security/protected_routes_manifest.json`
+- `auth-middleware` — `src/actions.ts`
+
+**Reviewer:** ateles-agent (automated, G4 lane)
+**Date:** 2026-06-25
+
+---
+
+## Adversarial review — per Step 3.5 prompt sections
+
+### 1. AAuth admission as `/mcp` authentication path — session-admission race RESOLVED (PR #1731, #1788)
+
+**What the change does.** Before #1731, an AAuth-signed request that resolved to an active `agent_grant` already authenticated REST/CLI direct-write endpoints (via the `aauthAdmission()` middleware stamping `req.authenticatedUserId`). The `/mcp` StreamableHTTP handler was widened to let admitted requests past the 401 gate, but `server.ts initialize` only read `authenticatedUserId` from an OAuth connection-id or Bearer token. An admitted-but-no-OAuth MCP request therefore fell through to `getUnauthenticatedResponse()` and every tool call threw `-32600`. The fix adds `setSessionAdmission()` on `NeotomaServer` so the `/mcp` handler threads the admission result onto the server instance per request; `initialize` then reads `this.sessionAdmission` to authenticate the session when OAuth/Bearer is absent.
+
+**PR #1788 — request-scope ALS threading (admission race fix).** The initial implementation stored admission in a shared `NeotomaServer.sessionAdmission` field. Under highly concurrent admitted `/mcp` requests from different grant owners, request B could overwrite A's admission immediately before A's `initialize` read it — a potential owner-pivot race. PR #1788 removes the shared field entirely and threads admission through the per-request AsyncLocalStorage context (`runWithRequestContext` in `actions.ts`) so each request's admission is isolated. The `setSessionAdmission()` method is now a no-op (deprecated); `initialize` reads admission from the ALS context directly. The CLI dispatch path (`executeToolForCli`) explicitly passes `aauthAdmission: null` — intentional design: CLI callers use local auth, not grant-based AAuth.
+
+**Exposure if mis-implemented.** The two obvious failure modes are:
+1. *Unadmitted requests authenticated*: if the ALS context stored a stale or insufficiently-verified admission, a request without a valid agent_grant could become authenticated.
+2. *Owner pivot*: if `user_id` were derived from the request body rather than from the admission, a caller could supply a different user's ID. The prior shared-field race was a variant of this: request B's grant owner could shadow A's session.
+
+**Why it is safe as shipped.**
+
+- `admitFromAAuthContext` returns `admitted: true` only when `signature_verified === true` AND the matched grant has `status === "active"`. A forged or unmatched signature stays `admitted: false` and the session falls through to `getUnauthenticatedResponse()` exactly as before.
+- The session `user_id` is taken exclusively from `admission.user_id`, which is the grant owner's ID, set at grant creation and never request-derived. The commit message and threat_model.md update both confirm "user_id is always the grant owner — never a request-supplied id — so an AAuth caller cannot pivot owners."
+- Admission is stored in and read from the per-request AsyncLocalStorage scope (`runWithRequestContext`), not a shared field. Two concurrent requests from different grant owners each see only their own ALS context — the race is structurally impossible.
+- OAuth connection-id and Bearer are checked first; the ALS admission context is consulted only after those fail to produce a user. Existing callers with OAuth or Bearer are entirely unaffected.
+- Per-`(op, entity_type)` capability enforcement (`enforceAgentCapability`) and protected-entity-type governance (`assertCanWriteProtectedBatch`) run on every tool call for admitted sessions, identical to the REST path. An admitted MCP session cannot exceed its grant ceiling or touch governance types it wasn't granted.
+- Regression coverage:
+  - `tests/integration/aauth_mcp_initialize_admission.test.ts` — asserts initialize authenticates from a threaded admission and that an unadmitted session stays unauthenticated.
+  - `tests/integration/aauth_mcp_capability_parity.test.ts` — asserts per-tool capability scope through the real ALS wiring (updated to reflect the ALS-based design).
+  - `tests/integration/aauth_mcp_session_admission_race.test.ts` — **new in #1788**: red-before-fix, green-after-fix proof that concurrent requests from different grant owners cannot cross-contaminate sessions.
+
+**Residual risk.** None identified. The shared `sessionAdmission` field — the only cross-request state that could enable a race — has been removed. The per-request ALS pattern is the same isolation primitive used throughout `actions.ts` for other per-request context (agent identity, authenticated user ID). The residual risk flagged in the prior draft ("sessionAdmission field on NeotomaServer is a single shared field; concurrency safety relies on Node.js single-threaded event loop semantics — low risk") is **resolved** by #1788.
+
+**Gate:** G1 (classify-diff catches `src/actions.ts` changes), G3 (`test:security:auth-matrix` + `protected_routes_manifest`), G4 (this review). G2 `security:lint` found no `no-auth-local-fallback` or `loopback-trust-in-production` violations in the changed paths.
+
+**Operator action:** Upgrade to v0.17.0. AAuth-admitted MCP sessions now receive parity with REST sessions and are concurrency-safe; no bearer token needed if the agent has a valid `agent_grant`. No configuration change required; existing Bearer/OAuth callers are unaffected.
+
+---
+
+### 2. Proxy session recovery — bounded retry + per-request timeout (PR #1750)
+
+**What the change does.** The stdio MCP proxy dropped sessions on backend restarts or non-sticky replica routing (503 / connection-refused / hang). The fix adds a bounded re-initialize + retry loop (`DEFAULT_MAX_ATTEMPTS=4`, exponential backoff), a per-request timeout (`DEFAULT_REQUEST_TIMEOUT_MS=15s`), and generalised transport-error + timeout handling. Configurable via `NEOTOMA_MCP_PROXY_TIMEOUT_MS` and `NEOTOMA_MCP_PROXY_MAX_ATTEMPTS`.
+
+**Exposure if mis-implemented.** The proxy layer sits between the CLI/agent and the backend. A mis-implemented retry could:
+1. *Re-play mutating calls* after a partial write, causing duplicate entities.
+2. *Authenticate against a different backend instance* with a stale session, bypassing that instance's per-session auth state.
+
+**Why it is safe as shipped.**
+
+- The retry loop re-initializes a fresh MCP session before replaying the original call. It does not replay the original call against a stale session — it drops the session, re-handshakes, and retries. So the session auth on the retry is as strong as an initial connection.
+- Mutation idempotency: Neotoma's `store` and `correct` are already content-addressed / idempotency-keyed. A replayed call after a partial write will resolve to the same entity via the idempotency key.
+- `initialize` itself is never auto-retried (the client owns the handshake), preventing a loop that could exhaust a rate limit on the auth endpoint.
+- Exhaustion (after `maxRetries` attempts) emits a structured JSON-RPC error and never hangs — the client gets a deterministic failure signal.
+- Unit coverage: `src/proxy/mcp_stdio_proxy.test.ts` covers session-loss recovery, restart/timeout recovery, exhaustion, and the no-retry-for-initialize contract.
+
+**Residual risk.** None identified beyond standard retry semantics (potential N-fold server load under restart storms). No auth surface is widened.
+
+**Gate:** G1 (classify-diff does not flag `src/proxy/mcp_stdio_proxy.ts` directly — the proxy layer is not in the auth-middleware path). G2 `security:lint` clean. Covered by the `test:security:auth-matrix` suite which tests the real auth gates, not the proxy transport.
+
+**Operator action:** Upgrade to v0.17.0. MCP proxy sessions now survive backend restarts and replica routing events. `NEOTOMA_MCP_PROXY_TIMEOUT_MS` and `NEOTOMA_MCP_PROXY_MAX_ATTEMPTS` are available for tuning; defaults (`15000ms`, `4`) are reasonable for most deployments.
+
+---
+
+### 3. Real server version in `initialize` response (PR #1689)
+
+**What the change does.** The MCP `initialize` response hardcoded version `"1.0.0"` in three places. This prevented clients from detecting client/server drift. The fix introduces `src/shared/package_version.ts` (reads `package.json`, returns `"0.0.0"` on failure) and replaces all three hardcoded sites.
+
+**Exposure if mis-implemented.** If `readPackageVersion` returned a caller-influenced value (e.g. read from a request header), a downgrade or version-spoofing attack could confuse upgrade logic. Alternatively, if it read from the wrong `package.json`, version detection would silently lie.
+
+**Why it is safe as shipped.** `readPackageVersion` reads `package.json` from a `projectRoot` path resolved at server startup, not from any request input. The helper has a safe fallback (`"0.0.0"`) that degrades gracefully without throwing. Unit tests (`tests/unit/mcp_initialize_version.test.ts`, 6 tests) assert the helper returns the real version and that the server card and initialize both report a non-`"1.0.0"` value. No auth surface is touched.
+
+**Residual risk.** None. This is a pure informational fix.
+
+**Gate:** G1 (classify-diff does not flag this path). G4 (this review notes it for completeness). Impact is visibility-only.
+
+**Operator action:** Upgrade to v0.17.0. Clients that inspect `serverInfo.version` in the initialize response now see the real server version, enabling accurate drift detection.
+
+---
+
+### 4. `user_id`-scoped observation queries (PR #1753)
+
+**What the change does.** Two queries in `storeStructuredInternal` (`server.ts`) lacked `user_id` filters:
+1. The existing-observation check queried by observation `id` alone. A content-addressed observation from a different user with the same `id` could cause the current user's insert to be silently skipped, leaving a write/read gap.
+2. The snapshot-computation observations fetch queried by `entity_id` alone, allowing cross-user observations to bleed into the snapshot.
+
+Both queries are now scoped with `.eq('user_id', userId)`.
+
+**Exposure if mis-implemented.** The pre-fix queries ran in a multi-user or multi-tenant deployment and could have caused: (a) a user's observation to be silently dropped because another user's observation collided on the content-addressed ID; (b) another user's observation data appearing in a snapshot retrieved by the current user. This is a data-isolation bug, not an auth bypass (a caller cannot read another user's entities — the snapshot is computed and returned, not stored cross-user). However, a sufficiently adversarial caller could craft a store call that intentionally collides with another user's observation ID to suppress that user's write.
+
+**Why it is safe as shipped.** The fix adds `.eq('user_id', userId)` to both the existence check and the snapshot fetch. The `userId` value is taken from `this.getAuthenticatedUserId(parsed.user_id)`, which is the server-authenticated user, not the caller-supplied `user_id` field. Unit tests (`tests/unit/store_strict_and_consistency.test.ts`, 10 tests) cover the fixed paths.
+
+**Residual risk.** The `--strict` merge gate expansion (part of the same PR) permits merges via `canonical_name`, `email`, and stable ID fields. Heuristic fallbacks (`name`, `title`, fuzzy matches) are still refused. The permitted paths are deterministically unique, so unintended merges are low-risk. No auth surface is widened.
+
+**Gate:** G1 (classify-diff does not flag `src/server.ts` store query path directly). G4 (this review). Unit test coverage in `tests/unit/store_strict_and_consistency.test.ts`.
+
+**Operator action:** Upgrade to v0.17.0. Multi-user deployments that previously experienced silent observation drops or incorrect snapshots under content-addressed ID collisions will see correct write/read consistency after upgrade.
+
+---
+
+### 5. New `/identify_entity_by_signals` endpoint + manifest entry (PR #1603, #1670)
+
+**What the change does.** A new `POST /identify_entity_by_signals` endpoint resolves an entity from a multi-signal bundle. It is added to `openapi.yaml` with a `security: [bearerAuth: []]` block and added to `scripts/security/protected_routes_manifest.json` with `requires_auth: true`, `sandbox_allowed: "none"`, and expected 401 on no-auth and invalid-auth.
+
+**Exposure if mis-implemented.** If the route were registered without `auth.requireUser()`, it would expose entity identity resolution (name, email, domain, phone signals) to unauthenticated callers, potentially leaking whether a given identity is stored in the graph.
+
+**Why it is safe as shipped.** The manifest entry declares `requires_auth: true` and `sandbox_allowed: "none"`. G3 (`test:security:auth-matrix`) enforces that the route returns 401 for no-auth and invalid-auth. `openapi.yaml` has the `bearerAuth` security block. The manifest was regenerated via `npm run security:manifest:write` and is in sync with the OpenAPI document.
+
+**Residual risk.** The endpoint accepts open-ended `additional_signals` properties (the OpenAPI schema shows `additionalProperties: true` for that field). If a future refactor exposed internal matching signals as a side channel (timing or content), that would warrant a follow-up review. As shipped, the endpoint only returns a best-match entity and top-N candidates, which are already accessible to authenticated callers via existing retrieve endpoints.
+
+**Gate:** G1 (openapi.yaml changes flow through classify-diff `openapi-security` and `protected-routes-manifest` surfaces), G3 (`test:security:auth-matrix`), G5 (post-deploy probes will exercise the 401 row in the manifest).
+
+**Operator action:** Upgrade to v0.17.0. The endpoint is available to all authenticated callers.
+
+---
+
+### 6. Declarative write-time value constraints (PR #1756)
+
+**What the change does.** `register_schema` gains per-field `constraints` (`min`/`max`, `enum`, `pattern`, `banned`) and a schema-level `constraint_violation_policy` (`"reject"` | `"warn"`). Enforcement runs in both the MCP (`storeStructuredInternal`) and HTTP (`storeStructuredForApi`) store paths before the entity is written. Constraints are validated at registration time (type-appropriateness, `min <= max`, compilable regex) in `SchemaDefinition.validateSchemaDefinition`. No built-in schema declares constraints — the feature is purely opt-in.
+
+**Exposure if mis-implemented.** The primary security-adjacent concern is constraint bypass: if enforcement ran in one store path but not the other, a caller could route around the constraint via the unprotected path. A secondary concern is denial-of-service via over-eager constraint rejection on valid data.
+
+**Why it is safe as shipped.** Enforcement runs symmetrically in both MCP and HTTP paths (the same `field_constraints.ts` module is called from both). The `constraint_violation_policy: "warn"` option explicitly downgrades rejection to an advisory — caller controls risk. Constraints are applied only to schemas that declare them; schemas with no `constraints` field are completely unaffected. Registration-time validation prevents malformed constraints (e.g., non-compilable regexes) from being stored. 55 unit tests in `tests/unit/field_constraints.test.ts` cover the pure evaluation logic. No auth surface is touched.
+
+**Residual risk.** None identified for the shipped scope. The `required` field enforcement is a deliberate follow-up (not changed here) — when it lands it will warrant a separate review.
+
+**Gate:** G1 (classify-diff does not flag this path — no auth-middleware or openapi-security change). G4 (this review). Unit coverage in `tests/unit/field_constraints.test.ts`.
+
+**Operator action:** Upgrade to v0.17.0. Write-time constraints are available for schemas that declare them; no action required for existing schemas.
+
+---
+
+## G2 — Static rules (`npm run security:lint`)
+
+No `ERROR`-level findings. The changed files — `src/actions.ts` (admission threading via ALS), `src/server.ts` (ALS-based admission reads, user_id filters) — do not introduce bare `req.socket.remoteAddress` checks, `X-Forwarded-For` reads outside canonical helpers, or new `LOCAL_DEV_USER_ID` references. No `WARNING`-level findings were identified in the security-relevant paths.
+
+## G3 — Protected routes manifest + auth matrix
+
+`scripts/security/protected_routes_manifest.json` was updated to add `/identify_entity_by_signals` (`requires_auth: true`, `sandbox_allowed: "none"`, expected 401s). The manifest is in sync with `openapi.yaml` (verified by `npm run security:manifest:check` at time of commit). `npm run test:security:auth-matrix` covers the matrix.
+
+## Sign-off verdict
+
+**`yes`** — all material security changes are fail-safe by construction, regression-tested, and flagged correctly by the G1–G3 gates. No new unauthenticated public routes, no loopback-trust widening, no local-dev surface expansion. The `user_id`-scoped observation fix closes a data-isolation bug that could affect multi-user deployments. The `sessionAdmission` shared-field race (previously flagged as residual, low risk) is **resolved** by PR #1788 via per-request AsyncLocalStorage threading, with a dedicated regression test (`aauth_mcp_session_admission_race.test.ts`). Operators should upgrade to v0.17.0; bearer token rotation is not required.
+
+**Caveats to track as follow-ups (non-blocking):**
+1. The `/embed/graph` route (`/embed/*`) is unauthenticated by design (public iframe embed). It is not in the protected manifest; verify it is in the allow-list or explicitly excluded from G3 checks in future manifest updates. (The route serves static graph UI only — no data is emitted without the `apiBase` target's own auth enforcing; the current setup is correct but should be documented in the manifest allow-list.)
+2. `register_schema` `constraints.pattern` accepts arbitrary regex strings; the server validates compilability at registration time but does not apply ReDoS mitigation (catastrophic backtracking on large inputs). If untrusted schema registrations are ever permitted, add a regex complexity cap. Not applicable for the current trust model (schema registration is operator-only).


### PR DESCRIPTION
## Summary

Completes the v0.17.0 release supplement per the documented release process. The supplement was classified `security:classify-diff → sensitive=true` and was missing both Highlights and a Security hardening section, plus lacked comprehensive body coverage for several shipped changes.

**Files changed:**
- `docs/releases/in_progress/v0.17.0/github_release_supplement.md` — Highlights added, Security hardening section added, body expanded
- `docs/releases/in_progress/v0.17.0/security_review.md` — new, full adversarial G4 review

## What was added

### Highlights (5 bullets, ranked by upgrade motivation)
1. `identify_entity_by_signals` single-call resolver
2. `npm_check_update` capability delta flag
3. High-velocity overflow sink + `canonical_key` sightings
4. Chrome-less `/embed/graph` iframe route
5. AAuth-admitted agents can authenticate MCP sessions directly

### Security hardening section
Covers 3 material security changes (surfaces, exposure shape, gate, operator action):
1. AAuth admission as `/mcp` auth path (#1731) — auth-middleware surface
2. `user_id`-scoped observation queries — multi-user data isolation fix (#1753)
3. `/identify_entity_by_signals` endpoint — manifest + OpenAPI security block

Links `security_review.md`; notes `post_deploy_security_probes.md` pending post-deploy.

### Comprehensive body coverage additions
- CLI: `--aauth` flag (#1748, #1752), `NEOTOMA_AAUTH_PRIVATE_JWK_PATH` (#1744), `digest import --from-ndjson` (#1777)
- Agent-facing instruction changes: `at_ingested` parameter, `include_capability_delta` update-check rule
- All new env vars: `NEOTOMA_OVERFLOW_SINK`, `NEOTOMA_MCP_PROXY_TIMEOUT_MS`, `NEOTOMA_MCP_PROXY_MAX_ATTEMPTS`, `NEOTOMA_AAUTH_PRIVATE_JWK_PATH`
- Eval harness expansion: 11+ new eval scenarios in `packages/eval-harness`
- Explicit Breaking changes statement: no tightening in this release

### `security_review.md`
Adversarial review of all 5 security-relevant changes (AAuth MCP parity, proxy recovery, real version in initialize, user_id scoping, new endpoint manifest entry). G2/G3 gate summary. Sign-off verdict: **yes**, with 2 non-blocking follow-up caveats documented.

## Classify-diff output

```
sensitive=true
- openapi-security: openapi.yaml
- protected-routes-manifest: scripts/security/protected_routes_manifest.json
- security-gates: scripts/security/protected_routes_manifest.json
- auth-middleware: src/actions.ts
```

## Validation

`npx tsx scripts/render_github_release_notes.ts --tag v0.17.0 --head-ref HEAD` succeeds and renders all new sections (Highlights, Security hardening, Breaking changes with explicit tightening statement, Upgrade notes with all env vars).

Do NOT merge, tag, or publish — this is the supplement PR for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)