### PR TITLE
fix(store): enrich SOURCE_PRIORITY_IGNORED warning with field names and strategies

### DIFF
--- a/src/services/source_priority_warning.ts
+++ b/src/services/source_priority_warning.ts
@@ -96,8 +96,36 @@ export type SourcePriorityIgnoredWarning = {
 };
 
 /**
+ * Returns a list of written field names that will NOT honour source_priority,
+ * paired with their effective merge strategy (from mergePolicies, or
+ * "last_write" when the field is absent from the policy map / no schema exists).
+ *
+ * Returns an empty array when every written field honours priority (i.e. the
+ * caller should not emit a warning).
+ */
+export function ignoredFieldStrategies(opts: {
+  writtenFields: Record<string, unknown>;
+  mergePolicies: ReducerConfig["merge_policies"] | undefined | null;
+}): Array<{ field: string; strategy: string }> {
+  const { writtenFields, mergePolicies } = opts;
+  const result: Array<{ field: string; strategy: string }> = [];
+  for (const fieldName of Object.keys(writtenFields)) {
+    const policy = mergePolicies?.[fieldName];
+    if (!fieldHonorsPriority(policy)) {
+      // If the field has an explicit policy, report its strategy; otherwise it
+      // falls back to the auto-discovered default ("last_write").
+      result.push({ field: fieldName, strategy: policy?.strategy ?? "last_write" });
+    }
+  }
+  return result;
+}
+
+/**
  * Returns a structured store_warnings[] entry when `source_priority` will have
  * no effect on the observation, or `null` when no warning is warranted.
+ *
+ * The message now names each written field that ignores source_priority and
+ * states its effective merge strategy, making the warning self-diagnosing.
  *
  * Centralises both the predicate check and the message template so the HTTP
  * and MCP call sites are each a single expression rather than an ~11-line
@@ -118,15 +146,27 @@ export function buildSourcePriorityIgnoredWarning(opts: {
     return null;
   }
 
+  const ignored = ignoredFieldStrategies({ writtenFields, mergePolicies });
+
+  // Build a compact per-field summary: "field 'foo' uses last_write"
+  const fieldSummary = ignored
+    .map(({ field, strategy }) => `'${field}' uses ${strategy}`)
+    .join(", ");
+
+  const noSchema = !mergePolicies || Object.keys(mergePolicies).length === 0;
+  const policyNote = noSchema
+    ? " (reducer_config.merge_policies has no entries for this type)"
+    : " (reducer_config.merge_policies has no highest_priority entry for these fields)";
+
   return {
     code: "SOURCE_PRIORITY_IGNORED",
     message:
-      `${entityType} stored with source_priority ${sourcePriority} but no field ` +
-      "on this entity type uses a merge strategy that honours it. " +
+      `${entityType} stored with source_priority ${sourcePriority} but the written ` +
+      `field(s) ignore it — ${fieldSummary}${policyNote}. ` +
       "source_priority is only effective when a field's reducer policy is " +
       '`highest_priority` (or `most_specific` with `tie_breaker: "source_priority"`). ' +
-      "To fix: register a schema whose reducer_config sets the relevant field(s) to " +
-      "`highest_priority` so source_priority is honoured during reduction.",
+      "To fix: register a schema whose reducer_config.merge_policies sets the relevant " +
+      "field(s) to `highest_priority` so source_priority is honoured during reduction.",
     observation_index: observationIndex,
     entity_type: entityType,
     entity_id: entityId,

--- a/tests/integration/store_source_priority_ignored_warning.test.ts
+++ b/tests/integration/store_source_priority_ignored_warning.test.ts
@@ -173,6 +173,9 @@ describe("store_warnings: SOURCE_PRIORITY_IGNORED (#1755)", () => {
     expect(warn!.observation_index).toBe(0);
     expect(warn!.message).toContain("source_priority");
     expect(warn!.message).toContain("200");
+    // #1822: message must name the written field and its effective strategy.
+    expect(warn!.message).toContain("'label'");
+    expect(warn!.message).toContain("last_write");
   });
 
   it("MCP: default source_priority (100) + auto-discovered type → no warning", async () => {
@@ -247,6 +250,9 @@ describe("store_warnings: SOURCE_PRIORITY_IGNORED (#1755)", () => {
     expect(warn).toBeDefined();
     expect(warn!.entity_type).toBe(LAST_WRITE_TYPE);
     expect(warn!.observation_index).toBe(0);
+    // #1822: message must name the written fields and their effective strategy.
+    expect(warn!.message).toContain("'label'");
+    expect(warn!.message).toContain("last_write");
   });
 
   // ─── HTTP /store path ────────────────────────────────────────────────────────
@@ -283,6 +289,9 @@ describe("store_warnings: SOURCE_PRIORITY_IGNORED (#1755)", () => {
     expect(warn!.entity_id).toBe(entityId);
     expect(warn!.observation_index).toBe(0);
     expect(warn!.message).toContain("source_priority");
+    // #1822: message must name the written field and its effective strategy.
+    expect(warn!.message).toContain("'label'");
+    expect(warn!.message).toContain("last_write");
   });
 
   it("HTTP: default source_priority (100) + all-last_write schema → no warning", async () => {

--- a/tests/unit/source_priority_ignored_warning.test.ts
+++ b/tests/unit/source_priority_ignored_warning.test.ts
@@ -14,12 +14,18 @@
  *
  * Also covers the `most_specific` + `tie_breaker: "source_priority"` case
  * and edge cases (empty fields, undefined policies).
+ *
+ * Extended for #1822: `ignoredFieldStrategies` and
+ * `buildSourcePriorityIgnoredWarning` now include per-field strategy detail
+ * in the warning message so it is self-diagnosing.
  */
 
 import { describe, it, expect } from "vitest";
 import {
   fieldHonorsPriority,
+  ignoredFieldStrategies,
   sourcePriorityWillBeIgnored,
+  buildSourcePriorityIgnoredWarning,
 } from "../../src/services/source_priority_warning.js";
 
 // ---------------------------------------------------------------------------
@@ -209,5 +215,164 @@ describe("sourcePriorityWillBeIgnored", () => {
       });
       expect(result).toBe(false);
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ignoredFieldStrategies (#1822)
+// ---------------------------------------------------------------------------
+
+describe("ignoredFieldStrategies", () => {
+  it("returns all written fields with their strategies when none honour priority", () => {
+    const result = ignoredFieldStrategies({
+      writtenFields: { name: "Alice", title: "Engineer" },
+      mergePolicies: {
+        name: { strategy: "last_write" },
+        title: { strategy: "merge_array" },
+      },
+    });
+    expect(result).toHaveLength(2);
+    expect(result).toContainEqual({ field: "name", strategy: "last_write" });
+    expect(result).toContainEqual({ field: "title", strategy: "merge_array" });
+  });
+
+  it("defaults to last_write when the field has no policy entry", () => {
+    const result = ignoredFieldStrategies({
+      writtenFields: { unlisted: "value" },
+      mergePolicies: { other: { strategy: "highest_priority" } },
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({ field: "unlisted", strategy: "last_write" });
+  });
+
+  it("defaults to last_write when mergePolicies is undefined (no schema)", () => {
+    const result = ignoredFieldStrategies({
+      writtenFields: { notes: "text" },
+      mergePolicies: undefined,
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({ field: "notes", strategy: "last_write" });
+  });
+
+  it("defaults to last_write when mergePolicies is null", () => {
+    const result = ignoredFieldStrategies({
+      writtenFields: { notes: "text" },
+      mergePolicies: null,
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({ field: "notes", strategy: "last_write" });
+  });
+
+  it("excludes fields that honour priority", () => {
+    const result = ignoredFieldStrategies({
+      writtenFields: { name: "Alice", score: 42 },
+      mergePolicies: {
+        name: { strategy: "last_write" },
+        score: { strategy: "highest_priority" },
+      },
+    });
+    // Only 'name' is ignored; 'score' honours priority.
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({ field: "name", strategy: "last_write" });
+  });
+
+  it("returns empty array when all written fields honour priority", () => {
+    const result = ignoredFieldStrategies({
+      writtenFields: { score: 42 },
+      mergePolicies: { score: { strategy: "highest_priority" } },
+    });
+    expect(result).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildSourcePriorityIgnoredWarning — message detail (#1822)
+// ---------------------------------------------------------------------------
+
+describe("buildSourcePriorityIgnoredWarning message detail", () => {
+  it("names the ignored field and its strategy in the message (no schema)", () => {
+    const warn = buildSourcePriorityIgnoredWarning({
+      sourcePriority: 200,
+      writtenFields: { implied_vol: 0.25 },
+      mergePolicies: undefined,
+      observationIndex: 0,
+      entityType: "option_quote",
+      entityId: "eid-1",
+    });
+    expect(warn).not.toBeNull();
+    expect(warn!.message).toContain("'implied_vol'");
+    expect(warn!.message).toContain("last_write");
+  });
+
+  it("names multiple ignored fields in the message", () => {
+    const warn = buildSourcePriorityIgnoredWarning({
+      sourcePriority: 300,
+      writtenFields: { name: "Alice", status: "active" },
+      mergePolicies: {
+        name: { strategy: "last_write" },
+        status: { strategy: "last_write" },
+      },
+      observationIndex: 1,
+      entityType: "contact",
+      entityId: "eid-2",
+    });
+    expect(warn).not.toBeNull();
+    expect(warn!.message).toContain("'name'");
+    expect(warn!.message).toContain("'status'");
+    expect(warn!.message).toContain("last_write");
+  });
+
+  it("reports merge_array strategy when that is the effective policy", () => {
+    const warn = buildSourcePriorityIgnoredWarning({
+      sourcePriority: 150,
+      writtenFields: { tags: ["a", "b"] },
+      mergePolicies: { tags: { strategy: "merge_array" } },
+      observationIndex: 0,
+      entityType: "note",
+      entityId: "eid-3",
+    });
+    expect(warn).not.toBeNull();
+    expect(warn!.message).toContain("'tags'");
+    expect(warn!.message).toContain("merge_array");
+  });
+
+  it("includes the entity type and source_priority value in the message", () => {
+    const warn = buildSourcePriorityIgnoredWarning({
+      sourcePriority: 999,
+      writtenFields: { score: 42 },
+      mergePolicies: { score: { strategy: "last_write" } },
+      observationIndex: 0,
+      entityType: "leaderboard_entry",
+      entityId: "eid-4",
+    });
+    expect(warn).not.toBeNull();
+    expect(warn!.message).toContain("leaderboard_entry");
+    expect(warn!.message).toContain("999");
+    expect(warn!.message).toContain("'score'");
+    expect(warn!.message).toContain("last_write");
+  });
+
+  it("returns null when source_priority is default (100)", () => {
+    const warn = buildSourcePriorityIgnoredWarning({
+      sourcePriority: 100,
+      writtenFields: { name: "Alice" },
+      mergePolicies: undefined,
+      observationIndex: 0,
+      entityType: "contact",
+      entityId: "eid-5",
+    });
+    expect(warn).toBeNull();
+  });
+
+  it("returns null when a written field honours priority", () => {
+    const warn = buildSourcePriorityIgnoredWarning({
+      sourcePriority: 200,
+      writtenFields: { score: 42 },
+      mergePolicies: { score: { strategy: "highest_priority" } },
+      observationIndex: 0,
+      entityType: "leaderboard_entry",
+      entityId: "eid-6",
+    });
+    expect(warn).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Closes #1822

The `SOURCE_PRIORITY_IGNORED` warning (added in #1755) fires correctly when an observation sets `source_priority` but the field's merge strategy ignores it — but the message didn't say _which_ fields were ignoring it or _why_ (their effective merge strategy). This makes it self-diagnosing.

**Before:**
> `option_quote stored with source_priority 200 but no field on this entity type uses a merge strategy that honours it. ...`

**After:**
> `option_quote stored with source_priority 200 but the written field(s) ignore it — 'implied_vol' uses last_write (reducer_config.merge_policies has no entries for this type). source_priority is only effective when a field's reducer policy is \`highest_priority\` ...`

## Changes

- **`src/services/source_priority_warning.ts`**: add exported `ignoredFieldStrategies()` helper that returns each written field not honouring `source_priority` paired with its effective strategy (`last_write` default when absent from `merge_policies` or no schema registered). Update `buildSourcePriorityIgnoredWarning()` to embed the per-field summary in the message.
- **`tests/unit/source_priority_ignored_warning.test.ts`**: add `ignoredFieldStrategies` suite (6 cases) and `buildSourcePriorityIgnoredWarning message detail` suite (6 cases) asserting field names and strategies appear in the message.
- **`tests/integration/store_source_priority_ignored_warning.test.ts`**: add field-name + strategy assertions to the two warning-fires cases.

## Behaviour

No behaviour change — warning remains advisory/non-blocking. No new OpenAPI warning code. No new `store_warnings` fields.

## Test plan

- [x] `npx vitest run tests/unit/source_priority_ignored_warning.test.ts` — 32 tests pass
- [x] `npx vitest run tests/integration/store_source_priority_ignored_warning.test.ts` — 6 tests pass
- [x] `npx tsc --noEmit` — clean
- [x] `npm run format:check` — clean
- [x] `npx tsx scripts/generate-automated-test-catalog.ts` — no catalog changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)