### PR TITLE
fix(sandbox): degrade unresolvable session bearer to anonymous instead of 401

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -3631,6 +3631,26 @@ app.use(async (req, res, next) => {
         logger.info(`[Auth] ${req.method} ${req.path} auth_method=guest_capability`);
         return next();
       }
+      // Sandbox: a Bearer that resolves to no valid identity is almost always a
+      // returning visitor whose ephemeral sandbox session expired or was wiped
+      // by the weekly reset — the Inspector SPA keeps replaying the stale
+      // localStorage bearer. 401-walling it leaves the visitor stuck: the home,
+      // /me, and even DELETE /sandbox/session all 401, and the HttpOnly cookie
+      // can't be cleared client-side. Degrade to the anonymous public user
+      // (the same floor unauthenticated sandbox requests already get above) and
+      // clear the stale cookie so the Inspector loads and the pack picker lets
+      // them start fresh. This does NOT widen the trust boundary: anonymous is
+      // already the sandbox floor, writes stay gated by sandboxWriteGate /
+      // sandboxDestructiveGuard, and AAuth-only routes by aauthRequired.
+      if (isSandboxMode()) {
+        res.clearCookie(SESSION_COOKIE_NAME, { path: "/" });
+        const sandboxUser = ensureSandboxPublicUser();
+        stampUserPrincipal(req, sandboxUser.id);
+        logger.info(
+          `[Auth] ${req.method} ${req.path} auth_method=sandbox_public_stale_bearer user_id=${sandboxUser.id}`
+        );
+        return next();
+      }
       // Not a valid token
       logWarn("AuthInvalidToken", req, {
         error: authError instanceof Error ? authError.message : String(authError),

--- a/tests/integration/sandbox_stale_bearer_fallback.test.ts
+++ b/tests/integration/sandbox_stale_bearer_fallback.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Sandbox auth: an unresolvable Bearer degrades to the anonymous public user
+ * instead of 401-walling the request.
+ *
+ * Mirrors the sandbox fallback branch added to the auth middleware in
+ * `src/actions.ts` (the `validateSessionToken` catch). The full app can't be
+ * booted with NEOTOMA_SANDBOX_MODE=1 inside the shared test server (it conflicts
+ * with the global instance — same constraint noted in
+ * `tests/integration/sandbox_mode.test.ts` and
+ * `tests/integration/aauth_sandbox_attribution_partition.test.ts`), so this
+ * mounts a minimal app replicating the decision and asserts the contract:
+ *
+ *   - sandbox + Bearer that resolves to no identity → 200 as SANDBOX_PUBLIC_USER_ID,
+ *     stale session cookie cleared.
+ *   - non-sandbox + same Bearer → 401 (unchanged; no trust-boundary change).
+ *
+ * The real code path is additionally verified end-to-end against a booted
+ * sandbox server (a stale Bearer on GET /me returns 200 as the public user and
+ * sends `Set-Cookie: neotoma_sandbox_session=; Expires=...`).
+ */
+
+import { AddressInfo } from "node:net";
+import express from "express";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { SANDBOX_PUBLIC_USER_ID } from "../../src/services/local_auth.js";
+import { SESSION_COOKIE_NAME } from "../../src/services/sandbox/sessions.js";
+
+// Minimal handler mirroring the src/actions.ts fallback: a Bearer that fails
+// all real auth degrades to the public user (+ cookie clear) in sandbox mode,
+// and 401s otherwise.
+function makeApp(sandbox: boolean) {
+  const app = express();
+  app.get("/me", (req, res) => {
+    const auth = req.header("authorization") || "";
+    const hasBearer = auth.startsWith("Bearer ");
+    // Simulated: the Bearer does not resolve to any valid identity.
+    if (hasBearer) {
+      if (sandbox) {
+        res.clearCookie(SESSION_COOKIE_NAME, { path: "/" });
+        return res.json({ user_id: SANDBOX_PUBLIC_USER_ID, sandbox_mode: "hosted_sandbox" });
+      }
+      return res.status(401).json({ error: "AUTH_INVALID" });
+    }
+    return res.status(401).json({ error: "AUTH_REQUIRED" });
+  });
+  return app;
+}
+
+async function listen(app: express.Express): Promise<{ url: string; close: () => Promise<void> }> {
+  const server = app.listen(0, "127.0.0.1");
+  await new Promise<void>((r) => server.once("listening", () => r()));
+  const { port } = server.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: () => new Promise<void>((r) => server.close(() => r())),
+  };
+}
+
+describe("sandbox stale-bearer fallback", () => {
+  let close: (() => Promise<void>) | null = null;
+  afterEach(async () => {
+    if (close) await close();
+    close = null;
+  });
+
+  it("sandbox mode: unresolvable Bearer → 200 as the public user, cookie cleared", async () => {
+    const s = await listen(makeApp(true));
+    close = s.close;
+    const res = await fetch(`${s.url}/me`, {
+      headers: { authorization: "Bearer stale-or-wiped-sandbox-bearer" },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { user_id: string };
+    expect(body.user_id).toBe(SANDBOX_PUBLIC_USER_ID);
+    const setCookie = res.headers.get("set-cookie") || "";
+    expect(setCookie).toContain(SESSION_COOKIE_NAME);
+    expect(setCookie.toLowerCase()).toContain("expires=");
+  });
+
+  it("non-sandbox mode: unresolvable Bearer → 401 (unchanged)", async () => {
+    const s = await listen(makeApp(false));
+    close = s.close;
+    const res = await fetch(`${s.url}/me`, {
+      headers: { authorization: "Bearer stale-or-wiped-sandbox-bearer" },
+    });
+    expect(res.status).toBe(401);
+  });
+});


### PR DESCRIPTION
## Problem (security-sensitive auth path)

A returning visitor to `sandbox.neotoma.io` whose ephemeral session expired or was wiped by the weekly reset keeps replaying a stale `localStorage` bearer (the Inspector SPA sends `Authorization: Bearer <old>`). The auth middleware's sandbox public-user fallback is gated to **no-Bearer** requests, so the stale Bearer falls through to a **401** on `/me`, `/stats`, `/schemas`, `/entities/query`. `DELETE /sandbox/session` *also* 401s and the `HttpOnly` cookie can't be cleared client-side — so the visitor is **locked out of the Inspector** until they manually clear cookies. Because the weekly wipe expires everyone's session, **every returning visitor** hits this. It was invisible until the data-driven Inspector + pack picker moved to the sandbox root (#1768/#1789).

## Fix

In the auth middleware's bearer-validation failure path, **in sandbox mode only**, attribute the request to the anonymous `SANDBOX_PUBLIC_USER_ID` and clear the stale `neotoma_sandbox_session` cookie, instead of returning 401. The Inspector then loads anonymously and the pack picker lets the visitor start a fresh session.

### Exposure analysis (no trust-boundary widening)
- **Anonymous is already the sandbox floor** — unauthenticated (no-Bearer) sandbox requests already resolve to `SANDBOX_PUBLIC_USER_ID` a few lines above. This change extends that same floor to requests carrying a *non-resolving* Bearer; it grants no access that an unauthenticated caller didn't already have.
- **Gated to `isSandboxMode()`** — non-sandbox deployments are unchanged (stale/invalid Bearer still 401s). Test covers both.
- **Writes stay gated** by `sandboxWriteGate` / `sandboxDestructiveGuard`; AAuth-only routes by `aauthRequired`. Real Ed25519/session/MCP/env bearers and verified AAuth identities are all resolved *before* this fallback, so legitimate auth is unaffected.

## Verification
- End-to-end against the built server (`NEOTOMA_SANDBOX_MODE=1`): `GET /me` with a garbage Bearer → **200** as `11111111-…` (public user) + `Set-Cookie: neotoma_sandbox_session=; Expires=1970` (was 401).
- Regression test `tests/integration/sandbox_stale_bearer_fallback.test.ts` (sandbox → 200 public + cookie clear; non-sandbox → 401), mirroring the repo's existing minimal-app pattern for this middleware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)