### PR TITLE
feat(sandbox): rich 'generic' showcase pack (graph + provenance + interpretation)

### DIFF
--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,8 +61,8 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **498**
-- Backend and repo Vitest files: **464**
+- Total automated test files: **499**
+- Backend and repo Vitest files: **465**
 - Frontend Vitest files: **9**
 - Playwright spec files: **25**
 
@@ -72,7 +72,7 @@ flowchart TD
 | Vitest unit tests | 135 |
 | Vitest service tests | 35 |
 | Source-adjacent tests | 61 |
-| Vitest integration tests | 140 |
+| Vitest integration tests | 141 |
 | Vitest CLI tests | 65 |
 | Vitest contract tests | 14 |
 | Vitest security tests | 3 |
@@ -361,7 +361,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm run test:integration` or `npx vitest run tests/integration`
 **Requirements:** Database configured; remote-dependent subsets additionally need `RUN_REMOTE_TESTS=1`.
-**Files (140):**
+**Files (141):**
 - `tests/integration/aauth_attribution_stamping.test.ts`
 - `tests/integration/aauth_mcp_capability_parity.test.ts`
 - `tests/integration/aauth_mcp_initialize_admission.test.ts`
@@ -476,6 +476,7 @@ flowchart TD
 - `tests/integration/root_landing.test.ts`
 - `tests/integration/sandbox_mode.test.ts`
 - `tests/integration/sandbox_report.test.ts`
+- `tests/integration/sandbox_stale_bearer_fallback.test.ts`
 - `tests/integration/schema_recommendation_integration.test.ts`
 - `tests/integration/session_introspection.test.ts`
 - `tests/integration/snapshot_ingestion_cutoff.test.ts`

--- a/scripts/seed_sandbox.ts
+++ b/scripts/seed_sandbox.ts
@@ -34,9 +34,30 @@ export interface SandboxAgentIdentity {
 export interface SandboxEntityBatch {
   agent_index: number;
   idempotency_prefix: string;
-  fixture: string;
+  /** Fixture reference (`reuse://` or `inline://`). Omit when `entities` is set. */
+  fixture?: string;
+  /**
+   * Inline entity objects (showcase packs author the data directly in the
+   * manifest). Each entity may carry a `_ref` string used by manifest-level
+   * `relationships` to wire the graph; any `_`-prefixed key is stripped before
+   * the entity is sent to /store.
+   */
+  entities?: Record<string, unknown>[];
   entity_type_override?: string;
   note?: string;
+}
+
+/**
+ * Manifest-level relationship between two seeded entities, referenced by the
+ * `_ref` handles assigned in entity_batches. Resolved to entity ids after all
+ * batches are stored, then created via /create_relationships — this is what
+ * populates the Relationships list and Graph Explorer.
+ */
+export interface SandboxRelationship {
+  source_ref: string;
+  target_ref: string;
+  relationship_type: string;
+  metadata?: Record<string, unknown>;
 }
 
 export interface SandboxUnstructuredSource {
@@ -45,6 +66,13 @@ export interface SandboxUnstructuredSource {
   mime_type: string;
   original_filename: string;
   note?: string;
+  /**
+   * Optional entities "extracted" from this file. When present, they are stored
+   * against the raw file source as an interpretation (source_ref: "unstructured"),
+   * populating the Sources → Interpretations → derived-entities chain.
+   */
+  interpretation_entities?: Record<string, unknown>[];
+  interpretation_config?: Record<string, unknown>;
 }
 
 export interface SandboxManifest {
@@ -54,6 +82,8 @@ export interface SandboxManifest {
   entity_batches: SandboxEntityBatch[];
   unstructured_sources: SandboxUnstructuredSource[];
   excluded_fixtures: string[];
+  /** Optional graph edges wired by `_ref` after entity batches are stored. */
+  relationships?: SandboxRelationship[];
 }
 
 export interface SeedOptions {
@@ -75,6 +105,7 @@ export interface SeedResult {
   entity_batches_submitted: number;
   entities_planned: number;
   unstructured_sources_submitted: number;
+  relationships_created: number;
   dry_run: boolean;
 }
 
@@ -160,6 +191,15 @@ async function resolveFixtureEntities(
   batch: SandboxEntityBatch,
   repoRoot: string
 ): Promise<Record<string, unknown>[]> {
+  // Inline entities authored directly in the manifest (showcase packs).
+  if (Array.isArray(batch.entities)) {
+    return batch.entities.map((row) =>
+      batch.entity_type_override ? { entity_type: batch.entity_type_override, ...row } : row
+    );
+  }
+  if (!batch.fixture) {
+    throw new Error(`Batch ${batch.idempotency_prefix} has neither 'entities' nor 'fixture'`);
+  }
   if (batch.fixture.startsWith("inline://")) {
     const key = batch.fixture.slice("inline://".length);
     return inlineConversation(key);
@@ -210,6 +250,7 @@ export async function seedSandbox(options: SeedOptions): Promise<SeedResult> {
       entity_batches_submitted: 0,
       entities_planned: 0,
       unstructured_sources_submitted: 0,
+      relationships_created: 0,
       dry_run: false,
     };
   }
@@ -225,6 +266,10 @@ export async function seedSandbox(options: SeedOptions): Promise<SeedResult> {
   let entityBatchesSubmitted = 0;
   let entitiesPlanned = 0;
   let unstructuredSubmitted = 0;
+  let relationshipsCreated = 0;
+  // `_ref` handle -> server-assigned entity id, so manifest relationships can
+  // wire the graph after every entity exists.
+  const refToEntityId = new Map<string, string>();
 
   for (let i = 0; i < manifest.entity_batches.length; i++) {
     const batch = manifest.entity_batches[i];
@@ -234,8 +279,22 @@ export async function seedSandbox(options: SeedOptions): Promise<SeedResult> {
         `Batch ${i} (${batch.idempotency_prefix}) references agent_index ${batch.agent_index}, which is out of range`
       );
     }
-    const entities = await resolveFixtureEntities(batch, repoRoot);
-    entitiesPlanned += entities.length;
+    const resolved = await resolveFixtureEntities(batch, repoRoot);
+    entitiesPlanned += resolved.length;
+
+    // Strip `_ref` (and any `_`-prefixed authoring keys) before /store; remember
+    // each entity's ref by position so we can map ids back from the response.
+    const refsByIndex: (string | undefined)[] = [];
+    const entities = resolved.map((row) => {
+      const clean: Record<string, unknown> = {};
+      let ref: string | undefined;
+      for (const [k, v] of Object.entries(row)) {
+        if (k === "_ref") ref = typeof v === "string" ? v : undefined;
+        else if (!k.startsWith("_")) clean[k] = v;
+      }
+      refsByIndex.push(ref);
+      return clean;
+    });
 
     if (options.dryRun) {
       logger(
@@ -252,19 +311,77 @@ export async function seedSandbox(options: SeedOptions): Promise<SeedResult> {
       source_priority: 80,
     });
 
-    const res = await fetchFn(`${baseUrl}/store`, {
-      method: "POST",
-      headers: headersForAgent(agent, options.bearer),
-      body,
-    });
-    if (!res.ok) {
-      const text = await res.text().catch(() => "");
-      throw new Error(
-        `seed batch ${batch.idempotency_prefix} failed: ${res.status} ${text.slice(0, 200)}`
-      );
+    try {
+      const res = await fetchFn(`${baseUrl}/store`, {
+        method: "POST",
+        headers: headersForAgent(agent, options.bearer),
+        body,
+      });
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        // Best-effort: one bad batch must not abort the rest of the seed.
+        logger(
+          `WARN: seed batch ${batch.idempotency_prefix} failed (${res.status}): ${text.slice(0, 200)}`
+        );
+        continue;
+      }
+      const result = (await res.json().catch(() => null)) as {
+        entities?: { observation_index?: number; entity_id?: string }[];
+      } | null;
+      for (const ent of result?.entities ?? []) {
+        const ref =
+          typeof ent.observation_index === "number"
+            ? refsByIndex[ent.observation_index]
+            : undefined;
+        if (ref && ent.entity_id) refToEntityId.set(ref, ent.entity_id);
+      }
+      entityBatchesSubmitted++;
+      logger(`seeded batch ${batch.idempotency_prefix} (${entities.length} entities)`);
+    } catch (err) {
+      logger(`WARN: seed batch ${batch.idempotency_prefix} threw: ${(err as Error).message}`);
     }
-    entityBatchesSubmitted++;
-    logger(`seeded batch ${batch.idempotency_prefix} (${entities.length} entities)`);
+  }
+
+  // Relationship pass — wire the graph from `_ref` handles now that ids exist.
+  if (!options.dryRun && Array.isArray(manifest.relationships) && manifest.relationships.length) {
+    const relAgent = manifest.agent_identities[0];
+    const resolvedRels = manifest.relationships
+      .map((rel) => {
+        const source_entity_id = refToEntityId.get(rel.source_ref);
+        const target_entity_id = refToEntityId.get(rel.target_ref);
+        if (!source_entity_id || !target_entity_id) {
+          logger(
+            `WARN: relationship ${rel.source_ref} -[${rel.relationship_type}]-> ${rel.target_ref} skipped (unresolved ref)`
+          );
+          return null;
+        }
+        return {
+          source_entity_id,
+          target_entity_id,
+          relationship_type: rel.relationship_type,
+          ...(rel.metadata ? { metadata: rel.metadata } : {}),
+        };
+      })
+      .filter((r): r is NonNullable<typeof r> => r !== null);
+
+    if (resolvedRels.length) {
+      try {
+        const res = await fetchFn(`${baseUrl}/create_relationships`, {
+          method: "POST",
+          headers: headersForAgent(relAgent, options.bearer),
+          body: JSON.stringify({ relationships: resolvedRels }),
+        });
+        if (res.ok) {
+          relationshipsCreated = resolvedRels.length;
+          logger(`created ${relationshipsCreated} relationships`);
+        } else {
+          const text = await res.text().catch(() => "");
+          logger(`WARN: create_relationships failed (${res.status}): ${text.slice(0, 200)}`);
+        }
+      } catch (err) {
+        logger(`WARN: create_relationships threw: ${(err as Error).message}`);
+      }
+    }
   }
 
   for (const source of manifest.unstructured_sources) {
@@ -284,7 +401,7 @@ export async function seedSandbox(options: SeedOptions): Promise<SeedResult> {
     const abs = path.join(repoRoot, source.fixture_path);
     const buf = await fs.readFile(abs);
     const base64 = buf.toString("base64");
-    const body = JSON.stringify({
+    const payload: Record<string, unknown> = {
       file_content: base64,
       mime_type: source.mime_type,
       original_filename: source.original_filename,
@@ -292,12 +409,25 @@ export async function seedSandbox(options: SeedOptions): Promise<SeedResult> {
         `sandbox-seed-unstructured-${source.original_filename}`,
         0
       ),
-    });
+    };
+    // Optional interpretation: attach extracted entities to the raw file source
+    // so the Sources → Interpretations → derived-entities chain is populated.
+    if (Array.isArray(source.interpretation_entities) && source.interpretation_entities.length) {
+      payload.entities = source.interpretation_entities;
+      payload.interpretation = {
+        source_ref: "unstructured",
+        ...(source.interpretation_config
+          ? { interpretation_config: source.interpretation_config }
+          : {}),
+      };
+    }
 
-    const res = await fetchFn(`${baseUrl}/store/unstructured`, {
+    // Unstructured storage is handled by the unified /store endpoint (file_content
+    // + optional interpretation); there is no separate /store/unstructured route.
+    const res = await fetchFn(`${baseUrl}/store`, {
       method: "POST",
       headers: headersForAgent(agent, options.bearer),
-      body,
+      body: JSON.stringify(payload),
     });
     if (!res.ok) {
       const text = await res.text().catch(() => "");
@@ -316,6 +446,7 @@ export async function seedSandbox(options: SeedOptions): Promise<SeedResult> {
     entity_batches_submitted: entityBatchesSubmitted,
     entities_planned: entitiesPlanned,
     unstructured_sources_submitted: unstructuredSubmitted,
+    relationships_created: relationshipsCreated,
     dry_run: options.dryRun === true,
   };
 }

--- a/tests/fixtures/sandbox/manifest.json
+++ b/tests/fixtures/sandbox/manifest.json
@@ -1,6 +1,6 @@
 {
-  "schema_version": "1.0",
-  "description": "Canonical sandbox seed manifest. Consumed by scripts/seed_sandbox.ts. Entities are stored under SANDBOX_PUBLIC_USER_ID. Four synthetic agent identities rotate through seeding so the /agents page shows diversity.",
+  "schema_version": "2.0",
+  "description": "Generic showcase pack: one connected world (a startup + the founder's life) — contacts, orgs, a place, projects, tasks, meetings, transactions, habits, a conversation, and notes — wired into a graph, with key entities re-stored by multiple agents for multi-source provenance. Exercises Entities, Entity types, Observations, Relationships, Graph, Sources, Timeline, and Conversations.",
   "agent_identities": [
     {
       "agent_sub": "sandbox-agent-chatgpt@neotoma.sandbox",
@@ -29,46 +29,507 @@
   ],
   "entity_batches": [
     {
-      "agent_index": 0,
-      "idempotency_prefix": "sandbox-seed-contacts",
-      "fixture": "reuse://tests/fixtures/json/contact.json",
-      "entity_type_override": "contact",
-      "note": "Reuses existing contact fixture (5 rows)."
+      "agent_index": 1,
+      "idempotency_prefix": "generic-people",
+      "entities": [
+        {
+          "_ref": "p_maya",
+          "entity_type": "contact",
+          "name": "Maya Chen",
+          "email": "maya@cedarlabs.example",
+          "role": "Co-founder & CEO",
+          "company": "Cedar Labs"
+        },
+        {
+          "_ref": "p_priya",
+          "entity_type": "contact",
+          "name": "Priya Nair",
+          "email": "priya@cedarlabs.example",
+          "role": "Head of Design",
+          "company": "Cedar Labs"
+        },
+        {
+          "_ref": "p_tom",
+          "entity_type": "contact",
+          "name": "Tom Okafor",
+          "email": "tom@northwind.example",
+          "role": "Partner",
+          "company": "Northwind Capital"
+        },
+        {
+          "_ref": "p_sam",
+          "entity_type": "contact",
+          "name": "Sam Park",
+          "email": "sam@acmeretail.example",
+          "role": "VP Engineering",
+          "company": "Acme Retail"
+        },
+        {
+          "_ref": "p_lena",
+          "entity_type": "contact",
+          "name": "Lena Voss",
+          "email": "lena@advisor.example",
+          "role": "Go-to-market Advisor"
+        }
+      ]
     },
     {
       "agent_index": 1,
-      "idempotency_prefix": "sandbox-seed-transactions",
-      "fixture": "reuse://tests/fixtures/json/transaction.json",
-      "entity_type_override": "transaction",
-      "note": "Reuses existing transaction fixture."
+      "idempotency_prefix": "generic-orgs",
+      "entities": [
+        {
+          "_ref": "o_cedar",
+          "entity_type": "organization",
+          "name": "Cedar Labs",
+          "industry": "Developer tools",
+          "website": "https://cedarlabs.example"
+        },
+        {
+          "_ref": "o_northwind",
+          "entity_type": "organization",
+          "name": "Northwind Capital",
+          "industry": "Venture capital",
+          "website": "https://northwind.example"
+        },
+        {
+          "_ref": "o_acme",
+          "entity_type": "organization",
+          "name": "Acme Retail",
+          "industry": "Retail",
+          "website": "https://acmeretail.example"
+        },
+        {
+          "_ref": "o_cloudhost",
+          "entity_type": "organization",
+          "name": "CloudHost",
+          "industry": "Infrastructure",
+          "website": "https://cloudhost.example"
+        }
+      ]
+    },
+    {
+      "agent_index": 1,
+      "idempotency_prefix": "generic-places",
+      "entities": [
+        {
+          "_ref": "pl_hq",
+          "entity_type": "place",
+          "name": "Barcelona HQ",
+          "address": "Carrer de Pallars 99",
+          "city": "Barcelona",
+          "country": "ES"
+        }
+      ]
+    },
+    {
+      "agent_index": 0,
+      "idempotency_prefix": "generic-projects",
+      "entities": [
+        {
+          "_ref": "pr_launch",
+          "entity_type": "project",
+          "name": "Sandbox Launch",
+          "status": "active",
+          "summary": "Ship the public sandbox + onboarding."
+        },
+        {
+          "_ref": "pr_fundraise",
+          "entity_type": "project",
+          "name": "Q3 Fundraise",
+          "status": "active",
+          "summary": "Raise the seed round."
+        }
+      ]
+    },
+    {
+      "agent_index": 0,
+      "idempotency_prefix": "generic-tasks",
+      "entities": [
+        {
+          "_ref": "t_picker",
+          "entity_type": "task",
+          "title": "Ship the pack picker",
+          "status": "done",
+          "priority": "high",
+          "due_date": "2026-06-20"
+        },
+        {
+          "_ref": "t_demo",
+          "entity_type": "task",
+          "title": "Record the product demo",
+          "status": "in_progress",
+          "priority": "medium",
+          "due_date": "2026-07-02"
+        },
+        {
+          "_ref": "t_onboard",
+          "entity_type": "task",
+          "title": "Write onboarding docs",
+          "status": "todo",
+          "priority": "medium",
+          "due_date": "2026-07-10"
+        },
+        {
+          "_ref": "t_update",
+          "entity_type": "task",
+          "title": "Send monthly investor update",
+          "status": "todo",
+          "priority": "high",
+          "due_date": "2026-07-01"
+        },
+        {
+          "_ref": "t_pricing",
+          "entity_type": "task",
+          "title": "Draft pricing page",
+          "status": "todo",
+          "priority": "low",
+          "due_date": "2026-07-15"
+        }
+      ]
     },
     {
       "agent_index": 2,
-      "idempotency_prefix": "sandbox-seed-habits",
-      "fixture": "reuse://tests/fixtures/json/habit.json",
-      "entity_type_override": "habit",
-      "note": "Reuses existing habit fixture."
-    },
-    {
-      "agent_index": 0,
-      "idempotency_prefix": "sandbox-seed-orders",
-      "fixture": "reuse://tests/fixtures/json/order.json",
-      "entity_type_override": "order",
-      "note": "Reuses existing order fixture."
+      "idempotency_prefix": "generic-meetings",
+      "entities": [
+        {
+          "_ref": "m_intro",
+          "entity_type": "meeting",
+          "title": "Cedar Labs ↔ Northwind intro call",
+          "date": "2026-06-18T15:00:00Z",
+          "location": "Video"
+        },
+        {
+          "_ref": "m_design",
+          "entity_type": "meeting",
+          "title": "Launch design review",
+          "date": "2026-06-22T10:00:00Z",
+          "location": "Barcelona HQ"
+        }
+      ]
     },
     {
       "agent_index": 3,
-      "idempotency_prefix": "sandbox-seed-conv-chatgpt",
-      "fixture": "inline://conversation_chatgpt",
-      "entity_type_override": "conversation",
-      "note": "Synthetic ChatGPT-style conversation; seeder expands into conversation + conversation_message rows."
+      "idempotency_prefix": "generic-transactions",
+      "entities": [
+        {
+          "_ref": "x_cloud",
+          "entity_type": "transaction",
+          "name": "CloudHost monthly invoice",
+          "amount": 420.0,
+          "currency": "EUR",
+          "direction": "debit",
+          "date": "2026-06-01"
+        },
+        {
+          "_ref": "x_priya",
+          "entity_type": "transaction",
+          "name": "Design contractor payment",
+          "amount": 3500.0,
+          "currency": "EUR",
+          "direction": "debit",
+          "date": "2026-06-05"
+        },
+        {
+          "_ref": "x_acme",
+          "entity_type": "transaction",
+          "name": "Acme Retail annual plan",
+          "amount": 12000.0,
+          "currency": "EUR",
+          "direction": "credit",
+          "date": "2026-06-12"
+        }
+      ]
+    },
+    {
+      "agent_index": 0,
+      "idempotency_prefix": "generic-habits",
+      "entities": [
+        {
+          "_ref": "h_run",
+          "entity_type": "habit",
+          "name": "Morning run",
+          "cadence": "daily"
+        },
+        {
+          "_ref": "h_review",
+          "entity_type": "habit",
+          "name": "Weekly review",
+          "cadence": "weekly"
+        }
+      ]
     },
     {
       "agent_index": 1,
-      "idempotency_prefix": "sandbox-seed-conv-claude",
-      "fixture": "inline://conversation_claude",
-      "entity_type_override": "conversation",
-      "note": "Synthetic Claude-style conversation; seeder expands into conversation + conversation_message rows."
+      "idempotency_prefix": "generic-conversation",
+      "entities": [
+        {
+          "_ref": "c_launch",
+          "entity_type": "conversation",
+          "canonical_name": "Planning the sandbox launch",
+          "title": "Planning the sandbox launch",
+          "platform": "claude",
+          "started_at": "2026-06-15T09:00:00Z",
+          "ended_at": "2026-06-15T09:20:00Z",
+          "turn_count": 4
+        },
+        {
+          "_ref": "cm_1",
+          "entity_type": "conversation_message",
+          "canonical_name": "launch-msg-1",
+          "role": "user",
+          "sender_kind": "user",
+          "content": "What's left before we can open the sandbox to the public?",
+          "turn_key": "conv-launch:turn:1",
+          "timestamp": "2026-06-15T09:00:00Z"
+        },
+        {
+          "_ref": "cm_2",
+          "entity_type": "conversation_message",
+          "canonical_name": "launch-msg-2",
+          "role": "assistant",
+          "sender_kind": "assistant",
+          "content": "The pack picker and per-visitor seeding. Once those land, we can flip it on.",
+          "turn_key": "conv-launch:turn:2",
+          "timestamp": "2026-06-15T09:00:40Z"
+        },
+        {
+          "_ref": "cm_3",
+          "entity_type": "conversation_message",
+          "canonical_name": "launch-msg-3",
+          "role": "user",
+          "sender_kind": "user",
+          "content": "Great — let's target next week and prep the investor update alongside.",
+          "turn_key": "conv-launch:turn:3",
+          "timestamp": "2026-06-15T09:01:30Z"
+        }
+      ]
+    },
+    {
+      "agent_index": 0,
+      "idempotency_prefix": "generic-notes",
+      "entities": [
+        {
+          "_ref": "n_fundraise",
+          "entity_type": "note",
+          "title": "Fundraise strategy notes",
+          "content": "Target $2M seed. Lead: Northwind. Highlight sandbox traction + design polish."
+        },
+        {
+          "_ref": "n_retro",
+          "entity_type": "note",
+          "title": "Launch retro",
+          "content": "Pack picker shipped on time; seeding bug caught in review. Tighten QA on auth paths."
+        }
+      ]
+    },
+    {
+      "agent_index": 0,
+      "idempotency_prefix": "generic-prov-chatgpt",
+      "entities": [
+        {
+          "_ref": "p_maya2",
+          "entity_type": "contact",
+          "name": "Maya Chen",
+          "phone": "+34 600 111 222",
+          "linkedin": "https://linkedin.example/in/mayachen"
+        },
+        {
+          "_ref": "o_cedar2",
+          "entity_type": "organization",
+          "name": "Cedar Labs",
+          "headcount": 8,
+          "founded": "2025"
+        },
+        {
+          "_ref": "pr_launch2",
+          "entity_type": "project",
+          "name": "Sandbox Launch",
+          "target_date": "2026-06-25"
+        }
+      ]
+    },
+    {
+      "agent_index": 2,
+      "idempotency_prefix": "generic-prov-cursor",
+      "entities": [
+        {
+          "_ref": "p_maya3",
+          "entity_type": "contact",
+          "name": "Maya Chen",
+          "timezone": "Europe/Madrid",
+          "pronouns": "she/her"
+        },
+        {
+          "_ref": "o_cedar3",
+          "entity_type": "organization",
+          "name": "Cedar Labs",
+          "stage": "seed",
+          "hq": "Barcelona"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "source_ref": "p_maya",
+      "target_ref": "o_cedar",
+      "relationship_type": "works_at"
+    },
+    {
+      "source_ref": "p_priya",
+      "target_ref": "o_cedar",
+      "relationship_type": "works_at"
+    },
+    {
+      "source_ref": "p_tom",
+      "target_ref": "o_northwind",
+      "relationship_type": "works_at"
+    },
+    {
+      "source_ref": "p_sam",
+      "target_ref": "o_acme",
+      "relationship_type": "works_at"
+    },
+    {
+      "source_ref": "p_lena",
+      "target_ref": "o_cedar",
+      "relationship_type": "related_to",
+      "metadata": {
+        "role": "advisor"
+      }
+    },
+    {
+      "source_ref": "o_cedar",
+      "target_ref": "pl_hq",
+      "relationship_type": "located_at"
+    },
+    {
+      "source_ref": "o_northwind",
+      "target_ref": "o_cedar",
+      "relationship_type": "invested_in",
+      "metadata": {
+        "round": "seed"
+      }
+    },
+    {
+      "source_ref": "o_acme",
+      "target_ref": "o_cedar",
+      "relationship_type": "contracted_with"
+    },
+    {
+      "source_ref": "pr_launch",
+      "target_ref": "o_cedar",
+      "relationship_type": "related_to"
+    },
+    {
+      "source_ref": "pr_fundraise",
+      "target_ref": "o_cedar",
+      "relationship_type": "related_to"
+    },
+    {
+      "source_ref": "t_picker",
+      "target_ref": "pr_launch",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "t_demo",
+      "target_ref": "pr_launch",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "t_onboard",
+      "target_ref": "pr_launch",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "t_update",
+      "target_ref": "pr_fundraise",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "t_pricing",
+      "target_ref": "pr_fundraise",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "p_maya",
+      "target_ref": "t_picker",
+      "relationship_type": "manages"
+    },
+    {
+      "source_ref": "p_priya",
+      "target_ref": "t_demo",
+      "relationship_type": "manages"
+    },
+    {
+      "source_ref": "m_intro",
+      "target_ref": "o_northwind",
+      "relationship_type": "related_to"
+    },
+    {
+      "source_ref": "m_intro",
+      "target_ref": "p_tom",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "m_intro",
+      "target_ref": "p_maya",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "m_design",
+      "target_ref": "pr_launch",
+      "relationship_type": "related_to"
+    },
+    {
+      "source_ref": "m_design",
+      "target_ref": "p_priya",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "x_cloud",
+      "target_ref": "o_cloudhost",
+      "relationship_type": "transacted_with"
+    },
+    {
+      "source_ref": "x_priya",
+      "target_ref": "p_priya",
+      "relationship_type": "transacted_with"
+    },
+    {
+      "source_ref": "x_acme",
+      "target_ref": "o_acme",
+      "relationship_type": "transacted_with"
+    },
+    {
+      "source_ref": "cm_1",
+      "target_ref": "c_launch",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "cm_2",
+      "target_ref": "c_launch",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "cm_3",
+      "target_ref": "c_launch",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "c_launch",
+      "target_ref": "pr_launch",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "n_fundraise",
+      "target_ref": "pr_fundraise",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "n_retro",
+      "target_ref": "pr_launch",
+      "relationship_type": "references"
     }
   ],
   "unstructured_sources": [
@@ -85,9 +546,34 @@
       "mime_type": "application/json",
       "original_filename": "contacts_sample.json",
       "note": "Reused contact fixture stored as an unstructured source for the Sources page."
+    },
+    {
+      "agent_index": 1,
+      "fixture_path": "tests/fixtures/sandbox/synthetic/meeting_transcript_acme.txt",
+      "mime_type": "text/plain",
+      "original_filename": "acme_onboarding_call.txt",
+      "note": "Synthetic meeting transcript; interpreted into a meeting + follow-up task to populate the Interpretations surface.",
+      "interpretation_config": {
+        "extractor_type": "sandbox-seed-demo",
+        "extractor_version": "1.0",
+        "model": "showcase-fixture"
+      },
+      "interpretation_entities": [
+        {
+          "entity_type": "meeting",
+          "title": "Customer call: Acme Retail onboarding",
+          "date": "2026-06-19T16:00:00Z",
+          "summary": "Onboarding call covering per-team isolation and CSV import; agreed to send onboarding doc and schedule a team demo."
+        },
+        {
+          "entity_type": "task",
+          "title": "Schedule Acme team demo",
+          "status": "todo",
+          "priority": "high",
+          "due_date": "2026-06-26"
+        }
+      ]
     }
   ],
-  "excluded_fixtures": [
-    "tests/fixtures/feedback/simon_apr21_reports.json"
-  ]
+  "excluded_fixtures": []
 }

--- a/tests/fixtures/sandbox/synthetic/meeting_transcript_acme.txt
+++ b/tests/fixtures/sandbox/synthetic/meeting_transcript_acme.txt
@@ -1,0 +1,14 @@
+Customer call — Acme Retail onboarding
+Date: 2026-06-19
+
+Maya: Thanks for joining, Sam. We're excited to get Acme Retail onto the Neotoma sandbox.
+Sam: Likewise. Our main need is per-team isolation and a clean import path for our existing records.
+Maya: Both are covered — a separate workspace per team, plus a CSV importer that maps to your schema.
+Sam: Great. Could we get a walkthrough for the wider engineering team next week?
+Maya: Absolutely. I'll send an onboarding doc and set up a demo session.
+
+Action items:
+- Maya to send the onboarding doc to Sam.
+- Schedule an Acme team demo for next week.
+
+(Synthetic transcript authored for the Neotoma sandbox showcase — no real persons or data.)

--- a/tests/unit/sandbox_generic_manifest.test.ts
+++ b/tests/unit/sandbox_generic_manifest.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Integrity guard for the 'generic' sandbox showcase manifest.
+ *
+ * The pack is hand-authored data, so a wiring mistake (a relationship pointing
+ * at a `_ref` no entity declares, or an invalid relationship_type) would
+ * silently drop edges at seed time. These checks fail loudly instead, and also
+ * assert the pack stays *rich* (so a future edit can't quietly flatten it back
+ * to the thin pre-showcase state).
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { describe, it, expect } from "vitest";
+
+import { RelationshipTypeSchema } from "../../src/shared/action_schemas.js";
+
+const manifestPath = path.resolve(
+  __dirname,
+  "..",
+  "..",
+  "tests",
+  "fixtures",
+  "sandbox",
+  "manifest.json"
+);
+
+interface Batch {
+  entities?: Record<string, unknown>[];
+  fixture?: string;
+}
+interface Rel {
+  source_ref: string;
+  target_ref: string;
+  relationship_type: string;
+}
+interface Manifest {
+  schema_version: string;
+  entity_batches: Batch[];
+  relationships?: Rel[];
+  unstructured_sources?: { interpretation_entities?: unknown[] }[];
+}
+
+const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8")) as Manifest;
+
+function allRefs(): Set<string> {
+  const refs = new Set<string>();
+  for (const b of manifest.entity_batches) {
+    for (const e of b.entities ?? []) {
+      const ref = (e as { _ref?: string })._ref;
+      if (typeof ref === "string") refs.add(ref);
+    }
+  }
+  return refs;
+}
+
+describe("generic sandbox showcase manifest", () => {
+  it("every relationship references a declared entity _ref", () => {
+    const refs = allRefs();
+    const dangling: string[] = [];
+    for (const r of manifest.relationships ?? []) {
+      if (!refs.has(r.source_ref)) dangling.push(`source ${r.source_ref}`);
+      if (!refs.has(r.target_ref)) dangling.push(`target ${r.target_ref}`);
+    }
+    expect(dangling, `dangling refs: ${dangling.join(", ")}`).toEqual([]);
+  });
+
+  it("every relationship_type is a valid RelationshipType", () => {
+    const valid = new Set(RelationshipTypeSchema.options as readonly string[]);
+    const bad = (manifest.relationships ?? [])
+      .map((r) => r.relationship_type)
+      .filter((t) => !valid.has(t));
+    expect(bad, `invalid relationship_types: ${[...new Set(bad)].join(", ")}`).toEqual([]);
+  });
+
+  it("each entity_batch provides entities or a fixture", () => {
+    for (const b of manifest.entity_batches) {
+      expect(Array.isArray(b.entities) || typeof b.fixture === "string").toBe(true);
+    }
+  });
+
+  it("stays rich: many entity types, a real graph, and an interpretation", () => {
+    const types = new Set<string>();
+    let entityRows = 0;
+    for (const b of manifest.entity_batches) {
+      for (const e of b.entities ?? []) {
+        entityRows++;
+        const t = (e as { entity_type?: string }).entity_type;
+        if (t) types.add(t);
+      }
+    }
+    expect(manifest.schema_version).toBe("2.0");
+    expect(entityRows).toBeGreaterThanOrEqual(25);
+    expect(types.size).toBeGreaterThanOrEqual(8);
+    expect((manifest.relationships ?? []).length).toBeGreaterThanOrEqual(20);
+    // At least one interpreted source (Sources → Interpretations chain).
+    const interpreted = (manifest.unstructured_sources ?? []).some(
+      (s) => Array.isArray(s.interpretation_entities) && s.interpretation_entities.length > 0
+    );
+    expect(interpreted).toBe(true);
+  });
+});


### PR DESCRIPTION
## Why

The data packs seeded thin, unrelated rows, so the Inspector's **Relationships, Graph, Observations-provenance, Interpretations, and Sources** surfaces came up empty or trivial. Root cause wasn't just the data — the seeder only sent `{entities, idempotency_key}` to `/store`, so it *couldn't* express relationships, multi-source provenance, or interpretations even though `/store` supports them.

## Seeder (`scripts/seed_sandbox.ts`)
- `entity_batches` may carry inline **`entities`** with **`_ref`** handles (`_`-prefixed keys stripped before `/store`).
- new manifest **`relationships`** section: `_ref` source/target resolved to ids after batches, created via `/create_relationships` → populates **Relationships + Graph Explorer**.
- unstructured sources now POST the unified **`/store`** (the `/store/unstructured` route no longer exists — it was 404ing) and accept **`interpretation_entities`** so a file source yields an **interpretation → derived entities**.
- batch loop is **best-effort** (one bad batch no longer aborts the whole seed).

## Generic pack (`tests/fixtures/sandbox/manifest.json`, schema_version 2.0)
One connected world (a startup + the founder's life): **32 entities across 11 types** (contact, organization, place, project, task, meeting, transaction, habit, conversation, conversation_message, note), **31 relationships** forming a real graph, key entities **re-stored by multiple agents** for multi-source provenance, a conversation + messages, and a **synthetic transcript interpreted** into a meeting + follow-up task.

## Verified end-to-end (booted sandbox)
`seed_status=seeded` · **32 entities** · **31 relationships** (part_of/references/related_to/works_at/transacted_with/manages/…) · **1 interpretation** · **47 sources**. Guarded by `tests/unit/sandbox_generic_manifest.test.ts` (relationship refs resolve, valid `relationship_type`s, pack stays rich). `tsc` clean; catalog regenerated.

## Follow-up
The use-case packs (crm, financial-ops, meetings, …) still use the thin format — templating them onto this richer format is the next step (you chose "generic flagship first").

🤖 Generated with [Claude Code](https://claude.com/claude-code)