### PR TITLE
test(ci): gate cross-surface store/reference contract parity on the PR lane

### DIFF
--- a/.github/workflows/ci_test_lanes.yml
+++ b/.github/workflows/ci_test_lanes.yml
@@ -92,6 +92,45 @@ jobs:
       - name: Validate documentation dependencies
         run: npm run validate:doc-deps
 
+  contract_parity:
+    # Focused PR-time cross-surface contract-parity lane.
+    #
+    # Retrospective ent_68a9270e2e656da847c10ced: the `source_storage:'reference'`
+    # feature shipped incomplete to an evaluator across three releases because the
+    # covering integration tests ran only in the nightly remote_integration
+    # workflow — never on the PR baseline lane, which runs `test:unit` (no DB).
+    #
+    # This lane runs ONLY the parity-critical store/reference integration tests
+    # (MCP + REST surfaces driven through one shared scenario matrix) on every PR.
+    # It deliberately does NOT pull the whole nightly integration suite onto each
+    # PR — just the cross-surface parity gate — so it stays fast (~a few seconds
+    # of tests). The tests run against the same local SQLite backend the nightly
+    # job uses (default mode: RUN_REMOTE_TESTS unset), with file-parallelism
+    # disabled to avoid SQLite lock contention between the two HTTP-server files.
+    #
+    # Implements task_policy cross_surface_contract_parity_tested_all_surfaces
+    # (ent_2ad0677fe23c0c1878ae43e8) and
+    # fixed_means_behavior_verified_not_contract_accepted (ent_db0b7855d47012084477fb00).
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build server (integration tests boot the in-process Actions server)
+        run: npm run build:server
+
+      - name: Run cross-surface contract-parity integration tests
+        run: npm run test:contract-parity
+
   frontend:
     runs-on: ubuntu-latest
     steps:

--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,8 +61,8 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **517**
-- Backend and repo Vitest files: **483**
+- Total automated test files: **518**
+- Backend and repo Vitest files: **484**
 - Frontend Vitest files: **9**
 - Playwright spec files: **25**
 
@@ -72,7 +72,7 @@ flowchart TD
 | Vitest unit tests | 144 |
 | Vitest service tests | 35 |
 | Source-adjacent tests | 64 |
-| Vitest integration tests | 145 |
+| Vitest integration tests | 146 |
 | Vitest CLI tests | 65 |
 | Vitest contract tests | 14 |
 | Vitest security tests | 4 |
@@ -373,7 +373,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm run test:integration` or `npx vitest run tests/integration`
 **Requirements:** Database configured; remote-dependent subsets additionally need `RUN_REMOTE_TESTS=1`.
-**Files (145):**
+**Files (146):**
 - `tests/integration/aauth_attribution_stamping.test.ts`
 - `tests/integration/aauth_mcp_capability_parity.test.ts`
 - `tests/integration/aauth_mcp_initialize_admission.test.ts`
@@ -503,6 +503,7 @@ flowchart TD
 - `tests/integration/store_explicit_canonical_name.test.ts`
 - `tests/integration/store_external_link_schema.test.ts`
 - `tests/integration/store_prefix_duplicate_candidates.test.ts`
+- `tests/integration/store_reference_source_parity.test.ts`
 - `tests/integration/store_registered_schema_alias_precedence.test.ts`
 - `tests/integration/store_required_unknown_field_signals.test.ts`
 - `tests/integration/store_resolution_attributes_hint.test.ts`

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "test:bench": "cross-env RUN_BENCH=1 vitest run tests/performance",
     "test:cross-layer": "vitest run tests/integration/cli_to_mcp_store.test.ts tests/integration/cli_to_mcp_entities.test.ts tests/integration/cli_to_mcp_relationships.test.ts tests/integration/cli_to_mcp_schemas.test.ts",
     "test:parity": "vitest run tests/contract/contract_mcp_cli_parity.test.ts",
+    "test:contract-parity": "vitest run --no-file-parallelism tests/integration/store_reference_source_parity.test.ts tests/integration/http_store_reference_source.test.ts tests/integration/mcp_store_reference_source.test.ts",
     "test:e2e:coverage": "npm run test:contract && npm run test:cross-layer",
     "test:agent-mcp": "vitest run tests/agent",
     "test:coverage": "vitest run --coverage",

--- a/tests/helpers/store_reference_parity.ts
+++ b/tests/helpers/store_reference_parity.ts
@@ -1,0 +1,165 @@
+/**
+ * Shared parity-matrix driver for `source_storage:'reference'` store scenarios.
+ *
+ * Retrospective ent_68a9270e2e656da847c10ced found that the by-reference
+ * source-storage feature shipped incomplete because contract parity across
+ * Neotoma's surfaces (MCP, HTTP/REST, CLI, SDK) was never tested on the same
+ * scenarios. This helper encodes a single scenario matrix and drives it across
+ * BOTH the MCP `store` tool dispatch and the REST `POST /store` route, so a
+ * regression on either surface (or a divergence between them) fails the same
+ * lane — implementing task_policy cross_surface_contract_parity_tested_all_surfaces
+ * (ent_2ad0677fe23c0c1878ae43e8).
+ *
+ * Each scenario asserts the EFFECT (storage_mode='reference' in the sources
+ * row), not merely that the input was accepted — per task_policy
+ * fixed_means_behavior_verified_not_contract_accepted (ent_db0b7855d47012084477fb00).
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { db } from "../../src/db.js";
+import { NeotomaServer } from "../../src/server.js";
+
+export type StoreSurface = "mcp" | "rest";
+
+export interface ReferenceParityResult {
+  /** source_id of the file (reference) leg, used to inspect the sources row. */
+  sourceId: string;
+  /** storage_mode the surface reported in its response envelope. */
+  reportedStorageMode: unknown;
+}
+
+/**
+ * Drives the MCP `store` tool through the real CallToolRequestSchema dispatch
+ * surface (`executeTool`) — the same code path the `/mcp` JSON-RPC route
+ * routes a `tools/call` for `store` into. Returns the file-leg source_id and
+ * the storage_mode the MCP envelope reported.
+ */
+export async function storeReferenceViaMcp(
+  server: NeotomaServer,
+  args: {
+    userId: string;
+    filePath: string;
+    idempotencyKey: string;
+    withEntities: boolean;
+  }
+): Promise<ReferenceParityResult> {
+  const dispatch = server as unknown as {
+    executeTool: (
+      name: string,
+      args: unknown
+    ) => Promise<{ content: Array<{ type: string; text: string }> }>;
+  };
+
+  const toolArgs: Record<string, unknown> = {
+    user_id: args.userId,
+    file_path: args.filePath,
+    mime_type: "text/plain",
+    source_storage: "reference",
+    file_idempotency_key: `${args.idempotencyKey}-file`,
+  };
+  if (args.withEntities) {
+    toolArgs.idempotency_key = args.idempotencyKey;
+    toolArgs.entities = [{ entity_type: "note", title: "parity-mcp", content: "body" }];
+  } else {
+    toolArgs.idempotency_key = args.idempotencyKey;
+  }
+
+  const result = await dispatch.executeTool("store", toolArgs);
+  const payload = JSON.parse(result.content[0]!.text) as Record<string, unknown>;
+
+  if (args.withEntities) {
+    const unstructured = payload.unstructured as Record<string, unknown> | undefined;
+    return {
+      sourceId: unstructured?.source_id as string,
+      reportedStorageMode: unstructured?.storage_mode,
+    };
+  }
+  return {
+    sourceId: payload.source_id as string,
+    reportedStorageMode: payload.storage_mode,
+  };
+}
+
+/**
+ * Drives the REST `POST /store` route over real HTTP. Returns the file-leg
+ * source_id and the storage_mode the REST envelope reported.
+ */
+export async function storeReferenceViaRest(
+  apiBase: string,
+  args: {
+    userId: string;
+    filePath: string;
+    idempotencyKey: string;
+    withEntities: boolean;
+  }
+): Promise<ReferenceParityResult> {
+  const body: Record<string, unknown> = {
+    user_id: args.userId,
+    file_path: args.filePath,
+    mime_type: "text/plain",
+    source_storage: "reference",
+    file_idempotency_key: `${args.idempotencyKey}-file`,
+    idempotency_key: args.idempotencyKey,
+  };
+  if (args.withEntities) {
+    body.entities = [{ entity_type: "note", title: "parity-rest", content: "body" }];
+  }
+
+  const resp = await fetch(`${apiBase}/store`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (resp.status !== 200) {
+    throw new Error(`REST /store returned ${resp.status}: ${await resp.text()}`);
+  }
+  const payload = (await resp.json()) as Record<string, unknown>;
+
+  if (args.withEntities) {
+    const unstructured = payload.unstructured as Record<string, unknown> | undefined;
+    return {
+      sourceId: unstructured?.source_id as string,
+      reportedStorageMode: unstructured?.storage_mode,
+    };
+  }
+  return {
+    sourceId: payload.source_id as string,
+    reportedStorageMode: payload.storage_mode,
+  };
+}
+
+/** Reads back the storage_mode persisted on the sources row (the EFFECT). */
+export async function readSourceStorageMode(sourceId: string): Promise<string | undefined> {
+  const { data } = await db.from("sources").select("storage_mode").eq("id", sourceId).single();
+  return (data as { storage_mode?: string } | null)?.storage_mode;
+}
+
+/** Writes a temp file and tracks its directory for cleanup. */
+export function makeReferenceTempFile(
+  tempDirs: string[],
+  content: string,
+  filename = "parity-ref.txt"
+): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "neotoma-parity-ref-"));
+  tempDirs.push(dir);
+  const filePath = path.join(dir, filename);
+  fs.writeFileSync(filePath, content, "utf-8");
+  return filePath;
+}
+
+/** The shared scenario matrix: each (surface × shape) cell. */
+export interface ParityScenario {
+  surface: StoreSurface;
+  shape: "file-only" | "file+entities";
+  label: string;
+}
+
+export const REFERENCE_PARITY_MATRIX: ParityScenario[] = [
+  { surface: "mcp", shape: "file-only", label: "MCP store — file-only" },
+  { surface: "mcp", shape: "file+entities", label: "MCP store — file+entities" },
+  { surface: "rest", shape: "file-only", label: "REST /store — file-only" },
+  { surface: "rest", shape: "file+entities", label: "REST /store — file+entities" },
+];

--- a/tests/integration/store_reference_source_parity.test.ts
+++ b/tests/integration/store_reference_source_parity.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Cross-surface contract-parity matrix for `source_storage:'reference'` store.
+ *
+ * Retrospective ent_68a9270e2e656da847c10ced: the by-reference source-storage
+ * feature shipped incomplete to an evaluator across three releases because
+ * contract parity across Neotoma's surfaces (MCP, REST, CLI, SDK) was never
+ * tested. Sibling tests (mcp_store_reference_source.test.ts,
+ * http_store_reference_source.test.ts) each cover ONE surface in isolation;
+ * this test drives the SAME scenario across BOTH the MCP `store` tool dispatch
+ * and the REST `POST /store` route via a shared parity-matrix helper, asserting
+ * an IDENTICAL effect (storage_mode='reference' in the sources row) for the
+ * file-only shape AND the combined entities[]+file shape.
+ *
+ * Implements task_policy:
+ *   - cross_surface_contract_parity_tested_all_surfaces (ent_2ad0677fe23c0c1878ae43e8)
+ *   - fixed_means_behavior_verified_not_contract_accepted (ent_db0b7855d47012084477fb00)
+ */
+
+import { createServer } from "node:http";
+import fs from "node:fs";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { app } from "../../src/actions.js";
+import { db } from "../../src/db.js";
+import { NeotomaServer } from "../../src/server.js";
+import {
+  makeReferenceTempFile,
+  readSourceStorageMode,
+  REFERENCE_PARITY_MATRIX,
+  storeReferenceViaMcp,
+  storeReferenceViaRest,
+} from "../helpers/store_reference_parity.js";
+
+const TEST_USER_ID = "00000000-0000-0000-0000-000000000001";
+const API_PORT = 18123;
+const API_BASE = `http://127.0.0.1:${API_PORT}`;
+
+describe("store source_storage:'reference' — MCP↔REST contract parity (#1826 retrospective)", () => {
+  let httpServer: ReturnType<typeof createServer>;
+  let mcpServer: NeotomaServer;
+  const createdSourceIds: string[] = [];
+  const tempDirs: string[] = [];
+
+  beforeAll(async () => {
+    // REST surface: real Express app over HTTP.
+    httpServer = createServer(app);
+    await new Promise<void>((resolve, reject) => {
+      httpServer.listen(API_PORT, "127.0.0.1", () => resolve());
+      httpServer.once("error", reject);
+    });
+
+    // MCP surface: NeotomaServer dispatch (the same path `/mcp` tools/call routes
+    // a `store` call into). Inject the test user so no real auth token is needed.
+    mcpServer = new NeotomaServer();
+    (mcpServer as unknown as { authenticatedUserId: string }).authenticatedUserId = TEST_USER_ID;
+  });
+
+  afterAll(async () => {
+    if (createdSourceIds.length > 0) {
+      await db.from("observations").delete().in("source_id", createdSourceIds);
+      await db.from("raw_fragments").delete().in("source_id", createdSourceIds);
+      await db.from("sources").delete().in("id", createdSourceIds);
+    }
+    for (const dir of tempDirs) {
+      try {
+        if (fs.existsSync(dir)) fs.rmSync(dir, { recursive: true, force: true });
+      } catch {
+        // ignore cleanup errors
+      }
+    }
+    await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+  });
+
+  for (const scenario of REFERENCE_PARITY_MATRIX) {
+    it(`${scenario.label} → storage_mode=reference on the sources row`, async () => {
+      const withEntities = scenario.shape === "file+entities";
+      const tag = `${scenario.surface}-${scenario.shape}`;
+      const filePath = makeReferenceTempFile(
+        tempDirs,
+        `parity-${tag}-${Date.now()}`,
+        `parity-${tag}.txt`
+      );
+      const idempotencyKey = `parity-${tag}-${Date.now()}`;
+
+      const result =
+        scenario.surface === "mcp"
+          ? await storeReferenceViaMcp(mcpServer, {
+              userId: TEST_USER_ID,
+              filePath,
+              idempotencyKey,
+              withEntities,
+            })
+          : await storeReferenceViaRest(API_BASE, {
+              userId: TEST_USER_ID,
+              filePath,
+              idempotencyKey,
+              withEntities,
+            });
+
+      // 1. The surface's response envelope reports reference mode.
+      expect(result.reportedStorageMode).toBe("reference");
+      expect(typeof result.sourceId).toBe("string");
+      createdSourceIds.push(result.sourceId);
+
+      // 2. The EFFECT: the persisted sources row carries storage_mode='reference'
+      //    — identical outcome regardless of surface or input shape.
+      const persistedMode = await readSourceStorageMode(result.sourceId);
+      expect(persistedMode).toBe("reference");
+    });
+  }
+
+  it("MCP and REST produce the identical persisted storage_mode for the same scenario", async () => {
+    // Drive the file-only scenario on both surfaces and assert the persisted
+    // effect is byte-for-byte the same value — this is the parity guarantee,
+    // not just that each surface independently "works".
+    const mcpFile = makeReferenceTempFile(tempDirs, `parity-cmp-mcp-${Date.now()}`, "cmp-mcp.txt");
+    const restFile = makeReferenceTempFile(
+      tempDirs,
+      `parity-cmp-rest-${Date.now()}`,
+      "cmp-rest.txt"
+    );
+
+    const mcp = await storeReferenceViaMcp(mcpServer, {
+      userId: TEST_USER_ID,
+      filePath: mcpFile,
+      idempotencyKey: `parity-cmp-mcp-${Date.now()}`,
+      withEntities: false,
+    });
+    const rest = await storeReferenceViaRest(API_BASE, {
+      userId: TEST_USER_ID,
+      filePath: restFile,
+      idempotencyKey: `parity-cmp-rest-${Date.now()}`,
+      withEntities: false,
+    });
+    createdSourceIds.push(mcp.sourceId, rest.sourceId);
+
+    const mcpMode = await readSourceStorageMode(mcp.sourceId);
+    const restMode = await readSourceStorageMode(rest.sourceId);
+    expect(mcpMode).toBe("reference");
+    expect(restMode).toBe(mcpMode);
+  });
+});


### PR DESCRIPTION
## Why

Retrospective [ent_68a9270e2e656da847c10ced] found that the `source_storage:'reference'` feature shipped incomplete to evaluator Jeroen across **three releases** because:

1. **Contract parity across surfaces was never tested** — the feature worked on one surface while another drifted.
2. **"Fixed" was declared from contract-acceptance, not behaviour** — a test that the input is accepted is not a test that the reported effect occurs.
3. **The covering integration test ran only in the nightly `remote_integration` workflow** — never on the PR baseline lane (which runs only `test:unit`, no DB), so it never gated a PR.

This PR implements two of the five preventions encoded as `task_policy` entities:

- `cross_surface_contract_parity_tested_all_surfaces` ([ent_2ad0677fe23c0c1878ae43e8])
- `fixed_means_behavior_verified_not_contract_accepted` ([ent_db0b7855d47012084477fb00])

(The other three — `evaluator_dry_run_before_fixed_claim` [ent_ab038841f0a3ed1ff6acb709], `hybrid_subagent_dispatch_for_swarm_roles` [ent_af149de1fa4666805a0bcdc8], `dispatch_work_to_owning_active_agent` [ent_662b57b0a32d4a854c2183e9] — are process policies wired into the swarm gate agents separately.)

## What

- **New focused PR-time lane** `contract_parity` in `.github/workflows/ci_test_lanes.yml`. It runs ONLY the parity-critical store/reference integration tests on every `pull_request`, against the same local SQLite backend the nightly integration job uses. It deliberately does **not** pull the whole nightly integration suite onto each PR — just the cross-surface parity gate — so it stays fast (a few seconds of tests).
- **`test:contract-parity` npm script** running `store_reference_source_parity.test.ts` + the two existing sibling reference tests, with `--no-file-parallelism` to avoid SQLite-lock contention between the two HTTP-server test files.
- **Shared MCP↔REST parity-matrix helper** (`tests/helpers/store_reference_parity.ts`) + **parity test** (`tests/integration/store_reference_source_parity.test.ts`) that drives the SAME scenario across:
  - the MCP `store` tool dispatch (`executeTool("store", …)` — the path the `/mcp` JSON-RPC route routes a `tools/call` into), and
  - the REST `POST /store` route,
  - for BOTH the **file-only** shape AND the combined **entities[]+file** shape,
  - asserting the **EFFECT** (`storage_mode=reference` on the sources row), not just that the input is accepted, and asserting MCP and REST produce the **identical** persisted value.

## Verification (run locally, green)

- `npm run test:contract-parity` → 3 files, 11 tests passed (~3.4s)
- `npm run format:check` → clean (src + new test files via prettier)
- `npm run lint` → 0 errors
- `npm run type-check` → clean
- `npm run validate:test-catalog` → up to date

## Audit — other single-surface-tested multi-surface capabilities (filed, not fixed here)

Per the retrospective's instruction, I audited the codebase for store/retrieve capabilities exposed on multiple surfaces (MCP tool + REST route + CLI command + `@neotoma/client` SDK) that have a test on only one surface, and filed a Neotoma `task` for each (status `pending`, priority `medium`, `assigned_to: cicada`, `repository_name: neotoma`, tag `contract_parity`), each `REFERS_TO` the retrospective. These are **not** fixed in this PR:

| Capability | Surfaces exposed | Gap | Task |
|---|---|---|---|
| `restore_relationship` | MCP, REST | REST has **zero** integration tests | ent_ea716256ab04b709bf678194 |
| `restore_entity` | MCP, REST | both surfaces smoke-only | ent_0838e5769717f98304ad6070 |
| `delete_relationship` | MCP, REST | MCP thin; **no typed SDK method** (TS+Py); no CLI | ent_2917f561ab2fa96648ad786f |
| `split_entity` | MCP, REST | MCP sparse; no SDK method; no CLI | ent_a25a6cae0702d253efedcd3c |
| `merge_entities` | MCP, REST | MCP round-trip weak; no SDK method; no CLI | ent_ef68e7681756a8cfbd468e3c |
| `delete_entity` | MCP, REST | both smoke-only; no SDK method; no CLI | ent_c42356e1a59534d07cea6c1f |
| `correct` | MCP, REST, CLI, TS+Py SDK | CLI + SDKs lack standalone functional (effect) tests | ent_92829ecb76bb29131f6570c7 |

## Notes

- Leaving for operator review — please do not auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
