### PR TITLE
feat(bundles): m3 activation — bundle state store + CLI + manage_bundles MCP

### DIFF
--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,15 +61,15 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **507**
-- Backend and repo Vitest files: **473**
+- Total automated test files: **509**
+- Backend and repo Vitest files: **475**
 - Frontend Vitest files: **9**
 - Playwright spec files: **25**
 
 ### Suite counts
 | Suite | Files |
 |---|---:|
-| Vitest unit tests | 139 |
+| Vitest unit tests | 141 |
 | Vitest service tests | 35 |
 | Source-adjacent tests | 62 |
 | Vitest integration tests | 143 |
@@ -109,7 +109,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/unit`
 **Requirements:** Basic `.env` if required by the module under test.
-**Files (139):**
+**Files (141):**
 - `tests/unit/aauth_admission.test.ts`
 - `tests/unit/aauth_attestation_apple_se.test.ts`
 - `tests/unit/aauth_attestation_revocation.test.ts`
@@ -134,6 +134,7 @@ flowchart TD
 - `tests/unit/attribution_policy.test.ts`
 - `tests/unit/bigint_serialization.test.ts`
 - `tests/unit/bundled_docs_nav.test.ts`
+- `tests/unit/bundles_activation.test.ts`
 - `tests/unit/bundles_loader.test.ts`
 - `tests/unit/canonical_markdown_body_heading.test.ts`
 - `tests/unit/capability_delta.test.ts`
@@ -181,6 +182,7 @@ flowchart TD
 - `tests/unit/inspector_skin.test.ts`
 - `tests/unit/keepalive_timeout.test.ts`
 - `tests/unit/list_timeline_events_unknown_type.test.ts`
+- `tests/unit/manage_bundles_tool.test.ts`
 - `tests/unit/markdown_mirror_paths.test.ts`
 - `tests/unit/mcp_dev_shim.test.ts`
 - `tests/unit/mcp_initialize_skills.test.ts`

--- a/src/cli/commands/bundles.ts
+++ b/src/cli/commands/bundles.ts
@@ -1,0 +1,150 @@
+/**
+ * `neotoma bundles <list|info|install|enable|disable>` (Bundles m3 activation).
+ *
+ * Surfaces the bundle registry and toggles persisted enable/disable state via
+ * the activation orchestration in `src/services/bundles/activation.ts`. The MCP
+ * `manage_bundles` tool mirrors these exact actions.
+ *
+ * Operates on the local filesystem registry + state file (no running server
+ * required), matching the m2 loader which discovers bundles from disk.
+ *
+ * Tracking: Neotoma plan `ent_089da2ecebc3bd804d63dcf2` (Bundles Strategy, m3).
+ */
+
+import type { Command } from "commander";
+
+function isJson(program: Command): boolean {
+  return Boolean((program.opts() as { json?: boolean }).json);
+}
+
+function emit(program: Command, payload: unknown, lines: () => string): void {
+  if (isJson(program)) {
+    process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+  } else {
+    process.stdout.write(`${lines()}\n`);
+  }
+}
+
+function fail(program: Command, message: string): void {
+  if (isJson(program)) {
+    process.stdout.write(`${JSON.stringify({ ok: false, error: message }, null, 2)}\n`);
+  } else {
+    process.stderr.write(`Error: ${message}\n`);
+  }
+  process.exitCode = 1;
+}
+
+export function registerBundlesCommand(program: Command): void {
+  const bundlesCommand = program
+    .command("bundles")
+    .description(
+      "Inspect and manage Neotoma bundles (the deliverable unit shipping schemas, " +
+        "record-type docs, and skills). list | info | install | enable | disable."
+    );
+
+  bundlesCommand
+    .command("list")
+    .description("List all bundles in the registry with type, version, and enabled state.")
+    .action(async () => {
+      const { listBundles } = await import("../../services/bundles/index.js");
+      const rows = listBundles();
+      emit(program, { bundles: rows }, () => {
+        if (rows.length === 0) return "No bundles found.";
+        const header = "BUNDLE                TYPE     VERSION  STATE      ALWAYS  TYPES";
+        const body = rows
+          .map((r) => {
+            const name = r.name.padEnd(21);
+            const type = (r.bundle_type ?? "-").padEnd(8);
+            const version = (r.version ?? "-").padEnd(8);
+            const state = (r.enabled ? "enabled" : "disabled").padEnd(10);
+            const always = (r.always_active ? "yes" : "no").padEnd(7);
+            const types = String(r.provides_entity_types_count ?? 0);
+            return `${name} ${type} ${version} ${state} ${always} ${types}`;
+          })
+          .join("\n");
+        return `${header}\n${body}`;
+      });
+    });
+
+  bundlesCommand
+    .command("info <bundle>")
+    .description("Show full manifest detail for one bundle.")
+    .action(async (bundle: string) => {
+      const { getBundleInfo } = await import("../../services/bundles/index.js");
+      const info = getBundleInfo(bundle);
+      if (!info) {
+        fail(program, `Unknown bundle "${bundle}". Run "neotoma bundles list".`);
+        return;
+      }
+      emit(program, info, () => {
+        const m = info.manifest;
+        const lines = [
+          `Bundle:               ${m.name}`,
+          `Type:                 ${m.bundle_type}`,
+          `Version:              ${m.version}`,
+          `Description:          ${m.description}`,
+          `State:                ${info.enabled ? "enabled" : "disabled"}${
+            info.always_active ? " (always active)" : ""
+          }`,
+          `requires_bundles:     ${m.requires_bundles.join(", ") || "(none)"}`,
+          `provides_entity_types:${m.provides_entity_types.length ? " " + m.provides_entity_types.join(", ") : " (none)"}`,
+          `provides_skills:      ${m.provides_skills.map((s) => s.name).join(", ") || "(none)"}`,
+          `serves_use_cases:     ${m.serves_use_cases.join(", ") || "(none)"}`,
+          `compatible_modes:     ${m.compatible_modes.join(", ")}`,
+        ];
+        return lines.join("\n");
+      });
+    });
+
+  bundlesCommand
+    .command("install <bundle>")
+    .description("Mark a bundle enabled (validates + records state).")
+    .action(async (bundle: string) => {
+      const { installBundle, UnknownBundleError } = await import("../../services/bundles/index.js");
+      try {
+        const result = installBundle(bundle);
+        emit(program, { ok: true, ...result }, () => result.message);
+      } catch (err) {
+        if (err instanceof UnknownBundleError) {
+          fail(program, err.message);
+          return;
+        }
+        fail(program, err instanceof Error ? err.message : String(err));
+      }
+    });
+
+  bundlesCommand
+    .command("enable <bundle>")
+    .description("Enable a previously-disabled bundle.")
+    .action(async (bundle: string) => {
+      const { enableBundle, UnknownBundleError } = await import("../../services/bundles/index.js");
+      try {
+        const result = enableBundle(bundle);
+        emit(program, { ok: true, ...result }, () => result.message);
+      } catch (err) {
+        if (err instanceof UnknownBundleError) {
+          fail(program, err.message);
+          return;
+        }
+        fail(program, err instanceof Error ? err.message : String(err));
+      }
+    });
+
+  bundlesCommand
+    .command("disable <bundle>")
+    .description("Disable a bundle. Refuses to disable an always-active default bundle.")
+    .action(async (bundle: string) => {
+      const { disableBundle, BundleStateError, UnknownBundleError } =
+        await import("../../services/bundles/index.js");
+      try {
+        const result = disableBundle(bundle);
+        emit(program, { ok: true, ...result }, () => result.message);
+      } catch (err) {
+        if (err instanceof UnknownBundleError || err instanceof BundleStateError) {
+          fail(program, err.message);
+          return;
+        }
+        fail(program, err instanceof Error ? err.message : String(err));
+      }
+    });
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -68,6 +68,7 @@ import {
 } from "../mcp_instruction_doc.js";
 import { registerProcessesCommands } from "./commands/processes.js";
 import { registerDbCommand } from "./commands/db.js";
+import { registerBundlesCommand } from "./commands/bundles.js";
 import { registerPeersCommand } from "./peers.js";
 import { buildInspectorFeedbackAdminUnlockPageUrl } from "./inspector_admin_unlock_url.js";
 import {
@@ -11222,6 +11223,8 @@ registerDbCommand(program, {
     return path.resolve(dataDir, dbFile);
   },
 });
+
+registerBundlesCommand(program);
 
 // ── Logs ──────────────────────────────────────────────────────────────────
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -1595,6 +1595,74 @@ export class NeotomaServer {
     return this.buildTextResponse({ subscription: redactSubscriptionForClient(row) });
   }
 
+  private async handleManageBundles(
+    args: unknown
+  ): Promise<{ content: Array<{ type: string; text: string }> }> {
+    const schema = z.object({
+      action: z.enum(["list", "info", "install", "enable", "disable"]),
+      bundle: z.string().min(1).optional(),
+    });
+    const parsed = schema.parse(args ?? {});
+    const {
+      listBundles,
+      getBundleInfo,
+      installBundle,
+      enableBundle,
+      disableBundle,
+      BundleStateError,
+      UnknownBundleError,
+    } = await import("./services/bundles/index.js");
+
+    // m3 follow-up: AAuth admin-tier gating of install/disable belongs here,
+    // before the mutating actions below. Intentionally not implemented in m3.
+
+    try {
+      if (parsed.action === "list") {
+        return this.buildTextResponse({ ok: true, action: "list", bundles: listBundles() });
+      }
+      const bundle = parsed.bundle?.trim();
+      if (!bundle) {
+        throw new McpError(
+          ErrorCode.InvalidParams,
+          `manage_bundles: action "${parsed.action}" requires a "bundle" name.`
+        );
+      }
+      if (parsed.action === "info") {
+        const info = getBundleInfo(bundle);
+        if (!info) {
+          return this.buildTextResponse({
+            ok: false,
+            action: "info",
+            bundle,
+            error: `Unknown bundle "${bundle}".`,
+          });
+        }
+        return this.buildTextResponse({ ok: true, action: "info", ...info });
+      }
+      const result =
+        parsed.action === "install"
+          ? installBundle(bundle)
+          : parsed.action === "enable"
+            ? enableBundle(bundle)
+            : disableBundle(bundle);
+      return this.buildTextResponse({ ok: true, action: parsed.action, ...result });
+    } catch (err) {
+      if (err instanceof McpError) throw err;
+      if (err instanceof BundleStateError || err instanceof UnknownBundleError) {
+        return this.buildTextResponse({
+          ok: false,
+          action: parsed.action,
+          bundle: parsed.bundle,
+          error: err.message,
+        });
+      }
+      throw new McpError(
+        ErrorCode.InternalError,
+        `manage_bundles failed: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  }
+
   private async handleAddPeer(
     args: unknown,
     userId: string
@@ -2069,6 +2137,8 @@ export class NeotomaServer {
         return await this.handleResolveSyncConflict(args, this.getAuthenticatedUserId());
       case "publish_rendered_page":
         return await this.handlePublishRenderedPage(args);
+      case "manage_bundles":
+        return await this.handleManageBundles(args);
       default:
         throw new McpError(ErrorCode.MethodNotFound, `Unknown tool: ${name}`);
     }

--- a/src/services/bundles/activation.ts
+++ b/src/services/bundles/activation.ts
@@ -1,0 +1,151 @@
+/**
+ * Bundle activation orchestration (Bundles m3).
+ *
+ * Thin layer over the state store + loader that the CLI (`neotoma bundles`) and
+ * the MCP `manage_bundles` tool both call, so their behavior stays identical.
+ * Each mutation invalidates the cached registry so the next read (and the
+ * schema-mode enforcement that consults it) reflects the new enabled set.
+ *
+ * AAuth admin-tier gating of install/disable is OUT OF SCOPE for m3 — see the
+ * TODO marker in {@link assertAdminGateHook}. Do NOT implement AAuth here.
+ *
+ * Tracking: Neotoma plan `ent_089da2ecebc3bd804d63dcf2` (Bundles Strategy, m3).
+ */
+
+import {
+  BundleStateError,
+  getBundle,
+  getBundleRegistry,
+  isAlwaysActiveBundle,
+  isBundleEnabled,
+  listInstalledBundleViews,
+  resetBundleRegistryForTesting,
+  setBundleEnabled,
+  type BundleManifest,
+  type InstalledBundleView,
+} from "./loader.js";
+
+/**
+ * m3 follow-up hook: AAuth admin-tier gating of install/disable lands later
+ * (see PR body "m3 follow-ups"). Today this is a no-op so the machinery ships
+ * un-gated. When implemented, the gate belongs HERE — before any state mutation
+ * in {@link installBundle}/{@link enableBundle}/{@link disableBundle} — so both
+ * the CLI and MCP surfaces inherit it without duplication.
+ *
+ * @param _action the mutating action being attempted.
+ */
+function assertAdminGateHook(_action: "install" | "enable" | "disable"): void {
+  // TODO(bundles-m3-followup): require AAuth admin tier for install/disable.
+  // Intentionally a no-op in this PR.
+}
+
+/** A bundle's full manifest detail, for the `info` surface. */
+export interface BundleInfo {
+  name: string;
+  enabled: boolean;
+  always_active: boolean;
+  manifest: BundleManifest;
+}
+
+/** Outcome of a state-mutating activation action. */
+export interface BundleActionResult {
+  bundle: string;
+  enabled: boolean;
+  always_active: boolean;
+  /** Human-readable summary of what happened. */
+  message: string;
+}
+
+/** Lists every known bundle with its install/enable state and manifest metadata. */
+export function listBundles(): InstalledBundleView[] {
+  return listInstalledBundleViews();
+}
+
+/**
+ * Returns full manifest detail for one bundle, or `null` if no bundle by that
+ * name is in the registry.
+ */
+export function getBundleInfo(name: string): BundleInfo | null {
+  const loaded = getBundle(name);
+  if (!loaded) return null;
+  return {
+    name: loaded.manifest.name,
+    enabled: isBundleEnabled(loaded.manifest.name),
+    always_active: isAlwaysActiveBundle(loaded.manifest.name),
+    manifest: loaded.manifest,
+  };
+}
+
+/** Thrown when an activation action targets a bundle not in the registry. */
+export class UnknownBundleError extends Error {
+  constructor(name: string) {
+    super(
+      `Unknown bundle "${name}". Run "neotoma bundles list" to see available bundles. ` +
+        `(The registry currently ships the default-install bundles plus catalog references.)`
+    );
+    this.name = "UnknownBundleError";
+  }
+}
+
+function ensureKnown(name: string): void {
+  if (!getBundle(name)) {
+    throw new UnknownBundleError(name);
+  }
+}
+
+/**
+ * Mark a bundle enabled (install). Validates the bundle exists in the registry
+ * and records enabled state. Always-active default bundles are already enabled;
+ * installing them is a no-op success.
+ */
+export function installBundle(name: string): BundleActionResult {
+  assertAdminGateHook("install");
+  ensureKnown(name);
+  const enabled = setBundleEnabled(name, true);
+  resetBundleRegistryForTesting();
+  const always = isAlwaysActiveBundle(name);
+  return {
+    bundle: name,
+    enabled,
+    always_active: always,
+    message: always
+      ? `Bundle "${name}" is a default-install bundle and is always active.`
+      : `Bundle "${name}" installed and enabled.`,
+  };
+}
+
+/** Enable a previously-disabled bundle. */
+export function enableBundle(name: string): BundleActionResult {
+  assertAdminGateHook("enable");
+  ensureKnown(name);
+  const enabled = setBundleEnabled(name, true);
+  resetBundleRegistryForTesting();
+  return {
+    bundle: name,
+    enabled,
+    always_active: isAlwaysActiveBundle(name),
+    message: `Bundle "${name}" enabled.`,
+  };
+}
+
+/**
+ * Disable a bundle. Refuses to disable an always-active default bundle
+ * (rethrows the {@link BundleStateError} from the state store with the
+ * clear-error contract).
+ */
+export function disableBundle(name: string): BundleActionResult {
+  assertAdminGateHook("disable");
+  ensureKnown(name);
+  const enabled = setBundleEnabled(name, false); // throws BundleStateError for defaults
+  resetBundleRegistryForTesting();
+  return {
+    bundle: name,
+    enabled,
+    always_active: isAlwaysActiveBundle(name),
+    message:
+      `Bundle "${name}" disabled. Its schemas remain registered but its types ` +
+      `no longer auto-create under guided/locked; existing data is preserved.`,
+  };
+}
+
+export { BundleStateError, getBundleRegistry };

--- a/src/services/bundles/index.ts
+++ b/src/services/bundles/index.ts
@@ -13,18 +13,40 @@ export type {
 } from "./types.js";
 export { ManifestError, normalizeManifest, parseManifest } from "./manifest.js";
 export {
+  ALWAYS_ACTIVE_BUNDLES,
+  BundleStateError,
   bundleProviding,
+  bundleStatePath,
   bundlesRootDir,
   buildRegistry,
+  getBundle,
   getBundleRegistry,
   getProvidedEntityTypes,
+  isAlwaysActiveBundle,
+  isBundleEnabled,
+  listInstalledBundles,
+  listInstalledBundleViews,
   loadBundlesFrom,
   resetBundleRegistryForTesting,
+  resetBundleStateCacheForTesting,
   resolveRequires,
+  setBundleEnabled,
   type BundleRegistry,
+  type InstalledBundleState,
+  type InstalledBundleView,
 } from "./loader.js";
 export {
   checkAutoCreateAllowed,
   type AutoCreateBlockReason,
   type AutoCreateDecision,
 } from "./enforcement.js";
+export {
+  disableBundle,
+  enableBundle,
+  getBundleInfo,
+  installBundle,
+  listBundles,
+  UnknownBundleError,
+  type BundleActionResult,
+  type BundleInfo,
+} from "./activation.js";

--- a/src/services/bundles/loader.ts
+++ b/src/services/bundles/loader.ts
@@ -25,6 +25,7 @@ import { fileURLToPath } from "node:url";
 
 import { logger } from "../../utils/logger.js";
 import { ManifestError, parseManifest } from "./manifest.js";
+import { isBundleEnabled, listInstalledBundles } from "./state_store.js";
 import type { BundleManifest, LoadedBundle } from "./types.js";
 
 /**
@@ -69,7 +70,11 @@ export function loadBundlesFrom(root: string): LoadedBundle[] {
     const manifestPath = path.join(dir, "manifest.yaml");
     const source = fs.readFileSync(manifestPath, "utf8");
     const manifest = parseManifest(source, path.relative(root, manifestPath));
-    bundles.push({ manifest, dir, enabled: true });
+    // `enabled` reflects persisted install state: default bundles are always
+    // active; non-default bundles must be explicitly enabled (m3 state store).
+    // A disabled schema bundle's types stop counting as "provided" under
+    // guided/locked (see "Disable, not uninstall" in docs/foundation/bundles.md).
+    bundles.push({ manifest, dir, enabled: isBundleEnabled(manifest.name) });
   }
   return bundles;
 }
@@ -183,5 +188,64 @@ export function bundleProviding(entityType: string): string | undefined {
 export function resetBundleRegistryForTesting(): void {
   cached = undefined;
 }
+
+/**
+ * Returns the loaded bundle for `name`, or `undefined` if no bundle by that name
+ * is in the registry. Used by the CLI/MCP `info` surface and install validation.
+ */
+export function getBundle(name: string): LoadedBundle | undefined {
+  return getBundleRegistry().bundles.find((b) => b.manifest.name === name);
+}
+
+/**
+ * Loader-level install-state listing: the install state of every bundle known to
+ * the registry (plus any with persisted deviations), enriched with manifest
+ * metadata for display. Combines the state store with the discovered registry.
+ */
+export interface InstalledBundleView {
+  name: string;
+  enabled: boolean;
+  always_active: boolean;
+  /** Present when the bundle is in the discovered registry. */
+  bundle_type?: BundleManifest["bundle_type"];
+  version?: string;
+  provides_entity_types_count?: number;
+}
+
+/**
+ * Returns the install state for all known bundles, enriched with manifest data
+ * where available. The registry's bundle names seed the listing so newly added
+ * (but not-yet-toggled) bundles still appear.
+ */
+export function listInstalledBundleViews(): InstalledBundleView[] {
+  const registry = getBundleRegistry();
+  const byName = new Map(registry.bundles.map((b) => [b.manifest.name, b]));
+  const rows = listInstalledBundles(byName.keys());
+  return rows.map((row) => {
+    const loaded = byName.get(row.name);
+    return {
+      ...row,
+      ...(loaded
+        ? {
+            bundle_type: loaded.manifest.bundle_type,
+            version: loaded.manifest.version,
+            provides_entity_types_count: loaded.manifest.provides_entity_types.length,
+          }
+        : {}),
+    };
+  });
+}
+
+export {
+  ALWAYS_ACTIVE_BUNDLES,
+  BundleStateError,
+  bundleStatePath,
+  isAlwaysActiveBundle,
+  isBundleEnabled,
+  listInstalledBundles,
+  resetBundleStateCacheForTesting,
+  setBundleEnabled,
+  type InstalledBundleState,
+} from "./state_store.js";
 
 export type { BundleManifest, LoadedBundle };

--- a/src/services/bundles/state_store.ts
+++ b/src/services/bundles/state_store.ts
@@ -1,0 +1,197 @@
+/**
+ * Bundle install/enable state store (Bundles m3 activation).
+ *
+ * A persisted record of which bundles are enabled vs disabled. The default
+ * bundles (`core`, `infrastructure`, `core_workflows`) are **always active** and
+ * cannot be disabled — they are not stored here at all; their active state is a
+ * constant. Only deviations from the default (a non-default bundle that has been
+ * installed/enabled, or a bundle explicitly disabled) are persisted.
+ *
+ * Persistence design (justified in the m3 PR): a small JSON file under the
+ * Neotoma config dir, mirroring the CLI config pattern in `src/cli/config.ts`
+ * (`readConfig`/`writeConfig` → `~/.config/neotoma/config.json`). Rationale:
+ *
+ *   - Bundle enable/disable is small, machine-local **operator** config, not
+ *     user-scoped graph data. It does not belong in the entity graph the way
+ *     `submission_config`/`peer_config` do (those are per-user, per-target rows
+ *     written through the store pipeline with DB access).
+ *   - The loader-level enforcement (`getProvidedEntityTypes`, consulted by the
+ *     schema-mode gates) must be able to read this state **without a live DB or
+ *     authenticated session** — the same constraint that pushed bundle discovery
+ *     to the filesystem in m2. A file-backed store keeps enforcement pure and
+ *     testable in isolation (no Supabase/SQLite required).
+ *   - It is trivially overridable for tests via `NEOTOMA_BUNDLE_STATE_PATH`.
+ *
+ * The default-install bundles are the always-active set; see
+ * {@link isAlwaysActiveBundle}.
+ *
+ * Tracking: Neotoma plan `ent_089da2ecebc3bd804d63dcf2` (Bundles Strategy, m3).
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { logger } from "../../utils/logger.js";
+
+/**
+ * The default-install bundles. These ship in every Neotoma install, are always
+ * active, and cannot be disabled (per `docs/foundation/bundles.md`, "Default
+ * install" + "Disable, not uninstall"). Kept in sync with the bundle dirs under
+ * `src/services/bundles/`.
+ */
+export const ALWAYS_ACTIVE_BUNDLES: ReadonlySet<string> = new Set([
+  "core",
+  "infrastructure",
+  "core_workflows",
+]);
+
+/** Returns true if `name` is a default-install (always-active) bundle. */
+export function isAlwaysActiveBundle(name: string): boolean {
+  return ALWAYS_ACTIVE_BUNDLES.has(name);
+}
+
+/**
+ * On-disk shape of the bundle state file. `enabled` maps a bundle name to its
+ * persisted enabled flag. A name absent from the map falls back to its default
+ * (always-active bundles default enabled; everything else defaults disabled
+ * until installed). `version` allows future migrations.
+ */
+interface BundleStateFile {
+  version: 1;
+  /** bundle name -> explicit enabled flag (deviation from the default). */
+  enabled: Record<string, boolean>;
+}
+
+const STATE_VERSION = 1 as const;
+
+/** Resolves the bundle state file path (overridable for tests). */
+export function bundleStatePath(): string {
+  const override = process.env.NEOTOMA_BUNDLE_STATE_PATH?.trim();
+  if (override) return override;
+  return path.join(os.homedir(), ".config", "neotoma", "bundle_state.json");
+}
+
+let cached: BundleStateFile | undefined;
+
+function emptyState(): BundleStateFile {
+  return { version: STATE_VERSION, enabled: {} };
+}
+
+function readStateFile(): BundleStateFile {
+  if (cached !== undefined) return cached;
+  const filePath = bundleStatePath();
+  try {
+    const raw = fs.readFileSync(filePath, "utf8");
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      typeof (parsed as BundleStateFile).enabled === "object" &&
+      (parsed as BundleStateFile).enabled !== null
+    ) {
+      const enabledRaw = (parsed as BundleStateFile).enabled as Record<string, unknown>;
+      const enabled: Record<string, boolean> = {};
+      for (const [name, value] of Object.entries(enabledRaw)) {
+        if (typeof value === "boolean") enabled[name] = value;
+      }
+      cached = { version: STATE_VERSION, enabled };
+      return cached;
+    }
+  } catch (err) {
+    // Missing file is the common case (nothing installed beyond defaults).
+    if ((err as NodeJS.ErrnoException)?.code !== "ENOENT") {
+      logger.warn(
+        `[bundles] failed to read bundle state (${bundleStatePath()}): ${
+          err instanceof Error ? err.message : String(err)
+        }; treating as empty.`
+      );
+    }
+  }
+  cached = emptyState();
+  return cached;
+}
+
+function writeStateFile(state: BundleStateFile): void {
+  const filePath = bundleStatePath();
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(state, null, 2));
+  cached = state;
+}
+
+/**
+ * Returns whether a bundle is enabled. Always-active default bundles are always
+ * enabled regardless of stored state. Non-default bundles default to disabled
+ * (not installed) unless an explicit `true` is persisted.
+ */
+export function isBundleEnabled(name: string): boolean {
+  if (isAlwaysActiveBundle(name)) return true;
+  const state = readStateFile();
+  return state.enabled[name] === true;
+}
+
+/** One row in the installed-bundles listing. */
+export interface InstalledBundleState {
+  name: string;
+  enabled: boolean;
+  always_active: boolean;
+}
+
+/**
+ * Returns the install state for the given bundle names (defaults to the
+ * always-active set plus any names with persisted state). Always-active bundles
+ * are reported `enabled: true, always_active: true`.
+ */
+export function listInstalledBundles(knownBundleNames?: Iterable<string>): InstalledBundleState[] {
+  const state = readStateFile();
+  const names = new Set<string>([
+    ...ALWAYS_ACTIVE_BUNDLES,
+    ...Object.keys(state.enabled),
+    ...(knownBundleNames ?? []),
+  ]);
+  return [...names].sort().map((name) => ({
+    name,
+    enabled: isBundleEnabled(name),
+    always_active: isAlwaysActiveBundle(name),
+  }));
+}
+
+/** Thrown when an operation is refused (e.g. disabling an always-active bundle). */
+export class BundleStateError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "BundleStateError";
+  }
+}
+
+/**
+ * Persist a bundle's enabled flag. Refuses to disable an always-active default
+ * bundle (throws {@link BundleStateError}). Enabling an always-active bundle is a
+ * no-op (they are always enabled). For non-default bundles, the flag is written
+ * to the state file.
+ *
+ * @returns the resulting enabled state for the bundle.
+ */
+export function setBundleEnabled(name: string, enabled: boolean): boolean {
+  if (isAlwaysActiveBundle(name)) {
+    if (!enabled) {
+      throw new BundleStateError(
+        `Bundle "${name}" is a default-install bundle and is always active; it cannot be disabled.`
+      );
+    }
+    // Enabling an always-active bundle is a no-op.
+    return true;
+  }
+  const state = readStateFile();
+  const next: BundleStateFile = {
+    version: STATE_VERSION,
+    enabled: { ...state.enabled, [name]: enabled },
+  };
+  writeStateFile(next);
+  return enabled;
+}
+
+/** Test-only: clears the in-memory cache so the next read re-reads the file. */
+export function resetBundleStateCacheForTesting(): void {
+  cached = undefined;
+}

--- a/src/tool_definitions.ts
+++ b/src/tool_definitions.ts
@@ -1444,6 +1444,30 @@ export function buildToolDefinitions(
         additionalProperties: false,
       },
     },
+    {
+      name: "manage_bundles",
+      description: desc(
+        "manage_bundles",
+        "Inspect and manage Neotoma bundles (the deliverable unit shipping schemas, record-type docs, and skills). action=list returns all bundles with type/version/enabled/always_active/provides count; action=info (with bundle) returns full manifest detail; action=install/enable/disable (with bundle) toggle persisted enable state. Default-install bundles (core, infrastructure, core_workflows) are always active and cannot be disabled. Disabling a schema bundle stops its types from auto-creating under guided/locked while preserving existing data. Returns structured JSON."
+      ),
+      inputSchema: {
+        type: "object",
+        properties: {
+          action: {
+            type: "string",
+            enum: ["list", "info", "install", "enable", "disable"],
+            description: "The bundle management action to perform.",
+          },
+          bundle: {
+            type: "string",
+            description:
+              "Bundle name. Required for info, install, enable, and disable; ignored for list.",
+          },
+        },
+        required: ["action"],
+        additionalProperties: false,
+      },
+    },
   ];
 
   return tools;
@@ -1511,6 +1535,7 @@ export const NEOTOMA_TOOL_NAMES = [
   "npm_check_update",
   "neotoma_turn_summary",
   "publish_rendered_page",
+  "manage_bundles",
 ] as const;
 
 export type NeotomaToolName = (typeof NEOTOMA_TOOL_NAMES)[number];

--- a/tests/cli/cli_command_coverage_guard.test.ts
+++ b/tests/cli/cli_command_coverage_guard.test.ts
@@ -53,6 +53,7 @@ describe("CLI command coverage guard", () => {
       "upload",
       "db", // subcommands covered by db_migrate_encryption.test.ts (migrate-encryption) and db_repair_schema_lag.test.ts (repair-schema-lag)
       "onboarding", // subcommands covered by onboarding_import_transcripts.test.ts (import-transcripts)
+      "bundles", // list/info/install/enable/disable behavior covered by tests/unit/bundles_activation.test.ts + manage_bundles_tool.test.ts
     ]);
 
     // Commands intentionally help-only due interactivity or generic dispatch.

--- a/tests/unit/bundles_activation.test.ts
+++ b/tests/unit/bundles_activation.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Unit tests for the Bundles m3 activation core: the install/enable state store,
+ * the activation orchestration (list/info/install/enable/disable), the refusal
+ * to disable an always-active default bundle, and the enforcement consequence
+ * (a disabled schema bundle's types stop counting as "provided").
+ *
+ * Plan: ent_089da2ecebc3bd804d63dcf2 (Bundles Strategy, m3).
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  ALWAYS_ACTIVE_BUNDLES,
+  BundleStateError,
+  bundleStatePath,
+  buildRegistry,
+  checkAutoCreateAllowed,
+  disableBundle,
+  enableBundle,
+  getBundleInfo,
+  getProvidedEntityTypes,
+  installBundle,
+  isAlwaysActiveBundle,
+  isBundleEnabled,
+  listBundles,
+  listInstalledBundles,
+  parseManifest,
+  resetBundleRegistryForTesting,
+  resetBundleStateCacheForTesting,
+  setBundleEnabled,
+  UnknownBundleError,
+} from "../../src/services/bundles/index.js";
+import { resetSchemaModeCacheForTesting } from "../../src/services/schema_mode.js";
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "bundle-state-"));
+  process.env.NEOTOMA_BUNDLE_STATE_PATH = path.join(tmpDir, "bundle_state.json");
+  resetBundleStateCacheForTesting();
+  resetBundleRegistryForTesting();
+  resetSchemaModeCacheForTesting();
+  delete process.env.NEOTOMA_SCHEMA_MODE;
+});
+
+afterEach(() => {
+  delete process.env.NEOTOMA_BUNDLE_STATE_PATH;
+  delete process.env.NEOTOMA_SCHEMA_MODE;
+  resetBundleStateCacheForTesting();
+  resetBundleRegistryForTesting();
+  resetSchemaModeCacheForTesting();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("state store — defaults", () => {
+  it("the three default-install bundles are always active and enabled", () => {
+    expect([...ALWAYS_ACTIVE_BUNDLES].sort()).toEqual(["core", "core_workflows", "infrastructure"]);
+    for (const name of ALWAYS_ACTIVE_BUNDLES) {
+      expect(isAlwaysActiveBundle(name)).toBe(true);
+      expect(isBundleEnabled(name)).toBe(true);
+    }
+  });
+
+  it("a non-default bundle defaults to disabled until installed", () => {
+    expect(isBundleEnabled("financial_ops")).toBe(false);
+  });
+});
+
+describe("state store — round-trip", () => {
+  it("setBundleEnabled persists across a cache reset (re-reads the file)", () => {
+    expect(setBundleEnabled("financial_ops", true)).toBe(true);
+    expect(fs.existsSync(bundleStatePath())).toBe(true);
+
+    // Drop the in-memory cache; the next read must come from disk.
+    resetBundleStateCacheForTesting();
+    expect(isBundleEnabled("financial_ops")).toBe(true);
+
+    setBundleEnabled("financial_ops", false);
+    resetBundleStateCacheForTesting();
+    expect(isBundleEnabled("financial_ops")).toBe(false);
+  });
+
+  it("listInstalledBundles reports always-active defaults plus persisted state", () => {
+    setBundleEnabled("financial_ops", true);
+    const rows = listInstalledBundles();
+    const byName = new Map(rows.map((r) => [r.name, r]));
+    expect(byName.get("core")).toMatchObject({ enabled: true, always_active: true });
+    expect(byName.get("financial_ops")).toMatchObject({
+      enabled: true,
+      always_active: false,
+    });
+  });
+});
+
+describe("state store — refuse to disable a default bundle", () => {
+  it("setBundleEnabled(core, false) throws BundleStateError", () => {
+    expect(() => setBundleEnabled("core", false)).toThrow(BundleStateError);
+    expect(() => setBundleEnabled("core", false)).toThrow(/always active/i);
+  });
+
+  it("enabling an always-active bundle is a no-op success", () => {
+    expect(setBundleEnabled("core", true)).toBe(true);
+  });
+});
+
+describe("activation — list and info output shape", () => {
+  it("list returns the three default bundles with enriched metadata", () => {
+    const rows = listBundles();
+    const names = rows.map((r) => r.name);
+    expect(names).toEqual(expect.arrayContaining(["core", "core_workflows", "infrastructure"]));
+    const core = rows.find((r) => r.name === "core")!;
+    expect(core.always_active).toBe(true);
+    expect(core.enabled).toBe(true);
+    expect(core.bundle_type).toBe("schema");
+    expect(typeof core.version).toBe("string");
+    expect(core.provides_entity_types_count).toBeGreaterThan(0);
+  });
+
+  it("info returns full manifest detail for a known bundle", () => {
+    const info = getBundleInfo("core_workflows");
+    expect(info).not.toBeNull();
+    expect(info!.manifest.bundle_type).toBe("skill");
+    expect(info!.manifest.requires_bundles).toContain("core");
+    expect(info!.manifest.provides_entity_types).toEqual([]);
+    expect(info!.always_active).toBe(true);
+    expect(info!.enabled).toBe(true);
+  });
+
+  it("info returns null for an unknown bundle", () => {
+    expect(getBundleInfo("does_not_exist")).toBeNull();
+  });
+});
+
+describe("activation — install / enable / disable", () => {
+  it("install of a default bundle is a no-op success (always active)", () => {
+    const result = installBundle("core");
+    expect(result.always_active).toBe(true);
+    expect(result.enabled).toBe(true);
+    expect(result.message).toMatch(/always active/i);
+  });
+
+  it("install/enable/disable of an unknown bundle throws UnknownBundleError", () => {
+    expect(() => installBundle("nope")).toThrow(UnknownBundleError);
+    expect(() => enableBundle("nope")).toThrow(UnknownBundleError);
+    expect(() => disableBundle("nope")).toThrow(UnknownBundleError);
+  });
+
+  it("disable of a default bundle throws BundleStateError with a clear message", () => {
+    expect(() => disableBundle("infrastructure")).toThrow(BundleStateError);
+    expect(() => disableBundle("infrastructure")).toThrow(/cannot be disabled/i);
+  });
+});
+
+describe("enforcement — disabling a (hypothetical) non-default schema bundle hides its types", () => {
+  it("buildRegistry drops a disabled bundle's provided types from the provided set", () => {
+    const enabledBundle = {
+      dir: "/enabled",
+      enabled: true,
+      manifest: parseManifest(
+        `name: alpha\nversion: 1.0.0\ndescription: a\nbundle_type: schema\nprovides_entity_types:\n  - widget`
+      ),
+    };
+    const disabledBundle = {
+      dir: "/disabled",
+      enabled: false,
+      manifest: parseManifest(
+        `name: beta\nversion: 1.0.0\ndescription: b\nbundle_type: schema\nprovides_entity_types:\n  - gadget`
+      ),
+    };
+    const reg = buildRegistry([enabledBundle, disabledBundle]);
+    expect(reg.providedEntityTypes.has("widget")).toBe(true);
+    expect(reg.providedEntityTypes.has("gadget")).toBe(false);
+  });
+
+  it("real loader: toggling state changes the live provided set used by enforcement", () => {
+    // Simulate a non-default schema bundle that provides a type by writing state
+    // for one of the default schema bundles is not possible (they cannot be
+    // disabled), so we exercise the loader's enabled-flag wiring directly:
+    // disabling at the file level removes the bundle's types from the live set.
+    //
+    // Use 'infrastructure' to prove default bundles are immune even if the file
+    // somehow contains a stale disable flag (defaults are always-active).
+    fs.writeFileSync(
+      bundleStatePath(),
+      JSON.stringify({ version: 1, enabled: { infrastructure: false } })
+    );
+    resetBundleStateCacheForTesting();
+    resetBundleRegistryForTesting();
+
+    // infrastructure types remain provided — defaults override stored state.
+    const provided = getProvidedEntityTypes();
+    expect(provided.has("issue")).toBe(true);
+    expect(provided.has("plan")).toBe(true);
+
+    // guided enforcement still allows the infrastructure-provided type.
+    expect(checkAutoCreateAllowed("issue", "guided").allowed).toBe(true);
+  });
+});

--- a/tests/unit/manage_bundles_tool.test.ts
+++ b/tests/unit/manage_bundles_tool.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Unit tests for the Bundles m3 MCP tool `manage_bundles`:
+ *  - it is advertised by buildToolDefinitions() and listed in NEOTOMA_TOOL_NAMES;
+ *  - the handler returns structured JSON for list/info and for the mutating
+ *    actions, mirroring the CLI;
+ *  - it refuses to disable an always-active default bundle with a clear error.
+ *
+ * Plan: ent_089da2ecebc3bd804d63dcf2 (Bundles Strategy, m3).
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { buildToolDefinitions, NEOTOMA_TOOL_NAMES } from "../../src/tool_definitions.js";
+import { NeotomaServer } from "../../src/server.js";
+import {
+  resetBundleRegistryForTesting,
+  resetBundleStateCacheForTesting,
+} from "../../src/services/bundles/index.js";
+
+type TextResponse = { content: Array<{ type: string; text: string }> };
+
+function parseResponse(res: TextResponse): Record<string, unknown> {
+  expect(res.content[0]?.type).toBe("text");
+  return JSON.parse(res.content[0]!.text) as Record<string, unknown>;
+}
+
+async function callManageBundles(args: unknown): Promise<Record<string, unknown>> {
+  const server = new NeotomaServer();
+  const res = (await (
+    server as unknown as {
+      handleManageBundles(a: unknown): Promise<TextResponse>;
+    }
+  ).handleManageBundles(args)) as TextResponse;
+  return parseResponse(res);
+}
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "manage-bundles-"));
+  process.env.NEOTOMA_BUNDLE_STATE_PATH = path.join(tmpDir, "bundle_state.json");
+  resetBundleStateCacheForTesting();
+  resetBundleRegistryForTesting();
+});
+
+afterEach(() => {
+  delete process.env.NEOTOMA_BUNDLE_STATE_PATH;
+  resetBundleStateCacheForTesting();
+  resetBundleRegistryForTesting();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("manage_bundles registration", () => {
+  it("is advertised by buildToolDefinitions() with the expected schema", () => {
+    const tool = buildToolDefinitions().find((t) => t.name === "manage_bundles");
+    expect(tool).toBeDefined();
+    expect(tool!.inputSchema).toMatchObject({
+      properties: {
+        action: { enum: ["list", "info", "install", "enable", "disable"] },
+        bundle: { type: "string" },
+      },
+      required: ["action"],
+    });
+  });
+
+  it("is in NEOTOMA_TOOL_NAMES", () => {
+    expect(NEOTOMA_TOOL_NAMES).toContain("manage_bundles");
+  });
+});
+
+describe("manage_bundles handler", () => {
+  it("action=list returns the bundle set as structured JSON", async () => {
+    const out = await callManageBundles({ action: "list" });
+    expect(out.ok).toBe(true);
+    expect(out.action).toBe("list");
+    const bundles = out.bundles as Array<{ name: string }>;
+    expect(bundles.map((b) => b.name)).toEqual(
+      expect.arrayContaining(["core", "core_workflows", "infrastructure"])
+    );
+  });
+
+  it("action=info returns full manifest detail for a known bundle", async () => {
+    const out = await callManageBundles({ action: "info", bundle: "core_workflows" });
+    expect(out.ok).toBe(true);
+    expect(out.always_active).toBe(true);
+    const manifest = out.manifest as { bundle_type: string; requires_bundles: string[] };
+    expect(manifest.bundle_type).toBe("skill");
+    expect(manifest.requires_bundles).toContain("core");
+  });
+
+  it("action=info on an unknown bundle returns ok:false", async () => {
+    const out = await callManageBundles({ action: "info", bundle: "no_such_bundle" });
+    expect(out.ok).toBe(false);
+    expect(String(out.error)).toMatch(/unknown bundle/i);
+  });
+
+  it("action=disable on a default bundle returns ok:false with a clear error", async () => {
+    const out = await callManageBundles({ action: "disable", bundle: "core" });
+    expect(out.ok).toBe(false);
+    expect(String(out.error)).toMatch(/cannot be disabled/i);
+  });
+
+  it("action=install on an unknown bundle returns ok:false (UnknownBundleError)", async () => {
+    const out = await callManageBundles({ action: "install", bundle: "no_such_bundle" });
+    expect(out.ok).toBe(false);
+    expect(String(out.error)).toMatch(/unknown bundle/i);
+  });
+
+  it("a mutating action without a bundle name throws InvalidParams", async () => {
+    await expect(callManageBundles({ action: "install" })).rejects.toThrow(/requires a "bundle"/i);
+  });
+});


### PR DESCRIPTION
## Summary

Milestone **m3 (activation)** of the Bundles Strategy (plan `ent_089da2ecebc3bd804d63dcf2`, spec `docs/foundation/bundles.md`). Builds on the m2 runtime (loader, default install, schema-mode enforcement). Delivers the activation core: a persisted install/enable-state store, the `neotoma bundles` CLI, and the `manage_bundles` MCP tool.

## State-store design choice

A small **JSON file under the Neotoma config dir** (`~/.config/neotoma/bundle_state.json`), mirroring the existing CLI config pattern in `src/cli/config.ts` (`readConfig`/`writeConfig`), overridable via `NEOTOMA_BUNDLE_STATE_PATH` for tests.

Why this over a Neotoma entity type (the `submission_config`/`peer_config` pattern):

- Bundle enable/disable is small, **machine-local operator config**, not user-scoped graph data. `submission_config`/`peer_config` are per-user, per-target rows written through the store pipeline with live DB access; bundle state has none of those properties.
- The loader-level enforcement (`getProvidedEntityTypes`, consulted by the schema-mode gates) must read this state **without a live DB or authenticated session** — the same constraint that pushed m2 bundle discovery to the filesystem. A file-backed store keeps enforcement pure and unit-testable in isolation.
- Trivially overridable + resettable for tests.

Only deviations from the default are persisted; the always-active set (`core`, `infrastructure`, `core_workflows`) is a constant and is never written, never disablable.

## What's in this PR

- **State store** (`src/services/bundles/state_store.ts`): `isBundleEnabled`, `listInstalledBundles`, `setBundleEnabled` (+ `ALWAYS_ACTIVE_BUNDLES`, `isAlwaysActiveBundle`, `BundleStateError`, test reset). Refuses to disable a default bundle.
- **Enforcement wiring** (`loader.ts`): `loadBundlesFrom` sources each bundle's `enabled` flag from the state store. `buildRegistry` already filters provided types on `enabled`, so a **disabled schema bundle's types stop counting as "provided" under guided/locked** while existing data is preserved ("Disable, not uninstall"). `evolving` (default) parity is unchanged.
- **Activation orchestration** (`activation.ts`): `listBundles`, `getBundleInfo`, `installBundle`, `enableBundle`, `disableBundle`; each mutation invalidates the registry cache. Shared by CLI + MCP so behavior is identical.
- **CLI** `neotoma bundles <list|info|install|enable|disable>` (`src/cli/commands/bundles.ts`, registered next to `db`/`processes`). Honors the global `--json` flag and surrounding exit-code conventions.
- **MCP tool** `manage_bundles` (action: list|info|install|enable|disable, + bundle). Added to `buildToolDefinitions`, `NEOTOMA_TOOL_NAMES`, and the `executeTool` dispatch switch; returns structured JSON.
- **Tests** (`tests/unit/bundles_activation.test.ts`, `tests/unit/manage_bundles_tool.test.ts`): state-store round-trip, refuse-to-disable-default, list/info shape, the `manage_bundles` handler, and that a disabled (hypothetical non-default) schema bundle's types drop from the provided set used by enforcement.

Today the registry ships only the 3 default bundles + catalog references, so `install`/`enable` of a not-yet-built catalog bundle correctly returns `UnknownBundleError` — the machinery is built and validated.

## Out of scope (m3 follow-ups)

- Skill copy into `.claude/skills/`, `.cursor/skills/`, `.codex/skills/` on install
- guided-mode skill auto-install prompt
- **AAuth admin-tier gating** of install/disable — a clearly-marked hook/TODO is left where the gate belongs (`activation.ts` `assertAdminGateHook`, and a matching comment in the server handler); not implemented here
- `neotoma setup` use-case step
- castor-agent's infrastructure seed-ownership migration

## Merge order

m1 #1798 → m2 #1800 → **this PR** (based on `feat/bundles-m2-linter-usecases`).

## Verification

- `npx tsc --noEmit`: 0 errors
- `npm run lint`: 0 errors (only pre-existing `no-explicit-any` warnings, none in new files)
- `npx prettier --check` on all touched files: clean
- New tests: `bundles_activation` (14) + `manage_bundles_tool` (8) pass; existing `bundles_loader` (21) still green
- Affected contract tests pass: `mcp_tool_dispatch_coverage` (63), `openclaw_plugin` (21, incl. tool-count parity), `contract_mapping` (7), `contract_mcp_cli_parity` (9), `mcp_server_card` (2), `capability_delta` (17)
- `npm run bundles:check`: OK (3 bundles)
- `npm run generate:test-catalog` + `npm run generate:capability-manifest --check`: up-to-date (manage_bundles enters the capability manifest when first released)
- CLI smoke-tested: `list`, `info`, `--json`, and the refuse-to-disable-default error path

🤖 Generated with [Claude Code](https://claude.com/claude-code)