### PR TITLE
fix(snapshot): honour at/at_ingested on offline HTTP path (#1819)

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -201,6 +201,7 @@ import { listBundles, getBundleInfo } from "./services/bundles/index.js";
 import { getTimelineEventForUser, listTimelineEventsForUser } from "./services/timeline_query.js";
 import { buildComplianceScorecard } from "./services/compliance/scorecard.js";
 import { getAgent, listAgentRecords, listAgents } from "./services/agents_directory.js";
+import { computeEntitySnapshotAtTime } from "./services/entity_snapshot_at_time.js";
 // import { setupDocumentationRoutes } from "./routes/documentation.js";
 
 type ErrorEnvelope = {
@@ -8464,8 +8465,34 @@ app.post("/get_entity_snapshot", async (req, res) => {
     return sendValidationError(res, parsed.error.issues);
   }
 
-  const { entity_id } = parsed.data;
+  const { entity_id, at, at_ingested } = parsed.data;
 
+  // When at/at_ingested cutoffs are requested, use the shared observation-replay
+  // helper so the offline path honours them with the same semantics as the MCP
+  // path in server.ts. Without cutoffs, fall through to the fast materialized
+  // entity_snapshots table read (unchanged behaviour).
+  if (at || at_ingested) {
+    let userId: string;
+    try {
+      userId = await getAuthenticatedUserId(req);
+    } catch (err) {
+      return sendError(res, 401, "UNAUTHORIZED", (err as Error).message);
+    }
+
+    try {
+      const result = await computeEntitySnapshotAtTime(entity_id, userId, at, at_ingested);
+      if (result === null) {
+        return sendError(res, 404, "RESOURCE_NOT_FOUND", "Entity not found");
+      }
+      logDebug("Success:get_entity_snapshot:at_time", req, { entity_id, at, at_ingested });
+      return res.json(result);
+    } catch (err) {
+      logError("Error:get_entity_snapshot:at_time", req, err);
+      return sendError(res, 500, "DB_QUERY_FAILED", (err as Error).message);
+    }
+  }
+
+  // Fast path: no cutoffs — read the materialized snapshot directly.
   const { data, error } = await db
     .from("entity_snapshots")
     .select("*")

--- a/src/server.ts
+++ b/src/server.ts
@@ -115,6 +115,7 @@ import {
   submitIssue,
 } from "./services/issues/issue_operations.js";
 import { syncIssuesFromGitHub } from "./services/issues/sync_issues_from_github.js";
+import { computeEntitySnapshotAtTime } from "./services/entity_snapshot_at_time.js";
 
 type StoreRelationshipRef = {
   relationship_type: string;
@@ -2862,7 +2863,6 @@ export class NeotomaServer {
     args: unknown
   ): Promise<{ content: Array<{ type: string; text: string }> }> {
     const { getEntityWithProvenance } = await import("./services/entity_queries.js");
-    const { observationReducer } = await import("./reducers/observation_reducer.js");
     const { renderEntityCompactText } = await import("./services/canonical_markdown.js");
     const { schemaRegistry } = await import("./services/schema_registry.js");
 
@@ -2950,7 +2950,8 @@ export class NeotomaServer {
     }
 
     // If 'at' (event-time) or 'at_ingested' (ingestion-time) cutoff is provided,
-    // compute a point-in-time snapshot.
+    // compute a point-in-time snapshot via the shared helper so this path and
+    // the offline/HTTP path (actions.ts) stay in sync.
     //
     // - `at`          filters on `observed_at`  (event time): "what had happened by T"
     // - `at_ingested` filters on `created_at`   (row time):   "what did we know by T"
@@ -2961,111 +2962,28 @@ export class NeotomaServer {
     // backfilled/late-arriving observations.
     if (parsed.at || parsed.at_ingested) {
       try {
-        // Validate timestamps
-        if (parsed.at) {
-          const atTimestamp = new Date(parsed.at);
-          if (isNaN(atTimestamp.getTime())) {
-            throw new McpError(
-              ErrorCode.InvalidParams,
-              `Invalid timestamp format for 'at': ${parsed.at}. Expected ISO 8601 format.`
-            );
-          }
-        }
-        if (parsed.at_ingested) {
-          const atIngestedTimestamp = new Date(parsed.at_ingested);
-          if (isNaN(atIngestedTimestamp.getTime())) {
-            throw new McpError(
-              ErrorCode.InvalidParams,
-              `Invalid timestamp format for 'at_ingested': ${parsed.at_ingested}. Expected ISO 8601 format.`
-            );
-          }
-        }
-
-        // Build observations query applying whichever bounds are set
-        let obsQuery = db
-          .from("observations")
-          .select("*")
-          .eq("entity_id", entity.entity_id)
-          .eq("user_id", userId);
-
-        if (parsed.at) {
-          // Event-time upper bound: filter by when the event occurred
-          obsQuery = obsQuery.lte("observed_at", parsed.at);
-        }
-        if (parsed.at_ingested) {
-          // Ingestion-time upper bound: filter by when the row was inserted
-          obsQuery = obsQuery.lte("created_at", parsed.at_ingested);
-        }
-
-        const { data: observations, error: obsError } = await obsQuery.order("observed_at", {
-          ascending: false,
-        });
-
-        if (obsError) {
-          throw new McpError(
-            ErrorCode.InternalError,
-            `Failed to get observations: ${obsError.message}`
-          );
-        }
-
-        if (!observations || observations.length === 0) {
-          // No observations visible at this point in time - return empty snapshot
-          return renderEntitySnapshotResponse({
-            entity_id: entity.entity_id,
-            entity_type: entity.entity_type,
-            schema_version: entity.entity_type, // Fallback
-            snapshot: {},
-            provenance: {},
-            computed_at: new Date().toISOString(),
-            observation_count: 0,
-            last_observation_at: null,
-          });
-        }
-
-        // Map observations to reducer's expected format
-        const mappedObservations = observations.map((obs: any) => ({
-          id: obs.id,
-          entity_id: obs.entity_id,
-          entity_type: obs.entity_type,
-          schema_version: obs.schema_version,
-          source_id: obs.source_id || "",
-          observed_at: obs.observed_at,
-          specificity_score: obs.specificity_score,
-          source_priority: obs.source_priority,
-          observation_source: obs.observation_source ?? null,
-          fields: obs.fields,
-          created_at: obs.created_at,
-          user_id: obs.user_id,
-        }));
-
-        // Compute historical snapshot using reducer
-        const historicalSnapshot = await observationReducer.computeSnapshot(
+        const historicalResult = await computeEntitySnapshotAtTime(
           entity.entity_id,
-          mappedObservations
+          userId,
+          parsed.at,
+          parsed.at_ingested
         );
 
-        if (!historicalSnapshot) {
-          throw new McpError(
-            ErrorCode.InternalError,
-            `Failed to compute historical snapshot for entity ${entity.entity_id}`
-          );
+        if (!historicalResult) {
+          // Entity disappeared between the existence check and the cutoff query —
+          // treat the same as "not found" at this point in time.
+          throw new McpError(ErrorCode.InvalidParams, `Entity not found: ${parsed.entity_id}`);
         }
 
-        // Get raw_fragments for historical snapshot (same logic as current snapshot)
+        // Fetch current raw_fragments for the historical response; they are not
+        // time-sensitive (fragment content doesn't change) so we reuse the current
+        // value just as the previous inlined implementation did.
         const { getEntityWithProvenance } = await import("./services/entity_queries.js");
         const currentEntity = await getEntityWithProvenance(entity.entity_id);
 
-        // Format response to match EntityWithProvenance structure
         return renderEntitySnapshotResponse({
-          entity_id: historicalSnapshot.entity_id,
-          entity_type: historicalSnapshot.entity_type,
-          schema_version: historicalSnapshot.schema_version,
-          snapshot: historicalSnapshot.snapshot,
-          raw_fragments: currentEntity?.raw_fragments, // Use current raw_fragments (they don't change with historical snapshots)
-          provenance: historicalSnapshot.provenance,
-          computed_at: historicalSnapshot.computed_at,
-          observation_count: historicalSnapshot.observation_count,
-          last_observation_at: historicalSnapshot.last_observation_at,
+          ...historicalResult,
+          raw_fragments: currentEntity?.raw_fragments,
         });
       } catch (error) {
         if (error instanceof McpError) {

--- a/src/services/entity_snapshot_at_time.ts
+++ b/src/services/entity_snapshot_at_time.ts
@@ -1,0 +1,197 @@
+/**
+ * Shared helper: compute a point-in-time entity snapshot by replaying observations.
+ *
+ * Both the MCP path (server.ts › retrieveEntitySnapshot) and the offline/HTTP
+ * path (actions.ts › POST /get_entity_snapshot) must honour the `at` /
+ * `at_ingested` cutoff parameters with identical semantics. Extracting the
+ * logic here ensures the two paths cannot drift.
+ *
+ * Semantics
+ * ---------
+ * - `at`          — upper bound on `observed_at` (event time).  "What had happened by T?"
+ * - `at_ingested` — upper bound on `created_at` (ingestion time). "What did we KNOW by T?"
+ * - When both are supplied, both bounds are applied (AND), giving the most
+ *   conservative "knowledge-as-of" view and preventing look-ahead leaks from
+ *   backfilled / late-arriving observations.
+ *
+ * Returns `null` when the entity_id does not exist (or is out of scope for the
+ * given userId).  Returns an `EntitySnapshotAtTimeResult` with `observation_count
+ * === 0` and an empty `snapshot` when the entity exists but has no observations
+ * visible at the requested cutoff.
+ */
+
+import { db } from "../db.js";
+import { observationReducer } from "../reducers/observation_reducer.js";
+import type { Observation } from "../reducers/observation_reducer.js";
+
+// ---------------------------------------------------------------------------
+// Result type
+// ---------------------------------------------------------------------------
+
+export interface EntitySnapshotAtTimeResult {
+  entity_id: string;
+  entity_type: string;
+  schema_version: string;
+  snapshot: Record<string, unknown>;
+  provenance: Record<string, string>;
+  computed_at: string;
+  observation_count: number;
+  last_observation_at: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute a point-in-time snapshot for `entityId`.
+ *
+ * @param entityId   - The entity to retrieve.
+ * @param userId     - Scope reads to this user (required; prevents cross-user reads).
+ * @param at         - Optional event-time upper bound (ISO 8601).
+ * @param atIngested - Optional ingestion-time upper bound (ISO 8601).
+ *
+ * @returns
+ *   - `null`  when the entity does not exist / is not owned by `userId`.
+ *   - An `EntitySnapshotAtTimeResult` otherwise (observation_count may be 0).
+ *
+ * @throws `Error` with a descriptive message when a timestamp is not valid
+ *   ISO 8601 or when the DB query fails.
+ */
+export async function computeEntitySnapshotAtTime(
+  entityId: string,
+  userId: string,
+  at?: string,
+  atIngested?: string
+): Promise<EntitySnapshotAtTimeResult | null> {
+  // ------------------------------------------------------------------
+  // 1. Validate timestamps before touching the DB.
+  // ------------------------------------------------------------------
+  if (at) {
+    const ts = new Date(at);
+    if (isNaN(ts.getTime())) {
+      throw new Error(
+        `Invalid timestamp format for 'at': ${at}. Expected ISO 8601 format.`
+      );
+    }
+  }
+  if (atIngested) {
+    const ts = new Date(atIngested);
+    if (isNaN(ts.getTime())) {
+      throw new Error(
+        `Invalid timestamp format for 'at_ingested': ${atIngested}. Expected ISO 8601 format.`
+      );
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // 2. Resolve entity_type from the entities table (also serves as an
+  //    existence + ownership check).
+  // ------------------------------------------------------------------
+  const { data: entityRow, error: entityError } = await db
+    .from("entities")
+    .select("id, entity_type, merged_to_entity_id")
+    .eq("id", entityId)
+    .eq("user_id", userId)
+    .single();
+
+  if (entityError || !entityRow) {
+    // Entity does not exist or is not owned by this user.
+    return null;
+  }
+
+  // Redirect through merge chains (one level; recursive merges are unusual
+  // but follow the server.ts pattern of delegating to getEntityWithProvenance).
+  const resolvedEntityId = entityRow.merged_to_entity_id ?? entityId;
+  const entityType: string = entityRow.entity_type as string;
+
+  // ------------------------------------------------------------------
+  // 3. Build and execute the observations query with optional cutoffs.
+  // ------------------------------------------------------------------
+  let obsQuery = db
+    .from("observations")
+    .select("*")
+    .eq("entity_id", resolvedEntityId)
+    .eq("user_id", userId);
+
+  if (at) {
+    obsQuery = obsQuery.lte("observed_at", at);
+  }
+  if (atIngested) {
+    obsQuery = obsQuery.lte("created_at", atIngested);
+  }
+
+  const { data: observations, error: obsError } = await obsQuery.order("observed_at", {
+    ascending: false,
+  });
+
+  if (obsError) {
+    throw new Error(`Failed to get observations: ${obsError.message}`);
+  }
+
+  // ------------------------------------------------------------------
+  // 4. Handle zero-observation case (entity exists but nothing visible
+  //    at the requested cutoff).
+  // ------------------------------------------------------------------
+  if (!observations || observations.length === 0) {
+    return {
+      entity_id: resolvedEntityId,
+      entity_type: entityType,
+      schema_version: entityType, // fallback when no observations
+      snapshot: {},
+      provenance: {},
+      computed_at: new Date().toISOString(),
+      observation_count: 0,
+      last_observation_at: null,
+    };
+  }
+
+  // ------------------------------------------------------------------
+  // 5. Map raw rows to the Observation interface and replay through
+  //    the reducer to obtain a consistent point-in-time snapshot.
+  // ------------------------------------------------------------------
+  const mappedObservations: Observation[] = (observations as any[]).map((obs) => ({
+    id: obs.id,
+    entity_id: obs.entity_id,
+    entity_type: obs.entity_type,
+    schema_version: obs.schema_version,
+    source_id: obs.source_id || "",
+    observed_at: obs.observed_at,
+    specificity_score: obs.specificity_score,
+    source_priority: obs.source_priority,
+    observation_source: obs.observation_source ?? null,
+    fields: obs.fields,
+    created_at: obs.created_at,
+    user_id: obs.user_id,
+  }));
+
+  const historicalSnapshot = await observationReducer.computeSnapshot(
+    resolvedEntityId,
+    mappedObservations
+  );
+
+  if (!historicalSnapshot) {
+    // Reducer returned null → entity is deleted at this point in time.
+    return {
+      entity_id: resolvedEntityId,
+      entity_type: entityType,
+      schema_version: entityType,
+      snapshot: {},
+      provenance: {},
+      computed_at: new Date().toISOString(),
+      observation_count: 0,
+      last_observation_at: null,
+    };
+  }
+
+  return {
+    entity_id: historicalSnapshot.entity_id,
+    entity_type: historicalSnapshot.entity_type,
+    schema_version: historicalSnapshot.schema_version,
+    snapshot: historicalSnapshot.snapshot,
+    provenance: historicalSnapshot.provenance,
+    computed_at: historicalSnapshot.computed_at,
+    observation_count: historicalSnapshot.observation_count,
+    last_observation_at: historicalSnapshot.last_observation_at,
+  };
+}

--- a/src/services/entity_snapshot_at_time.ts
+++ b/src/services/entity_snapshot_at_time.ts
@@ -70,9 +70,7 @@ export async function computeEntitySnapshotAtTime(
   if (at) {
     const ts = new Date(at);
     if (isNaN(ts.getTime())) {
-      throw new Error(
-        `Invalid timestamp format for 'at': ${at}. Expected ISO 8601 format.`
-      );
+      throw new Error(`Invalid timestamp format for 'at': ${at}. Expected ISO 8601 format.`);
     }
   }
   if (atIngested) {

--- a/tests/integration/snapshot_ingestion_cutoff.test.ts
+++ b/tests/integration/snapshot_ingestion_cutoff.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for retrieve_entity_snapshot at_ingested cutoff (#1757)
+ * Tests for retrieve_entity_snapshot at_ingested cutoff (#1757, #1819)
  *
  * Verifies that the `at_ingested` parameter (ingestion-time cutoff) correctly
  * excludes observations that have a past `observed_at` but arrived after the
@@ -8,12 +8,21 @@
  * The distinction:
  *   - `at`          filters on `observed_at` (event time):    "what had happened by T"
  *   - `at_ingested` filters on `created_at`  (ingestion time): "what did we know by T"
+ *
+ * #1819: the at/at_ingested cutoffs were ONLY applied on the MCP (server.ts) path;
+ * the offline/HTTP path (actions.ts › POST /get_entity_snapshot) silently ignored
+ * them and always returned the materialized snapshot. The shared helper
+ * `computeEntitySnapshotAtTime` fixes both paths — the suites below cover both.
  */
 
-import { describe, it, expect, afterAll } from "vitest";
+import { createServer } from "node:http";
+import { describe, it, expect, afterAll, beforeAll } from "vitest";
 import { randomUUID } from "crypto";
 import { db } from "../../src/db.js";
 import { NeotomaServer } from "../../src/server.js";
+import { app } from "../../src/actions.js";
+import { LOCAL_DEV_USER_ID } from "../../src/services/local_auth.js";
+import { computeEntitySnapshotAtTime } from "../../src/services/entity_snapshot_at_time.js";
 import { TestIdTracker } from "../helpers/cleanup_helpers.js";
 
 // ---------------------------------------------------------------------------
@@ -259,5 +268,249 @@ describe("retrieve_entity_snapshot — at_ingested ingestion-time cutoff (#1757)
 
     expect(caughtError).toBeDefined();
     expect((caughtError as Error).message).toMatch(/at_ingested/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #1819 — offline/HTTP path (actions.ts) must honour at/at_ingested
+// ---------------------------------------------------------------------------
+// These tests exercise the shared `computeEntitySnapshotAtTime` helper and the
+// actions.ts HTTP handler directly so the offline transport cannot silently
+// regress to reading only the materialized entity_snapshots table.
+// ---------------------------------------------------------------------------
+
+describe("retrieve_entity_snapshot — offline/HTTP path honours at_ingested (#1819)", () => {
+  const tracker = new TestIdTracker();
+  // The offline path uses LOCAL_DEV_USER_ID when called from localhost without
+  // a Bearer token. The direct-helper tests pass this userId explicitly.
+  const testUserId = LOCAL_DEV_USER_ID;
+
+  // HTTP server for the actions.ts handler tests
+  let httpServer: ReturnType<typeof createServer>;
+  const httpPort = 18267; // avoid collision with other test suites
+  const httpBase = `http://127.0.0.1:${httpPort}`;
+
+  beforeAll(async () => {
+    httpServer = createServer(app);
+    await new Promise<void>((resolve, reject) => {
+      httpServer.listen(httpPort, "127.0.0.1", () => resolve());
+      httpServer.once("error", reject);
+    });
+  });
+
+  afterAll(async () => {
+    await tracker.cleanup();
+    await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+  });
+
+  // -------------------------------------------------------------------------
+  // Helpers
+  // -------------------------------------------------------------------------
+
+  /** Insert a source row and return its id. */
+  async function insertSource(tag: string): Promise<string> {
+    const { data: source, error } = await db
+      .from("sources")
+      .insert({
+        user_id: testUserId,
+        content_hash: `hash_1819_${tag}_${randomUUID()}`,
+        storage_url: `file:///test/1819_${tag}.txt`,
+        mime_type: "text/plain",
+        file_size: 0,
+      })
+      .select()
+      .single();
+    if (error || !source) throw new Error(`insertSource failed: ${error?.message}`);
+    tracker.trackSource(source.id);
+    return source.id;
+  }
+
+  /** Insert an observation row with explicit created_at (simulates backfill). */
+  async function insertObservation(opts: {
+    entityId: string;
+    sourceId: string;
+    observedAt: string;
+    createdAt: string;
+    fields: Record<string, unknown>;
+  }): Promise<void> {
+    const { error } = await db.from("observations").insert({
+      entity_id: opts.entityId,
+      entity_type: "task",
+      schema_version: "1.0",
+      source_id: opts.sourceId,
+      user_id: testUserId,
+      observed_at: opts.observedAt,
+      created_at: opts.createdAt,
+      fields: opts.fields,
+    });
+    if (error) throw new Error(`insertObservation failed: ${error.message}`);
+  }
+
+  // -------------------------------------------------------------------------
+  // Test 1: computeEntitySnapshotAtTime — the shared helper
+  // -------------------------------------------------------------------------
+
+  it("computeEntitySnapshotAtTime: at_ingested excludes backfilled observation", async () => {
+    const entityId = `ent_test_1819_helper_${randomUUID().replace(/-/g, "").slice(0, 12)}`;
+    tracker.trackEntity(entityId);
+    const sourceId = await insertSource("helper");
+
+    const threeDaysAgo = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString();
+    const twoDaysAgo = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString();
+    const oneDayAgo = new Date(Date.now() - 1 * 24 * 60 * 60 * 1000).toISOString();
+    const now = new Date().toISOString();
+
+    // obs_early: genuinely historical
+    await insertObservation({
+      entityId,
+      sourceId,
+      observedAt: threeDaysAgo,
+      createdAt: threeDaysAgo,
+      fields: { title: "Early", status: "pending" },
+    });
+
+    // obs_backfill: describes the past (observed_at T-2) but ingested NOW
+    await insertObservation({
+      entityId,
+      sourceId,
+      observedAt: twoDaysAgo,
+      createdAt: now,
+      fields: { title: "Backfill", status: "done" },
+    });
+
+    // --- no cutoff: both observations → reducer picks backfill (observed_at T-2 > T-3)
+    const noCutoff = await computeEntitySnapshotAtTime(entityId, testUserId);
+    expect(noCutoff).not.toBeNull();
+    expect(noCutoff!.observation_count).toBe(2);
+    expect(noCutoff!.snapshot.status).toBe("done");
+
+    // --- at_ingested = oneDayAgo: backfill (created_at = now) is EXCLUDED
+    const cutoff = await computeEntitySnapshotAtTime(entityId, testUserId, undefined, oneDayAgo);
+    expect(cutoff).not.toBeNull();
+    expect(cutoff!.observation_count).toBe(1);
+    expect(cutoff!.snapshot.status).toBe("pending");
+
+    // --- at_ingested before any ingestion: empty snapshot
+    const tooEarly = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString();
+    const empty = await computeEntitySnapshotAtTime(entityId, testUserId, undefined, tooEarly);
+    expect(empty).not.toBeNull();
+    expect(empty!.observation_count).toBe(0);
+    expect(empty!.snapshot).toEqual({});
+  });
+
+  it("computeEntitySnapshotAtTime: at (event-time) excludes future-observed observations", async () => {
+    const entityId = `ent_test_1819_at_${randomUUID().replace(/-/g, "").slice(0, 12)}`;
+    tracker.trackEntity(entityId);
+    const sourceId = await insertSource("at");
+
+    const threeDaysAgo = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString();
+    const yesterday = new Date(Date.now() - 1 * 24 * 60 * 60 * 1000).toISOString();
+    const tomorrow = new Date(Date.now() + 1 * 24 * 60 * 60 * 1000).toISOString();
+
+    await insertObservation({
+      entityId,
+      sourceId,
+      observedAt: threeDaysAgo,
+      createdAt: threeDaysAgo,
+      fields: { title: "Old", status: "pending" },
+    });
+    // future-dated observation
+    await insertObservation({
+      entityId,
+      sourceId,
+      observedAt: tomorrow,
+      createdAt: threeDaysAgo,
+      fields: { title: "Future", status: "done" },
+    });
+
+    // at = yesterday: future obs excluded → status remains "pending"
+    const result = await computeEntitySnapshotAtTime(entityId, testUserId, yesterday);
+    expect(result).not.toBeNull();
+    expect(result!.observation_count).toBe(1);
+    expect(result!.snapshot.status).toBe("pending");
+  });
+
+  it("computeEntitySnapshotAtTime: returns null for unknown entity", async () => {
+    const result = await computeEntitySnapshotAtTime(
+      "ent_does_not_exist_1819",
+      testUserId,
+      undefined,
+      new Date().toISOString()
+    );
+    expect(result).toBeNull();
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 2: HTTP handler (actions.ts POST /get_entity_snapshot)
+  // -------------------------------------------------------------------------
+
+  it("HTTP /get_entity_snapshot: at_ingested cutoff is honoured (offline path)", async () => {
+    const entityId = `ent_test_1819_http_${randomUUID().replace(/-/g, "").slice(0, 12)}`;
+    tracker.trackEntity(entityId);
+    const sourceId = await insertSource("http");
+
+    const threeDaysAgo = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString();
+    const twoDaysAgo = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString();
+    const oneDayAgo = new Date(Date.now() - 1 * 24 * 60 * 60 * 1000).toISOString();
+    const now = new Date().toISOString();
+
+    await insertObservation({
+      entityId,
+      sourceId,
+      observedAt: threeDaysAgo,
+      createdAt: threeDaysAgo,
+      fields: { title: "Early HTTP", status: "pending" },
+    });
+    await insertObservation({
+      entityId,
+      sourceId,
+      observedAt: twoDaysAgo,
+      createdAt: now,
+      fields: { title: "Backfill HTTP", status: "done" },
+    });
+
+    // POST without cutoff — returns the materialized snapshot (or empty if not yet
+    // computed). We don't assert specific values here as the entity_snapshots table
+    // may not be populated yet; the key assertion is that at_ingested is applied.
+
+    // POST with at_ingested = oneDayAgo should EXCLUDE the backfill (created_at = now)
+    // and return observation_count=1 with status="pending"
+    const resp = await fetch(`${httpBase}/get_entity_snapshot`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ entity_id: entityId, at_ingested: oneDayAgo }),
+    });
+
+    expect(resp.ok).toBe(true);
+    const data = await resp.json() as Record<string, unknown>;
+
+    // The response must reflect only the early observation
+    expect(data.observation_count).toBe(1);
+    expect((data.snapshot as Record<string, unknown>).status).toBe("pending");
+  });
+
+  it("HTTP /get_entity_snapshot: invalid at_ingested returns 500 with message", async () => {
+    const entityId = `ent_test_1819_http_invalid_${randomUUID().replace(/-/g, "").slice(0, 12)}`;
+    tracker.trackEntity(entityId);
+    const sourceId = await insertSource("http-invalid");
+
+    await insertObservation({
+      entityId,
+      sourceId,
+      observedAt: new Date().toISOString(),
+      createdAt: new Date().toISOString(),
+      fields: { title: "Validation", status: "pending" },
+    });
+
+    const resp = await fetch(`${httpBase}/get_entity_snapshot`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ entity_id: entityId, at_ingested: "not-a-valid-iso-timestamp" }),
+    });
+
+    // The handler wraps errors from computeEntitySnapshotAtTime as 500
+    expect(resp.status).toBe(500);
+    const body = await resp.json() as Record<string, unknown>;
+    expect((body.message as string | undefined)?.toLowerCase()).toMatch(/at_ingested/i);
   });
 });


### PR DESCRIPTION
## Summary

- **Root cause (two paths, one broken):** `retrieve_entity_snapshot` with `at`/`at_ingested` was silently ignored on the offline/local-transport path. The offline route hits `src/actions.ts › POST /get_entity_snapshot`, which only read the materialised `entity_snapshots` table and never applied the cutoff filters. The working observation-replay logic existed only in `src/server.ts › retrieveEntitySnapshot` (the MCP path). `EntitySnapshotRequestSchema` already accepted both params, so callers received no error — just a stale snapshot.

- **Fix:** extract a shared helper `src/services/entity_snapshot_at_time.ts` (`computeEntitySnapshotAtTime`) that both paths now call. The helper validates timestamps, queries the `observations` table with `.lte("observed_at", at)` / `.lte("created_at", atIngested)` filters, replays through `observationReducer`, and returns a point-in-time snapshot. Both paths cannot drift again.

- **Tests:** add 5 new tests in `tests/integration/snapshot_ingestion_cutoff.test.ts` that specifically exercise the offline path: 3 test `computeEntitySnapshotAtTime` directly and 2 test the `actions.ts` HTTP handler via a live Express server, including the backfill exclusion scenario from the bug report.

## Files changed

| File | Change |
|---|---|
| `src/services/entity_snapshot_at_time.ts` | New shared service — the canonical observation-replay logic |
| `src/actions.ts` | Add import; when `at`/`at_ingested` present, call helper instead of table read |
| `src/server.ts` | Replace inlined observation-replay block with call to shared helper |
| `tests/integration/snapshot_ingestion_cutoff.test.ts` | 5 new tests for the offline path (#1819) |

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run tests/integration/snapshot_ingestion_cutoff.test.ts` — 8/8 pass (3 original + 5 new)
- [x] New tests exercise `computeEntitySnapshotAtTime` directly and the `actions.ts` HTTP handler via a live Express server
- [x] Backfill exclusion scenario: `at_ingested` before backfill `created_at` returns only the early observation

Closes #1819

🤖 Generated with [Claude Code](https://claude.com/claude-code)