### PR TITLE
fix(docs): exclude marketing site/ from the browsable /docs index

### DIFF
--- a/scripts/build_bundled_docs.ts
+++ b/scripts/build_bundled_docs.ts
@@ -24,7 +24,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { resolveFrontmatter } from "../src/services/docs/doc_frontmatter.js";
 import { loadManifest } from "../src/services/docs/manifest_loader.js";
-import { NON_PUBLIC_TOP_FOLDERS } from "../src/services/docs/visibility.js";
+import { isIndexExcludedTopFolder } from "../src/services/docs/visibility.js";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(here, "..");
@@ -32,15 +32,12 @@ const docsRoot = path.join(repoRoot, "docs");
 const manifestPath = path.join(docsRoot, "site", "site_doc_manifest.yaml");
 const outRoot = path.join(repoRoot, "dist", "docs");
 
-// Top-level `docs/` folders excluded from the bundle. The non-public surface
-// set is shared with the runtime `/docs` route via `NON_PUBLIC_TOP_FOLDERS`.
-// The bundle additionally drops `site` (the marketing-site pages): the package
-// ships `.md` docs only, not the marketing tree, so npm installs never serve
-// `site/`. From-source hosts DO serve it (the root-landing footer links into
-// `site/pages/en/*`), which is why `site` is a bundler-only exclusion and not
-// in the shared set. Per-file `visibility` filtering (below) handles internal
+// Top-level `docs/` folders excluded from the bundle are defined once in
+// `src/services/docs/visibility.ts` (`INDEX_EXCLUDED_TOP_FOLDERS` = the
+// non-public surface plus `site`) and shared with the runtime browsable index
+// via `isIndexExcludedTopFolder`. The bundle applies the exclusion
+// unconditionally; per-file `visibility` filtering (below) handles internal
 // docs inside kept folders.
-const BUNDLE_EXCLUDED_TOP = new Set([...NON_PUBLIC_TOP_FOLDERS, "site"]);
 const SKIP_DIRS = new Set(["node_modules", ".git", "archived", "private"]);
 
 function collectMarkdown(root: string): string[] {
@@ -56,7 +53,7 @@ function collectMarkdown(root: string): string[] {
       if (ent.isDirectory()) {
         if (SKIP_DIRS.has(ent.name)) continue;
         const childRel = rel ? `${rel}/${ent.name}` : ent.name;
-        if (BUNDLE_EXCLUDED_TOP.has(childRel.split("/")[0])) continue;
+        if (isIndexExcludedTopFolder(childRel)) continue;
         walk(path.join(absDir, ent.name), childRel);
       } else if (ent.isFile() && ent.name.endsWith(".md")) {
         out.push(rel ? `${rel}/${ent.name}` : ent.name);

--- a/src/services/docs/bundled_nav.ts
+++ b/src/services/docs/bundled_nav.ts
@@ -6,6 +6,8 @@
 
 import type { DocsIndex, DocEntry } from "./index_builder.js";
 import type { RootLandingNavCategory, RootLandingNavItem } from "../root_landing/site_nav.js";
+import { lookupDoc } from "./render.js";
+import type { VisibilityEnv } from "./visibility.js";
 
 export interface BundledDocsQuickLink {
   label: string;
@@ -138,14 +140,51 @@ function footerHref(docsNavBase: string, slug: string): string {
 }
 
 /**
+ * Footer/quick-link slugs that resolve via DIRECT lookup even though their
+ * folder is excluded from the browsable index — i.e. the `site/pages/*`
+ * marketing pages. The footer columns deep-link into these, so we validate
+ * them against `lookupDoc` rather than index membership: present on from-source
+ * hosts (where `docs/site/` exists), absent on npm installs (bundle drops
+ * `site/`), matching each deployment's real reachability.
+ *
+ * Deterministic: a pure function of the static link lists + the docs tree.
+ */
+export function resolveExtraKnownFooterSlugs(opts: {
+  docsRoot: string;
+  env: VisibilityEnv;
+  manifestEntries?: Map<string, { status?: string }>;
+}): Set<string> {
+  const candidates = new Set<string>();
+  for (const col of BUNDLED_DOCS_FOOTER_COLUMNS) {
+    for (const link of col.links) {
+      if (link.slug && !/^https?:\/\//i.test(link.slug)) candidates.add(link.slug);
+    }
+  }
+  const known = new Set<string>();
+  for (const slug of candidates) {
+    const res = lookupDoc(slug, {
+      docsRoot: opts.docsRoot,
+      env: opts.env,
+      manifestEntries: opts.manifestEntries,
+    });
+    if (res.ok) known.add(slug);
+  }
+  return known;
+}
+
+/**
  * Footer columns for the MCP root landing page when `bundledDocsNav` is active.
- * Drops links whose doc slug is absent from the visibility-filtered index.
+ * Drops links whose doc slug is neither in the visibility-filtered index nor in
+ * `extraKnownSlugs` (directly-resolvable slugs such as `site/pages/*`, computed
+ * via {@link resolveExtraKnownFooterSlugs}).
  */
 export function buildBundledDocsFooterColumns(
   index: DocsIndex,
-  docsNavBase: string
+  docsNavBase: string,
+  extraKnownSlugs?: ReadonlySet<string>
 ): RootLandingNavCategory[] {
   const known = slugSet(index);
+  if (extraKnownSlugs) for (const s of extraKnownSlugs) known.add(s);
   const columns: RootLandingNavCategory[] = [];
 
   for (const col of BUNDLED_DOCS_FOOTER_COLUMNS) {

--- a/src/services/docs/index_builder.test.ts
+++ b/src/services/docs/index_builder.test.ts
@@ -46,6 +46,13 @@ beforeAll(() => {
   // `releases` resolves to `visibility: public` via FOLDER_DEFAULTS, but it is a
   // non-public top folder: excluded from the public surface unless show-internal.
   fs.writeFileSync(path.join(docsRoot, "releases", "v1.md"), "# Release v1\n\nNotes.\n");
+  // `site` is public per FOLDER_DEFAULTS but is excluded from the browsable
+  // index (marketing pages); still resolvable via direct lookup.
+  fs.mkdirSync(path.join(docsRoot, "site", "pages", "en"), { recursive: true });
+  fs.writeFileSync(
+    path.join(docsRoot, "site", "pages", "en", "install.md"),
+    "# Install\n\nSetup.\n"
+  );
   fs.writeFileSync(
     path.join(docsRoot, "foundation", "philosophy.md"),
     "# Philosophy\n\nPrinciples.\n"
@@ -106,6 +113,15 @@ describe("buildDocsIndex", () => {
       ...c.subcategories.flatMap((s) => s.docs.map((d) => d.slug)),
     ]);
     expect(slugs).not.toContain("releases/v1");
+  });
+
+  it("excludes the marketing site/ folder from the browsable index by default", () => {
+    const idx = buildDocsIndex({ docsRoot, manifest: MANIFEST, env: { NODE_ENV: "production" } });
+    const slugs = idx.categories.flatMap((c) => [
+      ...c.uncategorized.map((d) => d.slug),
+      ...c.subcategories.flatMap((s) => s.docs.map((d) => d.slug)),
+    ]);
+    expect(slugs.some((s) => s.startsWith("site/"))).toBe(false);
   });
 
   it("includes non-public top folders with the show-internal flag", () => {

--- a/src/services/docs/index_builder.ts
+++ b/src/services/docs/index_builder.ts
@@ -16,7 +16,7 @@ import path from "node:path";
 import { resolveFrontmatter, type DocFrontmatter } from "./doc_frontmatter.js";
 import {
   isVisible,
-  isNonPublicTopFolder,
+  isIndexExcludedTopFolder,
   shouldShowInternal,
   type VisibilityEnv,
 } from "./visibility.js";
@@ -134,11 +134,12 @@ export function buildDocsIndex(opts: BuildDocsIndexOptions): DocsIndex {
   // Resolve all entries up front (single pass).
   const all: DocEntry[] = [];
   for (const rel of files) {
-    // Non-public top-level folders (release history, feature units, the
-    // marketing site, internal-process trees) are not part of the public docs
-    // surface. Drop them unless show-internal is enabled, so a from-source host
-    // matches the curated npm bundle. See `NON_PUBLIC_TOP_FOLDERS`.
-    if (!showInternal && isNonPublicTopFolder(rel)) continue;
+    // Folders excluded from the browsable index (release history, feature
+    // units, the marketing site, internal-process trees) are dropped unless
+    // show-internal is enabled, so a from-source host matches the curated npm
+    // bundle. site/ is index-excluded but still deep-linkable; see
+    // `INDEX_EXCLUDED_TOP_FOLDERS`.
+    if (!showInternal && isIndexExcludedTopFolder(rel)) continue;
     const abs = path.join(docsRoot, rel);
     let source = "";
     try {

--- a/src/services/docs/render.test.ts
+++ b/src/services/docs/render.test.ts
@@ -25,6 +25,13 @@ beforeAll(() => {
     path.join(docsRoot, "releases", "changelog.md"),
     "# Changelog\n\nRelease history.\n"
   );
+  // `site` is excluded from the browsable index but MUST remain directly
+  // resolvable so the root-landing footer deep-links keep working.
+  fs.mkdirSync(path.join(docsRoot, "site", "pages", "en"), { recursive: true });
+  fs.writeFileSync(
+    path.join(docsRoot, "site", "pages", "en", "install.md"),
+    "# Install\n\nSetup.\n"
+  );
   fs.writeFileSync(
     path.join(docsRoot, "private", "secret.md"),
     "# Secret\n\nShould never render.\n"
@@ -110,5 +117,11 @@ describe("lookupDoc — visibility", () => {
     });
     expect(r.ok).toBe(true);
     if (r.ok) expect(r.doc.frontmatter.title).toBe("Changelog");
+  });
+
+  it("resolves a site/ page by default (excluded from index, still deep-linkable)", () => {
+    const r = lookupDoc("site/pages/en/install", { docsRoot, env: { NODE_ENV: "production" } });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.doc.frontmatter.title).toBe("Install");
   });
 });

--- a/src/services/docs/visibility.test.ts
+++ b/src/services/docs/visibility.test.ts
@@ -3,6 +3,7 @@ import {
   isVisible,
   shouldShowInternal,
   isNonPublicTopFolder,
+  isIndexExcludedTopFolder,
   NON_PUBLIC_TOP_FOLDERS,
 } from "./visibility.js";
 
@@ -62,5 +63,20 @@ describe("isNonPublicTopFolder", () => {
     for (const folder of NON_PUBLIC_TOP_FOLDERS) {
       expect(isNonPublicTopFolder(`${folder}/x.md`)).toBe(true);
     }
+  });
+});
+
+describe("isIndexExcludedTopFolder", () => {
+  it("excludes the non-public folders AND site from the browsable index", () => {
+    expect(isIndexExcludedTopFolder("releases/v1.md")).toBe(true);
+    expect(isIndexExcludedTopFolder("feature_units/x.md")).toBe(true);
+    // site/ is index-excluded here (unlike isNonPublicTopFolder, which keeps it
+    // resolvable for direct lookup).
+    expect(isIndexExcludedTopFolder("site/pages/en/install.md")).toBe(true);
+    expect(isNonPublicTopFolder("site/pages/en/install.md")).toBe(false);
+  });
+  it("keeps public-surface folders in the index", () => {
+    expect(isIndexExcludedTopFolder("foundation/core_identity.md")).toBe(false);
+    expect(isIndexExcludedTopFolder("getting_started/what_is_neotoma.md")).toBe(false);
   });
 });

--- a/src/services/docs/visibility.ts
+++ b/src/services/docs/visibility.ts
@@ -48,12 +48,11 @@ export function isVisible(fm: Pick<DocFrontmatter, "visibility">, env: Visibilit
  * dev. The bundler applies the exclusion unconditionally (the package never
  * ships internal content).
  *
- * NOTE: `site/` (the marketing-site pages) is intentionally NOT here. It is a
- * *packaging* exclusion, not a surface exclusion: from-source hosts serve it
- * (the root-landing footer links into `site/pages/en/*`), while the npm bundle
- * drops it because the package ships `.md` docs only, not the marketing tree.
- * The bundler adds `site` to its own exclusion set; see
- * `scripts/build_bundled_docs.ts`.
+ * NOTE: `site/` (the marketing-site pages) is intentionally NOT here so that
+ * DIRECT lookups of `site/pages/en/*` keep resolving (the root-landing footer
+ * deep-links into them). `site/` IS excluded from the browsable index and the
+ * npm bundle via {@link INDEX_EXCLUDED_TOP_FOLDERS}, so the ~170 multilingual
+ * marketing pages do not flood the in-app docs browser.
  */
 export const NON_PUBLIC_TOP_FOLDERS: ReadonlySet<string> = new Set([
   "releases",
@@ -72,8 +71,37 @@ export const NON_PUBLIC_TOP_FOLDERS: ReadonlySet<string> = new Set([
 /**
  * True when a `docs/`-relative path lives under a non-public top-level folder.
  * `relPath` is POSIX, `docs/`-relative (e.g. `releases/in_progress/foo.md`).
+ *
+ * This set gates DIRECT slug lookup (`render.lookupDoc`). It excludes `site`,
+ * so footer deep-links into `site/pages/en/*` still resolve on from-source
+ * hosts. For the BROWSABLE index, use {@link isIndexExcludedTopFolder}.
  */
 export function isNonPublicTopFolder(relPath: string): boolean {
   const top = relPath.split("/")[0];
   return NON_PUBLIC_TOP_FOLDERS.has(top);
+}
+
+/**
+ * Top-level folders excluded from the BROWSABLE `/docs` index and the npm
+ * bundle: the non-public surface PLUS `site` (the marketing-site pages). The
+ * ~170 multilingual `site/pages/{en,es}/*` files are marketing content, not
+ * developer docs, so they are kept out of the in-app docs browser even on
+ * from-source hosts — but they remain reachable by direct URL (see
+ * {@link isNonPublicTopFolder}) so the root-landing footer keeps working.
+ *
+ * Shared by `index_builder.buildDocsIndex` (gated by show-internal) and the
+ * build-time bundler (`scripts/build_bundled_docs.ts`, unconditional).
+ */
+export const INDEX_EXCLUDED_TOP_FOLDERS: ReadonlySet<string> = new Set([
+  ...NON_PUBLIC_TOP_FOLDERS,
+  "site",
+]);
+
+/**
+ * True when a `docs/`-relative path is excluded from the browsable index / npm
+ * bundle (non-public folders plus `site`). See {@link INDEX_EXCLUDED_TOP_FOLDERS}.
+ */
+export function isIndexExcludedTopFolder(relPath: string): boolean {
+  const top = relPath.split("/")[0];
+  return INDEX_EXCLUDED_TOP_FOLDERS.has(top);
 }

--- a/src/services/root_landing/index.ts
+++ b/src/services/root_landing/index.ts
@@ -38,6 +38,7 @@ import { renderLandingMarkdown } from "./md_template.js";
 import {
   buildBundledDocsNavCategories,
   buildBundledDocsFooterColumns,
+  resolveExtraKnownFooterSlugs,
 } from "../docs/bundled_nav.js";
 import { getBundledDocsIndex } from "../docs/index.js";
 
@@ -274,7 +275,14 @@ export function buildLandingContext(
         envSource: env as Record<string, string | undefined>,
       });
       landingIndex = buildBundledDocsNavCategories(docsIndex);
-      footerNav = buildBundledDocsFooterColumns(docsIndex, base);
+      // site/ is excluded from the browsable index but its pages remain
+      // deep-linkable; validate footer site-links via direct lookup so the
+      // landing footer keeps Install/Privacy/Terms/etc. on from-source hosts.
+      const extraKnownFooterSlugs = resolveExtraKnownFooterSlugs({
+        docsRoot,
+        env: env as Record<string, string | undefined>,
+      });
+      footerNav = buildBundledDocsFooterColumns(docsIndex, base, extraKnownFooterSlugs);
     } catch {
       // Fall back to the static nav if the docs tree can't be loaded.
     }

--- a/tests/unit/bundled_docs_nav.test.ts
+++ b/tests/unit/bundled_docs_nav.test.ts
@@ -8,14 +8,22 @@ import {
   buildBundledDocsFooterColumns,
   buildBundledDocsNavCategories,
   resolveBundledDocsQuickLinks,
+  resolveExtraKnownFooterSlugs,
 } from "../../src/services/docs/bundled_nav.js";
 import { buildLandingContext } from "../../src/services/root_landing/index.js";
 import type express from "express";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const docsRoot = path.join(repoRoot, "docs");
 
 describe("bundled docs nav", () => {
   const index = getBundledDocsIndex({ repoRoot, envSource: { NODE_ENV: "production" } });
+  // site/ is excluded from the browsable index but footer links deep-link into
+  // it; these slugs are validated via direct lookup, not index membership.
+  const extraKnown = resolveExtraKnownFooterSlugs({
+    docsRoot,
+    env: { NODE_ENV: "production" },
+  });
 
   it("quick-link slugs exist in the bundled docs index", () => {
     const slugs = new Set<string>();
@@ -52,7 +60,7 @@ describe("bundled docs nav", () => {
     }
   });
 
-  it("footer link slugs exist in the bundled docs index", () => {
+  it("footer link slugs resolve via the index or direct lookup", () => {
     const slugs = new Set<string>();
     for (const doc of index.featured) slugs.add(doc.slug);
     for (const cat of index.categories) {
@@ -61,20 +69,31 @@ describe("bundled docs nav", () => {
         for (const doc of sub.docs) slugs.add(doc.slug);
       }
     }
+    for (const s of extraKnown) slugs.add(s);
     for (const col of BUNDLED_DOCS_FOOTER_COLUMNS) {
       for (const link of col.links) {
         if (link.slug === "" || /^https?:\/\//i.test(link.slug)) continue;
-        expect(slugs.has(link.slug), `missing footer slug: ${link.slug}`).toBe(true);
+        expect(slugs.has(link.slug), `unresolvable footer slug: ${link.slug}`).toBe(true);
       }
     }
   });
 
+  it("site/ footer slugs are resolvable but NOT in the browsable index", () => {
+    const indexSlugs = new Set<string>();
+    for (const cat of index.categories) {
+      for (const doc of cat.uncategorized) indexSlugs.add(doc.slug);
+      for (const sub of cat.subcategories) for (const doc of sub.docs) indexSlugs.add(doc.slug);
+    }
+    // Marketing site pages must not flood the browsable index...
+    expect([...indexSlugs].some((s) => s.startsWith("site/"))).toBe(false);
+    // ...but the footer's site deep-links still resolve directly.
+    expect(extraKnown.has("site/pages/en/install")).toBe(true);
+  });
+
   it("buildBundledDocsFooterColumns emits /docs hrefs on same origin", () => {
-    const footer = buildBundledDocsFooterColumns(index, "http://127.0.0.1:3180");
+    const footer = buildBundledDocsFooterColumns(index, "http://127.0.0.1:3180", extraKnown);
     expect(footer.some((c) => c.title === "Product")).toBe(true);
-    const install = footer
-      .flatMap((c) => c.items)
-      .find((i) => i.label === "Install");
+    const install = footer.flatMap((c) => c.items).find((i) => i.label === "Install");
     expect(install?.href).toBe("http://127.0.0.1:3180/docs/site/pages/en/install");
   });
 


### PR DESCRIPTION
## Problems

After #1794 curated the in-app `/docs` route, the marketing-site pages under `docs/site/pages/` were still flooding the browsable docs index on from-source hosts (e.g. `neotoma.markmhendrickson.com/docs`): ~170 multilingual pages (`en/` + `es/`), surfacing language-duplicated entries like "CRM", "Agent auth", "Build vs buy" twice each.

`site/` was deliberately kept in the runtime surface by #1794 because the root-landing footer deep-links into `site/pages/en/*` (Install, Privacy, Terms, API, ...) and the footer drops any link not present in the docs index. So curating `site/` out naively would have broken the footer.

## Solutions

Separate "what's browsable in the index" from "what's reachable by direct URL":

- Add `INDEX_EXCLUDED_TOP_FOLDERS` (= `NON_PUBLIC_TOP_FOLDERS` + `site`) and `isIndexExcludedTopFolder()` to `visibility.ts`.
- `buildDocsIndex` and the bundler now use the index-exclusion set, so `site/` no longer appears in the browsable `/docs` index. (Bundle output is unchanged — it already excluded `site/`.)
- `lookupDoc` keeps using `NON_PUBLIC_TOP_FOLDERS` (no `site`), so `site/` pages remain reachable by direct URL.
- The root-landing footer validates its `site/` deep-links via direct lookup (`resolveExtraKnownFooterSlugs`) instead of index membership, so Install / Privacy / Terms / API / MCP / CLI / SDK links survive while `site/` is hidden from browsing.

## Behavior change

- The in-app `/docs` browser no longer lists marketing-site pages (the language-duplicated clutter is gone).
- `site/pages/*` URLs still resolve directly (e.g. the footer links still open).
- No change for npm installs (the bundle never shipped `site/`).
- `NEOTOMA_DOCS_SHOW_INTERNAL=true` still reveals everything, including `site/`, for local dev.

## Test plan

- `npm run type-check` — clean.
- Docs + nav + landing suites green (92 tests): `src/services/docs/**`, `tests/unit/bundled_docs_nav.test.ts`, `tests/integration/docs_route.test.ts`.
  - New/updated: `visibility.test.ts` (`isIndexExcludedTopFolder` excludes `site` while `isNonPublicTopFolder` keeps it); `index_builder.test.ts` (`site/` absent from index by default); `render.test.ts` (`site/` page resolves by default); `bundled_docs_nav.test.ts` (footer slugs validated via index ∪ direct lookup; `site/` footer slugs resolvable but not in the browsable index; landing footer keeps the Legal column).
- Bundler re-run: still copies 359 docs (unchanged).
- `npm run lint` (0 errors), `format:check`, `lint:site-copy`, `validate:doc-deps` — pass.

Note: the local pre-commit full unit+integration suite was skipped via the hook-sanctioned `NEOTOMA_SKIP_TESTS=1` (not `--no-verify`) due to the same unrelated environmental failures as #1799 (unbuilt Inspector SPA; parallel-SQLite flakiness). CI runs the full suite here.
