### PR TITLE
fix(store): populate entity_snapshot_after + deduplicated marker on dedup replay (#1840)

### DIFF
--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,8 +61,8 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **518**
-- Backend and repo Vitest files: **484**
+- Total automated test files: **519**
+- Backend and repo Vitest files: **485**
 - Frontend Vitest files: **9**
 - Playwright spec files: **25**
 
@@ -72,7 +72,7 @@ flowchart TD
 | Vitest unit tests | 144 |
 | Vitest service tests | 35 |
 | Source-adjacent tests | 64 |
-| Vitest integration tests | 146 |
+| Vitest integration tests | 147 |
 | Vitest CLI tests | 65 |
 | Vitest contract tests | 14 |
 | Vitest security tests | 4 |
@@ -373,7 +373,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm run test:integration` or `npx vitest run tests/integration`
 **Requirements:** Database configured; remote-dependent subsets additionally need `RUN_REMOTE_TESTS=1`.
-**Files (146):**
+**Files (147):**
 - `tests/integration/aauth_attribution_stamping.test.ts`
 - `tests/integration/aauth_mcp_capability_parity.test.ts`
 - `tests/integration/aauth_mcp_initialize_admission.test.ts`
@@ -499,6 +499,7 @@ flowchart TD
 - `tests/integration/store_builtin_identity_opt_out_schemas.test.ts`
 - `tests/integration/store_conversation_message_count.test.ts`
 - `tests/integration/store_conversation_message_role_conflict.test.ts`
+- `tests/integration/store_dedup_snapshot_after.test.ts`
 - `tests/integration/store_exercise_log_device_schema.test.ts`
 - `tests/integration/store_explicit_canonical_name.test.ts`
 - `tests/integration/store_external_link_schema.test.ts`

--- a/src/server.ts
+++ b/src/server.ts
@@ -5235,6 +5235,35 @@ export class NeotomaServer {
           ...new Set((fragmentRows ?? []).map((r: { fragment_key: string }) => r.fragment_key)),
         ].sort();
 
+        // Issue #1840: on a deduplicated (idempotency-replay) store, the early
+        // return must still surface the current snapshot in
+        // `entity_snapshot_after`. Previously this path omitted the field, so
+        // callers that validate writes by inspecting the response saw a false
+        // empty snapshot ({}) even though getEntitySnapshot returned the real
+        // one. No new observation is written, so we read the persisted snapshot
+        // directly. Mark each entry `deduplicated: true` so callers can tell a
+        // replay from a fresh write.
+        const { getSnapshot: getSnapshotForReplay } =
+          await import("./services/snapshot_computation.js");
+        const replaySnapshotByEntityId = new Map<string, Record<string, unknown>>();
+        for (const replayEntityId of new Set<string>(existingEntityIds as string[])) {
+          try {
+            const snap = await getSnapshotForReplay(replayEntityId, userId);
+            if (snap?.snapshot) {
+              replaySnapshotByEntityId.set(
+                replayEntityId,
+                snap.snapshot as Record<string, unknown>
+              );
+            }
+          } catch (snapErr) {
+            logger.warn(
+              `store replay: snapshot fetch failed for ${replayEntityId}: ${
+                snapErr instanceof Error ? snapErr.message : String(snapErr)
+              }`
+            );
+          }
+        }
+
         return this.buildTextResponse({
           source_id: existingSource.id,
           entities:
@@ -5243,6 +5272,8 @@ export class NeotomaServer {
                 entity_id: obs.entity_id,
                 entity_type: obs.entity_type,
                 observation_id: obs.id,
+                entity_snapshot_after: replaySnapshotByEntityId.get(obs.entity_id) ?? null,
+                deduplicated: true,
               })
             ) ?? [],
           unknown_fields_count: replayUnknownFieldNames.length,
@@ -5420,6 +5451,7 @@ export class NeotomaServer {
       identityBasis: string;
       identityRule: string;
       action: string;
+      deduplicated: boolean;
       duplicateCandidates?: import("./services/entity_resolution.js").ResolverDuplicateCandidate[];
     }> = [];
     // Track the resolved fields per observation index for schema-driven store_warnings.
@@ -5860,6 +5892,10 @@ export class NeotomaServer {
         identityBasis: resolverTrace.identityBasis,
         identityRule: resolverTrace.identityRule,
         action: resolverTrace.action,
+        // Issue #1840: an existing observation row means this store deduplicated
+        // (no new observation was inserted). Surface it so callers can tell a
+        // replay from a fresh write on the normal (non-idempotency-replay) path.
+        deduplicated: Boolean(existingObservation),
         ...(resolverTrace.duplicateCandidates && resolverTrace.duplicateCandidates.length > 0
           ? { duplicateCandidates: resolverTrace.duplicateCandidates }
           : {}),
@@ -6347,6 +6383,7 @@ export class NeotomaServer {
         identity_basis: e.identityBasis,
         identity_rule: e.identityRule,
         entity_snapshot_after: snapshotByEntityId.get(e.entityId) ?? null,
+        deduplicated: e.deduplicated,
         ...(e.duplicateCandidates && e.duplicateCandidates.length > 0
           ? {
               prefix_duplicate_candidates: e.duplicateCandidates.map((c) => ({

--- a/tests/integration/store_dedup_snapshot_after.test.ts
+++ b/tests/integration/store_dedup_snapshot_after.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Regression test for issue #1840:
+ * store response returns empty `entity_snapshot_after` ({}) on deduplicated
+ * observation replay.
+ *
+ * When an identical observation is stored twice (same entity, same field
+ * values, same priority), the second store correctly deduplicates (observation
+ * count stays 1) but the store response must still return the current,
+ * populated snapshot in `entity_snapshot_after` and mark the entity entry with
+ * `deduplicated: true`.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { db } from "../../src/db.js";
+import { NeotomaServer } from "../../src/server.js";
+import { randomUUID } from "crypto";
+import { cleanupTestEntityType } from "../helpers/test_schema_helpers.js";
+import { getSnapshot } from "../../src/services/snapshot_computation.js";
+
+const TEST_USER_ID = "00000000-0000-0000-0000-000000000000";
+
+describe("store: dedup replay populates entity_snapshot_after (#1840)", () => {
+  const server = new NeotomaServer();
+  (server as any).authenticatedUserId = TEST_USER_ID;
+  const entityType = `dedup_test_${randomUUID().replace(/-/g, "").substring(0, 8)}`;
+  const createdEntityIds: string[] = [];
+  const createdSourceIds: string[] = [];
+
+  afterEach(async () => {
+    if (createdSourceIds.length > 0) {
+      await db.from("raw_fragments").delete().in("source_id", createdSourceIds);
+      await db.from("observations").delete().in("source_id", createdSourceIds);
+      await db.from("sources").delete().in("id", createdSourceIds);
+      createdSourceIds.length = 0;
+    }
+    if (createdEntityIds.length > 0) {
+      await db.from("entity_snapshots").delete().in("entity_id", createdEntityIds);
+      await db.from("observations").delete().in("entity_id", createdEntityIds);
+      await db.from("entities").delete().in("id", createdEntityIds);
+      createdEntityIds.length = 0;
+    }
+    await cleanupTestEntityType(entityType, TEST_USER_ID);
+  });
+
+  it("second identical store dedups but still returns a populated snapshot + deduplicated marker", async () => {
+    await db.from("schema_registry").insert({
+      entity_type: entityType,
+      schema_version: "1.0",
+      schema_definition: {
+        fields: {
+          value: { type: "number", required: false },
+          label: { type: "string", required: true },
+        },
+      },
+      reducer_config: {
+        merge_policies: {
+          value: { strategy: "last_write" },
+          label: { strategy: "last_write" },
+        },
+      },
+      active: true,
+      scope: "user",
+      user_id: TEST_USER_ID,
+    });
+
+    const entityPayload = {
+      entity_type: entityType,
+      name: "test",
+      label: "t",
+      value: 42,
+    };
+
+    // The CLI derives the idempotency key as a deterministic content hash of the
+    // entities payload, so an identical re-store reuses the SAME key and hits the
+    // idempotency-replay path. Mirror that here with one shared key.
+    const sharedIdempotencyKey = `test-1840-${randomUUID()}`;
+
+    // First store — establishes the snapshot.
+    const storeOne = await (server as any).store({
+      user_id: TEST_USER_ID,
+      idempotency_key: sharedIdempotencyKey,
+      entities: [entityPayload],
+      source_priority: 5,
+      observation_source: "sensor",
+    });
+    const responseOne = JSON.parse(storeOne.content[0].text);
+    expect(responseOne.entities).toHaveLength(1);
+    const entryOne = responseOne.entities[0];
+    createdEntityIds.push(entryOne.entity_id);
+    createdSourceIds.push(responseOne.source_id);
+
+    expect(entryOne.entity_snapshot_after).toMatchObject({ value: 42, label: "t" });
+
+    const entityId: string = entryOne.entity_id;
+
+    // Second store — identical content, identical priority, SAME idempotency key
+    // → idempotency-replay dedup (exactly what the CLI does on a re-store).
+    const storeTwo = await (server as any).store({
+      user_id: TEST_USER_ID,
+      idempotency_key: sharedIdempotencyKey,
+      entities: [entityPayload],
+      source_priority: 5,
+      observation_source: "sensor",
+    });
+    const responseTwo = JSON.parse(storeTwo.content[0].text);
+    if (responseTwo.source_id) createdSourceIds.push(responseTwo.source_id);
+    expect(responseTwo.entities).toHaveLength(1);
+    const entryTwo = responseTwo.entities[0];
+
+    // Observation count must stay at 1 (dedup worked).
+    const { count: obsCount } = await db
+      .from("observations")
+      .select("id", { count: "exact", head: true })
+      .eq("entity_id", entityId)
+      .eq("user_id", TEST_USER_ID);
+    expect(obsCount).toBe(1);
+
+    // The snapshot in the response must be populated, NOT {}.
+    expect(entryTwo.entity_snapshot_after).toBeTruthy();
+    expect(entryTwo.entity_snapshot_after).toMatchObject({ value: 42, label: "t" });
+
+    // The entity entry must carry the deduplicated marker.
+    expect(entryTwo.deduplicated).toBe(true);
+
+    // It must match what getEntitySnapshot returns directly.
+    const direct = await getSnapshot(entityId, TEST_USER_ID);
+    expect(entryTwo.entity_snapshot_after).toEqual(direct?.snapshot);
+  });
+});


### PR DESCRIPTION
## Root cause

`neotoma store` (CLI) derives its `idempotency_key` as a **deterministic content hash** of the entities payload (`createIdempotencyKey({ entities })` in `src/cli/index.ts`). So re-storing identical content reuses the **same** idempotency key, which makes the second call hit the **idempotency-replay early return** inside `NeotomaServer.store` (`src/server.ts`, the `if (existingSource) { ... }` block).

That replay path rebuilt the response `entities` array with only `entity_id` / `entity_type` / `observation_id` — it **omitted `entity_snapshot_after` entirely**, which the CLI/contract renders as an empty `{}`. Meanwhile the snapshot in the DB was correct, so `getEntitySnapshot` returned the populated snapshot. The bug was therefore **response-assembly only**, no data corruption — exactly as the issue describes.

(The separate content-addressed dedup path — same content, *different* idempotency key — already populated `entity_snapshot_after` correctly, but carried no signal that the write was a replay.)

## The fix

`src/server.ts`:
- **Replay early return**: for each existing entity, read the persisted snapshot via `getSnapshot(...)` and set `entity_snapshot_after`, plus a per-entity `deduplicated: true` marker.
- **Main store path**: set `deduplicated` from whether an existing observation row was found (i.e. no new insert), and surface it in the response `entities`.

No dedup or storage semantics change — `observation_count` still stays at 1; this only fixes how the response is assembled.

## The test

`tests/integration/store_dedup_snapshot_after.test.ts` — stores an identical observation twice with a shared (content-derived) idempotency key, then asserts the second response has:
- `deduplicated: true`
- a populated `entity_snapshot_after` (`{ value: 42, label: "t" }`), **not** `{}`
- `entity_snapshot_after` equals what `getEntitySnapshot` returns directly
- observation count stays at **1** (dedup intact)

Test fails on `main` (snapshot absent / `deduplicated` undefined) and passes with this change.

## Verification

- New regression test: pass
- `tests/integration/fixture_mcp_store_replay.test.ts` (34 tests, exercises the replay path): pass
- `mcp_store_variations`, `store_explicit_canonical_name`, `store_prefix_duplicate_candidates`: pass
- `tsc --noEmit`: clean; eslint/prettier: clean
- Security gates: `security:manifest:check` in sync, `security:classify-diff` → `sensitive=false`, `validate:test-catalog` up to date

## Generated files

None needed. No `action_schemas`/`openapi`/`contract` file references `entity_snapshot_after` or `deduplicated` (the MCP store response is a free-form `buildTextResponse` text payload), so nothing to regenerate.

Closes #1840

🤖 Generated with [Claude Code](https://claude.com/claude-code)