### PR TITLE
fix(sandbox): build Inspector with root base path so it renders at /

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,16 @@ RUN npm run build:server
 FROM node:20-alpine AS inspector-build
 WORKDIR /app/inspector
 ARG VITE_NEOTOMA_SANDBOX_UI=""
+# Vite base path = router basename (main.tsx derives ROUTER_BASENAME from
+# import.meta.env.BASE_URL). Default "/inspector/" for installs that reach the
+# Inspector at /inspector. The sandbox serves the SPA at the site ROOT, so it
+# must build with "/" (otherwise <Router basename="/inspector"> can't match "/"
+# and renders a blank page) — fly.sandbox.toml overrides this to "/".
+ARG VITE_PUBLIC_BASE_PATH="/inspector/"
 COPY inspector/package*.json ./
 RUN npm ci
 COPY inspector/ ./
-RUN VITE_PUBLIC_BASE_PATH="/inspector/" \
+RUN VITE_PUBLIC_BASE_PATH="$VITE_PUBLIC_BASE_PATH" \
     VITE_NEOTOMA_SANDBOX_UI="$VITE_NEOTOMA_SANDBOX_UI" \
     npm run build
 

--- a/fly.sandbox.toml
+++ b/fly.sandbox.toml
@@ -23,6 +23,10 @@ primary_region = 'lhr'
 
 [build.args]
   VITE_NEOTOMA_SANDBOX_UI = "1"
+  # The sandbox serves the Inspector SPA at the site root, so build it with a
+  # root base path → router basename "/" matches "/". (Default "/inspector/"
+  # would render blank at root.)
+  VITE_PUBLIC_BASE_PATH = "/"
 
 [env]
   NODE_ENV = "production"


### PR DESCRIPTION
## Why

After #1768 served the Inspector SPA at the sandbox **root**, the deployed `sandbox.neotoma.io` came up **blank**. Console:

```
<Router basename="/inspector"> is not able to match the URL "/" ... so the <Router> won't render anything.
```

Root cause: `inspector/src/main.tsx` derives `ROUTER_BASENAME` from `import.meta.env.BASE_URL`, and the Dockerfile hardcodes `VITE_PUBLIC_BASE_PATH="/inspector/"`. So the bundled SPA has basename `/inspector`, which cannot match `/` → blank page. (My pre-merge checks missed it: `curl` only confirmed the shell HTML loads, and the Playwright e2e built the SPA with the default root base, so it passed locally but not in the Fly image.)

## Fix

- Make `VITE_PUBLIC_BASE_PATH` a Dockerfile **build ARG**, default `"/inspector/"` (no change for installs that reach the Inspector at `/inspector`).
- Override it to `"/"` for the sandbox via `fly.sandbox.toml` `[build.args]`, since the sandbox serves the SPA at root.

The server already serves `/assets/*` at root (`installInspectorRootStaticAssets`), so a root-base build resolves. This also aligns the Playwright e2e (default root base) with what the sandbox now ships.

## Verified live

Deployed to `neotoma-sandbox` and confirmed in a browser on the fresh `neotoma-sandbox.fly.dev` host: Inspector renders at `/` with the **pack picker** ("Start a sandbox session" + Generic starter → Start session), populated stat tiles, orientation note, v0.17.0. Shell now loads `/assets/index-*.js` (root base) instead of `/inspector/assets/*`.

## Follow-up (separate, pre-existing)

A returning visitor whose sandbox session has expired (e.g. after the weekly wipe) carries a stale `neotoma_sandbox_session` cookie, and sandbox auth returns `401` instead of falling back to the anonymous public user — so the Inspector 401-walls instead of showing the pack picker. Now that the Inspector (not a static landing page) is at root, this is user-visible. Worth a middleware fix: on an invalid/expired sandbox cookie, clear it and fall back to anonymous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)