### PR TITLE
fix(site): enable remark-gfm so markdown tables render

### DIFF
--- a/docs/site/generated/DOCS_MARKDOWN_AUDIT.md
+++ b/docs/site/generated/DOCS_MARKDOWN_AUDIT.md
@@ -2,15 +2,15 @@
 
 Excludes `docs/private` and paths containing `archived`, `releases`, or `in_progress` directory names.
 
-Total files: **693**
+Total files: **707**
 
 ## By top-level folder under docs/
 
-- **site**: 176
+- **site**: 177
 - **developer**: 122
-- **plans**: 68
+- **plans**: 69
+- **subsystems**: 49
 - **reports**: 48
-- **subsystems**: 48
 - **ui**: 42
 - **foundation**: 24
 - **architecture**: 20
@@ -19,12 +19,13 @@ Total files: **693**
 - **specs**: 14
 - **conventions**: 12
 - **integrations**: 12
+- **icp**: 10
 - **proposals**: 10
 - **testing**: 10
-- **icp**: 8
+- **operations**: 9
 - **legal**: 8
 - **security**: 6
-- **operations**: 4
+- **getting_started**: 4
 - **observability**: 3
 - **implementation**: 2
 - **infrastructure**: 2

--- a/docs/site/generated/docs_markdown_audit.json
+++ b/docs/site/generated/docs_markdown_audit.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-06-24T15:09:52.380Z",
-  "total_files": 693,
+  "generated_at": "2026-06-25T10:51:11.155Z",
+  "total_files": 707,
   "by_top_level_folder": {
     "api": 1,
     "architecture": 20,
@@ -10,7 +10,8 @@
     "examples": 1,
     "feature_units": 20,
     "foundation": 24,
-    "icp": 8,
+    "getting_started": 4,
+    "icp": 10,
     "implementation": 2,
     "infrastructure": 2,
     "integrations": 12,
@@ -18,9 +19,9 @@
     "migration": 2,
     "NEOTOMA_MANIFEST.md": 1,
     "observability": 3,
-    "operations": 4,
+    "operations": 9,
     "performance": 1,
-    "plans": 68,
+    "plans": 69,
     "proposals": 10,
     "prototypes": 2,
     "reference": 1,
@@ -28,10 +29,10 @@
     "reports": 48,
     "research": 1,
     "security": 6,
-    "site": 176,
+    "site": 177,
     "skills": 1,
     "specs": 14,
-    "subsystems": 48,
+    "subsystems": 49,
     "templates": 2,
     "testing": 10,
     "ui": 42,
@@ -844,6 +845,22 @@
       "top": "foundation"
     },
     {
+      "rel": "docs/getting_started/getting_started.md",
+      "top": "getting_started"
+    },
+    {
+      "rel": "docs/getting_started/using_the_inspector.md",
+      "top": "getting_started"
+    },
+    {
+      "rel": "docs/getting_started/what_is_neotoma.md",
+      "top": "getting_started"
+    },
+    {
+      "rel": "docs/getting_started/working_with_your_memory.md",
+      "top": "getting_started"
+    },
+    {
       "rel": "docs/icp/developer_release_targeting.md",
       "top": "icp"
     },
@@ -853,6 +870,14 @@
     },
     {
       "rel": "docs/icp/general_release_criteria.md",
+      "top": "icp"
+    },
+    {
+      "rel": "docs/icp/icp_from_functionality.md",
+      "top": "icp"
+    },
+    {
+      "rel": "docs/icp/icp_reconciliation.md",
       "top": "icp"
     },
     {
@@ -996,6 +1021,14 @@
       "top": "observability"
     },
     {
+      "rel": "docs/operations/agent_access_control.md",
+      "top": "operations"
+    },
+    {
+      "rel": "docs/operations/configuration.md",
+      "top": "operations"
+    },
+    {
       "rel": "docs/operations/debugging/error_debug_instructions.md",
       "top": "operations"
     },
@@ -1004,11 +1037,23 @@
       "top": "operations"
     },
     {
+      "rel": "docs/operations/deployment.md",
+      "top": "operations"
+    },
+    {
+      "rel": "docs/operations/encryption.md",
+      "top": "operations"
+    },
+    {
       "rel": "docs/operations/health_check.md",
       "top": "operations"
     },
     {
       "rel": "docs/operations/runbook.md",
+      "top": "operations"
+    },
+    {
+      "rel": "docs/operations/running_the_server.md",
       "top": "operations"
     },
     {
@@ -1053,6 +1098,10 @@
     },
     {
       "rel": "docs/plans/bug-report-and-contribution-client-guidance.md",
+      "top": "plans"
+    },
+    {
+      "rel": "docs/plans/bundled_docs_reconciliation_plan.md",
       "top": "plans"
     },
     {
@@ -1562,6 +1611,10 @@
     {
       "rel": "docs/security/threat_model.md",
       "top": "security"
+    },
+    {
+      "rel": "docs/site/documentation_outline.md",
+      "top": "site"
     },
     {
       "rel": "docs/site/generated/DOCS_MARKDOWN_AUDIT.md",
@@ -2361,6 +2414,10 @@
     },
     {
       "rel": "docs/subsystems/auth.md",
+      "top": "subsystems"
+    },
+    {
+      "rel": "docs/subsystems/conflict_resolution.md",
       "top": "subsystems"
     },
     {

--- a/frontend/src/site/repo_info.json
+++ b/frontend/src/site/repo_info.json
@@ -1,5 +1,5 @@
 {
   "version": "0.17.0",
-  "releasesCount": 35,
+  "releasesCount": 36,
   "starsCount": 25
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -117,6 +117,7 @@
         "pdfkit": "^0.17.2",
         "postcss": "^8.4.32",
         "prettier": "^3.7.4",
+        "remark-gfm": "^4.0.1",
         "shadcn": "^4.7.0",
         "sharp": "^0.33.5",
         "tailwindcss": "^3.4.0",
@@ -9712,12 +9713,53 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mdast-util-from-markdown": {
@@ -9739,6 +9781,113 @@
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0",
         "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -10013,6 +10162,134 @@
         "micromark-util-subtokenize": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/micromark-extension-mdx-expression": {
@@ -12452,6 +12729,25 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-mdx": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-3.1.1.tgz",
@@ -12496,6 +12792,22 @@
         "mdast-util-to-hast": "^13.0.0",
         "unified": "^11.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -368,6 +368,7 @@
     "pdfkit": "^0.17.2",
     "postcss": "^8.4.32",
     "prettier": "^3.7.4",
+    "remark-gfm": "^4.0.1",
     "shadcn": "^4.7.0",
     "sharp": "^0.33.5",
     "tailwindcss": "^3.4.0",

--- a/src/shared/capability_manifest.json
+++ b/src/shared/capability_manifest.json
@@ -75,6 +75,9 @@
     "health_check_snapshots": {
       "addedInVersion": "v0.4.3"
     },
+    "identify_entity_by_signals": {
+      "addedInVersion": "v0.17.0"
+    },
     "list_entity_submissions": {
       "addedInVersion": "v0.12.0"
     },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import mdx from "@mdx-js/rollup";
+import remarkGfm from "remark-gfm";
 import path from "path";
 import { fileURLToPath } from "url";
 
@@ -11,7 +12,7 @@ export default defineConfig({
   // pick-port --print-resources and earlier terminal output are not cleared on HMR/restart.
   clearScreen: false,
   plugins: [
-    { ...mdx({ providerImportSource: "@mdx-js/react" }), enforce: "pre" },
+    { ...mdx({ providerImportSource: "@mdx-js/react", remarkPlugins: [remarkGfm] }), enforce: "pre" },
     react(),
   ],
   root: "frontend",


### PR DESCRIPTION
## Summary

- Adds `remark-gfm@^4.0.1` as a dependency and wires it into the `@mdx-js/rollup` plugin in `vite.config.ts` so GFM tables in `docs/site/pages/*.mdx` compile to HTML `<table>` elements instead of raw `|...|` pipe text.
- This was the first release (v0.17.0) to ship MDX pages with tables, which exposed the missing plugin.

## Second compile-site check

The static prerender script `scripts/build_github_pages_site.tsx` does **not** have its own MDX compile step. It reads the Vite-built `public/index.html` and uses Playwright to render the SPA. No additional plugin needed there.

## Verification evidence

Build (`npm run build:ui`) produces `public/assets/main-*.js` containing:
- **195 occurrences** of `jsx(t.td` — table cells compiled to React elements
- **35 occurrences** of `jsx(t.th` — header cells
- **0 occurrences** of raw `|---|` separator syntax

The Signal-bundle table in `identify-entity-by-signals.mdx` compiles to:
```
e.jsx(t.td,{children:"email"})...e.jsx(t.td,{children:"1.0"})...
```
(before the fix: the raw `| email | 1.0 | ... |` pipe text would have appeared verbatim)

## Validators

All pass on this branch:
- `npm run validate:mdx-site` — ✓ MDX site page metadata validation passed
- `npm run validate:routes` — ✓ Route parity OK — 161 routes, 158 indexable, 185 metadata entries
- `npm run validate:locales` — ✓ Locale parity validated for 13 locales

## Rebase status

Branch was already on top of `origin/main` tip (`05bea8335`) — no rebase needed; no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>