### PR TITLE
fix(sources): reach by-reference storage over HTTP + via file+entities calls (#1826, #1827)

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1758,6 +1758,15 @@ components:
           description: Required with file_content, optional with file_path
         original_filename:
           type: string
+        source_storage:
+          type: string
+          enum: [inline, reference]
+          default: inline
+          description: >-
+            Storage mode for an accompanying file. "inline" (default) reads and
+            ingests the bytes; "reference" registers the file by path +
+            content_hash WITHOUT copying its bytes (requires file_path, not
+            file_content). Mirrors the MCP store tool. (#1826)
         user_id:
           type: string
         commit:

--- a/src/server.ts
+++ b/src/server.ts
@@ -4655,6 +4655,9 @@ export class NeotomaServer {
         mime_type: parsed.mime_type,
         original_filename: parsed.original_filename,
         source_priority: parsed.source_priority,
+        // Propagate by-reference storage to the file leg (#1827): without this the
+        // recursive store() defaults to inline and silently copies the bytes.
+        source_storage: parsed.source_storage,
       });
       try {
         const text = unstructuredResponse.content[0]?.text ?? "{}";
@@ -4706,6 +4709,9 @@ export class NeotomaServer {
           mime_type: parsed.mime_type,
           original_filename: parsed.original_filename,
           source_priority: parsed.source_priority,
+          // Propagate by-reference storage to the file leg (#1827): without this the
+          // recursive store() defaults to inline and silently copies the bytes.
+          source_storage: parsed.source_storage,
         });
         try {
           const text = unstructuredResponse.content[0]?.text ?? "{}";

--- a/src/shared/openapi_types.ts
+++ b/src/shared/openapi_types.ts
@@ -3327,6 +3327,12 @@ export interface components {
       /** @description Required with file_content, optional with file_path */
       mime_type?: string;
       original_filename?: string;
+      /**
+       * @description Storage mode for an accompanying file. "inline" (default) reads and ingests the bytes; "reference" registers the file by path + content_hash WITHOUT copying its bytes (requires file_path, not file_content). Mirrors the MCP store tool. (#1826)
+       * @default inline
+       * @enum {string}
+       */
+      source_storage?: "inline" | "reference";
       user_id?: string;
       /**
        * @description When false, runs in plan/dry-run mode: resolves entities and returns

--- a/tests/unit/unknown_fields_guard.test.ts
+++ b/tests/unit/unknown_fields_guard.test.ts
@@ -82,6 +82,24 @@ describe("unknownFieldsGuard", () => {
     expect(res.status).not.toHaveBeenCalled();
   });
 
+  it("allows source_storage on POST /store (by-reference storage over HTTP, #1826)", () => {
+    _resetUnknownFieldsGuardCache();
+    const req = {
+      method: "POST",
+      path: "/store",
+      body: {
+        idempotency_key: "k",
+        file_path: "/tmp/sample.pdf",
+        source_storage: "reference",
+      },
+    } as any;
+    const res = buildRes();
+    const next = vi.fn();
+    unknownFieldsGuard(req, res, next);
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
   it("passes through when the route is not a closed OpenAPI shape", () => {
     _resetUnknownFieldsGuardCache();
     const req = {


### PR DESCRIPTION
Two last-mile wiring gaps in v0.18.0 by-reference source storage (#1775), found by an evaluator who validated the engine end-to-end (zero-byte writes, `SOURCE_UNAVAILABLE`/`SOURCE_REFERENCE_STALE` drift cases all reproduced cleanly).

### #1826 — unreachable over HTTP
`source_storage` was absent from `openapi.yaml` `StoreRequest` (which is `additionalProperties: false`), so the unknown-fields edge guard rejected `POST /store` with `ERR_UNKNOWN_FIELD`. It only worked over `/mcp` (where `tool_definitions.ts` + the Zod schema accept it).
**Fix:** add `source_storage` (`enum: [inline, reference]`) to the HTTP contract. **Test:** `tests/unit/unknown_fields_guard.test.ts` now asserts `source_storage:"reference"` passes the POST /store guard.

### #1827 — silent inline fallback with `entities[]` + file
In the `entities[] + file_path + source_storage:"reference"` shape (the natural "file + its entities" call), the `hasEntities && hasUnstructured` branches recurse into `store()` for the file leg **without forwarding `source_storage`**, so the file silently stored inline and copied bytes — no error, wrong mode.
**Fix:** propagate `source_storage: parsed.source_storage` in both recursive `this.store({...})` calls (server.ts).

### Validation
- `unknown_fields_guard` 9/9 pass (incl. new case); eslint + tsc clean; openapi parses.
- The #1827 fix is the propagation; the originating evaluator has a clean repro and can re-verify. A dedicated `app`-harness integration test (POST file+entities+reference → assert reference source row) is a sensible fast-follow.

Closes #1826, closes #1827.

🤖 Generated with [Claude Code](https://claude.com/claude-code)