### PR TITLE
fix(entity-resolution): reject source_name/data_source/origin as canonical_name

### DIFF
--- a/src/services/entity_resolution.ts
+++ b/src/services/entity_resolution.ts
@@ -596,6 +596,14 @@ export function deriveCanonicalNameFromFieldsWithTrace(
       "import_date",
       "import_source_file",
       "source",
+      // Provenance/origin labels — like `source`, these describe where the
+      // entity came from rather than what it is. Accepting them as canonical
+      // names causes unrelated entities to merge under a shared provenance
+      // label (e.g. every auto-merged entity named after "stale cache" or
+      // "gmail import"). `source` was already rejected; add siblings.
+      "source_name",
+      "data_source",
+      "origin",
       "currency",
       "currency_code",
       "category",

--- a/tests/services/entity_resolution.test.ts
+++ b/tests/services/entity_resolution.test.ts
@@ -432,6 +432,64 @@ describe("Entity Resolution Service", () => {
       expect(typeof canonical).toBe("string");
     });
 
+    // Regression: #1821 — source_name provenance field must never become
+    // the canonical_name for auto-discovered entity types.
+    describe("source_name / provenance-key exclusion (#1821)", () => {
+      it("uses name over source_name when both are present", () => {
+        // The reporter stored {name, source_name}; canonical_name must come
+        // from `name`, not from the provenance label.
+        // Note: formatCanonicalNameForStorage normalises underscores to spaces,
+        // so "spy_priority_test" is stored as "spy priority test".
+        const result = deriveCanonicalNameFromFieldsWithTrace("spy_priority", {
+          name: "spy_priority_test",
+          source_name: "stale cache",
+        });
+        expect(result.canonicalName).toContain("spy priority test");
+        expect(result.canonicalName).not.toContain("stale cache");
+        expect(result.identityBasis).toBe("heuristic_name");
+        expect(result.identityRule).toBe("name_key:name");
+      });
+
+      it("refuses to derive canonical_name from source_name alone (no name present)", () => {
+        // A second write arriving with only {source_name} must not mint an
+        // entity named after the provenance label.
+        expect(() =>
+          deriveCanonicalNameFromFields("spy_priority", {
+            source_name: "stale cache",
+          }),
+        ).toThrow(CanonicalNameUnresolvedError);
+      });
+
+      it("refuses to derive canonical_name from data_source alone", () => {
+        expect(() =>
+          deriveCanonicalNameFromFields("custom_type", {
+            data_source: "webhook_import",
+          }),
+        ).toThrow(CanonicalNameUnresolvedError);
+      });
+
+      it("refuses to derive canonical_name from origin alone", () => {
+        expect(() =>
+          deriveCanonicalNameFromFields("custom_type", {
+            origin: "webhook_import",
+          }),
+        ).toThrow(CanonicalNameUnresolvedError);
+      });
+
+      it("heuristic fallback still picks a legitimate payload field when source_name is also present", () => {
+        // When neither name nor id fields are present but another legitimate
+        // string field exists alongside source_name, the fallback must pick
+        // the legitimate field, not source_name.
+        const result = deriveCanonicalNameFromFieldsWithTrace("custom_widget", {
+          source_name: "import_batch_7",
+          widget_label: "Dashboard Widget",
+        });
+        expect(result.canonicalName).toContain("Dashboard Widget");
+        expect(result.identityBasis).toBe("heuristic_fallback");
+        expect(result.identityRule).toContain("widget_label");
+      });
+    });
+
     // R1: ordered identity precedence with partial matches.
     describe("ordered identity precedence (R1)", () => {
       const orderedContactSchema = {


### PR DESCRIPTION
## Summary

Closes #1821

On auto-discovered entity types (no registered schema, no `canonical_name_fields`), the step-4 alphabetical-first-string-field fallback in `deriveCanonicalNameFromFieldsWithTrace` could pick `source_name` as the entity's `canonical_name` when a preferred-name field (`name`, `full_name`, `title`, etc.) was absent on a given write.

**Root cause verified:** The `rejectKeys` set in step 4 already excluded `source` but not `source_name`, `data_source`, or `origin`. Because step 4 iterates sorted field names and `s` sorts before most other letters, `source_name` was selected ahead of legitimate fields on writes that omitted `name`. This explains the reported behaviour: a second observation/auto-merge write carrying only `{source_name: "stale cache"}` minted (or updated) an entity whose `canonical_name` became the provenance label rather than the entity's actual name (`"spy_priority_test"`).

## Fix

Add `source_name`, `data_source`, and `origin` to `rejectKeys` in `deriveCanonicalNameFromFieldsWithTrace` step 4 (`src/services/entity_resolution.ts`). These are provenance labels — they describe *where* data came from, not *what the entity is* — the same class of field as `source`, which was already rejected. Preferred-name fields still win when present (step 2 runs before step 4), so the fix has no effect on well-formed payloads that include `name`.

**Scope:** the change is a one-line set extension inside the heuristic fallback; no other resolution paths are affected.

## Robust long-term fix

Declare `canonical_name_fields` + `canonical_name_strict: true` per schema (the #1761 mechanism). That makes identity deterministic and disables the heuristic fallback entirely for registered schemas. This PR makes the heuristic safe as a backstop for auto-discovered types that have not yet been explicitly registered.

## Tests added (`tests/services/entity_resolution.test.ts`)

- `name` wins over `source_name` when both are present
- `source_name` alone throws `CanonicalNameUnresolvedError`
- `data_source` alone throws `CanonicalNameUnresolvedError`
- `origin` alone throws `CanonicalNameUnresolvedError`
- Legitimate heuristic payload field beats `source_name` when picked by step 4

## Verification

```
npx vitest run tests/services/entity_resolution.test.ts
# 64 tests, 64 passed

npx tsc --noEmit      # clean
npm run format:check  # clean
npx tsx scripts/generate-automated-test-catalog.ts --check  # up to date
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)