### PR TITLE
chore(tests): regenerate stale automated test catalog on main

### DIFF
--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,8 +61,8 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **501**
-- Backend and repo Vitest files: **467**
+- Total automated test files: **502**
+- Backend and repo Vitest files: **468**
 - Frontend Vitest files: **9**
 - Playwright spec files: **25**
 
@@ -72,7 +72,7 @@ flowchart TD
 | Vitest unit tests | 136 |
 | Vitest service tests | 35 |
 | Source-adjacent tests | 62 |
-| Vitest integration tests | 141 |
+| Vitest integration tests | 142 |
 | Vitest CLI tests | 65 |
 | Vitest contract tests | 14 |
 | Vitest security tests | 3 |
@@ -363,7 +363,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm run test:integration` or `npx vitest run tests/integration`
 **Requirements:** Database configured; remote-dependent subsets additionally need `RUN_REMOTE_TESTS=1`.
-**Files (141):**
+**Files (142):**
 - `tests/integration/aauth_attribution_stamping.test.ts`
 - `tests/integration/aauth_mcp_capability_parity.test.ts`
 - `tests/integration/aauth_mcp_initialize_admission.test.ts`
@@ -478,6 +478,7 @@ flowchart TD
 - `tests/integration/root_landing.test.ts`
 - `tests/integration/sandbox_mode.test.ts`
 - `tests/integration/sandbox_report.test.ts`
+- `tests/integration/sandbox_seed_token_bypass.test.ts`
 - `tests/integration/sandbox_stale_bearer_fallback.test.ts`
 - `tests/integration/schema_recommendation_integration.test.ts`
 - `tests/integration/session_introspection.test.ts`


### PR DESCRIPTION
## Problem

`main`'s `docs/testing/automated_test_catalog.md` has been **stale since #1797**, which merged `tests/integration/sandbox_seed_token_bypass.test.ts` without regenerating the catalog. The `baseline` CI job runs `validate:test-catalog --check`, so **every PR opened against main fails `baseline`** on this check — including fixture-only or docs-only PRs that touch no tests.

Confirmed by running `npm run validate:test-catalog` on a clean `origin/main` checkout: ❌ stale.

## Fix

Regenerated the catalog (`npm run generate:test-catalog`). The drift is exactly:
- `tests/integration/sandbox_seed_token_bypass.test.ts` added to the integration file list
- repo-wide total 501→502, backend 467→468, integration count 141→142

Generator output is deterministic (stable across repeated runs); `validate:test-catalog` passes after the change.

## Impact

Unblocks `baseline` for all open PRs once they pick this up (rebase / merge main). Standalone and low-risk — a single generated-doc file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)