### PR TITLE
docs(developer): by-reference source storage + mirror write-back

### DIFF
--- a/docs/developer/mirror_writeback.md
+++ b/docs/developer/mirror_writeback.md
@@ -1,0 +1,38 @@
+# Mirror write-back (`neotoma mirror push`)
+
+## Overview
+
+Mirror profiles render Neotoma entities to on-disk markdown files (Neotoma → disk). By default this is one-way: if you edit a mirrored file directly, your changes are overwritten on the next render. **Write-back** lets those edits flow back into Neotoma as corrections.
+
+## Enabling
+
+Write-back is opt-in per profile:
+
+```yaml
+allow_disk_writeback: true
+```
+
+With the flag off (the default), mirrors stay one-way and safe.
+
+## Pushing edits
+
+```bash
+neotoma mirror push <path|profile>        # apply on-disk edits as corrections
+neotoma mirror push <path> --check        # dry-run: show the corrections, change nothing
+```
+
+`mirror push` parses the edited markdown back into the entity's **editable** fields and writes the changes as `correct()` observations — stamped `observation_source: "human"`, with the file path recorded as provenance. Generated or managed regions (frontmatter, "do not edit" headers) are ignored, so regenerated content never round-trips into the entity.
+
+## Conflict handling
+
+`mirror push` keeps a last-synced base for each mirrored file and does a 3-way comparison of `{base, on-disk, current canonical}`:
+
+- If the canonical entity is **unchanged** since the base, your on-disk edits apply as corrections.
+- If **both** the file and the canonical entity changed, the push reports a conflict instead of overwriting — resolve it explicitly.
+
+`--check` previews exactly what would be applied before you commit. Write-back never deletes.
+
+## See also
+
+- Design and discussion: [neotoma#1776](https://github.com/markmhendrickson/neotoma/issues/1776)
+- [Neotoma CLI reference](./cli_reference.md)

--- a/docs/developer/source_storage_by_reference.md
+++ b/docs/developer/source_storage_by_reference.md
@@ -1,0 +1,48 @@
+# Storing sources by reference
+
+## Overview
+
+By default, attaching a file to a `store` (or `parse_file`) call reads the bytes and persists them as a content-addressed blob inside Neotoma (`source_storage: "inline"`). For large files, or files that already live durably on disk — a PDF on your machine, a media archive — copying the bytes can bloat the database without adding value.
+
+**By-reference source storage** registers a source by its path and content hash **without** copying its bytes. The source is still first-class in the graph; only the bytes stay on disk.
+
+## Usage
+
+Pass `source_storage: "reference"` on the store request (default is `"inline"`):
+
+```jsonc
+store({
+  file_path: "/Users/you/Documents/contract.pdf",
+  source_storage: "reference"
+})
+```
+
+Neotoma reads the file once to compute its `content_hash` (SHA-256) and metadata (size, MIME type, mtime), then persists a `sources` row that records **where the bytes are**, not the bytes themselves.
+
+## What gets stored
+
+| | `inline` (default) | `reference` |
+| --- | --- | --- |
+| Bytes | copied into Neotoma | left on disk |
+| `content_hash` | yes | yes |
+| `path` / `host_id` | — | yes |
+| Dedup + interpretation linkage | yes | yes |
+
+Content-addressing, deduplication, and interpretation linkage all work identically — a reference source behaves like any other source.
+
+## Retrieval
+
+Fetching a reference source resolves its `path` at read time:
+
+- **Present:** you get the path + metadata (and bytes on demand).
+- **Moved or deleted:** the call returns a structured `SOURCE_UNAVAILABLE` (with the path + last-known hash), never a misleading empty blob.
+- **Changed since registration:** a re-hash surfaces `SOURCE_REFERENCE_STALE`.
+
+## Tradeoffs
+
+Reference sources are **host-local**: availability depends on the file staying where it was registered, and they are not portable across machines. Use `inline` (the default) for anything that must be durable and portable inside Neotoma itself; use `reference` for large local files you want represented in the graph without the storage cost.
+
+## See also
+
+- Design and discussion: [neotoma#1775](https://github.com/markmhendrickson/neotoma/issues/1775)
+- [What to store in Neotoma](../foundation/what_to_store.md)

--- a/src/shared/capability_manifest.json
+++ b/src/shared/capability_manifest.json
@@ -108,6 +108,9 @@
     "list_timeline_events": {
       "addedInVersion": "v0.4.3"
     },
+    "manage_bundles": {
+      "addedInVersion": "v0.18.0"
+    },
     "merge_entities": {
       "addedInVersion": "v0.4.3"
     },


### PR DESCRIPTION
Adds public reference docs for the two v0.18.0 features so they point at real docs instead of only design issues:

- `docs/developer/source_storage_by_reference.md` — `store({ source_storage: "reference" })` (#1775 / #1803)
- `docs/developer/mirror_writeback.md` — `neotoma mirror push` (#1776 / #1802)

Both land in the public `developer` category and the browsable `/docs` index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)