### PR TITLE
feat(sandbox): add originating conversations + record provenance to use-case packs

### DIFF
--- a/tests/fixtures/sandbox/use_cases/agent-auth/manifest.json
+++ b/tests/fixtures/sandbox/use_cases/agent-auth/manifest.json
@@ -174,9 +174,168 @@
           "key_alg": "Ed25519"
         }
       ]
+    },
+    {
+      "agent_index": 2,
+      "idempotency_prefix": "aa-conv",
+      "entities": [
+        {
+          "_ref": "conv_aa",
+          "entity_type": "conversation",
+          "canonical_name": "AAuth trust graph setup",
+          "title": "AAuth trust graph setup",
+          "platform": "cursor",
+          "started_at": "2026-06-11T11:00:00Z",
+          "ended_at": "2026-06-11T11:22:00Z",
+          "turn_count": 6,
+          "idempotency_hint": "conv-sandbox-agent-auth-1",
+          "conversation_id": "conv-sandbox-agent-auth-1"
+        },
+        {
+          "_ref": "conv_aa_m1",
+          "entity_type": "conversation_message",
+          "canonical_name": "agent-auth-msg-1",
+          "role": "user",
+          "sender_kind": "user",
+          "content": "Set up the AAuth grants for the swarm. Corvus (content agent) needs contacts:read, and Apis (orchestrator) needs tasks:write. Both active. Register Apis and Corvus as agents under the ateles-swarm.",
+          "turn_key": "conv-sandbox-agent-auth-1:turn:1",
+          "timestamp": "2026-06-11T11:00:00Z",
+          "conversation_id": "conv-sandbox-agent-auth-1"
+        },
+        {
+          "_ref": "conv_aa_m2",
+          "entity_type": "conversation_message",
+          "canonical_name": "agent-auth-msg-2",
+          "role": "assistant",
+          "sender_kind": "assistant",
+          "content": "Registered Apis (apis@ateles-swarm) and Corvus (corvus@ateles-swarm) as agents. Created an active \"contacts:read\" grant scoped to Corvus and an active \"tasks:write\" grant scoped to Apis. I recorded the matching allow decisions: Corvus reads contacts, Apis writes tasks.",
+          "turn_key": "conv-sandbox-agent-auth-1:turn:2",
+          "timestamp": "2026-06-11T11:05:00Z",
+          "conversation_id": "conv-sandbox-agent-auth-1"
+        },
+        {
+          "_ref": "conv_aa_m3",
+          "entity_type": "conversation_message",
+          "canonical_name": "agent-auth-msg-3",
+          "role": "user",
+          "sender_kind": "user",
+          "content": "Monedula (payments agent) requested payments:execute. We held a governance vote and it was rejected 2 of 3. Revoke that grant and make sure any payment attempt is denied.",
+          "turn_key": "conv-sandbox-agent-auth-1:turn:3",
+          "timestamp": "2026-06-11T11:12:00Z",
+          "conversation_id": "conv-sandbox-agent-auth-1"
+        },
+        {
+          "_ref": "conv_aa_m4",
+          "entity_type": "conversation_message",
+          "canonical_name": "agent-auth-msg-4",
+          "role": "assistant",
+          "sender_kind": "assistant",
+          "content": "Recorded the governance vote \"enable payments for Monedula\" with a 2/3 rejected tally and revoked the payments:execute grant. The policy evaluation for payments:execute now fails, and I logged a deny decision for Monedula's payment attempt with reason \"grant revoked\".",
+          "turn_key": "conv-sandbox-agent-auth-1:turn:4",
+          "timestamp": "2026-06-11T11:16:00Z",
+          "conversation_id": "conv-sandbox-agent-auth-1"
+        },
+        {
+          "_ref": "conv_aa_m5",
+          "entity_type": "conversation_message",
+          "canonical_name": "agent-auth-msg-5",
+          "role": "user",
+          "sender_kind": "user",
+          "content": "Confirm the delegation chain and that the scope check for contacts:read passes.",
+          "turn_key": "conv-sandbox-agent-auth-1:turn:5",
+          "timestamp": "2026-06-11T11:19:00Z",
+          "conversation_id": "conv-sandbox-agent-auth-1"
+        },
+        {
+          "_ref": "conv_aa_m6",
+          "entity_type": "conversation_message",
+          "canonical_name": "agent-auth-msg-6",
+          "role": "assistant",
+          "sender_kind": "assistant",
+          "content": "Confirmed. The delegation chain Operator → Apis → Corvus (depth 2) is recorded, the contacts:read scope check passes, and Apis has an active activity webhook subscription.",
+          "turn_key": "conv-sandbox-agent-auth-1:turn:6",
+          "timestamp": "2026-06-11T11:22:00Z",
+          "conversation_id": "conv-sandbox-agent-auth-1"
+        }
+      ]
     }
   ],
   "relationships": [
+    {
+      "source_ref": "conv_aa_m1",
+      "target_ref": "conv_aa",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "conv_aa_m2",
+      "target_ref": "conv_aa",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "conv_aa_m3",
+      "target_ref": "conv_aa",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "conv_aa_m4",
+      "target_ref": "conv_aa",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "conv_aa_m5",
+      "target_ref": "conv_aa",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "conv_aa_m6",
+      "target_ref": "conv_aa",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "conv_aa",
+      "target_ref": "ag_apis",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_aa",
+      "target_ref": "ag_corvus",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_aa",
+      "target_ref": "ag_mon",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_aa",
+      "target_ref": "cg_read",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_aa",
+      "target_ref": "cg_write",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_aa",
+      "target_ref": "cg_pay",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_aa",
+      "target_ref": "ad_3",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_aa",
+      "target_ref": "gv_pay",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_aa",
+      "target_ref": "dc_apis",
+      "relationship_type": "references"
+    },
     {
       "source_ref": "cg_read",
       "target_ref": "ag_corvus",

--- a/tests/fixtures/sandbox/use_cases/content-ops/manifest.json
+++ b/tests/fixtures/sandbox/use_cases/content-ops/manifest.json
@@ -145,9 +145,168 @@
           "engagement_rate": 0.041
         }
       ]
+    },
+    {
+      "agent_index": 0,
+      "idempotency_prefix": "content-conv",
+      "entities": [
+        {
+          "_ref": "conv_content",
+          "entity_type": "conversation",
+          "canonical_name": "Sandbox launch content plan",
+          "title": "Sandbox launch content plan",
+          "platform": "chatgpt",
+          "started_at": "2026-06-22T14:00:00Z",
+          "ended_at": "2026-06-22T14:20:00Z",
+          "turn_count": 6,
+          "idempotency_hint": "conv-sandbox-content-ops-1",
+          "conversation_id": "conv-sandbox-content-ops-1"
+        },
+        {
+          "_ref": "conv_content_m1",
+          "entity_type": "conversation_message",
+          "canonical_name": "content-ops-msg-1",
+          "role": "user",
+          "sender_kind": "user",
+          "content": "Let's plan the Sandbox launch campaign. The core idea is \"Show the graph, not the chat\" — that one's approved. Spin up an X thread and a blog article around it.",
+          "turn_key": "conv-sandbox-content-ops-1:turn:1",
+          "timestamp": "2026-06-22T14:00:00Z",
+          "conversation_id": "conv-sandbox-content-ops-1"
+        },
+        {
+          "_ref": "conv_content_m2",
+          "entity_type": "conversation_message",
+          "canonical_name": "content-ops-msg-2",
+          "role": "assistant",
+          "sender_kind": "assistant",
+          "content": "Created the \"Sandbox launch\" campaign (active) and tied two content pieces to it: an X thread \"A sandbox you can actually click\" and a blog article \"Per-visitor sandbox seeding\". Both stem from the approved idea \"Show the graph, not the chat\" and are slated for X and the Neotoma Blog respectively.",
+          "turn_key": "conv-sandbox-content-ops-1:turn:2",
+          "timestamp": "2026-06-22T14:05:00Z",
+          "conversation_id": "conv-sandbox-content-ops-1"
+        },
+        {
+          "_ref": "conv_content_m3",
+          "entity_type": "conversation_message",
+          "canonical_name": "content-ops-msg-3",
+          "role": "user",
+          "sender_kind": "user",
+          "content": "Also start the \"Memory vs truth-layer series\" campaign in planning, with a LinkedIn post \"Why memory needs a truth layer\" as a draft. Idea behind it is \"Provenance you can click\" — keep that in the backlog for now.",
+          "turn_key": "conv-sandbox-content-ops-1:turn:3",
+          "timestamp": "2026-06-22T14:10:00Z",
+          "conversation_id": "conv-sandbox-content-ops-1"
+        },
+        {
+          "_ref": "conv_content_m4",
+          "entity_type": "conversation_message",
+          "canonical_name": "content-ops-msg-4",
+          "role": "assistant",
+          "sender_kind": "assistant",
+          "content": "Done. Added the \"Memory vs truth-layer series\" campaign in planning, created the LinkedIn draft \"Why memory needs a truth layer\" under it, and logged the backlog idea \"Provenance you can click\" that it draws from.",
+          "turn_key": "conv-sandbox-content-ops-1:turn:4",
+          "timestamp": "2026-06-22T14:14:00Z",
+          "conversation_id": "conv-sandbox-content-ops-1"
+        },
+        {
+          "_ref": "conv_content_m5",
+          "entity_type": "conversation_message",
+          "canonical_name": "content-ops-msg-5",
+          "role": "user",
+          "sender_kind": "user",
+          "content": "The thread and the blog are live now — record the publications. And pull the engagement on the launch thread.",
+          "turn_key": "conv-sandbox-content-ops-1:turn:5",
+          "timestamp": "2026-06-22T14:17:00Z",
+          "conversation_id": "conv-sandbox-content-ops-1"
+        },
+        {
+          "_ref": "conv_content_m6",
+          "entity_type": "conversation_message",
+          "canonical_name": "content-ops-msg-6",
+          "role": "assistant",
+          "sender_kind": "assistant",
+          "content": "Logged the \"X thread — launch\" publication (2026-06-24) and the \"Blog — seeding\" publication (2026-06-23). The launch thread has 18,400 impressions at a 4.1% engagement rate so far.",
+          "turn_key": "conv-sandbox-content-ops-1:turn:6",
+          "timestamp": "2026-06-22T14:20:00Z",
+          "conversation_id": "conv-sandbox-content-ops-1"
+        }
+      ]
     }
   ],
   "relationships": [
+    {
+      "source_ref": "conv_content_m1",
+      "target_ref": "conv_content",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "conv_content_m2",
+      "target_ref": "conv_content",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "conv_content_m3",
+      "target_ref": "conv_content",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "conv_content_m4",
+      "target_ref": "conv_content",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "conv_content_m5",
+      "target_ref": "conv_content",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "conv_content_m6",
+      "target_ref": "conv_content",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "conv_content",
+      "target_ref": "cp_launch",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_content",
+      "target_ref": "cp_series",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_content",
+      "target_ref": "id_graph",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_content",
+      "target_ref": "id_prov",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_content",
+      "target_ref": "co_thread",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_content",
+      "target_ref": "co_post",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_content",
+      "target_ref": "co_blog",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_content",
+      "target_ref": "pb_thread",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_content",
+      "target_ref": "pb_blog",
+      "relationship_type": "references"
+    },
     {
       "source_ref": "co_thread",
       "target_ref": "cp_launch",

--- a/tests/fixtures/sandbox/use_cases/crm/manifest.json
+++ b/tests/fixtures/sandbox/use_cases/crm/manifest.json
@@ -194,9 +194,163 @@
           "owner": "Sam"
         }
       ]
+    },
+    {
+      "agent_index": 1,
+      "idempotency_prefix": "crm-conv",
+      "entities": [
+        {
+          "_ref": "conv_crm",
+          "entity_type": "conversation",
+          "canonical_name": "Acme rollout pipeline review",
+          "title": "Acme rollout pipeline review",
+          "platform": "claude",
+          "started_at": "2026-06-10T09:30:00Z",
+          "ended_at": "2026-06-10T09:48:00Z",
+          "turn_count": 6,
+          "idempotency_hint": "conv-sandbox-crm-1",
+          "conversation_id": "conv-sandbox-crm-1"
+        },
+        {
+          "_ref": "conv_crm_m1",
+          "entity_type": "conversation_message",
+          "canonical_name": "crm-msg-1",
+          "role": "user",
+          "sender_kind": "user",
+          "content": "Just got off the Acme discovery call with Jordan Vance, their VP Ops. They're an enterprise retail account and want the platform rolled out across all stores. Mina Roy is the buyer. Set up the account and the deal — we're talking around $85k.",
+          "turn_key": "conv-sandbox-crm-1:turn:1",
+          "timestamp": "2026-06-10T09:30:00Z",
+          "conversation_id": "conv-sandbox-crm-1"
+        },
+        {
+          "_ref": "conv_crm_m2",
+          "entity_type": "conversation_message",
+          "canonical_name": "crm-msg-2",
+          "role": "assistant",
+          "sender_kind": "assistant",
+          "content": "Done. I've logged Acme Retail as an enterprise account, added Jordan Vance (VP Ops) and Mina Roy (Buyer) as contacts on it, and created the \"Acme platform rollout\" deal at $85,000 in the negotiation stage. I also recorded the discovery call as an engagement dated today.",
+          "turn_key": "conv-sandbox-crm-1:turn:2",
+          "timestamp": "2026-06-10T09:33:00Z",
+          "conversation_id": "conv-sandbox-crm-1"
+        },
+        {
+          "_ref": "conv_crm_m3",
+          "entity_type": "conversation_message",
+          "canonical_name": "crm-msg-3",
+          "role": "user",
+          "sender_kind": "user",
+          "content": "Good. Jordan owns this deal on their side. Add a task to send the Acme quote — it needs to go out by Friday the 12th. Also flag that we have two smaller deals open: the Globex pilot at $24k in proposal, and the Initech renewal at $12k which already closed won.",
+          "turn_key": "conv-sandbox-crm-1:turn:3",
+          "timestamp": "2026-06-10T09:40:00Z",
+          "conversation_id": "conv-sandbox-crm-1"
+        },
+        {
+          "_ref": "conv_crm_m4",
+          "entity_type": "conversation_message",
+          "canonical_name": "crm-msg-4",
+          "role": "assistant",
+          "sender_kind": "assistant",
+          "content": "Logged. Jordan Vance now manages the Acme rollout deal. I created a task \"Send Acme quote\" due 2026-06-12 and linked it to the rollout deal. The Globex pilot ($24k, proposal) and Initech renewal ($12k, closed won) are both on file against their accounts, with Dev Patel (Globex CTO) and Sara Kim (Initech Founder) as the contacts.",
+          "turn_key": "conv-sandbox-crm-1:turn:4",
+          "timestamp": "2026-06-10T09:44:00Z",
+          "conversation_id": "conv-sandbox-crm-1"
+        },
+        {
+          "_ref": "conv_crm_m5",
+          "entity_type": "conversation_message",
+          "canonical_name": "crm-msg-5",
+          "role": "user",
+          "sender_kind": "user",
+          "content": "One more — add a follow-up task for Globex due July 1, and put a rollout planning meeting on the books with Jordan for June 18.",
+          "turn_key": "conv-sandbox-crm-1:turn:5",
+          "timestamp": "2026-06-10T09:46:00Z",
+          "conversation_id": "conv-sandbox-crm-1"
+        },
+        {
+          "_ref": "conv_crm_m6",
+          "entity_type": "conversation_message",
+          "canonical_name": "crm-msg-6",
+          "role": "assistant",
+          "sender_kind": "assistant",
+          "content": "All set. Added \"Follow up with Globex\" due 2026-07-01 linked to the Globex pilot, and scheduled the \"Acme rollout planning\" meeting for 2026-06-18 with Jordan Vance, tied to the rollout deal.",
+          "turn_key": "conv-sandbox-crm-1:turn:6",
+          "timestamp": "2026-06-10T09:48:00Z",
+          "conversation_id": "conv-sandbox-crm-1"
+        }
+      ]
     }
   ],
   "relationships": [
+    {
+      "source_ref": "conv_crm_m1",
+      "target_ref": "conv_crm",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "conv_crm_m2",
+      "target_ref": "conv_crm",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "conv_crm_m3",
+      "target_ref": "conv_crm",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "conv_crm_m4",
+      "target_ref": "conv_crm",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "conv_crm_m5",
+      "target_ref": "conv_crm",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "conv_crm_m6",
+      "target_ref": "conv_crm",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "conv_crm",
+      "target_ref": "a_acme",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_crm",
+      "target_ref": "c_jordan",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_crm",
+      "target_ref": "c_mina",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_crm",
+      "target_ref": "d_acme",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_crm",
+      "target_ref": "e_call",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_crm",
+      "target_ref": "t_quote",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_crm",
+      "target_ref": "t_followup",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_crm",
+      "target_ref": "m_acme",
+      "relationship_type": "references"
+    },
     {
       "source_ref": "c_jordan",
       "target_ref": "a_acme",

--- a/tests/fixtures/sandbox/use_cases/customer-development/manifest.json
+++ b/tests/fixtures/sandbox/use_cases/customer-development/manifest.json
@@ -166,9 +166,173 @@
           "first_response_min": 12
         }
       ]
+    },
+    {
+      "agent_index": 3,
+      "idempotency_prefix": "cd-conv",
+      "entities": [
+        {
+          "_ref": "conv_cd",
+          "entity_type": "conversation",
+          "canonical_name": "Support triage and insight roll-up",
+          "title": "Support triage and insight roll-up",
+          "platform": "cli",
+          "started_at": "2026-06-16T10:00:00Z",
+          "ended_at": "2026-06-16T10:18:00Z",
+          "turn_count": 6,
+          "idempotency_hint": "conv-sandbox-customer-development-1",
+          "conversation_id": "conv-sandbox-customer-development-1"
+        },
+        {
+          "_ref": "conv_cd_m1",
+          "entity_type": "conversation_message",
+          "canonical_name": "customer-development-msg-1",
+          "role": "user",
+          "sender_kind": "user",
+          "content": "Acme Retail (enterprise) just called — their SSO login is failing for the whole team. Open a high-priority ticket and log the call.",
+          "turn_key": "conv-sandbox-customer-development-1:turn:1",
+          "timestamp": "2026-06-16T10:00:00Z",
+          "conversation_id": "conv-sandbox-customer-development-1"
+        },
+        {
+          "_ref": "conv_cd_m2",
+          "entity_type": "conversation_message",
+          "canonical_name": "customer-development-msg-2",
+          "role": "assistant",
+          "sender_kind": "assistant",
+          "content": "Opened ticket \"SSO login fails\" at high priority against Acme Retail and recorded the \"Acme support call\" interaction for today. Since it's an org-wide auth outage I escalated it to L2 and routed it to the platform team (rationale: auth subsystem). First response was 12 minutes, assignee Dev Patel.",
+          "turn_key": "conv-sandbox-customer-development-1:turn:2",
+          "timestamp": "2026-06-16T10:05:00Z",
+          "conversation_id": "conv-sandbox-customer-development-1"
+        },
+        {
+          "_ref": "conv_cd_m3",
+          "entity_type": "conversation_message",
+          "canonical_name": "customer-development-msg-3",
+          "role": "user",
+          "sender_kind": "user",
+          "content": "Globex also pinged us on chat — their CSV export truncates on big files. And Sara Kim from Initech asked a low-priority question about pricing tiers.",
+          "turn_key": "conv-sandbox-customer-development-1:turn:3",
+          "timestamp": "2026-06-16T10:10:00Z",
+          "conversation_id": "conv-sandbox-customer-development-1"
+        },
+        {
+          "_ref": "conv_cd_m4",
+          "entity_type": "conversation_message",
+          "canonical_name": "customer-development-msg-4",
+          "role": "assistant",
+          "sender_kind": "assistant",
+          "content": "Logged the \"Globex chat thread\" interaction and a medium ticket \"CSV export truncates\" for Globex (now resolved). Also opened a low-priority ticket \"Question about pricing tiers\" for Sara Kim.",
+          "turn_key": "conv-sandbox-customer-development-1:turn:4",
+          "timestamp": "2026-06-16T10:13:00Z",
+          "conversation_id": "conv-sandbox-customer-development-1"
+        },
+        {
+          "_ref": "conv_cd_m5",
+          "entity_type": "conversation_message",
+          "canonical_name": "customer-development-msg-5",
+          "role": "user",
+          "sender_kind": "user",
+          "content": "Globex left feedback that export should stream large files, and Acme loves the new pack picker. Anything we should act on?",
+          "turn_key": "conv-sandbox-customer-development-1:turn:5",
+          "timestamp": "2026-06-16T10:16:00Z",
+          "conversation_id": "conv-sandbox-customer-development-1"
+        },
+        {
+          "_ref": "conv_cd_m6",
+          "entity_type": "conversation_message",
+          "canonical_name": "customer-development-msg-6",
+          "role": "assistant",
+          "sender_kind": "assistant",
+          "content": "Recorded both: the negative feedback \"Export should stream large files\" (Globex) and the positive \"Love the new pack picker\" (Acme). Rolling up the export signal, I logged a high-confidence insight: \"Large-account exports need streaming.\"",
+          "turn_key": "conv-sandbox-customer-development-1:turn:6",
+          "timestamp": "2026-06-16T10:18:00Z",
+          "conversation_id": "conv-sandbox-customer-development-1"
+        }
+      ]
     }
   ],
   "relationships": [
+    {
+      "source_ref": "conv_cd_m1",
+      "target_ref": "conv_cd",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "conv_cd_m2",
+      "target_ref": "conv_cd",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "conv_cd_m3",
+      "target_ref": "conv_cd",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "conv_cd_m4",
+      "target_ref": "conv_cd",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "conv_cd_m5",
+      "target_ref": "conv_cd",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "conv_cd_m6",
+      "target_ref": "conv_cd",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "conv_cd",
+      "target_ref": "ti_login",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_cd",
+      "target_ref": "ti_export",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_cd",
+      "target_ref": "ti_pricing",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_cd",
+      "target_ref": "it_call",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_cd",
+      "target_ref": "it_chat",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_cd",
+      "target_ref": "es_login",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_cd",
+      "target_ref": "rd_login",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_cd",
+      "target_ref": "fb_export",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_cd",
+      "target_ref": "fb_picker",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_cd",
+      "target_ref": "in_export",
+      "relationship_type": "references"
+    },
     {
       "source_ref": "ti_login",
       "target_ref": "k_acme",

--- a/tests/fixtures/sandbox/use_cases/engineering/manifest.json
+++ b/tests/fixtures/sandbox/use_cases/engineering/manifest.json
@@ -205,9 +205,173 @@
           "default_branch": "main"
         }
       ]
+    },
+    {
+      "agent_index": 1,
+      "idempotency_prefix": "eng-conv",
+      "entities": [
+        {
+          "_ref": "conv_eng",
+          "entity_type": "conversation",
+          "canonical_name": "Sandbox blank-page incident postmortem",
+          "title": "Sandbox blank-page incident postmortem",
+          "platform": "claude",
+          "started_at": "2026-06-20T16:00:00Z",
+          "ended_at": "2026-06-20T16:24:00Z",
+          "turn_count": 6,
+          "idempotency_hint": "conv-sandbox-engineering-1",
+          "conversation_id": "conv-sandbox-engineering-1"
+        },
+        {
+          "_ref": "conv_eng_m1",
+          "entity_type": "conversation_message",
+          "canonical_name": "engineering-msg-1",
+          "role": "user",
+          "sender_kind": "user",
+          "content": "The sandbox is rendering blank at root in inspector-web. Open a high-severity issue and an incident.",
+          "turn_key": "conv-sandbox-engineering-1:turn:1",
+          "timestamp": "2026-06-20T16:00:00Z",
+          "conversation_id": "conv-sandbox-engineering-1"
+        },
+        {
+          "_ref": "conv_eng_m2",
+          "entity_type": "conversation_message",
+          "canonical_name": "engineering-msg-2",
+          "role": "assistant",
+          "sender_kind": "assistant",
+          "content": "Opened high-severity issue \"Sandbox renders blank at root\" against the inspector-web service and a sev2 incident \"Sandbox blank-page incident\". Both are in the neotoma/inspector delivery graph.",
+          "turn_key": "conv-sandbox-engineering-1:turn:2",
+          "timestamp": "2026-06-20T16:05:00Z",
+          "conversation_id": "conv-sandbox-engineering-1"
+        },
+        {
+          "_ref": "conv_eng_m3",
+          "entity_type": "conversation_message",
+          "canonical_name": "engineering-msg-3",
+          "role": "user",
+          "sender_kind": "user",
+          "content": "Maya Chen has the fix on PR #1768 \"feat(sandbox): Inspector at root + picker\" — it closes that blank-root issue. PR #1766 \"fix(sandbox): per-session pack seeding\" already merged with commits 34d5ccd and aa5469a. Priya Nair reviewed #1766.",
+          "turn_key": "conv-sandbox-engineering-1:turn:3",
+          "timestamp": "2026-06-20T16:12:00Z",
+          "conversation_id": "conv-sandbox-engineering-1"
+        },
+        {
+          "_ref": "conv_eng_m4",
+          "entity_type": "conversation_message",
+          "canonical_name": "engineering-msg-4",
+          "role": "assistant",
+          "sender_kind": "assistant",
+          "content": "Logged merged PR #1768 against the inspector repo and linked it to the blank-root issue. PR #1766 is recorded against neotoma with commits 34d5ccd (wire seedForSession) and aa5469a (tenant-scope entity ids), plus an approve review of #1766. Maya manages #1768 and Priya manages the seeding work.",
+          "turn_key": "conv-sandbox-engineering-1:turn:4",
+          "timestamp": "2026-06-20T16:17:00Z",
+          "conversation_id": "conv-sandbox-engineering-1"
+        },
+        {
+          "_ref": "conv_eng_m5",
+          "entity_type": "conversation_message",
+          "canonical_name": "engineering-msg-5",
+          "role": "user",
+          "sender_kind": "user",
+          "content": "Dev Patel is deploying v0.17.0-dev to sandbox to resolve the incident. There's still an open issue about returning visitors getting 401-walled and an open PR #1790 for the anon fallback.",
+          "turn_key": "conv-sandbox-engineering-1:turn:5",
+          "timestamp": "2026-06-20T16:21:00Z",
+          "conversation_id": "conv-sandbox-engineering-1"
+        },
+        {
+          "_ref": "conv_eng_m6",
+          "entity_type": "conversation_message",
+          "canonical_name": "engineering-msg-6",
+          "role": "assistant",
+          "sender_kind": "assistant",
+          "content": "Recorded the successful \"sandbox v0.17.0-dev deploy\" to the sandbox environment (managed by Dev Patel), which resolves the blank-page incident. I also left open the \"Returning visitors 401-walled\" issue on neotoma-api and PR #1790 \"fix(sandbox): anon fallback for stale bearer\".",
+          "turn_key": "conv-sandbox-engineering-1:turn:6",
+          "timestamp": "2026-06-20T16:24:00Z",
+          "conversation_id": "conv-sandbox-engineering-1"
+        }
+      ]
     }
   ],
   "relationships": [
+    {
+      "source_ref": "conv_eng_m1",
+      "target_ref": "conv_eng",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "conv_eng_m2",
+      "target_ref": "conv_eng",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "conv_eng_m3",
+      "target_ref": "conv_eng",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "conv_eng_m4",
+      "target_ref": "conv_eng",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "conv_eng_m5",
+      "target_ref": "conv_eng",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "conv_eng_m6",
+      "target_ref": "conv_eng",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "conv_eng",
+      "target_ref": "is_blank",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_eng",
+      "target_ref": "is_lockout",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_eng",
+      "target_ref": "in_blank",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_eng",
+      "target_ref": "pr_seed",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_eng",
+      "target_ref": "pr_root",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_eng",
+      "target_ref": "pr_auth",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_eng",
+      "target_ref": "cm_seed",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_eng",
+      "target_ref": "cm_salt",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_eng",
+      "target_ref": "rv_seed",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_eng",
+      "target_ref": "dp_v017",
+      "relationship_type": "references"
+    },
     {
       "source_ref": "pr_seed",
       "target_ref": "r_api",

--- a/tests/fixtures/sandbox/use_cases/financial-ops/manifest.json
+++ b/tests/fixtures/sandbox/use_cases/financial-ops/manifest.json
@@ -156,9 +156,178 @@
           "paid_date": "2026-06-12"
         }
       ]
+    },
+    {
+      "agent_index": 0,
+      "idempotency_prefix": "fin-conv",
+      "entities": [
+        {
+          "_ref": "conv_fin",
+          "entity_type": "conversation",
+          "canonical_name": "June close and reconciliation",
+          "title": "June close and reconciliation",
+          "platform": "chatgpt",
+          "started_at": "2026-06-30T12:00:00Z",
+          "ended_at": "2026-06-30T12:20:00Z",
+          "turn_count": 6,
+          "idempotency_hint": "conv-sandbox-financial-ops-1",
+          "conversation_id": "conv-sandbox-financial-ops-1"
+        },
+        {
+          "_ref": "conv_fin_m1",
+          "entity_type": "conversation_message",
+          "canonical_name": "financial-ops-msg-1",
+          "role": "user",
+          "sender_kind": "user",
+          "content": "Let's close out June. We have three vendor invoices: CloudHost for €420 (due June 15), the LexCo Legal retainer for €2,500 (due July 1), and WeWork July rent €1,800 (due July 5). Log them.",
+          "turn_key": "conv-sandbox-financial-ops-1:turn:1",
+          "timestamp": "2026-06-30T12:00:00Z",
+          "conversation_id": "conv-sandbox-financial-ops-1"
+        },
+        {
+          "_ref": "conv_fin_m2",
+          "entity_type": "conversation_message",
+          "canonical_name": "financial-ops-msg-2",
+          "role": "assistant",
+          "sender_kind": "assistant",
+          "content": "Logged all three against their vendors: CloudHost €420 (paid), LexCo Legal retainer €2,500 (open, due 2026-07-01), and WeWork July rent €1,800 (open, due 2026-07-05). CloudHost, LexCo Legal, and WeWork are on file as organizations.",
+          "turn_key": "conv-sandbox-financial-ops-1:turn:2",
+          "timestamp": "2026-06-30T12:05:00Z",
+          "conversation_id": "conv-sandbox-financial-ops-1"
+        },
+        {
+          "_ref": "conv_fin_m3",
+          "entity_type": "conversation_message",
+          "canonical_name": "financial-ops-msg-3",
+          "role": "user",
+          "sender_kind": "user",
+          "content": "The CloudHost invoice was paid by SEPA on June 12. Post that and the other June movements to the operating ledger: €12,000 received from Acme Retail and €18,000 for payroll on the 28th.",
+          "turn_key": "conv-sandbox-financial-ops-1:turn:3",
+          "timestamp": "2026-06-30T12:10:00Z",
+          "conversation_id": "conv-sandbox-financial-ops-1"
+        },
+        {
+          "_ref": "conv_fin_m4",
+          "entity_type": "conversation_message",
+          "canonical_name": "financial-ops-msg-4",
+          "role": "assistant",
+          "sender_kind": "assistant",
+          "content": "Posted the CloudHost payment (€420 debit, 2026-06-12, SEPA) and linked it to the CloudHost invoice. Also posted the Acme Retail receipt (€12,000 credit) and June payroll (€18,000 debit) to the Operating ledger Q2 (period 2026-Q2, EUR).",
+          "turn_key": "conv-sandbox-financial-ops-1:turn:4",
+          "timestamp": "2026-06-30T12:14:00Z",
+          "conversation_id": "conv-sandbox-financial-ops-1"
+        },
+        {
+          "_ref": "conv_fin_m5",
+          "entity_type": "conversation_message",
+          "canonical_name": "financial-ops-msg-5",
+          "role": "user",
+          "sender_kind": "user",
+          "content": "Run the June bank reconciliation against that ledger.",
+          "turn_key": "conv-sandbox-financial-ops-1:turn:5",
+          "timestamp": "2026-06-30T12:17:00Z",
+          "conversation_id": "conv-sandbox-financial-ops-1"
+        },
+        {
+          "_ref": "conv_fin_m6",
+          "entity_type": "conversation_message",
+          "canonical_name": "financial-ops-msg-6",
+          "role": "assistant",
+          "sender_kind": "assistant",
+          "content": "Completed the June bank reconciliation (period 2026-06) against the Operating ledger Q2 — status balanced. All three posted transactions tie out.",
+          "turn_key": "conv-sandbox-financial-ops-1:turn:6",
+          "timestamp": "2026-06-30T12:20:00Z",
+          "conversation_id": "conv-sandbox-financial-ops-1"
+        }
+      ]
     }
   ],
   "relationships": [
+    {
+      "source_ref": "conv_fin_m1",
+      "target_ref": "conv_fin",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "conv_fin_m2",
+      "target_ref": "conv_fin",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "conv_fin_m3",
+      "target_ref": "conv_fin",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "conv_fin_m4",
+      "target_ref": "conv_fin",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "conv_fin_m5",
+      "target_ref": "conv_fin",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "conv_fin_m6",
+      "target_ref": "conv_fin",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "conv_fin",
+      "target_ref": "v_cloud",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_fin",
+      "target_ref": "v_legal",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_fin",
+      "target_ref": "v_office",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_fin",
+      "target_ref": "i_cloud",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_fin",
+      "target_ref": "i_legal",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_fin",
+      "target_ref": "i_office",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_fin",
+      "target_ref": "x_cloud",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_fin",
+      "target_ref": "x_acme",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_fin",
+      "target_ref": "x_payroll",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_fin",
+      "target_ref": "l_main",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_fin",
+      "target_ref": "r_june",
+      "relationship_type": "references"
+    },
     {
       "source_ref": "i_cloud",
       "target_ref": "v_cloud",

--- a/tests/fixtures/sandbox/use_cases/meetings/manifest.json
+++ b/tests/fixtures/sandbox/use_cases/meetings/manifest.json
@@ -153,9 +153,233 @@
           "timezone": "Europe/Madrid"
         }
       ]
+    },
+    {
+      "agent_index": 2,
+      "idempotency_prefix": "meet-conv-intro",
+      "entities": [
+        {
+          "_ref": "conv_meet_intro",
+          "entity_type": "conversation",
+          "canonical_name": "Cedar Labs intro call prep & recap",
+          "title": "Cedar Labs intro call prep & recap",
+          "platform": "cursor",
+          "started_at": "2026-06-18T16:00:00Z",
+          "ended_at": "2026-06-18T16:12:00Z",
+          "turn_count": 4,
+          "idempotency_hint": "conv-sandbox-meetings-1",
+          "conversation_id": "conv-sandbox-meetings-1"
+        },
+        {
+          "_ref": "conv_meet_intro_m1",
+          "entity_type": "conversation_message",
+          "canonical_name": "meetings-intro-msg-1",
+          "role": "user",
+          "sender_kind": "user",
+          "content": "We just had the Cedar Labs ↔ Northwind intro call on Zoom — Maya Chen (CEO) and Tom Okafor (investor) were on it. Capture the meeting and transcript.",
+          "turn_key": "conv-sandbox-meetings-1:turn:1",
+          "timestamp": "2026-06-18T16:00:00Z",
+          "conversation_id": "conv-sandbox-meetings-1"
+        },
+        {
+          "_ref": "conv_meet_intro_m2",
+          "entity_type": "conversation_message",
+          "canonical_name": "meetings-intro-msg-2",
+          "role": "assistant",
+          "sender_kind": "assistant",
+          "content": "Logged the \"Cedar Labs ↔ Northwind intro\" meeting (2026-06-18) with Maya Chen and Tom Okafor as attendees, plus the 2,100-word Zoom intro call transcript linked to it.",
+          "turn_key": "conv-sandbox-meetings-1:turn:2",
+          "timestamp": "2026-06-18T16:04:00Z",
+          "conversation_id": "conv-sandbox-meetings-1"
+        },
+        {
+          "_ref": "conv_meet_intro_m3",
+          "entity_type": "conversation_message",
+          "canonical_name": "meetings-intro-msg-3",
+          "role": "user",
+          "sender_kind": "user",
+          "content": "It went warm — Northwind is interested at seed. Write the recap and add an action item to send the investor deck by the 20th.",
+          "turn_key": "conv-sandbox-meetings-1:turn:3",
+          "timestamp": "2026-06-18T16:08:00Z",
+          "conversation_id": "conv-sandbox-meetings-1"
+        },
+        {
+          "_ref": "conv_meet_intro_m4",
+          "entity_type": "conversation_message",
+          "canonical_name": "meetings-intro-msg-4",
+          "role": "assistant",
+          "sender_kind": "assistant",
+          "content": "Saved the \"Intro call recap\" note (Northwind interested at seed; follow up with deck) and created the task \"Send investor deck\" due 2026-06-20, both linked to the intro meeting.",
+          "turn_key": "conv-sandbox-meetings-1:turn:4",
+          "timestamp": "2026-06-18T16:12:00Z",
+          "conversation_id": "conv-sandbox-meetings-1"
+        }
+      ]
+    },
+    {
+      "agent_index": 0,
+      "idempotency_prefix": "meet-conv-design",
+      "entities": [
+        {
+          "_ref": "conv_meet_design",
+          "entity_type": "conversation",
+          "canonical_name": "Launch design review recap",
+          "title": "Launch design review recap",
+          "platform": "chatgpt",
+          "started_at": "2026-06-22T11:00:00Z",
+          "ended_at": "2026-06-22T11:10:00Z",
+          "turn_count": 4,
+          "idempotency_hint": "conv-sandbox-meetings-2",
+          "conversation_id": "conv-sandbox-meetings-2"
+        },
+        {
+          "_ref": "conv_meet_design_m1",
+          "entity_type": "conversation_message",
+          "canonical_name": "meetings-design-msg-1",
+          "role": "user",
+          "sender_kind": "user",
+          "content": "The Launch design review wrapped on Google Meet with Priya Nair (design). Log the meeting and its transcript.",
+          "turn_key": "conv-sandbox-meetings-2:turn:1",
+          "timestamp": "2026-06-22T11:00:00Z",
+          "conversation_id": "conv-sandbox-meetings-2"
+        },
+        {
+          "_ref": "conv_meet_design_m2",
+          "entity_type": "conversation_message",
+          "canonical_name": "meetings-design-msg-2",
+          "role": "assistant",
+          "sender_kind": "assistant",
+          "content": "Logged the \"Launch design review\" meeting (2026-06-22) with Priya Nair and the 3,400-word Google Meet design review transcript linked to it.",
+          "turn_key": "conv-sandbox-meetings-2:turn:2",
+          "timestamp": "2026-06-22T11:03:00Z",
+          "conversation_id": "conv-sandbox-meetings-2"
+        },
+        {
+          "_ref": "conv_meet_design_m3",
+          "entity_type": "conversation_message",
+          "canonical_name": "meetings-design-msg-3",
+          "role": "user",
+          "sender_kind": "user",
+          "content": "Outcome: the picker is approved, just tighten the empty states. The picker specs are finalized. Recap it and note the QA action for the auth path.",
+          "turn_key": "conv-sandbox-meetings-2:turn:3",
+          "timestamp": "2026-06-22T11:06:00Z",
+          "conversation_id": "conv-sandbox-meetings-2"
+        },
+        {
+          "_ref": "conv_meet_design_m4",
+          "entity_type": "conversation_message",
+          "canonical_name": "meetings-design-msg-4",
+          "role": "assistant",
+          "sender_kind": "assistant",
+          "content": "Saved the \"Design review recap\" note (picker approved; tighten empty states), marked \"Finalize picker specs\" done, and added \"Add auth-path QA\" due 2026-06-30 against the upcoming Launch retro.",
+          "turn_key": "conv-sandbox-meetings-2:turn:4",
+          "timestamp": "2026-06-22T11:10:00Z",
+          "conversation_id": "conv-sandbox-meetings-2"
+        }
+      ]
     }
   ],
   "relationships": [
+    {
+      "source_ref": "conv_meet_intro_m1",
+      "target_ref": "conv_meet_intro",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "conv_meet_intro_m2",
+      "target_ref": "conv_meet_intro",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "conv_meet_intro_m3",
+      "target_ref": "conv_meet_intro",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "conv_meet_intro_m4",
+      "target_ref": "conv_meet_intro",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "conv_meet_intro",
+      "target_ref": "mt_intro",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_meet_intro",
+      "target_ref": "a_maya",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_meet_intro",
+      "target_ref": "a_tom",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_meet_intro",
+      "target_ref": "tr_intro",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_meet_intro",
+      "target_ref": "ai_deck",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_meet_intro",
+      "target_ref": "rc_intro",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_meet_design_m1",
+      "target_ref": "conv_meet_design",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "conv_meet_design_m2",
+      "target_ref": "conv_meet_design",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "conv_meet_design_m3",
+      "target_ref": "conv_meet_design",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "conv_meet_design_m4",
+      "target_ref": "conv_meet_design",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "conv_meet_design",
+      "target_ref": "mt_design",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_meet_design",
+      "target_ref": "a_priya",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_meet_design",
+      "target_ref": "tr_design",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_meet_design",
+      "target_ref": "ai_specs",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_meet_design",
+      "target_ref": "ai_qa",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_meet_design",
+      "target_ref": "rc_design",
+      "relationship_type": "references"
+    },
     {
       "source_ref": "mt_intro",
       "target_ref": "a_maya",

--- a/tests/fixtures/sandbox/use_cases/personal-agent/manifest.json
+++ b/tests/fixtures/sandbox/use_cases/personal-agent/manifest.json
@@ -182,9 +182,168 @@
           "best_streak": 34
         }
       ]
+    },
+    {
+      "agent_index": 3,
+      "idempotency_prefix": "pa-conv",
+      "entities": [
+        {
+          "_ref": "conv_pa",
+          "entity_type": "conversation",
+          "canonical_name": "Half-marathon training check-in",
+          "title": "Half-marathon training check-in",
+          "platform": "cli",
+          "started_at": "2026-06-23T07:00:00Z",
+          "ended_at": "2026-06-23T07:14:00Z",
+          "turn_count": 6,
+          "idempotency_hint": "conv-sandbox-personal-agent-1",
+          "conversation_id": "conv-sandbox-personal-agent-1"
+        },
+        {
+          "_ref": "conv_pa_m1",
+          "entity_type": "conversation_message",
+          "canonical_name": "personal-agent-msg-1",
+          "role": "user",
+          "sender_kind": "user",
+          "content": "I'm training for a half marathon in October. Set that as a goal and track a daily morning run habit toward it.",
+          "turn_key": "conv-sandbox-personal-agent-1:turn:1",
+          "timestamp": "2026-06-23T07:00:00Z",
+          "conversation_id": "conv-sandbox-personal-agent-1"
+        },
+        {
+          "_ref": "conv_pa_m2",
+          "entity_type": "conversation_message",
+          "canonical_name": "personal-agent-msg-2",
+          "role": "assistant",
+          "sender_kind": "assistant",
+          "content": "Created the goal \"Run a half marathon\" (target 2026-10-01) and a daily \"Morning run\" habit linked to it. Your morning-run streak is at 21 days right now, best ever 34.",
+          "turn_key": "conv-sandbox-personal-agent-1:turn:2",
+          "timestamp": "2026-06-23T07:03:00Z",
+          "conversation_id": "conv-sandbox-personal-agent-1"
+        },
+        {
+          "_ref": "conv_pa_m3",
+          "entity_type": "conversation_message",
+          "canonical_name": "personal-agent-msg-3",
+          "role": "user",
+          "sender_kind": "user",
+          "content": "Log this week's runs: 6km easy today, intervals 8km Wednesday, and a 14km long run Saturday with Sam my coach.",
+          "turn_key": "conv-sandbox-personal-agent-1:turn:3",
+          "timestamp": "2026-06-23T07:06:00Z",
+          "conversation_id": "conv-sandbox-personal-agent-1"
+        },
+        {
+          "_ref": "conv_pa_m4",
+          "entity_type": "conversation_message",
+          "canonical_name": "personal-agent-msg-4",
+          "role": "assistant",
+          "sender_kind": "assistant",
+          "content": "Logged all three workouts under the Morning run habit: 6km easy run (2026-06-23), 8km intervals (2026-06-25), and the 14km long run (2026-06-28) tagged with Sam (coach). I also saved the \"Training plan\" note: build to 18km long runs by September.",
+          "turn_key": "conv-sandbox-personal-agent-1:turn:4",
+          "timestamp": "2026-06-23T07:09:00Z",
+          "conversation_id": "conv-sandbox-personal-agent-1"
+        },
+        {
+          "_ref": "conv_pa_m5",
+          "entity_type": "conversation_message",
+          "canonical_name": "personal-agent-msg-5",
+          "role": "user",
+          "sender_kind": "user",
+          "content": "Remind me to register for the race by August 1. And I have a dentist appointment June 27 — don't schedule a hard run that morning.",
+          "turn_key": "conv-sandbox-personal-agent-1:turn:5",
+          "timestamp": "2026-06-23T07:11:00Z",
+          "conversation_id": "conv-sandbox-personal-agent-1"
+        },
+        {
+          "_ref": "conv_pa_m6",
+          "entity_type": "conversation_message",
+          "canonical_name": "personal-agent-msg-6",
+          "role": "assistant",
+          "sender_kind": "assistant",
+          "content": "Added the task \"Register for the race\" due 2026-08-01 (linked to your half-marathon goal) and noted the Dentist event on 2026-06-27, related to that task so the morning stays light.",
+          "turn_key": "conv-sandbox-personal-agent-1:turn:6",
+          "timestamp": "2026-06-23T07:14:00Z",
+          "conversation_id": "conv-sandbox-personal-agent-1"
+        }
+      ]
     }
   ],
   "relationships": [
+    {
+      "source_ref": "conv_pa_m1",
+      "target_ref": "conv_pa",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "conv_pa_m2",
+      "target_ref": "conv_pa",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "conv_pa_m3",
+      "target_ref": "conv_pa",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "conv_pa_m4",
+      "target_ref": "conv_pa",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "conv_pa_m5",
+      "target_ref": "conv_pa",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "conv_pa_m6",
+      "target_ref": "conv_pa",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "conv_pa",
+      "target_ref": "go_fit",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_pa",
+      "target_ref": "hb_run",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_pa",
+      "target_ref": "wo_mon",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_pa",
+      "target_ref": "wo_wed",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_pa",
+      "target_ref": "wo_sat",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_pa",
+      "target_ref": "pn_plan",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_pa",
+      "target_ref": "pt_register",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_pa",
+      "target_ref": "ev_dentist",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_pa",
+      "target_ref": "pc_sam",
+      "relationship_type": "references"
+    },
     {
       "source_ref": "wo_mon",
       "target_ref": "hb_run",

--- a/tests/fixtures/sandbox/use_cases/personal-data/manifest.json
+++ b/tests/fixtures/sandbox/use_cases/personal-data/manifest.json
@@ -183,9 +183,188 @@
           "source": "Garmin"
         }
       ]
+    },
+    {
+      "agent_index": 1,
+      "idempotency_prefix": "pdd-conv",
+      "entities": [
+        {
+          "_ref": "conv_pd",
+          "entity_type": "conversation",
+          "canonical_name": "Quantified-self weekly sync",
+          "title": "Quantified-self weekly sync",
+          "platform": "claude",
+          "started_at": "2026-06-25T20:00:00Z",
+          "ended_at": "2026-06-25T20:16:00Z",
+          "turn_count": 6,
+          "idempotency_hint": "conv-sandbox-personal-data-1",
+          "conversation_id": "conv-sandbox-personal-data-1"
+        },
+        {
+          "_ref": "conv_pd_m1",
+          "entity_type": "conversation_message",
+          "canonical_name": "personal-data-msg-1",
+          "role": "user",
+          "sender_kind": "user",
+          "content": "Goal for the quarter: lower my resting heart rate to 55 bpm. Track a daily morning run and a daily meditate habit toward it.",
+          "turn_key": "conv-sandbox-personal-data-1:turn:1",
+          "timestamp": "2026-06-25T20:00:00Z",
+          "conversation_id": "conv-sandbox-personal-data-1"
+        },
+        {
+          "_ref": "conv_pd_m2",
+          "entity_type": "conversation_message",
+          "canonical_name": "personal-data-msg-2",
+          "role": "assistant",
+          "sender_kind": "assistant",
+          "content": "Created the goal \"Lower resting heart rate\" (target 55 bpm) and two daily habits linked to it: \"Morning run\" and \"Meditate\".",
+          "turn_key": "conv-sandbox-personal-data-1:turn:2",
+          "timestamp": "2026-06-25T20:03:00Z",
+          "conversation_id": "conv-sandbox-personal-data-1"
+        },
+        {
+          "_ref": "conv_pd_m3",
+          "entity_type": "conversation_message",
+          "canonical_name": "personal-data-msg-3",
+          "role": "user",
+          "sender_kind": "user",
+          "content": "Sync this week from Garmin: a 6km run Monday (34 min), a 45-min strength session Tuesday, and a 14km long run Sunday (82 min).",
+          "turn_key": "conv-sandbox-personal-data-1:turn:3",
+          "timestamp": "2026-06-25T20:07:00Z",
+          "conversation_id": "conv-sandbox-personal-data-1"
+        },
+        {
+          "_ref": "conv_pd_m4",
+          "entity_type": "conversation_message",
+          "canonical_name": "personal-data-msg-4",
+          "role": "assistant",
+          "sender_kind": "assistant",
+          "content": "Synced all three workouts: 6km run (34 min, avg HR 148, source Garmin), 45-min strength, and the 14km long run (82 min). The 6km and long runs are linked to your Morning run habit.",
+          "turn_key": "conv-sandbox-personal-data-1:turn:4",
+          "timestamp": "2026-06-25T20:10:00Z",
+          "conversation_id": "conv-sandbox-personal-data-1"
+        },
+        {
+          "_ref": "conv_pd_m5",
+          "entity_type": "conversation_message",
+          "canonical_name": "personal-data-msg-5",
+          "role": "user",
+          "sender_kind": "user",
+          "content": "Today's metrics: resting HR 58, weight 72.4kg, slept 7.4h. Also log my €49 gym membership and €140 running shoes, and keep units metric with a 7am workout time.",
+          "turn_key": "conv-sandbox-personal-data-1:turn:5",
+          "timestamp": "2026-06-25T20:13:00Z",
+          "conversation_id": "conv-sandbox-personal-data-1"
+        },
+        {
+          "_ref": "conv_pd_m6",
+          "entity_type": "conversation_message",
+          "canonical_name": "personal-data-msg-6",
+          "role": "assistant",
+          "sender_kind": "assistant",
+          "content": "Logged today's health metrics (resting HR 58 bpm, weight 72.4 kg, sleep 7.4 h) — the HR reading is tied to the morning 6km run. Recorded the €49 gym membership and €140 running shoes transactions, and set your preferences: units metric, workout time 07:00.",
+          "turn_key": "conv-sandbox-personal-data-1:turn:6",
+          "timestamp": "2026-06-25T20:16:00Z",
+          "conversation_id": "conv-sandbox-personal-data-1"
+        }
+      ]
     }
   ],
   "relationships": [
+    {
+      "source_ref": "conv_pd_m1",
+      "target_ref": "conv_pd",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "conv_pd_m2",
+      "target_ref": "conv_pd",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "conv_pd_m3",
+      "target_ref": "conv_pd",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "conv_pd_m4",
+      "target_ref": "conv_pd",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "conv_pd_m5",
+      "target_ref": "conv_pd",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "conv_pd_m6",
+      "target_ref": "conv_pd",
+      "relationship_type": "part_of"
+    },
+    {
+      "source_ref": "conv_pd",
+      "target_ref": "pd_go",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_pd",
+      "target_ref": "pd_hb",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_pd",
+      "target_ref": "pd_med",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_pd",
+      "target_ref": "pd_w1",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_pd",
+      "target_ref": "pd_w2",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_pd",
+      "target_ref": "pd_w3",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_pd",
+      "target_ref": "pd_hr",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_pd",
+      "target_ref": "pd_wt",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_pd",
+      "target_ref": "pd_sleep",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_pd",
+      "target_ref": "pd_gym",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_pd",
+      "target_ref": "pd_shoes",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_pd",
+      "target_ref": "pd_pref",
+      "relationship_type": "references"
+    },
+    {
+      "source_ref": "conv_pd",
+      "target_ref": "pd_pref2",
+      "relationship_type": "references"
+    },
     {
       "source_ref": "pd_w1",
       "target_ref": "pd_hb",


### PR DESCRIPTION
## What

Every sandbox use-case showcase pack previously seeded structured records (accounts, contacts, deals, invoices, tickets, PRs, workouts, etc.) but **zero conversation history** — so an Inspector visitor saw records that appeared from nowhere, with no dialogue or provenance story. This PR adds the conversation that produced each pack's records, demonstrating Neotoma's core model: structured records are extracted from conversations.

For each of the 9 packs in `tests/fixtures/sandbox/use_cases/<pack>/manifest.json` I added one (or two, for `meetings`) `conversation` entity plus alternating user/assistant `conversation_message` entities, authored entirely in the manifest (no seeder change required — `scripts/seed_sandbox.ts` stores any entity_type in `entity_batches` as-is and wires `_ref` relationships).

The message content concretely narrates that pack's actual records — naming the real contacts, deal amounts, invoice numbers, ticket titles, PR numbers, workouts, etc. — and the assistant turns sound like an agent confirming what it stored.

## Linking approach

- Each `conversation_message` `-[part_of]->` its `conversation`.
- Each `conversation` `-[references]->` every record it derived (account, contact, deal, task, invoice, ticket, PR, commit, workout, health_metric, …). These edges make the conversation→records mapping explicit in the graph.

## Per-pack additions

| Pack | agent_index (platform) | conversations | messages | rels added |
|---|---|---|---|---|
| crm | 1 (claude) | 1 | 6 | 14 |
| agent-auth | 2 (cursor) | 1 | 6 | 15 |
| content-ops | 0 (chatgpt) | 1 | 6 | 15 |
| customer-development | 3 (cli) | 1 | 6 | 16 |
| engineering | 1 (claude) | 1 | 6 | 16 |
| financial-ops | 0 (chatgpt) | 1 | 6 | 17 |
| meetings | 2 (cursor) + 0 (chatgpt) | 2 | 8 | 20 |
| personal-agent | 3 (cli) | 1 | 6 | 15 |
| personal-data | 1 (claude) | 1 | 6 | 19 |

`agent_index` is rotated across packs so the `/agents` page shows attribution diversity. `meetings` warranted two conversations (an intro-call prep/recap thread and a separate design-review recap), attributed to two different agents.

## Generic pack decision

The generic pack (`tests/fixtures/sandbox/manifest.json`) was **left as-is**. It already contains an inline `conversation` (`c_launch`) with messages wired `part_of` it, and that conversation already has a `references` edge to a co-present record (`pr_launch`). Its conversation→record provenance is already demonstrated, so no change was needed (and touching it risks the richness guard in `sandbox_generic_manifest.test.ts`).

## Tests / tooling

- `npx vitest run tests/unit/sandbox_generic_manifest.test.ts tests/unit/sandbox_pack_registry.test.ts tests/unit/sandbox_seeder_command.test.ts` — **15/15 pass**. No test-expectation changes were needed: those tests assert the generic manifest's richness and the registry/seeder command, none assert per-pack entity counts.
- All 9 edited manifests re-parsed as valid JSON; every `_ref` used in `relationships` is defined in some `entity_batches` entity (no dangling refs); no duplicate `_ref` within a pack.
- `npx prettier --check` on all edited manifests — clean.
- No test files added/removed, so the test catalog was not regenerated.
- Content is fictional and PII-free per the fixtures README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
