### PR TITLE
fix(cli): preserve per-field reducer_config in schemas register

### DIFF
--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,15 +61,15 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **515**
-- Backend and repo Vitest files: **481**
+- Total automated test files: **516**
+- Backend and repo Vitest files: **482**
 - Frontend Vitest files: **9**
 - Playwright spec files: **25**
 
 ### Suite counts
 | Suite | Files |
 |---|---:|
-| Vitest unit tests | 143 |
+| Vitest unit tests | 144 |
 | Vitest service tests | 35 |
 | Source-adjacent tests | 64 |
 | Vitest integration tests | 144 |
@@ -109,7 +109,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/unit`
 **Requirements:** Basic `.env` if required by the module under test.
-**Files (143):**
+**Files (144):**
 - `tests/unit/aauth_admission.test.ts`
 - `tests/unit/aauth_attestation_apple_se.test.ts`
 - `tests/unit/aauth_attestation_revocation.test.ts`
@@ -142,6 +142,7 @@ flowchart TD
 - `tests/unit/cli_aauth_tpm2_attestation.test.ts`
 - `tests/unit/cli_aauth_yubikey_attestation.test.ts`
 - `tests/unit/cli_bug_fixes.test.ts`
+- `tests/unit/cli_schema_register_reducer_config.test.ts`
 - `tests/unit/client_diagnose.test.ts`
 - `tests/unit/client_helpers.test.ts`
 - `tests/unit/client_turn_report.test.ts`

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -27,6 +27,7 @@ import { LOCAL_DEV_USER_ID } from "../services/local_auth.js";
 import { createApiClient } from "../shared/api_client.js";
 import { WIN_SHELL, shellOnWin } from "../shared/spawn_platform.js";
 import { parseCliCorrectedValue } from "./parse_cli_corrected_value.js";
+import { parseSchemaFields } from "./parse_schema_fields.js";
 import { getOpenApiOperationMapping } from "../shared/contract_mappings.js";
 import { getEntityDisplayName } from "../shared/entity_display_name.js";
 import { getRecordDisplaySummary } from "../shared/record_display_summary.js";
@@ -13796,26 +13797,9 @@ schemasCommand
       if (!fieldsJson) {
         throw new Error("--fields or --schema is required (JSON object of field definitions)");
       }
-      const parsedFields = JSON.parse(fieldsJson);
-      let schemaFields: Record<string, any>;
-      if (Array.isArray(parsedFields)) {
-        schemaFields = {};
-        parsedFields.forEach((f: any) => {
-          schemaFields[f.field_name] = { type: f.field_type, required: f.required ?? false };
-        });
-      } else if (parsedFields.fields) {
-        // Already a schema definition object
-        schemaFields = parsedFields.fields;
-      } else {
-        schemaFields = Object.fromEntries(
-          Object.entries(parsedFields).map(([name, def]: [string, any]) => [
-            name,
-            { type: def.type ?? "string", required: def.required ?? false },
-          ])
-        );
-      }
+      const { schemaFields, mergePolicies } = parseSchemaFields(JSON.parse(fieldsJson));
       const schemaDefinition = { fields: schemaFields };
-      const reducerConfig = { merge_policies: {} };
+      const reducerConfig = { merge_policies: mergePolicies };
       const { data, error } = await api.POST("/register_schema", {
         body: {
           entity_type: entityType,

--- a/src/cli/parse_schema_fields.ts
+++ b/src/cli/parse_schema_fields.ts
@@ -1,0 +1,83 @@
+/**
+ * Parses the `--fields` JSON argument for `neotoma schemas register`.
+ *
+ * Three input forms are accepted:
+ *   1. Object map: `{ fieldName: { type, required?, reducer_config?, ... } }`
+ *   2. Pre-built schema object: `{ fields: { fieldName: { ... } }, reducer_config?: { merge_policies } }`
+ *   3. Array form: `[{ field_name, field_type, required?, reducer_config? }, ...]`
+ *
+ * Per-field `reducer_config: { strategy, tie_breaker? }` is extracted from each field
+ * definition and collected into the top-level `reducer_config.merge_policies` map that
+ * the server expects — it must NOT remain inside the field definition.
+ */
+
+export interface FieldReducerConfig {
+  strategy: string;
+  tie_breaker?: string;
+}
+
+export interface ParsedSchemaFields {
+  schemaFields: Record<string, Record<string, unknown>>;
+  mergePolicies: Record<string, FieldReducerConfig>;
+}
+
+/**
+ * Parse a raw `--fields` JSON value (already `JSON.parse`'d) into separated
+ * `schemaFields` and `mergePolicies`.
+ */
+export function parseSchemaFields(parsedFields: unknown): ParsedSchemaFields {
+  const mergePolicies: Record<string, FieldReducerConfig> = {};
+  const schemaFields: Record<string, Record<string, unknown>> = {};
+
+  function extractPolicy(fieldName: string, fieldDef: Record<string, unknown>): void {
+    const rc = fieldDef["reducer_config"] as FieldReducerConfig | undefined;
+    if (rc?.strategy) {
+      const policy: FieldReducerConfig = { strategy: rc.strategy };
+      if (rc.tie_breaker) {
+        policy.tie_breaker = rc.tie_breaker;
+      }
+      mergePolicies[fieldName] = policy;
+    }
+  }
+
+  if (Array.isArray(parsedFields)) {
+    // Form 3: array of { field_name, field_type, required?, reducer_config?, ... }
+    for (const f of parsedFields as Record<string, unknown>[]) {
+      const fieldName = f["field_name"] as string;
+      const { reducer_config: _rc, field_name: _fn, field_type, required, ...rest } = f;
+      schemaFields[fieldName] = { type: field_type, required: required ?? false, ...rest };
+      extractPolicy(fieldName, f);
+    }
+  } else if (
+    parsedFields !== null &&
+    typeof parsedFields === "object" &&
+    "fields" in (parsedFields as object)
+  ) {
+    // Form 2: pre-built schema definition object with a top-level `fields` key
+    const schemaObj = parsedFields as Record<string, unknown>;
+    const rawFields = schemaObj["fields"] as Record<string, Record<string, unknown>>;
+    for (const [fieldName, fieldDef] of Object.entries(rawFields)) {
+      const { reducer_config: _rc, ...fieldProps } = fieldDef;
+      schemaFields[fieldName] = fieldProps;
+      extractPolicy(fieldName, fieldDef);
+    }
+    // Also honour any pre-existing top-level reducer_config.merge_policies
+    const topLevelRc = schemaObj["reducer_config"] as
+      | { merge_policies?: Record<string, FieldReducerConfig> }
+      | undefined;
+    if (topLevelRc?.merge_policies) {
+      Object.assign(mergePolicies, topLevelRc.merge_policies);
+    }
+  } else {
+    // Form 1: plain object map { fieldName: { type, required?, reducer_config?, ... } }
+    for (const [name, def] of Object.entries(
+      parsedFields as Record<string, Record<string, unknown>>
+    )) {
+      const { reducer_config: _rc, type, required, ...rest } = def;
+      schemaFields[name] = { type: type ?? "string", required: required ?? false, ...rest };
+      extractPolicy(name, def);
+    }
+  }
+
+  return { schemaFields, mergePolicies };
+}

--- a/tests/unit/cli_schema_register_reducer_config.test.ts
+++ b/tests/unit/cli_schema_register_reducer_config.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Unit tests for #1820 — `neotoma schemas register` silently drops per-field
+ * `reducer_config` so every field defaults to `last_write`.
+ *
+ * The fix extracts `reducer_config` from each field definition across all three
+ * `--fields` input forms and promotes it to the top-level
+ * `reducer_config.merge_policies` map that the server expects.
+ */
+
+import { describe, expect, it } from "vitest";
+import { parseSchemaFields } from "../../src/cli/parse_schema_fields.js";
+
+describe("#1820 parseSchemaFields: per-field reducer_config → top-level merge_policies", () => {
+  // ---------------------------------------------------------------------------
+  // Form 1: object map { fieldName: { type, required?, reducer_config?, ... } }
+  // ---------------------------------------------------------------------------
+
+  describe("object-map form (--fields '{\"x\":{\"type\":\"number\",\"reducer_config\":{...}}}')", () => {
+    it("extracts strategy into mergePolicies for a single field", () => {
+      const input = {
+        x: { type: "number", required: false, reducer_config: { strategy: "highest_priority" } },
+      };
+      const { schemaFields, mergePolicies } = parseSchemaFields(input);
+
+      expect(mergePolicies).toEqual({ x: { strategy: "highest_priority" } });
+      // reducer_config must NOT appear inside the field definition
+      expect(schemaFields["x"]).not.toHaveProperty("reducer_config");
+      expect(schemaFields["x"]).toEqual({ type: "number", required: false });
+    });
+
+    it("extracts strategy + tie_breaker when both are provided", () => {
+      const input = {
+        score: {
+          type: "number",
+          reducer_config: { strategy: "highest_priority", tie_breaker: "observed_at" },
+        },
+      };
+      const { mergePolicies } = parseSchemaFields(input);
+
+      expect(mergePolicies["score"]).toEqual({
+        strategy: "highest_priority",
+        tie_breaker: "observed_at",
+      });
+    });
+
+    it("omits a field from mergePolicies when it has no reducer_config", () => {
+      const input = {
+        name: { type: "string" },
+        score: { type: "number", reducer_config: { strategy: "most_specific" } },
+      };
+      const { mergePolicies, schemaFields } = parseSchemaFields(input);
+
+      expect(Object.keys(mergePolicies)).toEqual(["score"]);
+      expect(schemaFields["name"]).toEqual({ type: "string", required: false });
+    });
+
+    it("produces empty mergePolicies when no fields carry reducer_config", () => {
+      const input = { a: { type: "string" }, b: { type: "boolean", required: true } };
+      const { mergePolicies } = parseSchemaFields(input);
+
+      expect(mergePolicies).toEqual({});
+    });
+
+    it("handles multiple fields each with their own reducer_config strategy", () => {
+      const input = {
+        priority: {
+          type: "number",
+          reducer_config: { strategy: "highest_priority" },
+        },
+        tags: {
+          type: "string",
+          reducer_config: { strategy: "merge_array" },
+        },
+        label: { type: "string" },
+      };
+      const { mergePolicies, schemaFields } = parseSchemaFields(input);
+
+      expect(mergePolicies["priority"].strategy).toBe("highest_priority");
+      expect(mergePolicies["tags"].strategy).toBe("merge_array");
+      expect(mergePolicies).not.toHaveProperty("label");
+      expect(schemaFields["priority"]).not.toHaveProperty("reducer_config");
+      expect(schemaFields["tags"]).not.toHaveProperty("reducer_config");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Form 2: pre-built schema object { fields: { ... }, reducer_config?: { merge_policies } }
+  // ---------------------------------------------------------------------------
+
+  describe("pre-built schema object form ({ fields: { ... } })", () => {
+    it("extracts per-field reducer_config from fields sub-object", () => {
+      const input = {
+        fields: {
+          score: {
+            type: "number",
+            required: false,
+            reducer_config: { strategy: "highest_priority" },
+          },
+        },
+      };
+      const { schemaFields, mergePolicies } = parseSchemaFields(input);
+
+      expect(mergePolicies).toEqual({ score: { strategy: "highest_priority" } });
+      expect(schemaFields["score"]).not.toHaveProperty("reducer_config");
+    });
+
+    it("merges top-level reducer_config.merge_policies with per-field entries", () => {
+      const input = {
+        fields: {
+          x: { type: "number", reducer_config: { strategy: "most_specific" } },
+          y: { type: "string" },
+        },
+        reducer_config: {
+          merge_policies: { y: { strategy: "last_write" } },
+        },
+      };
+      const { mergePolicies } = parseSchemaFields(input);
+
+      expect(mergePolicies["x"].strategy).toBe("most_specific");
+      expect(mergePolicies["y"].strategy).toBe("last_write");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Form 3: array of { field_name, field_type, required?, reducer_config? }
+  // ---------------------------------------------------------------------------
+
+  describe("array form ([{ field_name, field_type, reducer_config? }])", () => {
+    it("extracts reducer_config from array-element field definitions", () => {
+      const input = [
+        {
+          field_name: "score",
+          field_type: "number",
+          required: false,
+          reducer_config: { strategy: "highest_priority" },
+        },
+      ];
+      const { schemaFields, mergePolicies } = parseSchemaFields(input);
+
+      expect(mergePolicies).toEqual({ score: { strategy: "highest_priority" } });
+      expect(schemaFields["score"]).not.toHaveProperty("reducer_config");
+      expect(schemaFields["score"]).toEqual({ type: "number", required: false });
+    });
+
+    it("handles mixed array where only some entries have reducer_config", () => {
+      const input = [
+        { field_name: "name", field_type: "string", required: false },
+        {
+          field_name: "priority",
+          field_type: "number",
+          required: false,
+          reducer_config: { strategy: "highest_priority", tie_breaker: "source_priority" },
+        },
+      ];
+      const { mergePolicies } = parseSchemaFields(input);
+
+      expect(Object.keys(mergePolicies)).toEqual(["priority"]);
+      expect(mergePolicies["priority"]).toEqual({
+        strategy: "highest_priority",
+        tie_breaker: "source_priority",
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- `neotoma schemas register --fields '{"x":{"type":"number","reducer_config":{"strategy":"highest_priority"}}}' --activate` returned success but stored `reducer_config: { merge_policies: {} }`, silently dropping the per-field strategy and defaulting every field to `last_write`.
- Root cause: all three `--fields` parse branches in `src/cli/index.ts` discarded the `reducer_config` key from each field definition and hardcoded `const reducerConfig = { merge_policies: {} }`.
- Fix: extract field-parsing into `src/cli/parse_schema_fields.ts`, which strips `reducer_config` from each field definition across all three input forms (object-map, pre-built schema object, array) and promotes it into the top-level `reducer_config.merge_policies` map the server expects.

Closes #1820

## Test plan

- [x] `parseSchemaFields` unit tests covering all three input forms (9 tests) — `tests/unit/cli_schema_register_reducer_config.test.ts`
- [x] `npx tsc --noEmit` clean (no TypeScript errors)
- [x] `npm run generate:test-catalog` updated
- [x] Existing test suite unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)