### PR TITLE
chore(release): v0.18.1

### DIFF
--- a/docs/releases/in_progress/v0.18.1/github_release_supplement.md
+++ b/docs/releases/in_progress/v0.18.1/github_release_supplement.md
@@ -1,0 +1,18 @@
+# v0.18.1 Release Supplement
+
+## Summary
+
+Patch release that connects the two last-mile pipes on v0.18.0 **by-reference source storage** (#1775), so it is reachable over HTTP and through the natural "file + its entities" call shape. Both gaps were found by a developer-release evaluator who validated the engine end-to-end (zero-byte writes, `SOURCE_UNAVAILABLE` / `SOURCE_REFERENCE_STALE` drift cases) against a production DB.
+
+## Fixes
+
+- **By-reference storage reachable over HTTP (#1826).** `source_storage` was missing from `openapi.yaml` `StoreRequest` (which is `additionalProperties: false`), so the edge guard rejected `POST /store` with `ERR_UNKNOWN_FIELD` — the field only worked over the `/mcp` route. Added `source_storage` (`enum: [inline, reference]`) to the HTTP contract and regenerated `openapi_types.ts`.
+- **No more silent inline fallback with `entities[]` + file (#1827).** `store({ entities, file_path, source_storage: "reference" })` silently stored **inline** and copied the bytes, because the `hasEntities && hasUnstructured` branches recursed into `store()` for the file leg without forwarding `source_storage`. It is now propagated, so the natural "file + its entities" call stores by reference as intended.
+
+## Behavior changes
+
+- Both surfaces (HTTP `POST /store` and the file+entities call shape) now honor `source_storage: "reference"` identically to the single-file MCP path. No other behavior change; `inline` remains the default.
+
+## Breaking changes
+
+- None.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neotoma",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neotoma",
-      "version": "0.18.0",
+      "version": "0.18.1",
       "license": "MIT",
       "dependencies": {
         "@hellocoop/httpsig": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neotoma",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "MCP server for structured personal data memory with unified source ingestion",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
Patch release. Connects the two last-mile pipes on v0.18.0 by-reference source storage:
- By-reference storage reachable over HTTP `POST /store` (#1826)
- No silent inline fallback with `entities[]` + file (#1827)

Both merged in #1830. Notes: `docs/releases/in_progress/v0.18.1/github_release_supplement.md`. Version bump + supplement only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)