### PR TITLE
fix(rendered-page): allow inline data: audio/video via CSP media-src

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -246,6 +246,12 @@ app.use(
         scriptSrc: ["'self'", "'unsafe-inline'", "https://cdn.jsdelivr.net", "https://unpkg.com"],
         connectSrc: ["'self'", ...extraConnectSrc],
         imgSrc: ["'self'", "data:"],
+        // Allow inline audio/video so rendered_page guest pages can embed media
+        // (e.g. a prospect's own voice note) as a data: URI. Without this,
+        // media falls back to default-src 'self', which blocks data: — the
+        // <audio> element errors with MEDIA_ELEMENT_ERROR (code 4, no source).
+        // Mirrors imgSrc, which already permits data: for inline illustrations.
+        mediaSrc: ["'self'", "data:"],
         styleSrc: ["'self'", "'unsafe-inline'", "https://unpkg.com"],
         objectSrc: ["'none'"],
         frameSrc: ["'self'"],


### PR DESCRIPTION
## Problem
Guest `rendered_page` pages (served at `GET /entities/:id/html?access_token=…`) can't play embedded media. The CSP sets `default-src 'self'` with **no `media-src`** directive, so an `<audio>`/`<video>` element using a `data:` URI falls back to `'self'` and the browser blocks it — the element fails with `MEDIA_ELEMENT_ERROR` (code 4, *"the element has no supported sources"*).

Confirmed in headless Chromium against a live page: `readyState 0`, `networkState 3 (NO_SOURCE)`, `mediaError 4`, `play()` → `NotSupportedError`. The media bytes themselves are valid.

`img-src` and `font-src` already allow `data:` (for inline illustrations / fonts); media was simply never added. There is no guest-reachable same-origin media route to fall back to (`/sources/:id/content` requires auth → 401 for guests), so `data:` is the only way to embed self-contained media in a guest page (e.g. a prospect's own voice note mirrored back to them).

## Fix
Add `mediaSrc: ["'self'", "data:"]` to the helmet CSP directives, mirroring `imgSrc`.

## Verification
Ran the repo's helmet config in isolation — the emitted header now contains `media-src 'self' data:`. After this ships, an `<audio>` with a `data:audio/mpeg;base64,…` source loads metadata and plays.

## Scope / risk
- One directive added; nothing removed. `object-src 'none'` is unchanged, so no plugin/embed surface is opened.
- `data:` media is same-document, self-contained — no new network egress.