### PR TITLE
feat(dx): surface conflict-resolution config + as_of on the tool surface (#1784)

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1060,6 +1060,11 @@ components:
           type: number
         source_priority:
           type: integer
+          description: >-
+            Trust/priority of this observation's source. Only affects snapshot
+            resolution for fields whose merge strategy is highest_priority (set
+            via register_schema reducer_config); under the default last_write
+            strategy it is stored but ignored.
         observation_source:
           type: string
           nullable: true
@@ -1716,6 +1721,11 @@ components:
           $ref: "#/components/schemas/StoreInterpretationInput"
         source_priority:
           type: integer
+          description: >-
+            Trust/priority of this observation's source. Only affects snapshot
+            resolution for fields whose merge strategy is highest_priority (set
+            via register_schema reducer_config); under the default last_write
+            strategy it is stored but ignored.
         observation_source:
           type: string
           enum: [sensor, llm_summary, workflow_state, human, import, sync]
@@ -1812,6 +1822,11 @@ components:
           $ref: "#/components/schemas/StoreInterpretationInput"
         source_priority:
           type: integer
+          description: >-
+            Trust/priority of this observation's source. Only affects snapshot
+            resolution for fields whose merge strategy is highest_priority (set
+            via register_schema reducer_config); under the default last_write
+            strategy it is stored but ignored.
         observation_source:
           type: string
           enum: [sensor, llm_summary, workflow_state, human, import, sync]

--- a/src/shared/openapi_types.ts
+++ b/src/shared/openapi_types.ts
@@ -2799,6 +2799,7 @@ export interface components {
       /** Format: date-time */
       observed_at?: string;
       specificity_score?: number;
+      /** @description Trust/priority of this observation's source. Only affects snapshot resolution for fields whose merge strategy is highest_priority (set via register_schema reducer_config); under the default last_write strategy it is stored but ignored. */
       source_priority?: number;
       /**
        * @description Classifies the *kind* of write that produced this observation,
@@ -3292,6 +3293,7 @@ export interface components {
        */
       relationships?: components["schemas"]["StoreRelationshipInput"][];
       interpretation?: components["schemas"]["StoreInterpretationInput"];
+      /** @description Trust/priority of this observation's source. Only affects snapshot resolution for fields whose merge strategy is highest_priority (set via register_schema reducer_config); under the default last_write strategy it is stored but ignored. */
       source_priority?: number;
       /**
        * @description Classifies the *kind* of write being performed, orthogonal to
@@ -3371,6 +3373,7 @@ export interface components {
        */
       relationships?: components["schemas"]["StoreRelationshipInput"][];
       interpretation?: components["schemas"]["StoreInterpretationInput"];
+      /** @description Trust/priority of this observation's source. Only affects snapshot resolution for fields whose merge strategy is highest_priority (set via register_schema reducer_config); under the default last_write strategy it is stored but ignored. */
       source_priority?: number;
       /**
        * @description Classifies the *kind* of write being performed, orthogonal to

--- a/src/tool_definitions.ts
+++ b/src/tool_definitions.ts
@@ -56,7 +56,7 @@ export function buildToolDefinitions(
       name: "retrieve_entity_snapshot",
       description: desc(
         "retrieve_entity_snapshot",
-        "Retrieve the current snapshot of an entity with provenance information. Supports point-in-time reconstruction via 'at' (event-time cutoff: filters on observed_at) and 'at_ingested' (ingestion-time cutoff: filters on created_at, prevents look-ahead from backfilled observations). When both are supplied, both bounds are applied."
+        "Retrieve the current snapshot of an entity with provenance information. Supports point-in-time / as-of reconstruction ('what did we know at time T') via 'at' (event-time cutoff: filters on observed_at) and 'at_ingested' (ingestion-time cutoff: filters on created_at, prevents look-ahead from backfilled observations). When both are supplied, both bounds are applied."
       ),
       inputSchema: getOpenApiInputSchemaOrThrow("retrieve_entity_snapshot"),
     },
@@ -863,7 +863,7 @@ export function buildToolDefinitions(
       name: "register_schema",
       description: desc(
         "register_schema",
-        "Register a new schema or schema version. Supports both global and user-specific schemas."
+        "Register a new schema or schema version (global or user-specific). This is also where you configure per-field CONFLICT RESOLUTION via reducer_config: pick a merge strategy per field (last_write [default], highest_priority, most_specific, merge_array) plus tie-breakers (observed_at, source_priority). To make an observation's source_priority actually take effect, set that field's strategy to highest_priority here — under the default last_write, source_priority is recorded but ignored."
       ),
       inputSchema: {
         type: "object",
@@ -875,7 +875,8 @@ export function buildToolDefinitions(
           },
           reducer_config: {
             type: "object",
-            description: "Reducer configuration with merge policies",
+            description:
+              "Per-field conflict-resolution config. merge_policies maps each field to a strategy: last_write (default — latest observed_at wins), highest_priority (the observation with the largest source_priority wins), most_specific, or merge_array; with an optional tie_breaker (observed_at | source_priority). Set highest_priority to honor source_priority — without it, source_priority is stored but ignored.",
           },
           schema_version: { type: "string", default: "1.0" },
           user_specific: { type: "boolean", default: false },


### PR DESCRIPTION
## Why

Agents discover capability from tool names, parameter schemas, and descriptions — **not from `docs/`**. An external evaluation concluded the per-field reducer config and `as_of` snapshot were *missing* when both existed (since ~Dec 2025 / Jan 2026), because the tool surface didn't name them. Docs (#1758) are necessary but not sufficient.

Closes #1784.

## Changes (description-only; no behavior change)

- **`register_schema`**: tool description now names per-field **conflict resolution** via `reducer_config` (strategies `last_write`/`highest_priority`/`most_specific`/`merge_array` + tie-breakers) and that `source_priority` only takes effect under `highest_priority`. The `reducer_config` param is fully described.
- **store paths**: the `source_priority` param had **no description** in openapi — added one (the static counterpart to the runtime `SOURCE_PRIORITY_IGNORED` warning from #1755).
- **`retrieve_entity_snapshot`**: description adds the "as-of" synonym for findability (it already named point-in-time from #1757).

openapi types regenerated; tsc / prettier / test-catalog clean.

## Follow-ups (tracked in #1784, not here)
- Generalize the in-band capability-hint pattern (the #1755 warning is the template).
- Expose the active `reducer_config` on read so an agent *sees* merge policies exist.