### PR TITLE
feat(bundles): m2 runtime (canonical, reconciled with #363) — loader, default install, enforcement, linter, use_cases

### DIFF
--- a/docs/bundles/m5/phase0_field_coverage.md
+++ b/docs/bundles/m5/phase0_field_coverage.md
@@ -1,0 +1,411 @@
+# Phase 0b — Field coverage analysis for P0 bundles
+
+**Plan:** `ent_7f4ae2e060dbca4ecc6fe0f1` (Bundles m5)
+**Source:** Production schema_registry snapshot via `list_entity_types`, 2026-05-21, owner instance.
+**Purpose:** Distill production field sets to canonical bundle field definitions. Production schemas have grown organically (e.g. `email_message` has 45 fields; `contact` has 46) — m5 bundles will ship a **curated core** + retain extension via `raw_fragments`.
+
+## Curation rules
+
+For each entity type:
+
+1. **Promote to core fields** anything used by ≥30% of observations OR semantically required for the type's identity.
+2. **Retain via raw_fragments** anything ad-hoc, per-source, or platform-specific (gmail_message_id, gmail_thread_id, twitter handles, etc.).
+3. **Canonicalize aliases**: collapse `from` / `from_address` / `from_email` / `from_display` / `from_name` / `sender_name` / `sender_email` into a clear minimal set.
+4. **Required fields only when truly required** for the type to be a distinct entity (e.g. `published_date` for `post`).
+
+---
+
+## `crm` bundle
+
+### `company` (production: 123, fields used: 18)
+
+**Promote (canonical 9):**
+
+- `name` (string, required) — identity
+- `description` (string)
+- `website` (string)
+- `url` (string)
+- `category` (string)
+- `stage` (string) — `prospect | active | inactive | acquired | shut_down`
+- `business_model` (string)
+- `founded` (number) — year
+- `notes` (text)
+
+**Retain via raw_fragments:** `company_id` (legacy import), `import_date`, `import_source_file`, `data_source`, `tagline`, `founder`, `product`.
+
+**canonical_name_fields:** `["name"]`.
+
+### `deal` (no production observations yet — site-defined)
+
+**Promote (canonical 8):**
+
+- `name` (string, required)
+- `account_id` (string) — REFERS_TO company
+- `stage` (string) — `lead | qualified | proposal | negotiation | closed_won | closed_lost`
+- `amount` (number)
+- `currency` (string, default `USD`)
+- `close_date` (date)
+- `owner` (string) — REFERS_TO contact
+- `notes` (text)
+
+### `account` (no production observations — site-defined)
+
+**Promote (canonical 5):**
+
+- `name` (string, required)
+- `company_id` (string) — REFERS_TO company
+- `type` (string) — `customer | prospect | partner | vendor`
+- `health` (string) — `green | yellow | red`
+- `renewal_date` (date)
+
+### `engagement` (overlaps with production `outreach_interaction`, 13)
+
+**Promote (canonical 7):**
+
+- `subject` (string, required)
+- `contact_id` (string, required) — REFERS_TO contact
+- `channel` (string) — `email | call | meeting | message | event`
+- `direction` (string) — `inbound | outbound`
+- `occurred_at` (date, required)
+- `outcome` (string)
+- `notes` (text)
+
+### `pipeline_stage` (config-style)
+
+**Promote (canonical 4):**
+
+- `name` (string, required)
+- `position` (number, required)
+- `pipeline_name` (string, required)
+- `probability` (number) — 0..1
+
+**Identity:** composite `(pipeline_name, name)`.
+
+### Bundle additions promoted from phase 0a
+
+- `contact_group` (49) — add as `provides_entity_types` entry.
+- `outreach_interaction` aliased to `engagement`.
+
+---
+
+## `communications` bundle
+
+### `email_message` (production: 204, 45 fields)
+
+**Promote (canonical 12):**
+
+- `subject` (string, required)
+- `from_email` (string, required)
+- `from_name` (string)
+- `to_addresses` (array<string>, required)
+- `cc` (array<string>)
+- `received_at` (date, required for inbound)
+- `sent_at` (date, required for outbound)
+- `direction` (string) — `inbound | outbound | draft`
+- `body_text` (text)
+- `body_excerpt` (string)
+- `thread_id` (string) — REFERS_TO email_thread
+- `mailbox` (string)
+
+**Retain via raw_fragments:** `gmail_message_id`, `gmail_thread_id`, `gmail_draft_id`, `api_response_data`, `attachment_filenames`, `local_attachment_paths`, `language`, `prepayment_signal_*`, `has_html`, `attachment_count`, `supersedes_message_id`.
+
+**canonical_name_fields:** `["thread_id", "received_at", "from_email"]` (provider-agnostic — falls back to heuristic if absent).
+
+### `email_thread` (production: 3, 9 fields)
+
+**Promote (canonical 5):**
+
+- `subject` (string, required)
+- `participants` (array<string>, required)
+- `first_message_at` (date, required)
+- `last_message_at` (date)
+- `message_count` (number)
+
+### `email_draft` (production: 2)
+
+**Promote (canonical 6):**
+
+- `subject` (string, required)
+- `to_addresses` (array<string>)
+- `body_text` (text)
+- `created_at` (date, required)
+- `in_reply_to` (string) — gmail_message_id of parent
+- `status` (string) — `drafting | ready | sent | discarded`
+
+### `post` (production: 365, 22 fields)
+
+**Promote (canonical 11):**
+
+- `slug` (string, required) — identity
+- `title` (string, required)
+- `excerpt` (string)
+- `body` (text)
+- `summary` (string)
+- `category` (string)
+- `tags` (array<string>)
+- `published` (boolean)
+- `published_date` (date)
+- `hero_image` (string) — URL or file_asset id
+- `status` (string) — `draft | scheduled | published | archived`
+
+**Retain via raw_fragments:** `read_time`, `hero_image_style`, `share_tweet`, `og_image`, `hero_image_square`, `created_date`, `updated_date`, `import_date`, `import_source_file`.
+
+**canonical_name_fields:** `["slug"]`.
+
+### `social_post` (production: 16, 30 fields)
+
+**Promote (canonical 12):**
+
+- `platform` (string, required) — `twitter | linkedin | mastodon | bluesky | other`
+- `content` (text, required)
+- `author_handle` (string)
+- `url` (string)
+- `post_id` (string)
+- `post_type` (string) — `original | reply | quote | thread`
+- `status` (string) — `draft | scheduled | published`
+- `published_date` (date)
+- `tags` (array<string>)
+- `hashtags` (array<string>)
+- `in_reply_to_url` (string)
+- `thread_id` (string)
+
+**Retain via raw_fragments:** `series`, `series_part`, `blog_post_slug`, `hook`, `media_urls`, `mentions`, `likes`, `shares`, `comments`, `char_count_approx`.
+
+### `social_share_draft` (production: 165, 27 fields)
+
+**Promote (canonical 10):**
+
+- `platform` (string, required)
+- `content` (text, required)
+- `title` (string)
+- `status` (string) — `drafting | scheduled | published | discarded`
+- `scheduled_at` (date)
+- `published_at` (date)
+- `post_url` (string)
+- `tags` (array<string>)
+- `hashtags` (array<string>)
+- `is_thread` (boolean)
+
+**Retain via raw_fragments:** `source_entity_id`, `media_urls`, `version`, `thread_position`, `qt_target_*`, `tweet_number`, `target_post_url`, `additional_platforms`.
+
+### `post_idea` (production: 44, 12 fields)
+
+**Promote (canonical 6):**
+
+- `title` (string, required)
+- `content` (text)
+- `topics` (array<string>)
+- `status` (string) — `captured | drafting | published | discarded`
+- `captured_on` (date)
+- `source_url` (string)
+
+### `blog_post` (production: 7)
+
+**Promote (canonical 8):**
+
+- `title` (string, required)
+- `url` (string)
+- `content` (text, required)
+- `author` (string)
+- `published_at` (date)
+- `summary` (string)
+- `tags` (array<string>)
+- `platform` (string) — `substack | medium | personal | other`
+
+### `message` (production: 3, low conf.)
+
+**Promote (canonical 5):**
+
+- `content` (text, required)
+- `sender` (string)
+- `channel` (string) — `sms | imessage | signal | whatsapp | other`
+- `sent_at` (date, required)
+- `direction` (string)
+
+---
+
+## `personal_data` bundle
+
+### `workout_session` (production: 37, currently 4 fields — under-defined)
+
+**Promote (canonical 6):**
+
+- `date` (date, required)
+- `location` (string)
+- `notes` (text)
+- `status` (string) — `planned | in_progress | completed | skipped`
+- `duration_minutes` (number)
+- `bodyweight_kg` (number)
+
+### `exercise_log` (production: 44, 15 fields — already well-shaped)
+
+**Promote (canonical, keep as-is, 9 fields):**
+
+- `date` (date, required)
+- `exercise_name` (string, required)
+- `exercise_name_normalized` (string)
+- `set_number` (number)
+- `reps` (number)
+- `weight_kg` (number)
+- `effort` (string) — RPE scale or descriptor
+- `set_type` (string) — `warmup | working | failure | dropset`
+- `notes` (text)
+
+**REFERS_TO** `workout_session` via session_id.
+
+### `exercise_set` (production: 19, 9 fields)
+
+**Promote (canonical, keep as-is, 8 fields):** `exercise_name`, `session_id`, `set_number`, `weight_kg`, `reps`, `is_warmup`, `is_failure`, `timestamp`, `notes`. Likely consolidate with `exercise_log` in m5 — same shape minus naming convention. Decision deferred to phase 1.
+
+### `recurring_expense` (production: 173, 26 fields — over-fitted to owner's needs)
+
+**Promote (canonical 12):**
+
+- `merchant` (string, required)
+- `expense_description` (string)
+- `expense_type` (string) — `subscription | bill | rent | insurance | other`
+- `billing_frequency` (string) — `monthly | quarterly | annually | weekly`
+- `occurrences_per_year` (number)
+- `payment_amount` (number, required)
+- `currency` (string, required)
+- `payment_method` (string)
+- `started` (date)
+- `ended` (date)
+- `renews` (date)
+- `notes` (text)
+
+**Retain via raw_fragments:** dual-currency amounts (`payment_amount_eur`, `payment_amount_usd`, `monthly_eur`, etc.), `pct_fixed_expenses`, `pct_net_income`, `inflates`, `yearly_savings_eur`, `location`, `observation_kind`, `source_file`.
+
+### `transaction` (personal-scope, production: 113)
+
+Defer field shape to financial_ops bundle phase. personal_data bundle re-exports `transaction` with `category` filter or alias.
+
+### `income` (production: 43)
+
+**Promote (canonical 8):**
+
+- `source` (string, required)
+- `amount` (number, required)
+- `currency` (string, required)
+- `received_at` (date, required)
+- `category` (string) — `salary | contract | dividend | other`
+- `payer` (string)
+- `payment_method` (string)
+- `notes` (text)
+
+### `transcription` (production: 739)
+
+**Promote (canonical 7):**
+
+- `content` (text, required)
+- `source_audio_id` (string) — REFERS_TO file_asset
+- `recorded_at` (date)
+- `transcribed_at` (date, required)
+- `duration_seconds` (number)
+- `language` (string)
+- `transcription_model` (string) — `whisper-large-v3 | gpt-4o-transcribe | etc`
+
+### `meeting_transcription` (production: 36)
+
+Sub-type of `transcription` with additional fields:
+
+- `meeting_id` (string) — REFERS_TO event
+- `participants` (array<string>)
+
+Decision: keep as separate entity_type with `transcription` as alias category, OR fold into `transcription` with `category: meeting`. Defer to phase 1.
+
+### `preference` (consolidating 5 variants, production total ~30)
+
+**Promote (canonical 6):**
+
+- `subject` (string, required) — what the preference is about
+- `value` (string, required) — the preference content
+- `category` (string) — `ui | retrieval | instruction | general`
+- `priority` (string) — `must | should | may`
+- `captured_at` (date, required)
+- `notes` (text)
+
+### `standing_rule` (production: 35)
+
+**Promote (canonical 5):**
+
+- `rule_text` (string, required)
+- `scope` (string) — `global | session | project | workflow`
+- `created_at` (date, required)
+- `active` (boolean, default true)
+- `notes` (text)
+
+### `health_event` (production: 3)
+
+**Promote (canonical 5):**
+
+- `event_type` (string, required) — `injury | illness | checkup | medication | other`
+- `description` (string, required)
+- `occurred_at` (date, required)
+- `severity` (string) — `mild | moderate | severe`
+- `resolved_at` (date)
+
+### `dispute` family (production: 20 + ~10 sub-types)
+
+Consolidate into single `dispute` entity (production: 2 exists at 36 fields, well-shaped).
+**Promote (canonical 12):**
+
+- `title` (string, required)
+- `counterparty` (string, required)
+- `invoice_ref` (string)
+- `invoice_date` (date)
+- `amount` (number)
+- `currency` (string)
+- `status` (string) — `open | in_progress | resolved | dropped`
+- `disputed_date` (date, required)
+- `work_scope` (string)
+- `issues_summary` (text)
+- `next_steps` (text)
+- `notes` (text)
+
+**Retain via raw_fragments:** `isap_*` jurisdiction-specific fields, `legacy_dispute_id`, `grupo_kiak_invoice_ref`, dual-currency amounts.
+
+### `device` (production: 10)
+
+**Promote (canonical 5):**
+
+- `name` (string, required)
+- `device_type` (string) — `phone | laptop | desktop | tablet | wearable | other`
+- `make` (string)
+- `model` (string)
+- `acquired_at` (date)
+
+### `location` (production: 11, 10 fields)
+
+**Promote (canonical 6):**
+
+- `name` (string, required) — identity
+- `locality` (string) — city
+- `administrative_area` (string) — state/province
+- `country` (string)
+- `latitude` (number)
+- `longitude` (number)
+
+---
+
+## Cross-bundle notes
+
+1. **`canonical_name` field**: production schemas frequently include `canonical_name` as a stored field. Bundle schemas should declare `canonical_name_fields` in SchemaDefinition rather than persisting a `canonical_name` column. Migration of existing data: defer to phase 1 per-bundle.
+
+2. **`source_file`, `import_date`, `import_source_file`, `data_source`**: provenance fields. These belong in `observations.metadata`, not the entity field set. Bundle schemas exclude them.
+
+3. **`title` / `name`**: many production types have both. Bundle convention: use `name` for entities with stable identity (company, contact, location); `title` for content artifacts (post, email_message, dispute).
+
+4. **`status` field**: nearly universal. Bundle convention: each entity type declares its own `status` enum in the schema; no shared global status.
+
+5. **Required field discipline**: production schemas are nearly all `required: false`. Bundle schemas tighten this — identity fields and temporal fields (`*_at`) are required where the entity isn't meaningful without them.
+
+## Summary
+
+P0 bundles ship with a curated canonical field set per entity type, trimmed from production sprawl. Numbers:
+
+- `crm`: 5 entity types, ~30 canonical fields total.
+- `communications`: 8 entity types, ~75 canonical fields total.
+- `personal_data`: 14 entity types, ~95 canonical fields total.
+
+This is the minimum sufficient set. Operators on `evolving` mode can extend via raw_fragments; promotions to bundle schemas happen via `update_schema_incremental` per the existing flow.

--- a/docs/bundles/m5/phase0_orphaned_type_map.md
+++ b/docs/bundles/m5/phase0_orphaned_type_map.md
@@ -1,0 +1,223 @@
+# Phase 0a — Orphaned production entity types → bundle homes
+
+**Plan:** `ent_7f4ae2e060dbca4ecc6fe0f1` (Bundles m5)
+**Source:** `get_entity_type_counts` snapshot, 2026-05-21, owner instance (49,997 entities, 320 distinct types).
+**Inclusion threshold:** types with count ≥ 3 (200 types). Lower-frequency types treated as one-off noise unless they cluster into a clear theme.
+
+## Methodology
+
+Each production type was scored against the m5 bundle catalog:
+
+- `match`: type explicitly listed in a bundle's `provides_entity_types`.
+- `aligned`: type semantically belongs in a bundle but isn't named yet — bundle should add it.
+- `gap`: high-frequency type with no obvious bundle home — candidate for a new bundle or a new field family.
+- `core`: already covered by default-install `core` or `infrastructure`.
+- `noise`: low-confidence one-off, exclude from catalog.
+
+## Mapping
+
+### `core` / `infrastructure` (default install)
+
+- `task` (17605), `conversation_message` (15688), `conversation` (3799), `agent_message` (3515), `contact` (1265), `issue` (977), `note` (702), `plan` (300), `file_asset` (136), `event` (48), `conversation_turn` (44), `document` (8) — core/infrastructure as defined.
+
+### `crm` bundle (P0)
+
+- `company` (123) — **aligned**, add to `provides_entity_types`.
+- `organization` (16) — **aligned**, alias of company.
+- `contact_group` (49) — **aligned**.
+- `contact_list` (1) — noise / alias of contact_group.
+- `person` (26) — **aligned**, alias of contact.
+- `outreach_interaction` (13) — **aligned**.
+- `outreach_activity` (1) — noise.
+- `outreach_decision` (1) — noise.
+- `linkedin_interaction` (1) — noise.
+- `social_media_interaction` (1) — noise.
+
+### `communications` bundle (P0)
+
+- `post` (365) — **match**.
+- `email_message` (204) — **match**.
+- `social_share_draft` (165) — **aligned**, add.
+- `social_share_schedule` (23) — **aligned**, add.
+- `social_post` (16) — **match**.
+- `email` (33) — **aligned**, alias of email_message.
+- `email_thread` (3) — **match**.
+- `email_draft` (2) — **match**.
+- `email_notification` (3) — **aligned**.
+- `outbound_email` (3) — **aligned**.
+- `email_note` (1) — noise.
+- `message` (3) — **match**.
+- `tweet` (3) — **aligned**.
+- `post_idea` (44) — **aligned**, add.
+- `post_reference` (4) — **aligned**.
+- `blog_post` (7) — **aligned**, add.
+- `blog_post_draft` (1) — noise / aligns to blog_post.
+- `social_reply` (2) — **aligned**.
+- `social_post_draft` (15) — **aligned**, alias of social_share_draft.
+- `social_feedback` (3) — **gap?** → likely `communications` if about messaging, `customer_ops` if about product. Defer.
+- `social_follow_candidate` (6) — **aligned**.
+- `social_draft_review` (2) — **aligned**.
+
+### `personal_data` bundle (P0)
+
+- `transcription` (739) — **gap** → new field family. Belongs in `personal_data` for personal voice notes, but high frequency suggests a dedicated field. Add to bundle.
+- `meeting_transcription` (36) — **aligned**, add.
+- `transcription_run` (8) — **aligned**, add.
+- `recurring_expense` (173) — **match**.
+- `workout_session` (37) — **match**.
+- `exercise_log` (44) — **match**.
+- `exercise_set` (19) — **match**.
+- `income` (43) — **match**.
+- `holiday_card_receipt` (48) — **aligned**, narrow personal-finance type.
+- `preference` (25), `instruction_preference` (1), `user_preference` (1), `retrieval_preference` (1), `ui_preference` (3) — **aligned**, consolidate as `preference` with `category` field.
+- `standing_rule` (35) — **aligned**, add.
+- `holiday_card_receipt` (48) — covered above.
+- `life_tenets` (1) — noise / aligns to standing_rule.
+- `goal` (1) — **match**, low-frequency but in catalog.
+- `habit` (1) — **match**.
+- `mood_state` (1) — **match**.
+- `health_event` (3) — **aligned**, add.
+- `device` (10), `device_profile` (1) — **aligned**, add to personal_data.
+- `location` (11) — **aligned**, add.
+- `dispute_note` (20), `dispute_update` (6), `dispute_document` (1), `dispute_index` (1), `dispute_query` (1), `dispute_work_summary` (1), `dispute` (2) — **gap** → personal-finance disputes (chargebacks/insurance). Cluster into new sub-area of `personal_data` or new bundle. Recommend: add `dispute` family to `personal_data`.
+
+### `financial_ops` bundle (P1)
+
+- `transaction` (113) — **match**.
+- `bank_transaction` (10) — **match**.
+- `crypto_transaction` (existing) / `crypto_transactions` (1) — **gap** → crypto-finance subset, consider a `crypto_finance` bundle or absorb into `financial_ops`.
+- `invoice` (12) — **match**.
+- `account_statement` (14) — **match**.
+- `financial_account` (76) — **aligned**, add.
+- `crypto_wallet` (73), `crypto_wallet_address` (86) — **gap** → recommend new `crypto_finance` bundle (depends_on financial_ops).
+- `fixed_cost` (1) — **match** (in schema_definitions).
+- `tax_filing` (5) — **match**.
+- `tax_form` (1) — **aligned**.
+- `tax_event` (existing schema, 0 here) — **match**.
+- `loan` (7) — **aligned**, add.
+- `insurance_policy` (1), `insurance_offer` (1) — **aligned**, add.
+- `transaction_summary` (4) — **aligned**.
+- `payment_query` (1) — noise.
+- `account_balance` (1) — **aligned**.
+
+### `devops` bundle (P1)
+
+- `repository` (19) — **match**.
+- `pull_request` (6) — **match**.
+- `deployment` (5), `deployment_status` (3), `deployment_configuration` (1), `deployment_decision` (1), `deployment_recommendation` (1), `deployment_run` (1), `deployment_update` (1) — **match** (consolidate via category field).
+- `code_change` (21) — **match**.
+- `git_commit` (1), `code_commit` (1), `git_push_result` (1), `codebase_change` (1), `codebase_entity` (1) — **aligned**, consolidate.
+- `ci_workflow_run` (1), `github_workflow_run` (2), `workflow_run` (3), `workflow_job` (1), `workflow_observation` (1) — **aligned**, consolidate.
+- `security_finding` (2) — **match**.
+- `build_result` (1) — **aligned**.
+- `migration_result` (1) — **aligned**.
+- `release` (3), `release_objective` (15), `release_phase` (2), `release_plan` (2), `release_intent` (2), `release_preview` (1), `release_request` (1), `release_result` (1), `release_strategy` (1), `release_gate` (6) — **gap** → release management cluster. Recommend: add `release` and `release_gate` to `devops`; consider whether this needs a sub-bundle.
+- `neotoma_repair` (27), `neotoma_qa_finding` (5), `neotoma_feedback` (3) — **noise/internal** (Neotoma-on-Neotoma development); store in `devops` with `category: internal_qa`.
+- `bug_report` (48), `ui_bug` (2), `ui_bug_report` (5), `ui_issue` (4) — **aligned**, add as `bug_report` alias family to `devops`.
+- `feature_request` (19), `feature_spec` (3) — **aligned**, add.
+- `architectural_decision` (18), `decision_record` (3), `decision_note` (4) — **aligned**, add `architectural_decision` to devops.
+- `breaking_change` (2), `supplement` (8) — **aligned**.
+- `pr` / `pull_request` already covered.
+- `mcp_server_status` (7), `mcp_server_update` (1), `mcp_endpoint` (1), `mcp_tool` (1) — **aligned**, MCP-runtime subfamily of devops.
+- `dns_check` (3), `dns_record` (3), `dns_issue` (1), `dns_provider` (2), `dns_validation_result` (1), `dnsimple_current_nameservers` (1), `cloudflare_activation_step` (1), `cloudflare_cli_attempt` (1), `cloudflare_dns_review` (1) — **gap** → infrastructure ops cluster. Recommend: add to `devops` under `infrastructure_config` family.
+
+### `contracts` bundle (P1)
+
+- `contract` (in schema_definitions, low production) — **match**.
+- `contract_discrepancy` (3) — **aligned**, add.
+- `contract_review` (2) — **aligned**.
+
+### `compliance` bundle (P1)
+
+- `legal_research` (19) — **aligned**, add.
+- `legal_review` (1) — **aligned**.
+- `audit_run` (2), `audit_result` (1), `compliance_pass` (1), `accessibility_audit` (1) — **aligned**, add `audit` family.
+- `claim` (6) — **aligned**, add.
+
+### `portfolio` bundle (P1)
+
+- `holding` (in schema_definitions, low production) — **match**.
+- `competitive_analysis` (42), `partnership_analysis` (15), `strategic_analysis` (4), `strategic_research` (4), `market_research` (2) — **gap** → strategy/research cluster. Recommend: split between `portfolio` (investor-facing) and a new `research` sub-area or `diligence` bundle.
+- `business_opportunity` (1), `financial_opportunity` (1) — **aligned**, add to `portfolio`.
+
+### `customer_ops` bundle (P2)
+
+- `product_feedback` (129) — **match-ish**, add to customer_ops (or to a `product` bundle — see gap below).
+- `feedback` (13), `feedback_note` (16), `feedback_analysis` (16), `feedback_aggregate_analysis` (3), `feedback_finding` (4), `feedback_artifact` (6), `feedback_scan` (2), `tester_feedback` (3), `user_feedback` (2), `social_feedback` (3), `ui_feedback` (9), `ui_copy_feedback` (5), `process_feedback` (1), `design_feedback` (1), `documentation_feedback` (3) — **gap** → product feedback cluster. Recommend: dedicate `product_feedback` family within `customer_ops`, or split into a new `product` bundle.
+- `bug_report` already in devops (overlap — disambiguate by `category`).
+- `tester_program` (1), `developer_release_tester` (52) — **aligned**, add.
+
+### New bundle proposal: `product` (P1, not in original catalog)
+
+**Rationale:** `product_feedback` (129) + feedback family + product analysis types form a cluster larger than several P2 bundles combined. This is owner's product-development workflow.
+
+- `product_feedback` (129)
+- `feedback`, `feedback_note`, `feedback_analysis`, `feedback_aggregate_analysis`, `feedback_finding`, `feedback_artifact`, `feedback_scan`
+- `product_decision` (2), `product_question` (1), `product_decision_question` (1), `product_announcement` (2), `product_analysis` (1), `product_behavior` (1), `product_copy_request` (1)
+- `user_persona_insight` (1), `target_persona` (1)
+- `feature_request` (19) — overlap with devops; disambiguate: customer-facing → product, internal-engineering → devops.
+
+### New bundle proposal: `crypto_finance` (P2, not in original catalog)
+
+**Rationale:** Owner has 159 crypto-wallet entities. Outside `crypto_engineering` (which is about security-sensitive engineering). Distinct domain.
+
+- `crypto_wallet` (73)
+- `crypto_wallet_address` (86)
+- `crypto_transaction` family (existing in schema_definitions)
+- `holding` (overlap with portfolio — disambiguate by `category: crypto`)
+
+### `research` (overlapping gap — defer)
+
+- `technical_research` (102), `legal_research` (19), `market_research` (2), `strategic_research` (4), `competitive_analysis` (42), `partnership_analysis` (15) — distributed across several bundles; do not create a standalone `research` bundle. Each goes to its domain bundle.
+
+### Site / web content (gap, candidate for `web` or `content` bundle — defer)
+
+- `web_page` (11), `website` (3), `website_domain` (1), `website_page` (1), `web_reference` (2), `web_console_warning` (1), `web_fetch_issue` (1)
+- `page` (5), `page` (1)
+- `link` (9), `external_link` (5)
+- `article` (7), `research_article` (2), `scraped_content` (1)
+- **Recommendation:** add `web_page`, `link`, `external_link` to `core` (universal references); leave the rest as noise.
+
+### UI/UX feedback cluster (consolidate into `product`)
+
+- `ui_change_request` (12), `ui_observation` (8), `ui_state` (5), `ui_screenshot` (5), `ui_copy_feedback` (5), `ui_request` (1), `ui_review` (2), `ui_render_issue` (3), `ui_section` (3), `ui_message_example` (3), `ui_page` (2), `ui_component` (1), `ui_context` (1), `ui_copy_bug` (1), `ui_error` (1) — fold into `product` bundle as `ui_*` family.
+
+### Image/media (gap → `media` bundle or add to `core`)
+
+- `image_asset` (107), `image` (5), `photo_album` (1), `visual_concept` (1), `visual_issue` (1), `screenshot_note` (4), `ui_screenshot` (5)
+- **Recommendation:** add `image_asset` and `image` to `core` (alongside `file_asset`); rest noise.
+
+### Internal/scaffolding (NOT bundled — Neotoma development artifacts)
+
+- `cross_layer_schema_*` (10 instances) — schema-debug entities, exclude from catalog.
+- `transcription_run`, `gmail_search_batch`, `mcp_server_status`, `oauth_*`, `auth_error` — internal-runtime. Keep in `devops` under category=internal.
+- `submission_config` (2) — already in `infrastructure`.
+- `env_var_mappings` (2) — internal config.
+- `guest_access_token` (619) — already in `infrastructure` family conceptually. Confirm.
+
+### Singletons (count ≤ 2, excluded from catalog scope)
+
+~120 types. Not addressed individually. Recommended action: leave in `evolving` mode if operator opts in, or promote to bundle catalog if they cluster meaningfully in a future review.
+
+## Summary delta vs original m5 catalog
+
+**New bundles to add:**
+
+1. `product` (P1) — covers product_feedback (129) + 14 feedback subtypes.
+2. `crypto_finance` (P2) — covers crypto_wallet (73) + crypto_wallet_address (86).
+
+**Bundles to expand `provides_entity_types`:**
+
+- `crm`: add `company`, `contact_group`, `outreach_interaction`.
+- `communications`: add `social_share_draft`, `post_idea`, `blog_post`, `email_thread`, `email_draft`.
+- `personal_data`: add `transcription` (high frequency: 739), `meeting_transcription`, `dispute` family, `standing_rule`, `preference`, `device`, `location`.
+- `devops`: add `bug_report`, `feature_request`, `architectural_decision`, `release`, `release_gate`, `dns_*` family, `mcp_*` family.
+- `compliance`: add `legal_research`, `audit` family, `claim`.
+- `core`: add `image_asset`, `image`, `web_page`, `link`, `external_link`.
+
+**Bundles unchanged:**
+
+- `financial_ops` (catalog already covers production types).
+- `contracts`, `portfolio`, `cases`, `diligence`, `procurement`, `customer_ops`, `trading`, `healthcare`, `logistics`, `government`, `agent_auth`, `crypto_engineering` — production data thin; honor site catalog as-is.
+
+**Bundles total: 20** (16 site use cases + `devops` + `product` + `crypto_finance` + adjustments above).

--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -134,6 +134,7 @@ flowchart TD
 - `tests/unit/attribution_policy.test.ts`
 - `tests/unit/bigint_serialization.test.ts`
 - `tests/unit/bundled_docs_nav.test.ts`
+- `tests/unit/bundles_loader.test.ts`
 - `tests/unit/canonical_markdown_body_heading.test.ts`
 - `tests/unit/capability_delta.test.ts`
 - `tests/unit/cli_aauth_tbs_attestation.test.ts`

--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,15 +61,15 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **504**
-- Backend and repo Vitest files: **470**
+- Total automated test files: **507**
+- Backend and repo Vitest files: **473**
 - Frontend Vitest files: **9**
 - Playwright spec files: **25**
 
 ### Suite counts
 | Suite | Files |
 |---|---:|
-| Vitest unit tests | 138 |
+| Vitest unit tests | 139 |
 | Vitest service tests | 35 |
 | Source-adjacent tests | 62 |
 | Vitest integration tests | 143 |
@@ -109,7 +109,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/unit`
 **Requirements:** Basic `.env` if required by the module under test.
-**Files (138):**
+**Files (139):**
 - `tests/unit/aauth_admission.test.ts`
 - `tests/unit/aauth_attestation_apple_se.test.ts`
 - `tests/unit/aauth_attestation_revocation.test.ts`

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "scripts": {
     "pretest": "npm run build:server",
     "build": "npm run build:server && npm run build:inspector",
-    "build:server": "tsc && node scripts/copy_pdf_worker_wrapper.js && npm run build:scripts && npm run build:bundled-docs",
+    "build:server": "tsc && node scripts/copy_pdf_worker_wrapper.js && node scripts/copy_bundle_assets.js && npm run build:scripts && npm run build:bundled-docs",
+    "bundles:check": "tsx scripts/bundles_check.ts",
     "build:bundled-docs": "tsx scripts/build_bundled_docs.ts",
     "build:scripts": "tsc -p tsconfig.scripts.json",
     "build:inspector": "node scripts/build_inspector.js",

--- a/scripts/bundles_check.ts
+++ b/scripts/bundles_check.ts
@@ -1,0 +1,124 @@
+#!/usr/bin/env tsx
+/**
+ * `npm run bundles:check` — bundle manifest linter (Bundles m2).
+ *
+ * Validates the bundle set under `src/services/bundles/`:
+ *
+ *   1. Every bundle has a well-formed `manifest.yaml` (parser enforces required
+ *      fields, types, and the skill-bundle empty-`provides_entity_types` rule).
+ *   2. `provides_entity_types` is empty for skill bundles (re-checked here for a
+ *      precise lint message even though the parser already rejects it).
+ *   3. Shared-schema ownership is consistent: any entity type referenced by 2+
+ *      bundles (via `references_shared_schemas` or `provides_entity_types`) must
+ *      have a descriptor in `_shared_schemas/<type>.ts` exporting `originated_by`.
+ *   4. `requires_bundles` resolve to installed bundles (no missing deps, no
+ *      cycles).
+ *
+ * Exit 0 on success, 1 on any violation. Pure filesystem read; no network.
+ *
+ * Tracking: Neotoma plan `ent_089da2ecebc3bd804d63dcf2` (Bundles Strategy).
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { ManifestError, loadBundlesFrom, resolveRequires } from "../src/services/bundles/index.js";
+import type { LoadedBundle } from "../src/services/bundles/index.js";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const bundlesDir = path.resolve(here, "..", "src", "services", "bundles");
+const sharedDir = path.join(bundlesDir, "_shared_schemas");
+
+const errors: string[] = [];
+
+function fail(msg: string): void {
+  errors.push(msg);
+}
+
+let bundles: LoadedBundle[] = [];
+try {
+  bundles = loadBundlesFrom(bundlesDir);
+} catch (err) {
+  fail(err instanceof ManifestError ? err.message : String(err));
+}
+
+if (bundles.length === 0 && errors.length === 0) {
+  fail(`no bundles discovered under ${bundlesDir}`);
+}
+
+// (2) skill bundles have empty provides_entity_types.
+for (const b of bundles) {
+  if (b.manifest.bundle_type === "skill" && b.manifest.provides_entity_types.length > 0) {
+    fail(`bundle "${b.manifest.name}": skill bundles must have empty provides_entity_types`);
+  }
+}
+
+// (4) requires_bundles resolve (and no cycles).
+try {
+  resolveRequires(bundles);
+} catch (err) {
+  fail(err instanceof ManifestError ? err.message : String(err));
+}
+
+// (3) shared-schema ownership consistency.
+// Count, per entity type, how many bundles touch it via provides or references.
+const refsByType = new Map<string, Set<string>>();
+for (const b of bundles) {
+  const touched = new Set<string>([
+    ...b.manifest.provides_entity_types,
+    ...b.manifest.references_shared_schemas,
+  ]);
+  for (const t of touched) {
+    if (!refsByType.has(t)) refsByType.set(t, new Set());
+    refsByType.get(t)!.add(b.manifest.name);
+  }
+}
+
+function sharedDescriptorExists(type: string): boolean {
+  const file = path.join(sharedDir, `${type}.ts`);
+  if (!fs.existsSync(file)) return false;
+  const src = fs.readFileSync(file, "utf8");
+  // Require an originated_by attribution in the descriptor.
+  return /originated_by\s*:/.test(src);
+}
+
+for (const [type, bundleNames] of refsByType) {
+  if (bundleNames.size >= 2) {
+    if (!sharedDescriptorExists(type)) {
+      fail(
+        `entity type "${type}" is referenced by ${bundleNames.size} bundles ` +
+          `(${[...bundleNames].sort().join(", ")}) but has no shared-schema ` +
+          `descriptor with originated_by at _shared_schemas/${type}.ts`
+      );
+    }
+  }
+}
+
+// Also: any bundle that declares references_shared_schemas: [X] must have a
+// descriptor for X (the second reference triggers ownership transfer; the
+// descriptor is the recorded result).
+for (const b of bundles) {
+  for (const type of b.manifest.references_shared_schemas) {
+    if (!sharedDescriptorExists(type)) {
+      fail(
+        `bundle "${b.manifest.name}" references shared schema "${type}" but ` +
+          `_shared_schemas/${type}.ts is missing or lacks originated_by`
+      );
+    }
+  }
+}
+
+if (errors.length > 0) {
+  console.error(`bundles:check FAILED with ${errors.length} issue(s):`);
+  for (const e of errors) console.error(`  - ${e}`);
+  process.exit(1);
+}
+
+console.log(
+  `bundles:check OK — ${bundles.length} bundle(s) validated ` +
+    `(${bundles
+      .map((b) => b.manifest.name)
+      .sort()
+      .join(", ")}).`
+);

--- a/scripts/copy_bundle_assets.js
+++ b/scripts/copy_bundle_assets.js
@@ -1,0 +1,52 @@
+/**
+ * Build-time bundle-asset copier (Bundles m2).
+ *
+ * `tsc` compiles the `.ts` files under `src/services/bundles/` to
+ * `dist/services/bundles/`, but does NOT copy the non-TS bundle assets
+ * (`manifest.yaml`, `skills/**\/SKILL.md`, `use_cases/*.yaml`,
+ * `use_cases/README.md`). The runtime loader anchors on its compiled module
+ * location, so it needs those assets beside the compiled JS. This script mirrors
+ * every non-`.ts` file under `src/services/bundles/` into
+ * `dist/services/bundles/`.
+ *
+ * Deterministic: a pure copy of the source tree's non-TS files.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..");
+const srcRoot = path.join(repoRoot, "src", "services", "bundles");
+const dstRoot = path.join(repoRoot, "dist", "services", "bundles");
+
+let copied = 0;
+
+function walk(srcDir, dstDir) {
+  let entries;
+  try {
+    entries = fs.readdirSync(srcDir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const src = path.join(srcDir, entry.name);
+    const dst = path.join(dstDir, entry.name);
+    if (entry.isDirectory()) {
+      walk(src, dst);
+    } else if (!entry.name.endsWith(".ts")) {
+      fs.mkdirSync(dstDir, { recursive: true });
+      fs.copyFileSync(src, dst);
+      copied += 1;
+    }
+  }
+}
+
+if (!fs.existsSync(srcRoot)) {
+  console.error(`[copy_bundle_assets] source not found: ${srcRoot}`);
+  process.exit(0);
+}
+
+walk(srcRoot, dstRoot);
+console.log(`[copy_bundle_assets] copied ${copied} bundle asset file(s) to dist/services/bundles`);

--- a/src/server.ts
+++ b/src/server.ts
@@ -5391,6 +5391,18 @@ export class NeotomaServer {
       }
 
       if (!schema) {
+        // Bundles m2: gate auto-create on the configured schema mode. Default
+        // mode `evolving` always allows (parity). `guided` permits only
+        // bundle-provided types; `locked` blocks all auto-create.
+        const { checkAutoCreateAllowed } = await import("./services/bundles/index.js");
+        const autoCreateDecision = checkAutoCreateAllowed(entityType);
+        if (!autoCreateDecision.allowed) {
+          throw new McpError(
+            ErrorCode.InvalidParams,
+            `ERR_SCHEMA_MODE_${autoCreateDecision.reason.toUpperCase()}: ${autoCreateDecision.message}`
+          );
+        }
+
         // Auto-create user-specific schema from structured data
         logger.error(`[STORE] No schema found for "${entityType}", inferring from data structure`);
 

--- a/src/services/bundles/_shared_schemas/interaction.ts
+++ b/src/services/bundles/_shared_schemas/interaction.ts
@@ -1,0 +1,17 @@
+/**
+ * Shared schema: `interaction` (Bundles m2).
+ *
+ * Originated by `core`; referenced by `core_workflows` (the session-loop skills
+ * record session interactions). Ownership transferred to `_shared_schemas/` at
+ * the second reference per `docs/foundation/bundles.md`.
+ */
+
+import type { SharedSchemaRef } from "./shared_schema.js";
+
+export const interactionSharedSchema: SharedSchemaRef = {
+  entity_type: "interaction",
+  originated_by: "core",
+  description: "A single session interaction (start-session / get-context turn record).",
+};
+
+export default interactionSharedSchema;

--- a/src/services/bundles/_shared_schemas/session_close.ts
+++ b/src/services/bundles/_shared_schemas/session_close.ts
@@ -1,0 +1,17 @@
+/**
+ * Shared schema: `session_close` (Bundles m2).
+ *
+ * Originated by `core`; referenced by `core_workflows` (the close-session skill
+ * records a session-close summary). Ownership transferred to `_shared_schemas/`
+ * at the second reference per `docs/foundation/bundles.md`.
+ */
+
+import type { SharedSchemaRef } from "./shared_schema.js";
+
+export const sessionCloseSharedSchema: SharedSchemaRef = {
+  entity_type: "session_close",
+  originated_by: "core",
+  description: "A session-close summary record produced by the close-session skill.",
+};
+
+export default sessionCloseSharedSchema;

--- a/src/services/bundles/_shared_schemas/shared_schema.ts
+++ b/src/services/bundles/_shared_schemas/shared_schema.ts
@@ -1,0 +1,24 @@
+/**
+ * Shared-schema descriptor (Bundles m2 runtime).
+ *
+ * Path `src/services/bundles/_shared_schemas/` holds the canonical descriptor for
+ * any entity type used by 2+ bundles (see `docs/foundation/bundles.md` ->
+ * "Shared schemas"). When bundle B declares `references_shared_schemas: [X]` for
+ * a type X originated in bundle A, the descriptor records `originated_by: A`.
+ *
+ * In m2 these descriptors carry ownership metadata only; the runtime entity
+ * schema continues to come from the existing registry / `schema_definitions.ts`
+ * when present. The `bundles:check` linter validates that every type referenced
+ * by 2+ bundles has a matching descriptor here with a consistent `originated_by`.
+ *
+ * Tracking: Neotoma plan `ent_089da2ecebc3bd804d63dcf2` (Bundles Strategy).
+ */
+
+export interface SharedSchemaRef {
+  /** Entity type this shared schema describes. */
+  entity_type: string;
+  /** Bundle that originated the schema (ownership transferred at 2nd reference). */
+  originated_by: string;
+  /** One-line description. */
+  description: string;
+}

--- a/src/services/bundles/core/manifest.yaml
+++ b/src/services/bundles/core/manifest.yaml
@@ -1,0 +1,29 @@
+# Bundle manifest — see docs/foundation/bundles.md
+# Default install: schema bundle, always active.
+name: core
+version: 1.0.0
+description: Core entity types every Neotoma install ships with.
+bundle_type: schema
+requires_bundles: []
+provides_entity_types:
+  - conversation
+  - conversation_message
+  - agent_message
+  - note
+  - task
+  - event
+  - contact
+  - file_asset
+  - document
+# Shared schemas added to core by other default-install bundles (core_workflows)
+# live in ../_shared_schemas/ once a second consumer triggers ownership transfer.
+references_shared_schemas: []
+extends_schemas: []
+provides_skills: []
+compatible_modes:
+  - evolving
+  - guided
+  - locked
+category: core
+serves_use_cases:
+  - personal_data

--- a/src/services/bundles/core_workflows/manifest.yaml
+++ b/src/services/bundles/core_workflows/manifest.yaml
@@ -1,0 +1,56 @@
+# Bundle manifest — see docs/foundation/bundles.md
+# Default install: skill bundle, always active.
+# Delivers the session-loop skills and adds `interaction` + `session_close`
+# shared schemas to core (see ../_shared_schemas/).
+name: core_workflows
+version: 1.0.0
+description: Session-loop skills (start-session, get-context, close-session) plus session shared schemas.
+bundle_type: skill
+requires_bundles:
+  - core
+# skill bundles MUST have empty provides_entity_types (enforced by the parser).
+provides_entity_types: []
+# These shared schemas are reused (not re-registered) by this bundle; their
+# canonical SchemaDefinition + originated_by live in ../_shared_schemas/.
+references_shared_schemas:
+  - interaction
+  - session_close
+extends_schemas: []
+provides_skills:
+  - name: start-session
+    depth: core
+    requires_entity_types:
+      - interaction
+      - conversation
+  - name: get-context
+    depth: core
+    requires_entity_types:
+      - interaction
+      - conversation
+  - name: close-session
+    depth: core
+    requires_entity_types:
+      - session_close
+      - interaction
+compatible_modes:
+  - evolving
+  - guided
+  - locked
+category: core_workflows
+serves_use_cases:
+  - agent_auth
+  - cases
+  - compliance
+  - contracts
+  - crm
+  - crypto_engineering
+  - customer_ops
+  - diligence
+  - financial_ops
+  - government
+  - healthcare
+  - logistics
+  - personal_data
+  - portfolio
+  - procurement
+  - trading

--- a/src/services/bundles/core_workflows/skills/close-session/SKILL.md
+++ b/src/services/bundles/core_workflows/skills/close-session/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: close-session
+description: Close a Neotoma working session — store the assistant reply and a session-close summary.
+source: neotoma_bundle:core_workflows
+requires_entity_types:
+  - session_close
+  - interaction
+triggers:
+  - close session
+  - end session
+  - wrap up
+---
+
+# Close session
+
+Closes the working session at the end of a turn:
+
+1. Store the assistant reply as the closing `interaction`.
+2. Write a `session_close` summary of what changed this session.
+3. Update any bound plan / todos touched during the session.
+
+Ships from the `core_workflows` bundle (default install). See
+`docs/foundation/bundles.md`.

--- a/src/services/bundles/core_workflows/skills/get-context/SKILL.md
+++ b/src/services/bundles/core_workflows/skills/get-context/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: get-context
+description: Retrieve the bounded context for the current session — recent interactions and relevant entities.
+source: neotoma_bundle:core_workflows
+requires_entity_types:
+  - interaction
+  - conversation
+triggers:
+  - get context
+  - load context
+  - what do you know
+---
+
+# Get context
+
+Performs bounded retrieval for the active session:
+
+1. Pull recent `interaction` records for the current `conversation`.
+2. Retrieve entities implied by the user message (by identifier or category).
+3. Return a compact context summary the agent reasons over this turn.
+
+Ships from the `core_workflows` bundle (default install). See
+`docs/foundation/bundles.md`.

--- a/src/services/bundles/core_workflows/skills/start-session/SKILL.md
+++ b/src/services/bundles/core_workflows/skills/start-session/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: start-session
+description: Begin a Neotoma working session — open a conversation and record the opening interaction.
+source: neotoma_bundle:core_workflows
+requires_entity_types:
+  - interaction
+  - conversation
+triggers:
+  - start session
+  - begin session
+  - open conversation
+---
+
+# Start session
+
+Opens a Neotoma working session at the top of a turn:
+
+1. Resolve or create the `conversation` entity for this thread.
+2. Record an opening `interaction` capturing the user's first message.
+3. Surface any bound plan / context the session should carry forward.
+
+Ships from the `core_workflows` bundle (default install). See
+`docs/foundation/bundles.md`.

--- a/src/services/bundles/enforcement.ts
+++ b/src/services/bundles/enforcement.ts
@@ -1,0 +1,86 @@
+/**
+ * Schema-mode auto-create enforcement (Bundles m2 runtime).
+ *
+ * Single decision function consulted at the two auto-create points
+ * (`src/server.ts` structured-store inference and
+ * `src/services/interpretation.ts` extracted-entity schema creation). Gated on
+ * {@link getSchemaMode}:
+ *
+ *   - `evolving` (default): always allowed. PARITY — the default install is a
+ *     no-op for existing users; any entity type may auto-create.
+ *   - `guided`: allowed only if an installed/enabled bundle provides the type.
+ *     Otherwise rejected with a structured error naming the providing bundle
+ *     (or "no bundle provides this type").
+ *   - `locked`: never allowed; rejected with an instruction to register
+ *     explicitly.
+ *
+ * The decision is pure data — call sites decide how to surface a rejection
+ * (throw, structured MCP error, raw_fragment). Centralizing it keeps the two
+ * gates identical.
+ *
+ * Tracking: Neotoma plan `ent_089da2ecebc3bd804d63dcf2` (Bundles Strategy).
+ */
+
+import { getSchemaMode, type SchemaMode } from "../schema_mode.js";
+import { bundleProviding } from "./loader.js";
+
+/** Why an auto-create was blocked. */
+export type AutoCreateBlockReason = "guided_unprovided" | "locked";
+
+/** Result of an auto-create gating check. */
+export type AutoCreateDecision =
+  | { allowed: true }
+  | {
+      allowed: false;
+      reason: AutoCreateBlockReason;
+      mode: SchemaMode;
+      entityType: string;
+      /** Bundle that would provide the type under `guided`, if any. */
+      providingBundle?: string;
+      /** Human-readable, structured-error-ready message. */
+      message: string;
+    };
+
+/**
+ * Decide whether `entityType` may auto-create under the current schema mode.
+ * `modeOverride` is for testing; production passes nothing and reads the env.
+ */
+export function checkAutoCreateAllowed(
+  entityType: string,
+  modeOverride?: SchemaMode
+): AutoCreateDecision {
+  const mode = modeOverride ?? getSchemaMode();
+
+  if (mode === "evolving") {
+    return { allowed: true };
+  }
+
+  if (mode === "locked") {
+    return {
+      allowed: false,
+      reason: "locked",
+      mode,
+      entityType,
+      message:
+        `Schema mode is "locked": auto-creating entity type "${entityType}" is not ` +
+        `permitted. Register the type explicitly via an installed bundle ` +
+        `(register_schema) before writing entities of this type.`,
+    };
+  }
+
+  // guided
+  const providingBundle = bundleProviding(entityType);
+  if (providingBundle) {
+    return { allowed: true };
+  }
+  return {
+    allowed: false,
+    reason: "guided_unprovided",
+    mode,
+    entityType,
+    message:
+      `Schema mode is "guided": entity type "${entityType}" is not provided by any ` +
+      `installed bundle, so it cannot auto-create. No bundle provides this type — ` +
+      `register it explicitly (register_schema) or install a bundle that provides it.`,
+  };
+}

--- a/src/services/bundles/index.ts
+++ b/src/services/bundles/index.ts
@@ -1,0 +1,30 @@
+/**
+ * Bundles runtime public surface (Bundles m2).
+ *
+ * See `docs/foundation/bundles.md`. Plan `ent_089da2ecebc3bd804d63dcf2`.
+ */
+
+export type {
+  BundleManifest,
+  BundleSkillSpec,
+  BundleType,
+  LoadedBundle,
+  RawBundleManifest,
+} from "./types.js";
+export { ManifestError, normalizeManifest, parseManifest } from "./manifest.js";
+export {
+  bundleProviding,
+  bundlesRootDir,
+  buildRegistry,
+  getBundleRegistry,
+  getProvidedEntityTypes,
+  loadBundlesFrom,
+  resetBundleRegistryForTesting,
+  resolveRequires,
+  type BundleRegistry,
+} from "./loader.js";
+export {
+  checkAutoCreateAllowed,
+  type AutoCreateBlockReason,
+  type AutoCreateDecision,
+} from "./enforcement.js";

--- a/src/services/bundles/infrastructure/manifest.yaml
+++ b/src/services/bundles/infrastructure/manifest.yaml
@@ -1,0 +1,24 @@
+# Bundle manifest — see docs/foundation/bundles.md
+# Default install: schema bundle, always active.
+name: infrastructure
+version: 1.0.0
+description: Infrastructure entity types for sessions, issues, plans, sync, and abuse reporting.
+bundle_type: schema
+requires_bundles: []
+provides_entity_types:
+  - issue
+  - plan
+  - subscription
+  - submission_config
+  - peer_config
+  - sandbox_abuse_report
+references_shared_schemas: []
+extends_schemas: []
+provides_skills: []
+compatible_modes:
+  - evolving
+  - guided
+  - locked
+category: infrastructure
+serves_use_cases:
+  - agent_auth

--- a/src/services/bundles/loader.ts
+++ b/src/services/bundles/loader.ts
@@ -1,0 +1,187 @@
+/**
+ * Bundle loader + registry (Bundles m2 runtime).
+ *
+ * Discovers bundle directories under `src/services/bundles/<name>/` (each with a
+ * `manifest.yaml`), parses + validates their manifests, resolves
+ * `requires_bundles`, and exposes "which entity types are provided by the
+ * installed/enabled bundles". This is the data source the mode-enforcement
+ * gating in `server.ts` and `interpretation.ts` consults under `guided`.
+ *
+ * The provided-types set is cached for the process lifetime (the default-install
+ * bundles are static). {@link resetBundleRegistryForTesting} clears the cache so
+ * tests can point the loader at fixtures.
+ *
+ * Path resolution: bundle manifests live under `src/` (dev/tsx/vitest) and are
+ * copied to `dist/services/bundles/` by `scripts/copy_bundle_assets.js` at build
+ * time, so {@link bundlesRootDir} resolves correctly in both layouts by anchoring
+ * on this module's own location.
+ *
+ * Tracking: Neotoma plan `ent_089da2ecebc3bd804d63dcf2` (Bundles Strategy).
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { logger } from "../../utils/logger.js";
+import { ManifestError, parseManifest } from "./manifest.js";
+import type { BundleManifest, LoadedBundle } from "./types.js";
+
+/**
+ * Directories that are part of the bundles service but are NOT bundles
+ * themselves (no manifest.yaml). Skipped during discovery.
+ */
+const NON_BUNDLE_DIRS = new Set(["_shared_schemas", "use_cases"]);
+
+/** Absolute path to the directory holding bundle subdirectories. */
+export function bundlesRootDir(): string {
+  return path.dirname(fileURLToPath(import.meta.url));
+}
+
+function discoverBundleDirs(root: string): string[] {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(root, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const dirs: string[] = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    if (entry.name.startsWith("_") || entry.name.startsWith(".")) continue;
+    if (NON_BUNDLE_DIRS.has(entry.name)) continue;
+    const dir = path.join(root, entry.name);
+    if (fs.existsSync(path.join(dir, "manifest.yaml"))) {
+      dirs.push(dir);
+    }
+  }
+  return dirs.sort();
+}
+
+/**
+ * Load and parse every bundle manifest under `root` (defaults to the real
+ * bundles dir). Throws {@link ManifestError} if any manifest is malformed.
+ */
+export function loadBundlesFrom(root: string): LoadedBundle[] {
+  const dirs = discoverBundleDirs(root);
+  const bundles: LoadedBundle[] = [];
+  for (const dir of dirs) {
+    const manifestPath = path.join(dir, "manifest.yaml");
+    const source = fs.readFileSync(manifestPath, "utf8");
+    const manifest = parseManifest(source, path.relative(root, manifestPath));
+    bundles.push({ manifest, dir, enabled: true });
+  }
+  return bundles;
+}
+
+/**
+ * Resolve `requires_bundles` across the loaded set: every required bundle must
+ * exist among the loaded bundles. Throws {@link ManifestError} on a missing
+ * dependency or a cycle, so install-time gaps surface loudly.
+ */
+export function resolveRequires(bundles: LoadedBundle[]): void {
+  const byName = new Map(bundles.map((b) => [b.manifest.name, b]));
+  for (const b of bundles) {
+    for (const dep of b.manifest.requires_bundles) {
+      if (!byName.has(dep)) {
+        throw new ManifestError(
+          `bundle "${b.manifest.name}" requires_bundles "${dep}" which is not installed`
+        );
+      }
+    }
+  }
+  // Cycle detection (DFS) — defensive; the default install is acyclic.
+  const visiting = new Set<string>();
+  const done = new Set<string>();
+  const visit = (name: string, stack: string[]): void => {
+    if (done.has(name)) return;
+    if (visiting.has(name)) {
+      throw new ManifestError(`requires_bundles cycle detected: ${[...stack, name].join(" -> ")}`);
+    }
+    visiting.add(name);
+    const node = byName.get(name);
+    for (const dep of node?.manifest.requires_bundles ?? []) {
+      visit(dep, [...stack, name]);
+    }
+    visiting.delete(name);
+    done.add(name);
+  };
+  for (const b of bundles) visit(b.manifest.name, []);
+}
+
+/** A loaded, dependency-resolved bundle registry. */
+export interface BundleRegistry {
+  bundles: LoadedBundle[];
+  /** Entity types provided by any enabled bundle -> the bundle name that provides it. */
+  providedEntityTypes: Map<string, string>;
+}
+
+/**
+ * Build a {@link BundleRegistry} from a set of loaded bundles: resolves
+ * `requires_bundles` and computes the provided-entity-types index from enabled
+ * bundles only.
+ */
+export function buildRegistry(bundles: LoadedBundle[]): BundleRegistry {
+  resolveRequires(bundles);
+  const providedEntityTypes = new Map<string, string>();
+  for (const b of bundles) {
+    if (!b.enabled) continue;
+    for (const t of b.manifest.provides_entity_types) {
+      if (!providedEntityTypes.has(t)) {
+        providedEntityTypes.set(t, b.manifest.name);
+      }
+    }
+  }
+  return { bundles, providedEntityTypes };
+}
+
+let cached: BundleRegistry | undefined;
+
+/**
+ * Returns the default-install bundle registry (all bundles discovered under the
+ * real bundles dir), cached for the process lifetime. Fail-open: if discovery or
+ * parsing fails, logs and returns an empty registry so a manifest mistake never
+ * crashes the server — enforcement then treats every type as unprovided under
+ * `guided`/`locked` and as provided under `evolving` (default), preserving
+ * parity for the default mode.
+ */
+export function getBundleRegistry(): BundleRegistry {
+  if (cached !== undefined) return cached;
+  try {
+    cached = buildRegistry(loadBundlesFrom(bundlesRootDir()));
+  } catch (err) {
+    if (err instanceof ManifestError) {
+      logger.error(`[bundles] failed to load bundle registry: ${err.message}`);
+    } else {
+      logger.error(
+        `[bundles] unexpected error loading bundle registry: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+    }
+    cached = { bundles: [], providedEntityTypes: new Map() };
+  }
+  return cached;
+}
+
+/**
+ * Returns the set of entity types provided by installed/enabled bundles.
+ */
+export function getProvidedEntityTypes(): Set<string> {
+  return new Set(getBundleRegistry().providedEntityTypes.keys());
+}
+
+/**
+ * Returns the bundle name that provides `entityType`, or `undefined` if no
+ * enabled bundle provides it.
+ */
+export function bundleProviding(entityType: string): string | undefined {
+  return getBundleRegistry().providedEntityTypes.get(entityType);
+}
+
+/** Test-only: clears the cached registry so the next call re-discovers. */
+export function resetBundleRegistryForTesting(): void {
+  cached = undefined;
+}
+
+export type { BundleManifest, LoadedBundle };

--- a/src/services/bundles/manifest.ts
+++ b/src/services/bundles/manifest.ts
@@ -1,0 +1,175 @@
+/**
+ * `manifest.yaml` parser + validator (Bundles m2 runtime).
+ *
+ * Parses a bundle manifest YAML string into a normalized {@link BundleManifest},
+ * applying defaults from the doc's "manifest.yaml field reference" table and
+ * enforcing the structural invariants the doc locks:
+ *
+ *   - `name`, `version`, `description`, `bundle_type` are required.
+ *   - skill bundles MUST have empty `provides_entity_types`.
+ *   - `compatible_modes` defaults to all three lock postures.
+ *   - list fields default to empty lists.
+ *
+ * Parsing is total over well-formed input and throws a {@link ManifestError}
+ * with a precise message on malformed input, so the loader and the
+ * `bundles:check` linter can report exactly which bundle/field is wrong.
+ *
+ * Tracking: Neotoma plan `ent_089da2ecebc3bd804d63dcf2` (Bundles Strategy).
+ */
+
+import * as yaml from "js-yaml";
+
+import type { SchemaMode } from "../schema_mode.js";
+import type { BundleManifest, BundleSkillSpec, BundleType, RawBundleManifest } from "./types.js";
+
+const ALL_MODES: SchemaMode[] = ["evolving", "guided", "locked"];
+const BUNDLE_TYPES: ReadonlySet<string> = new Set<BundleType>(["schema", "skill"]);
+
+/** Thrown when a manifest is missing required fields or has the wrong shape. */
+export class ManifestError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ManifestError";
+  }
+}
+
+function asString(value: unknown, field: string, where: string): string {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new ManifestError(`${where}: field "${field}" must be a non-empty string`);
+  }
+  return value.trim();
+}
+
+function asStringList(value: unknown, field: string, where: string): string[] {
+  if (value === undefined || value === null) return [];
+  if (!Array.isArray(value)) {
+    throw new ManifestError(`${where}: field "${field}" must be a list`);
+  }
+  return value.map((item, i) => {
+    if (typeof item !== "string" || item.trim() === "") {
+      throw new ManifestError(`${where}: field "${field}[${i}]" must be a non-empty string`);
+    }
+    return item.trim();
+  });
+}
+
+function asSkills(value: unknown, where: string): BundleSkillSpec[] {
+  if (value === undefined || value === null) return [];
+  if (!Array.isArray(value)) {
+    throw new ManifestError(`${where}: field "provides_skills" must be a list`);
+  }
+  return value.map((item, i) => {
+    // Allow a bare string shorthand: "- skill_name".
+    if (typeof item === "string") {
+      return { name: asString(item, `provides_skills[${i}]`, where) };
+    }
+    if (typeof item !== "object" || item === null) {
+      throw new ManifestError(`${where}: field "provides_skills[${i}]" must be a string or object`);
+    }
+    const obj = item as Record<string, unknown>;
+    const spec: BundleSkillSpec = {
+      name: asString(obj.name, `provides_skills[${i}].name`, where),
+    };
+    if (obj.requires_entity_types !== undefined) {
+      spec.requires_entity_types = asStringList(
+        obj.requires_entity_types,
+        `provides_skills[${i}].requires_entity_types`,
+        where
+      );
+    }
+    if (obj.depth !== undefined) {
+      spec.depth = asString(obj.depth, `provides_skills[${i}].depth`, where);
+    }
+    return spec;
+  });
+}
+
+function asModes(value: unknown, where: string): SchemaMode[] {
+  if (value === undefined || value === null) return [...ALL_MODES];
+  const list = asStringList(value, "compatible_modes", where);
+  if (list.length === 0) return [...ALL_MODES];
+  for (const m of list) {
+    if (!ALL_MODES.includes(m as SchemaMode)) {
+      throw new ManifestError(
+        `${where}: field "compatible_modes" has invalid value "${m}" ` +
+          `(valid: ${ALL_MODES.join(", ")})`
+      );
+    }
+  }
+  return list as SchemaMode[];
+}
+
+/**
+ * Normalize a raw parsed manifest object into a {@link BundleManifest}, applying
+ * defaults and validating invariants. `where` is a human-readable locator
+ * (e.g. the manifest path) used in error messages.
+ */
+export function normalizeManifest(raw: RawBundleManifest, where: string): BundleManifest {
+  const name = asString(raw.name, "name", where);
+  const version = asString(raw.version, "version", where);
+  const description = asString(raw.description, "description", where);
+  const bundleTypeRaw = asString(raw.bundle_type, "bundle_type", where);
+  if (!BUNDLE_TYPES.has(bundleTypeRaw)) {
+    throw new ManifestError(
+      `${where}: field "bundle_type" must be "schema" or "skill" (got "${bundleTypeRaw}")`
+    );
+  }
+  const bundle_type = bundleTypeRaw as BundleType;
+
+  const provides_entity_types = asStringList(
+    raw.provides_entity_types,
+    "provides_entity_types",
+    where
+  );
+
+  // Doc invariant: skill bundles MUST have empty provides_entity_types.
+  if (bundle_type === "skill" && provides_entity_types.length > 0) {
+    throw new ManifestError(
+      `${where}: skill bundle "${name}" must have empty provides_entity_types ` +
+        `(got ${JSON.stringify(provides_entity_types)})`
+    );
+  }
+
+  const manifest: BundleManifest = {
+    name,
+    version,
+    description,
+    bundle_type,
+    requires_bundles: asStringList(raw.requires_bundles, "requires_bundles", where),
+    provides_entity_types,
+    references_shared_schemas: asStringList(
+      raw.references_shared_schemas,
+      "references_shared_schemas",
+      where
+    ),
+    extends_schemas: asStringList(raw.extends_schemas, "extends_schemas", where),
+    provides_skills: asSkills(raw.provides_skills, where),
+    compatible_modes: asModes(raw.compatible_modes, where),
+    serves_use_cases: asStringList(raw.serves_use_cases, "serves_use_cases", where),
+  };
+
+  if (raw.category !== undefined && raw.category !== null) {
+    manifest.category = asString(raw.category, "category", where);
+  }
+
+  return manifest;
+}
+
+/**
+ * Parse a YAML manifest string into a normalized {@link BundleManifest}.
+ * `where` is a locator used in error messages (defaults to "<manifest>").
+ */
+export function parseManifest(source: string, where = "<manifest>"): BundleManifest {
+  let parsed: unknown;
+  try {
+    parsed = yaml.load(source);
+  } catch (err) {
+    throw new ManifestError(
+      `${where}: failed to parse YAML: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new ManifestError(`${where}: manifest must be a YAML mapping`);
+  }
+  return normalizeManifest(parsed as RawBundleManifest, where);
+}

--- a/src/services/bundles/types.ts
+++ b/src/services/bundles/types.ts
@@ -1,0 +1,91 @@
+/**
+ * Bundle model types (Bundles m2 runtime).
+ *
+ * A **bundle** is the deliverable unit through which Neotoma ships schemas,
+ * record-type docs, and skills. See `docs/foundation/bundles.md` for the
+ * authoritative model. These types mirror the "manifest.yaml field reference"
+ * table in that doc.
+ *
+ * Tracking: Neotoma plan `ent_089da2ecebc3bd804d63dcf2` (Bundles Strategy).
+ */
+
+import type { SchemaMode } from "../schema_mode.js";
+
+/** Bundle classification. Schema bundles originate entity types; skill bundles ship skills. */
+export type BundleType = "schema" | "skill";
+
+/**
+ * A skill contributed by a bundle, with its declared dependencies and depth
+ * tier. The shape is intentionally permissive — `provides_skills` is parsed
+ * for surface validation only in m2; full skill auto-loading lands with the
+ * harness work tracked in plan `ent_b5a51d1395d206e10945b6b1` (Resolve #205).
+ */
+export interface BundleSkillSpec {
+  /** Skill name (snake_case or kebab-case, matching the SKILL.md dir). */
+  name: string;
+  /** Entity types the skill requires to function. */
+  requires_entity_types?: string[];
+  /** Depth tier (e.g. "core", "extended"). Informational in m2. */
+  depth?: string;
+}
+
+/**
+ * Parsed `manifest.yaml` for a bundle. Every field corresponds to a row in the
+ * doc's "manifest.yaml field reference" table. Optional fields default per the
+ * loader (see {@link normalizeManifest}).
+ */
+export interface BundleManifest {
+  /** Bundle identifier (snake_case). */
+  name: string;
+  /** Bundle version (semver). */
+  version: string;
+  /** One-line summary. */
+  description: string;
+  /** Bundle classification. */
+  bundle_type: BundleType;
+  /** Bundle dependencies. Resolved at install time. */
+  requires_bundles: string[];
+  /** Types this bundle *originates*. MUST be empty for skill bundles. */
+  provides_entity_types: string[];
+  /** Shared schemas this bundle reuses without re-registering. */
+  references_shared_schemas: string[];
+  /** Explicit field-level extensions to schemas owned elsewhere. */
+  extends_schemas: string[];
+  /** Skill names with their dependencies and depth tiers. */
+  provides_skills: BundleSkillSpec[];
+  /** Lock postures supported. Defaults to all three. */
+  compatible_modes: SchemaMode[];
+  /** Populates the existing `SchemaMetadata.category` field. */
+  category?: string;
+  /** Informational. Use-case ids the bundle contributes to. */
+  serves_use_cases: string[];
+}
+
+/**
+ * A discovered bundle: its parsed manifest plus the absolute directory it was
+ * loaded from. `enabled` reflects install state (m2 default install bundles are
+ * always enabled; disable support is modeled but no disable surface ships yet).
+ */
+export interface LoadedBundle {
+  manifest: BundleManifest;
+  /** Absolute path to the bundle directory containing manifest.yaml. */
+  dir: string;
+  /** Whether the bundle is enabled (active for auto-create gating). */
+  enabled: boolean;
+}
+
+/** Raw (unnormalized) manifest shape as parsed from YAML, before defaulting. */
+export interface RawBundleManifest {
+  name?: unknown;
+  version?: unknown;
+  description?: unknown;
+  bundle_type?: unknown;
+  requires_bundles?: unknown;
+  provides_entity_types?: unknown;
+  references_shared_schemas?: unknown;
+  extends_schemas?: unknown;
+  provides_skills?: unknown;
+  compatible_modes?: unknown;
+  category?: unknown;
+  serves_use_cases?: unknown;
+}

--- a/src/services/bundles/use_cases/README.md
+++ b/src/services/bundles/use_cases/README.md
@@ -1,0 +1,29 @@
+# Machine-readable use-case → bundle map
+
+Each `<use_case>.yaml` here mirrors a row of the "Reconciled bundle catalog"
+table in `docs/foundation/bundles.md`. The map is many-to-many: a use case lists
+the bundles that together serve it; `core` and `infrastructure` are implicit
+(always active) and `core_workflows` is included by every use case.
+
+Schema fields per file:
+
+```yaml
+use_case: <id>            # matches docs/use_cases/<id>.md
+description: <one line>
+schema_bundles: [...]     # schema bundles required (excludes implicit core/infra)
+skill_bundles: [...]      # skill bundles (always includes core_workflows)
+```
+
+## Scope (m2)
+
+Real bundle directories exist only for `core`, `infrastructure`, and
+`core_workflows`. The 12 new schema bundles in the catalog (`agent_auth`,
+`cases`, `compliance`, `crm`, `communications`, `crypto_engineering`,
+`customer_ops`, `diligence`, `financial_ops`, `government`, `healthcare`,
+`logistics`, `personal_data`, `portfolio`, `procurement`, `trading`) are
+**catalog references only** in m2 — these YAML files name them but no bundle dir
+ships yet.
+
+Representative entries are scaffolded below. The full set of 16 use cases is
+tracked as a follow-up; entries not yet written are listed as TODO in the m2 PR
+body.

--- a/src/services/bundles/use_cases/agent_auth.yaml
+++ b/src/services/bundles/use_cases/agent_auth.yaml
@@ -1,0 +1,4 @@
+use_case: agent_auth
+description: Agent authorization and capability scoping.
+schema_bundles: [infrastructure, agent_auth]
+skill_bundles: [core_workflows]

--- a/src/services/bundles/use_cases/cases.yaml
+++ b/src/services/bundles/use_cases/cases.yaml
@@ -1,0 +1,4 @@
+use_case: cases
+description: Legal cases and investigation casework.
+schema_bundles: [cases, crm]
+skill_bundles: [core_workflows]

--- a/src/services/bundles/use_cases/compliance.yaml
+++ b/src/services/bundles/use_cases/compliance.yaml
@@ -1,0 +1,4 @@
+use_case: compliance
+description: Vendor risk and regulatory compliance.
+schema_bundles: [contracts, compliance]
+skill_bundles: [core_workflows]

--- a/src/services/bundles/use_cases/contracts.yaml
+++ b/src/services/bundles/use_cases/contracts.yaml
@@ -1,0 +1,4 @@
+use_case: contracts
+description: Contract lifecycle management.
+schema_bundles: [contracts]
+skill_bundles: [core_workflows]

--- a/src/services/bundles/use_cases/crm.yaml
+++ b/src/services/bundles/use_cases/crm.yaml
@@ -1,0 +1,4 @@
+use_case: crm
+description: Customer relationship management.
+schema_bundles: [crm, communications]
+skill_bundles: [core_workflows]

--- a/src/services/bundles/use_cases/crypto_engineering.yaml
+++ b/src/services/bundles/use_cases/crypto_engineering.yaml
@@ -1,0 +1,4 @@
+use_case: crypto_engineering
+description: Crypto and security engineering.
+schema_bundles: [crypto_engineering]
+skill_bundles: [core_workflows]

--- a/src/services/bundles/use_cases/customer_ops.yaml
+++ b/src/services/bundles/use_cases/customer_ops.yaml
@@ -1,0 +1,4 @@
+use_case: customer_ops
+description: Support and CX operations.
+schema_bundles: [crm, customer_ops]
+skill_bundles: [core_workflows]

--- a/src/services/bundles/use_cases/diligence.yaml
+++ b/src/services/bundles/use_cases/diligence.yaml
@@ -1,0 +1,4 @@
+use_case: diligence
+description: M&A and investment diligence.
+schema_bundles: [crm, financial_ops, contracts, diligence]
+skill_bundles: [core_workflows]

--- a/src/services/bundles/use_cases/financial_ops.yaml
+++ b/src/services/bundles/use_cases/financial_ops.yaml
@@ -1,0 +1,4 @@
+use_case: financial_ops
+description: Financial operations and accounting.
+schema_bundles: [financial_ops]
+skill_bundles: [core_workflows]

--- a/src/services/bundles/use_cases/government.yaml
+++ b/src/services/bundles/use_cases/government.yaml
@@ -1,0 +1,4 @@
+use_case: government
+description: Public sector and GovTech workflows.
+schema_bundles: [government, compliance]
+skill_bundles: [core_workflows]

--- a/src/services/bundles/use_cases/healthcare.yaml
+++ b/src/services/bundles/use_cases/healthcare.yaml
@@ -1,0 +1,4 @@
+use_case: healthcare
+description: Healthcare operations.
+schema_bundles: [healthcare, personal_data]
+skill_bundles: [core_workflows]

--- a/src/services/bundles/use_cases/logistics.yaml
+++ b/src/services/bundles/use_cases/logistics.yaml
@@ -1,0 +1,4 @@
+use_case: logistics
+description: Logistics and supply chain.
+schema_bundles: [logistics, financial_ops]
+skill_bundles: [core_workflows]

--- a/src/services/bundles/use_cases/personal_data.yaml
+++ b/src/services/bundles/use_cases/personal_data.yaml
@@ -1,0 +1,4 @@
+use_case: personal_data
+description: Personal agent state.
+schema_bundles: [personal_data]
+skill_bundles: [core_workflows]

--- a/src/services/bundles/use_cases/portfolio.yaml
+++ b/src/services/bundles/use_cases/portfolio.yaml
@@ -1,0 +1,4 @@
+use_case: portfolio
+description: Portfolio monitoring.
+schema_bundles: [financial_ops, portfolio]
+skill_bundles: [core_workflows]

--- a/src/services/bundles/use_cases/procurement.yaml
+++ b/src/services/bundles/use_cases/procurement.yaml
@@ -1,0 +1,4 @@
+use_case: procurement
+description: Procurement and sourcing.
+schema_bundles: [financial_ops, contracts, procurement]
+skill_bundles: [core_workflows]

--- a/src/services/bundles/use_cases/trading.yaml
+++ b/src/services/bundles/use_cases/trading.yaml
@@ -1,0 +1,4 @@
+use_case: trading
+description: Autonomous trading agents.
+schema_bundles: [financial_ops, trading]
+skill_bundles: [core_workflows]

--- a/src/services/interpretation.ts
+++ b/src/services/interpretation.ts
@@ -471,17 +471,35 @@ export async function runInterpretation(
 
       // When no known schema at all (neither DB nor code): optionally create a user-scoped schema from extracted fields
       let schemaCreationAttempted = false;
+      // Bundles m2: gate extracted-entity auto-create on the schema mode. Default
+      // `evolving` always allows (parity). `guided` permits only bundle-provided
+      // types; `locked` blocks all auto-create. When blocked, we skip creation
+      // and let the payload fall through to the raw_fragment preservation path
+      // below with a distinct reason.
+      let schemaModeBlock:
+        | Extract<import("./bundles/index.js").AutoCreateDecision, { allowed: false }>
+        | undefined;
       if (!schema && !codeSchema && config.create_schema_for_unknown !== false) {
-        schemaCreationAttempted = true;
-        schema = await schemaRegistry.ensureSchemaForExtractedEntity(
-          entityType,
-          entityData,
-          userId,
-          { create_if_missing: true }
-        );
-        if (schema) {
-          entityType = schema.entity_type;
-          currentEntityData = { ...entityData, entity_type: entityType };
+        const { checkAutoCreateAllowed } = await import("./bundles/index.js");
+        const decision = checkAutoCreateAllowed(entityType);
+        if (!decision.allowed) {
+          schemaModeBlock = decision;
+          logger.warn(
+            `[Interpretation] Schema mode "${decision.mode}" blocks auto-create of ` +
+              `entity_type "${entityType}"; preserving as raw_fragment. ${decision.message}`
+          );
+        } else {
+          schemaCreationAttempted = true;
+          schema = await schemaRegistry.ensureSchemaForExtractedEntity(
+            entityType,
+            entityData,
+            userId,
+            { create_if_missing: true }
+          );
+          if (schema) {
+            entityType = schema.entity_type;
+            currentEntityData = { ...entityData, entity_type: entityType };
+          }
         }
       }
 
@@ -498,9 +516,11 @@ export async function runInterpretation(
         // raw_fragment so the payload is preserved. Use a distinct reason so callers can tell
         // whether creation was attempted ("no_schema_registration_failed") or never tried
         // ("no_schema" — creation disabled via config.create_schema_for_unknown=false).
-        const noSchemaReason = schemaCreationAttempted
-          ? "no_schema_registration_failed"
-          : "no_schema";
+        const noSchemaReason = schemaModeBlock
+          ? `schema_mode_${schemaModeBlock.reason}`
+          : schemaCreationAttempted
+            ? "no_schema_registration_failed"
+            : "no_schema";
         logger.warn(
           `[Interpretation] No schema for entity_type "${entityType}" (resolved from extracted data); ` +
             `reason=${noSchemaReason}. Register a schema via register_schema to enable observations.`

--- a/src/services/schema_registry.ts
+++ b/src/services/schema_registry.ts
@@ -562,6 +562,14 @@ export interface SchemaMetadata {
   test?: boolean; // Mark schemas created for testing
   test_marked_at?: string; // ISO timestamp when test schema was marked
   guest_access_policy?: GuestAccessPolicyMode;
+  /**
+   * Bundle that originated this schema, e.g. `core` or `crm`. Added in Bundles m2.
+   * Optional/inert until the seed-ownership migration (m3) populates it; carried
+   * now so the registry interface is forward-compatible. (From PR #363, castor-agent.)
+   */
+  bundle?: string;
+  /** Version of the originating bundle at registration time, e.g. `1.0.0`. */
+  bundle_version?: string;
 }
 
 export interface SchemaRegistryEntry {

--- a/tests/unit/bundles_loader.test.ts
+++ b/tests/unit/bundles_loader.test.ts
@@ -1,0 +1,300 @@
+/**
+ * Unit tests for the Bundles m2 runtime: manifest parsing, loader resolution,
+ * the default-install provides-set, and mode enforcement at each lock posture.
+ *
+ * Plan: ent_089da2ecebc3bd804d63dcf2 (Bundles Strategy).
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  ManifestError,
+  buildRegistry,
+  checkAutoCreateAllowed,
+  getBundleRegistry,
+  getProvidedEntityTypes,
+  loadBundlesFrom,
+  parseManifest,
+  resetBundleRegistryForTesting,
+  resolveRequires,
+} from "../../src/services/bundles/index.js";
+import { resetSchemaModeCacheForTesting } from "../../src/services/schema_mode.js";
+
+const VALID_SCHEMA_MANIFEST = `
+name: demo_schema
+version: 1.0.0
+description: A demo schema bundle.
+bundle_type: schema
+provides_entity_types:
+  - widget
+  - gadget
+`;
+
+describe("parseManifest", () => {
+  it("parses a well-formed schema manifest and defaults list/mode fields", () => {
+    const m = parseManifest(VALID_SCHEMA_MANIFEST);
+    expect(m.name).toBe("demo_schema");
+    expect(m.version).toBe("1.0.0");
+    expect(m.bundle_type).toBe("schema");
+    expect(m.provides_entity_types).toEqual(["widget", "gadget"]);
+    expect(m.requires_bundles).toEqual([]);
+    expect(m.references_shared_schemas).toEqual([]);
+    expect(m.provides_skills).toEqual([]);
+    // compatible_modes defaults to all three.
+    expect(m.compatible_modes).toEqual(["evolving", "guided", "locked"]);
+    expect(m.serves_use_cases).toEqual([]);
+  });
+
+  it("rejects a missing required field", () => {
+    expect(() =>
+      parseManifest(`version: 1.0.0\ndescription: x\nbundle_type: schema`)
+    ).toThrow(ManifestError);
+  });
+
+  it("rejects an invalid bundle_type", () => {
+    expect(() =>
+      parseManifest(`name: x\nversion: 1.0.0\ndescription: y\nbundle_type: nonsense`)
+    ).toThrow(/bundle_type/);
+  });
+
+  it("rejects a skill bundle that provides entity types", () => {
+    expect(() =>
+      parseManifest(
+        `name: bad_skill\nversion: 1.0.0\ndescription: y\nbundle_type: skill\nprovides_entity_types:\n  - thing`
+      )
+    ).toThrow(/empty provides_entity_types/);
+  });
+
+  it("parses provides_skills objects and string shorthand", () => {
+    const m = parseManifest(`
+name: skills_bundle
+version: 1.0.0
+description: y
+bundle_type: skill
+requires_bundles:
+  - core
+provides_skills:
+  - name: do-thing
+    depth: core
+    requires_entity_types:
+      - task
+  - bare-skill
+`);
+    expect(m.provides_skills).toHaveLength(2);
+    expect(m.provides_skills[0]).toMatchObject({ name: "do-thing", depth: "core" });
+    expect(m.provides_skills[0].requires_entity_types).toEqual(["task"]);
+    expect(m.provides_skills[1]).toEqual({ name: "bare-skill" });
+  });
+
+  it("rejects an invalid compatible_modes value", () => {
+    expect(() =>
+      parseManifest(
+        `name: x\nversion: 1.0.0\ndescription: y\nbundle_type: schema\ncompatible_modes:\n  - frozen`
+      )
+    ).toThrow(/compatible_modes/);
+  });
+});
+
+describe("resolveRequires", () => {
+  it("passes when all deps are present", () => {
+    const bundles = [
+      {
+        dir: "/a",
+        enabled: true,
+        manifest: parseManifest(VALID_SCHEMA_MANIFEST),
+      },
+      {
+        dir: "/b",
+        enabled: true,
+        manifest: parseManifest(`
+name: needs_demo
+version: 1.0.0
+description: y
+bundle_type: skill
+requires_bundles:
+  - demo_schema
+`),
+      },
+    ];
+    expect(() => resolveRequires(bundles)).not.toThrow();
+  });
+
+  it("throws on a missing dependency", () => {
+    const bundles = [
+      {
+        dir: "/b",
+        enabled: true,
+        manifest: parseManifest(`
+name: orphan
+version: 1.0.0
+description: y
+bundle_type: skill
+requires_bundles:
+  - nonexistent
+`),
+      },
+    ];
+    expect(() => resolveRequires(bundles)).toThrow(/not installed/);
+  });
+});
+
+describe("buildRegistry provided-entity-types", () => {
+  it("indexes provided types from enabled bundles only", () => {
+    const enabled = {
+      dir: "/a",
+      enabled: true,
+      manifest: parseManifest(VALID_SCHEMA_MANIFEST),
+    };
+    const disabled = {
+      dir: "/b",
+      enabled: false,
+      manifest: parseManifest(`
+name: other_schema
+version: 1.0.0
+description: y
+bundle_type: schema
+provides_entity_types:
+  - hidden
+`),
+    };
+    const reg = buildRegistry([enabled, disabled]);
+    expect(reg.providedEntityTypes.get("widget")).toBe("demo_schema");
+    expect(reg.providedEntityTypes.has("hidden")).toBe(false);
+  });
+});
+
+describe("default install (real bundle dirs)", () => {
+  beforeEach(() => resetBundleRegistryForTesting());
+  afterEach(() => resetBundleRegistryForTesting());
+
+  it("discovers exactly the three default bundles", () => {
+    const reg = getBundleRegistry();
+    const names = reg.bundles.map((b) => b.manifest.name).sort();
+    expect(names).toEqual(["core", "core_workflows", "infrastructure"]);
+  });
+
+  it("core_workflows is a skill bundle requiring core with empty provides", () => {
+    const reg = getBundleRegistry();
+    const cw = reg.bundles.find((b) => b.manifest.name === "core_workflows")!;
+    expect(cw.manifest.bundle_type).toBe("skill");
+    expect(cw.manifest.provides_entity_types).toEqual([]);
+    expect(cw.manifest.requires_bundles).toContain("core");
+    expect(cw.manifest.references_shared_schemas).toEqual(
+      expect.arrayContaining(["interaction", "session_close"])
+    );
+  });
+
+  it("default provides-set includes core + infrastructure types", () => {
+    const provided = getProvidedEntityTypes();
+    for (const t of [
+      "conversation",
+      "conversation_message",
+      "agent_message",
+      "note",
+      "task",
+      "event",
+      "contact",
+      "file_asset",
+      "document",
+      "issue",
+      "plan",
+      "subscription",
+      "submission_config",
+      "peer_config",
+      "sandbox_abuse_report",
+    ]) {
+      expect(provided.has(t)).toBe(true);
+    }
+  });
+
+  it("the real bundles resolve their requires", () => {
+    const bundles = getBundleRegistry().bundles;
+    expect(() => resolveRequires(bundles)).not.toThrow();
+  });
+});
+
+describe("checkAutoCreateAllowed (mode enforcement)", () => {
+  beforeEach(() => {
+    resetSchemaModeCacheForTesting();
+    resetBundleRegistryForTesting();
+    delete process.env.NEOTOMA_SCHEMA_MODE;
+  });
+  afterEach(() => {
+    delete process.env.NEOTOMA_SCHEMA_MODE;
+    resetSchemaModeCacheForTesting();
+    resetBundleRegistryForTesting();
+  });
+
+  it("evolving (default): any type allowed — parity", () => {
+    const d = checkAutoCreateAllowed("totally_new_type");
+    expect(d.allowed).toBe(true);
+  });
+
+  it("evolving via explicit override allows unknown types", () => {
+    const d = checkAutoCreateAllowed("totally_new_type", "evolving");
+    expect(d.allowed).toBe(true);
+  });
+
+  it("guided: bundle-provided type allowed", () => {
+    const d = checkAutoCreateAllowed("task", "guided");
+    expect(d.allowed).toBe(true);
+  });
+
+  it("guided: unprovided type blocked with structured reason", () => {
+    const d = checkAutoCreateAllowed("totally_new_type", "guided");
+    expect(d.allowed).toBe(false);
+    if (!d.allowed) {
+      expect(d.reason).toBe("guided_unprovided");
+      expect(d.message).toMatch(/no bundle provides this type/i);
+    }
+  });
+
+  it("locked: every type blocked with register instruction", () => {
+    const d = checkAutoCreateAllowed("task", "locked");
+    expect(d.allowed).toBe(false);
+    if (!d.allowed) {
+      expect(d.reason).toBe("locked");
+      expect(d.message).toMatch(/register the type explicitly/i);
+    }
+  });
+
+  it("reads the env var when no override is passed (guided)", () => {
+    process.env.NEOTOMA_SCHEMA_MODE = "guided";
+    resetSchemaModeCacheForTesting();
+    expect(checkAutoCreateAllowed("contact").allowed).toBe(true);
+    expect(checkAutoCreateAllowed("totally_new_type").allowed).toBe(false);
+  });
+});
+
+describe("loadBundlesFrom (fixtures)", () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "bundles-test-"));
+  });
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("discovers bundle dirs and skips non-bundle dirs", () => {
+    fs.mkdirSync(path.join(tmp, "alpha"));
+    fs.writeFileSync(
+      path.join(tmp, "alpha", "manifest.yaml"),
+      `name: alpha\nversion: 1.0.0\ndescription: a\nbundle_type: schema\nprovides_entity_types:\n  - a1`
+    );
+    // _shared_schemas and a dir without manifest must be ignored.
+    fs.mkdirSync(path.join(tmp, "_shared_schemas"));
+    fs.mkdirSync(path.join(tmp, "not_a_bundle"));
+    const loaded = loadBundlesFrom(tmp);
+    expect(loaded.map((b) => b.manifest.name)).toEqual(["alpha"]);
+  });
+
+  it("propagates a malformed manifest as ManifestError", () => {
+    fs.mkdirSync(path.join(tmp, "broken"));
+    fs.writeFileSync(path.join(tmp, "broken", "manifest.yaml"), `name: broken`);
+    expect(() => loadBundlesFrom(tmp)).toThrow(ManifestError);
+  });
+});


### PR DESCRIPTION
## Bundles m2 — runtime (canonical, reconciled)

This is the **canonical m2 PR**, reconciling the two overlapping m2 implementations. It supersedes **#363** (castor-agent), whose unique value has been folded in here. Base is `main`; logically stacks on the m1 integration **#1798** (merge m1 first).

### Why this is the base (robustness)
- Targets `main` (mergeable lineage); #363 targeted the stranded `feat/bundles-m1`.
- Carries the three required deliverables #363 lacked: **`bundles:check` linter**, **`use_cases/*.yaml` (16)**, **`_shared_schemas/` ownership**, plus build glue (`copy_bundle_assets.js`) so compiled bundles ship in `dist/`.
- Parity-preserving: bundles land as an **additive metadata + enforcement layer**; existing boot-time schema seeds are untouched.

### m2 contents
- **Loader/registry:** `src/services/bundles/{types,manifest,loader,enforcement,index}.ts` — lazy registry built from copied manifests; `getProvidedEntityTypes()` / `bundleProviding()`.
- **Default bundles:** `core/`, `infrastructure/`, `core_workflows/` manifests + 3 SKILL.md.
- **Enforcement** at the two auto-create points (`src/server.ts` structured-store inference, `src/services/interpretation.ts` extracted-entity creation), gated on `getSchemaMode()`: `evolving`=parity, `guided`=bundle-gated, `locked`=blocked.
- **Linter:** `scripts/bundles_check.ts` + `bundles:check` npm script.
- **Use-case map:** all 16 `use_cases/*.yaml` + README.
- **m1 re-include:** `schema_mode.ts` (+ test) so this is independently buildable; merges trivially once #1798 lands.

### Folded in from castor-agent's #363
- `SchemaMetadata.bundle` / `bundle_version` provenance fields (forward-compat; populated by the m3 seed-ownership migration).
- `docs/bundles/m5/phase0_*.md` analysis docs (orphaned-type map + P0 field coverage).

### Deliberately deferred to m3 (robustness)
castor's #363 also migrates infrastructure schema seeding into the bundle loader — it **removes** the six explicit boot-time seeds (issue/plan/subscription/submission_config/peer_config/sandbox_abuse_report) in favor of `runBundleSeeds("infrastructure")`. That is the correct end state but risks a boot-time seeding regression, so it's **not** in this PR; it's captured as the m3 seed-ownership migration.

### Verification
- `tsc --noEmit` 0 errors; eslint 0 errors; prettier clean
- `bundles:check` OK (3 bundles); `build:server` succeeds, assets copy to `dist/services/bundles/`
- bundles loader 21/21, schema_mode 12/12, interpretation parity 9/9, store_unknown_fields 3/3
- Full local pre-commit suite skipped (`SKIP_TESTS=1`): pre-existing fork-worker flakiness reproduces on clean base, passes in isolation. CI is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)