### PR TITLE
fix(conflict-resolution): document default source_priority=100 footgun + SOURCE_PRIORITY_ESCALATION warning (#1838)

### DIFF
--- a/docs/subsystems/conflict_resolution.md
+++ b/docs/subsystems/conflict_resolution.md
@@ -1,6 +1,7 @@
 # Conflict Resolution — Merge Policies and Field Semantics
 
 **Related docs:**
+
 - [Reducer engine](reducer.md) — how merge strategies are executed
 - [Schema registry](schema_registry.md) — how to register a schema with custom policies
 - [Observation architecture](observation_architecture.md) — `source_priority` and `observed_at`
@@ -163,20 +164,20 @@ it silently.
   "schema_version": "1.0",
   "schema_definition": {
     "fields": {
-      "sensor_id":   { "type": "string", "required": true },
-      "value":       { "type": "number", "required": true },
-      "unit":        { "type": "string" },
+      "sensor_id": { "type": "string", "required": true },
+      "value": { "type": "number", "required": true },
+      "unit": { "type": "string" },
       "recorded_at": { "type": "date" },
-      "tags":        { "type": "array" }
+      "tags": { "type": "array" }
     }
   },
   "reducer_config": {
     "merge_policies": {
-      "sensor_id":   { "strategy": "last_write" },
-      "value":       { "strategy": "highest_priority", "tie_breaker": "observed_at" },
-      "unit":        { "strategy": "last_write" },
+      "sensor_id": { "strategy": "last_write" },
+      "value": { "strategy": "highest_priority", "tie_breaker": "observed_at" },
+      "unit": { "strategy": "last_write" },
       "recorded_at": { "strategy": "highest_priority", "tie_breaker": "observed_at" },
-      "tags":        { "strategy": "merge_array" }
+      "tags": { "strategy": "merge_array" }
     }
   },
   "activate": true
@@ -203,20 +204,20 @@ Or via the MCP tool:
   "schema_version": "1.0",
   "schema_definition": {
     "fields": {
-      "sensor_id":   { "type": "string", "required": true },
-      "value":       { "type": "number", "required": true },
-      "unit":        { "type": "string" },
+      "sensor_id": { "type": "string", "required": true },
+      "value": { "type": "number", "required": true },
+      "unit": { "type": "string" },
       "recorded_at": { "type": "date" },
-      "tags":        { "type": "array" }
+      "tags": { "type": "array" }
     }
   },
   "reducer_config": {
     "merge_policies": {
-      "sensor_id":   { "strategy": "last_write" },
-      "value":       { "strategy": "highest_priority", "tie_breaker": "observed_at" },
-      "unit":        { "strategy": "last_write" },
+      "sensor_id": { "strategy": "last_write" },
+      "value": { "strategy": "highest_priority", "tie_breaker": "observed_at" },
+      "unit": { "strategy": "last_write" },
       "recorded_at": { "strategy": "highest_priority", "tie_breaker": "observed_at" },
-      "tags":        { "strategy": "merge_array" }
+      "tags": { "strategy": "merge_array" }
     }
   },
   "activate": true
@@ -229,10 +230,10 @@ regardless of which was written more recently.
 
 ### `tie_breaker` options
 
-| Value | Behavior within the same `source_priority` tier |
-|-------|--------------------------------------------------|
-| `"observed_at"` (default) | Most recent observation wins |
-| `"source_priority"` | Falls through to `id ASC` (stable, not time-based) |
+| Value                     | Behavior within the same `source_priority` tier    |
+| ------------------------- | -------------------------------------------------- |
+| `"observed_at"` (default) | Most recent observation wins                       |
+| `"source_priority"`       | Falls through to `id ASC` (stable, not time-based) |
 
 ---
 
@@ -286,8 +287,8 @@ const obs = {
   entity_type: "invoice",
   fields: {
     vendor_name: fetchedName,
-    amount_due: fetchedAmount ?? 0,   // ← 0 is now a real observation
-  }
+    amount_due: fetchedAmount ?? 0, // ← 0 is now a real observation
+  },
 };
 
 // Correct — omit the field when the read failed
@@ -344,18 +345,58 @@ This footgun is tracked in
 **Mitigation today:** register an explicit schema (`register_schema`) for any entity type
 where source priority must be honored.
 
+### The default `source_priority = 100` footgun
+
+`source_priority` **defaults to `100`** (`z.number().optional().default(100)` in
+`src/shared/action_schemas.ts`). The default is unchanged for backward compatibility, but
+it has a sharp edge on any field whose reducer policy is `highest_priority` (or
+`most_specific` with `tie_breaker: "source_priority"`):
+
+> An **unprioritized** write — one that omits `--source-priority` / `source_priority` —
+> silently inherits priority `100`, which **outranks** any prior observation written with
+> an explicit priority **≤ 99** (e.g. a trusted import at `50`). The unprioritized write
+> wins the field. This is a silent **trust-escalation**: a caller who never thought about
+> priority at all can override a value that was deliberately ranked lower.
+
+Concretely, with a `highest_priority` schema on `value`:
+
+```
+obs_a: { value: "trusted-import", source_priority: 50 }   # explicit, deliberately low
+obs_b: { value: "casual-write" }                          # omitted → defaults to 100
+# Reducer winner: obs_b ("casual-write"), because 100 > 50.
+```
+
+**Why the default isn't being changed:** lowering it (e.g. to `0`) would silently flip the
+winner of existing reductions across every deployment — a breaking semantic change. The
+mitigation is detection + discipline, not a new default.
+
+**Limitation — default vs. explicit `100` are indistinguishable at write time:** zod
+applies `.default(100)` before the request handler runs, so by the time the write is
+processed there is no way to tell "caller omitted `source_priority`" from "caller
+explicitly passed `100`". The advisory below therefore fires on **both** cases (framed as
+"default/non-explicit 100"); a caller who genuinely intends priority `100` can ignore it.
+
+**Detection:** a write at priority `100` into a `highest_priority` field emits a
+non-blocking `SOURCE_PRIORITY_ESCALATION` `store_warning` (issue
+[#1838](https://github.com/markmhendrickson/neotoma/issues/1838)) naming the affected
+field(s). It is advisory only — nothing is rejected and no merge semantics change.
+
+**Mitigation today:** **always pass an explicit `--source-priority` / `source_priority`**
+for any priority-semantic write (one that targets a `highest_priority` field), reflecting
+how that write should rank against others — rather than relying on the implicit `100`.
+
 ---
 
 ## Quick Reference
 
-| I want... | Strategy | Notes |
-|-----------|----------|-------|
-| Latest write wins | `last_write` | Default for auto-discovered schemas |
-| Trusted source wins | `highest_priority` | Requires a registered schema; `source_priority` on observations |
-| Most specific value wins | `most_specific` | Requires `specificity_score` on observations |
-| Accumulate all values | `merge_array` | Field must be array type; corrections replace |
-| Field cleared | Write `null` explicitly | Use `correct()` at high priority |
-| Field kept from earlier observation | Omit the field | Do not write `0` or `null` as sentinel |
+| I want...                           | Strategy                | Notes                                                           |
+| ----------------------------------- | ----------------------- | --------------------------------------------------------------- |
+| Latest write wins                   | `last_write`            | Default for auto-discovered schemas                             |
+| Trusted source wins                 | `highest_priority`      | Requires a registered schema; `source_priority` on observations |
+| Most specific value wins            | `most_specific`         | Requires `specificity_score` on observations                    |
+| Accumulate all values               | `merge_array`           | Field must be array type; corrections replace                   |
+| Field cleared                       | Write `null` explicitly | Use `correct()` at high priority                                |
+| Field kept from earlier observation | Omit the field          | Do not write `0` or `null` as sentinel                          |
 
 ## Related Documents
 
@@ -364,3 +405,4 @@ where source priority must be honored.
 - [observation_architecture.md](observation_architecture.md) — `source_priority`, `observed_at`, `specificity_score`
 - [issue #1755](https://github.com/markmhendrickson/neotoma/issues/1755) — LWW-default footgun (source-priority silently ignored for auto-discovered schemas)
 - [issue #1756](https://github.com/markmhendrickson/neotoma/issues/1756) — write-time value constraints (range/enum/required-enforcement)
+- [issue #1838](https://github.com/markmhendrickson/neotoma/issues/1838) — default `source_priority = 100` footgun (unprioritized write silently outranks an explicit lower priority; `SOURCE_PRIORITY_ESCALATION` advisory)

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -7482,6 +7482,22 @@ export async function storeStructuredForApi(params: {
           entityId: r.entity_id,
         });
         if (spWarn) schemaStoreWarnings.push(spWarn);
+
+        // Issue #1838: SOURCE_PRIORITY_ESCALATION — mirror-image advisory. A
+        // write at the DEFAULT source_priority (100) into a `highest_priority`
+        // field silently OUTRANKS any prior observation written with an
+        // explicit lower priority. Non-blocking; reuses the same import.
+        const { buildSourcePriorityEscalationWarning } =
+          await import("./services/source_priority_warning.js");
+        const spEsc = buildSourcePriorityEscalationWarning({
+          sourcePriority,
+          writtenFields: r.fields,
+          mergePolicies: schemaEntry?.reducer_config?.merge_policies,
+          observationIndex: r.observation_index,
+          entityType: r.entity_type,
+          entityId: r.entity_id,
+        });
+        if (spEsc) schemaStoreWarnings.push(spEsc);
       }
     }
   }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -14272,7 +14272,13 @@ program
   .option("--file-path <path>", "Path to any file to store (unstructured pipeline)")
   .option("--file-content <content>", "Inline file content to store")
   .option("--user-id <id>", "User ID for the operation")
-  .option("--source-priority <level>", "Source priority level (default: 100)")
+  .option(
+    "--source-priority <level>",
+    "Source priority level (default: 100). Only affects fields whose reducer policy is " +
+      "highest_priority (or most_specific with tie_breaker source_priority); ignored elsewhere. " +
+      "The default 100 silently outranks an explicit lower priority on such fields — always pass " +
+      "an explicit value for priority-semantic writes. See docs/subsystems/conflict_resolution.md."
+  )
   .option(
     "--observation-source <kind>",
     "Kind of write: sensor, llm_summary (default), workflow_state, human, or import"
@@ -14519,7 +14525,13 @@ program
     "--file-idempotency-key <key>",
     "Optional idempotency key for the source file (default: derived from contents)"
   )
-  .option("--source-priority <level>", "Source priority level (default: 100)")
+  .option(
+    "--source-priority <level>",
+    "Source priority level (default: 100). Only affects fields whose reducer policy is " +
+      "highest_priority (or most_specific with tie_breaker source_priority); ignored elsewhere. " +
+      "The default 100 silently outranks an explicit lower priority on such fields — always pass " +
+      "an explicit value for priority-semantic writes. See docs/subsystems/conflict_resolution.md."
+  )
   .option(
     "--observation-source <kind>",
     "Kind of write: sensor, llm_summary (default), workflow_state, human, or import"

--- a/src/server.ts
+++ b/src/server.ts
@@ -6255,6 +6255,22 @@ export class NeotomaServer {
           entityId: e.entityId,
         });
         if (spWarn) schemaStoreWarnings.push(spWarn);
+
+        // Issue #1838: SOURCE_PRIORITY_ESCALATION — mirror-image advisory. A
+        // write at the DEFAULT source_priority (100) into a `highest_priority`
+        // field silently OUTRANKS any prior observation written with an
+        // explicit lower priority. Non-blocking; reuses the same import.
+        const { buildSourcePriorityEscalationWarning } =
+          await import("./services/source_priority_warning.js");
+        const spEsc = buildSourcePriorityEscalationWarning({
+          sourcePriority,
+          writtenFields: entityFields,
+          mergePolicies: schemaEntry?.reducer_config?.merge_policies,
+          observationIndex: i,
+          entityType: e.entityType,
+          entityId: e.entityId,
+        });
+        if (spEsc) schemaStoreWarnings.push(spEsc);
       }
     }
 

--- a/src/services/source_priority_warning.ts
+++ b/src/services/source_priority_warning.ts
@@ -172,3 +172,121 @@ export function buildSourcePriorityIgnoredWarning(opts: {
     entity_id: entityId,
   };
 }
+
+// ─── SOURCE_PRIORITY_ESCALATION (#1838) ──────────────────────────────────────
+//
+// The mirror-image footgun of SOURCE_PRIORITY_IGNORED. `source_priority`
+// defaults to 100 (see action_schemas.ts). When a caller writes to a field
+// governed by a `highest_priority` reducer WITHOUT passing an explicit
+// `--source-priority`, the write silently inherits priority 100 — which
+// OUTRANKS any prior observation that was written with an explicit lower
+// priority (e.g. a trusted import at priority 50). The result is a silent
+// trust-escalation: the unprioritized write wins the field.
+//
+// LIMITATION (#1838): zod applies `.default(100)` before the handler runs, so
+// at the warning call site we cannot distinguish "caller omitted
+// source_priority" from "caller explicitly passed 100". We therefore warn
+// whenever priority === 100 AND a highest_priority field is written, framed as
+// "default/non-explicit 100". A caller who genuinely wants priority 100 can
+// ignore the advisory; the warning is non-blocking.
+
+/**
+ * Returns the list of written field names whose merge policy honours
+ * source_priority (`highest_priority`, or `most_specific` with
+ * `tie_breaker: "source_priority"`). These are the fields where a default-100
+ * write can silently outrank an explicit lower priority.
+ */
+export function priorityHonouringFields(opts: {
+  writtenFields: Record<string, unknown>;
+  mergePolicies: ReducerConfig["merge_policies"] | undefined | null;
+}): Array<{ field: string; strategy: string }> {
+  const { writtenFields, mergePolicies } = opts;
+  const result: Array<{ field: string; strategy: string }> = [];
+  for (const fieldName of Object.keys(writtenFields)) {
+    const policy = mergePolicies?.[fieldName];
+    if (fieldHonorsPriority(policy)) {
+      result.push({ field: fieldName, strategy: policy?.strategy ?? "highest_priority" });
+    }
+  }
+  return result;
+}
+
+/**
+ * Returns true when a write at the default priority (100) participates in at
+ * least one field that honours source_priority — i.e. the write could silently
+ * outrank a prior observation written with an explicit lower priority.
+ *
+ * Conditions (all must hold):
+ *  1. `sourcePriority === 100` — the (possibly-defaulted) value. Because zod
+ *     applies the default before this runs, we cannot tell an omitted value
+ *     from an explicit 100; we warn on both.
+ *  2. At least one written field's merge policy honours source_priority.
+ */
+export function sourcePriorityMayEscalate(opts: {
+  sourcePriority: number;
+  writtenFields: Record<string, unknown>;
+  mergePolicies: ReducerConfig["merge_policies"] | undefined | null;
+}): boolean {
+  const { sourcePriority, writtenFields, mergePolicies } = opts;
+  if (sourcePriority !== 100) return false;
+  return priorityHonouringFields({ writtenFields, mergePolicies }).length > 0;
+}
+
+/**
+ * The shape of one store_warnings[] entry emitted by the
+ * SOURCE_PRIORITY_ESCALATION code path. Mirrors SourcePriorityIgnoredWarning.
+ */
+export type SourcePriorityEscalationWarning = {
+  code: "SOURCE_PRIORITY_ESCALATION";
+  message: string;
+  observation_index: number;
+  entity_type: string;
+  entity_id: string;
+};
+
+/**
+ * Returns a structured store_warnings[] entry when a default-priority (100)
+ * write participates in a `highest_priority` field and could silently outrank
+ * an explicit lower priority, or `null` when no warning is warranted.
+ *
+ * Mitigation surfaced in the message: pass an explicit `--source-priority`
+ * (CLI) / `source_priority` (API) for any write whose value should be ranked,
+ * so the relative trust is intentional rather than inherited from the default.
+ */
+export function buildSourcePriorityEscalationWarning(opts: {
+  sourcePriority: number;
+  writtenFields: Record<string, unknown>;
+  mergePolicies: ReducerConfig["merge_policies"] | undefined | null;
+  observationIndex: number;
+  entityType: string;
+  entityId: string;
+}): SourcePriorityEscalationWarning | null {
+  const { sourcePriority, writtenFields, mergePolicies, observationIndex, entityType, entityId } =
+    opts;
+
+  if (!sourcePriorityMayEscalate({ sourcePriority, writtenFields, mergePolicies })) {
+    return null;
+  }
+
+  const honouring = priorityHonouringFields({ writtenFields, mergePolicies });
+  const fieldSummary = honouring
+    .map(({ field, strategy }) => `'${field}' uses ${strategy}`)
+    .join(", ");
+
+  return {
+    code: "SOURCE_PRIORITY_ESCALATION",
+    message:
+      `${entityType} written at the default source_priority ${sourcePriority} into ` +
+      `field(s) that rank by priority — ${fieldSummary}. A default/non-explicit ` +
+      `priority ${sourcePriority} OUTRANKS any prior observation written with an ` +
+      "explicit lower priority (e.g. a trusted import at 50), silently escalating " +
+      "this write's trust. Note: an explicit source_priority of 100 is " +
+      "indistinguishable from the default at write time, so this advisory fires on " +
+      "both. To make ranking intentional, pass an explicit --source-priority " +
+      "(CLI) / source_priority (API) reflecting how this write should rank against " +
+      "others — see docs/subsystems/conflict_resolution.md.",
+    observation_index: observationIndex,
+    entity_type: entityType,
+    entity_id: entityId,
+  };
+}

--- a/tests/integration/store_source_priority_ignored_warning.test.ts
+++ b/tests/integration/store_source_priority_ignored_warning.test.ts
@@ -19,6 +19,13 @@
  *     schema → `SOURCE_PRIORITY_IGNORED` warning in the response body.
  *  5. HTTP `POST /store` path — default priority (100) + all-`last_write`
  *     schema → no warning.
+ *
+ * And for the mirror-image SOURCE_PRIORITY_ESCALATION warning (#1838):
+ *  6. MCP/HTTP `store` — DEFAULT priority (100) write into a registered
+ *     `highest_priority` field → `SOURCE_PRIORITY_ESCALATION` warning (the
+ *     unprioritized write would silently outrank an explicit lower priority).
+ *  7. MCP `store` — NON-default priority into the same field → no escalation
+ *     warning (the caller ranked intentionally).
  */
 
 import { createServer } from "node:http";
@@ -164,9 +171,7 @@ describe("store_warnings: SOURCE_PRIORITY_IGNORED (#1755)", () => {
     expect(body.entities && body.entities.length).toBe(1);
 
     const entityId = body.entities![0].entity_id;
-    const warn = (body.store_warnings ?? []).find(
-      (w) => w.code === "SOURCE_PRIORITY_IGNORED"
-    );
+    const warn = (body.store_warnings ?? []).find((w) => w.code === "SOURCE_PRIORITY_IGNORED");
     expect(warn).toBeDefined();
     expect(warn!.entity_type).toBe(AUTO_TYPE);
     expect(warn!.entity_id).toBe(entityId);
@@ -224,6 +229,95 @@ describe("store_warnings: SOURCE_PRIORITY_IGNORED (#1755)", () => {
     expect(hasWarning).toBe(false);
   });
 
+  // ─── SOURCE_PRIORITY_ESCALATION (#1838) ──────────────────────────────────────
+
+  it("MCP: default source_priority (100) + registered highest_priority schema → SOURCE_PRIORITY_ESCALATION warning", async () => {
+    const result = await callStore(server, {
+      user_id: TEST_USER_ID,
+      idempotency_key: `sp-escalation-${Date.now()}`,
+      commit: true,
+      // source_priority omitted → defaults to 100; `score` uses highest_priority.
+      entities: [
+        {
+          entity_type: PRIORITY_TYPE,
+          canonical_name: "priority-escalation-test",
+          score: 7,
+        },
+      ],
+    });
+
+    const body = JSON.parse(result.content[0].text) as StoreResponse;
+    expect(body.error).toBeUndefined();
+    expect(body.entities && body.entities.length).toBe(1);
+
+    const entityId = body.entities![0].entity_id;
+    const warn = (body.store_warnings ?? []).find((w) => w.code === "SOURCE_PRIORITY_ESCALATION");
+    expect(warn).toBeDefined();
+    expect(warn!.entity_type).toBe(PRIORITY_TYPE);
+    expect(warn!.entity_id).toBe(entityId);
+    expect(warn!.observation_index).toBe(0);
+    expect(warn!.message).toContain("100");
+    expect(warn!.message).toContain("'score'");
+    expect(warn!.message.toLowerCase()).toContain("outrank");
+    // No IGNORED warning — the field DOES honour priority.
+    const ignored = (body.store_warnings ?? []).some((w) => w.code === "SOURCE_PRIORITY_IGNORED");
+    expect(ignored).toBe(false);
+  });
+
+  it("MCP: non-default source_priority + highest_priority schema → no SOURCE_PRIORITY_ESCALATION warning", async () => {
+    const result = await callStore(server, {
+      user_id: TEST_USER_ID,
+      idempotency_key: `sp-no-escalation-${Date.now()}`,
+      commit: true,
+      source_priority: 999,
+      entities: [
+        {
+          entity_type: PRIORITY_TYPE,
+          canonical_name: "priority-no-escalation-test",
+          score: 11,
+        },
+      ],
+    });
+
+    const body = JSON.parse(result.content[0].text) as StoreResponse;
+    expect(body.error).toBeUndefined();
+    const hasEscalation = (body.store_warnings ?? []).some(
+      (w) => w.code === "SOURCE_PRIORITY_ESCALATION"
+    );
+    expect(hasEscalation).toBe(false);
+  });
+
+  it("HTTP: default source_priority (100) + highest_priority schema → SOURCE_PRIORITY_ESCALATION warning", async () => {
+    const res = await fetch(`${API_BASE}/store`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        idempotency_key: `http-sp-escalation-${Date.now()}`,
+        commit: true,
+        // source_priority omitted → defaults to 100.
+        entities: [
+          {
+            entity_type: PRIORITY_TYPE,
+            canonical_name: "http-priority-escalation-test",
+            score: 13,
+          },
+        ],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as StoreResponse;
+    expect(body.error).toBeUndefined();
+    expect(body.entities && body.entities.length).toBe(1);
+
+    const warn = (body.store_warnings ?? []).find((w) => w.code === "SOURCE_PRIORITY_ESCALATION");
+    expect(warn).toBeDefined();
+    expect(warn!.entity_type).toBe(PRIORITY_TYPE);
+    expect(warn!.observation_index).toBe(0);
+    expect(warn!.message).toContain("'score'");
+    expect(warn!.message.toLowerCase()).toContain("outrank");
+  });
+
   it("MCP: non-default source_priority + all-last_write registered schema → SOURCE_PRIORITY_IGNORED warning", async () => {
     const result = await callStore(server, {
       user_id: TEST_USER_ID,
@@ -244,9 +338,7 @@ describe("store_warnings: SOURCE_PRIORITY_IGNORED (#1755)", () => {
     expect(body.error).toBeUndefined();
     expect(body.entities && body.entities.length).toBe(1);
 
-    const warn = (body.store_warnings ?? []).find(
-      (w) => w.code === "SOURCE_PRIORITY_IGNORED"
-    );
+    const warn = (body.store_warnings ?? []).find((w) => w.code === "SOURCE_PRIORITY_IGNORED");
     expect(warn).toBeDefined();
     expect(warn!.entity_type).toBe(LAST_WRITE_TYPE);
     expect(warn!.observation_index).toBe(0);
@@ -281,9 +373,7 @@ describe("store_warnings: SOURCE_PRIORITY_IGNORED (#1755)", () => {
     expect(body.entities && body.entities.length).toBe(1);
 
     const entityId = body.entities![0].entity_id;
-    const warn = (body.store_warnings ?? []).find(
-      (w) => w.code === "SOURCE_PRIORITY_IGNORED"
-    );
+    const warn = (body.store_warnings ?? []).find((w) => w.code === "SOURCE_PRIORITY_IGNORED");
     expect(warn).toBeDefined();
     expect(warn!.entity_type).toBe(LAST_WRITE_TYPE);
     expect(warn!.entity_id).toBe(entityId);

--- a/tests/unit/source_priority_ignored_warning.test.ts
+++ b/tests/unit/source_priority_ignored_warning.test.ts
@@ -26,6 +26,9 @@ import {
   ignoredFieldStrategies,
   sourcePriorityWillBeIgnored,
   buildSourcePriorityIgnoredWarning,
+  priorityHonouringFields,
+  sourcePriorityMayEscalate,
+  buildSourcePriorityEscalationWarning,
 } from "../../src/services/source_priority_warning.js";
 
 // ---------------------------------------------------------------------------
@@ -38,15 +41,15 @@ describe("fieldHonorsPriority", () => {
   });
 
   it("returns true for most_specific with tie_breaker: source_priority", () => {
-    expect(
-      fieldHonorsPriority({ strategy: "most_specific", tie_breaker: "source_priority" }),
-    ).toBe(true);
+    expect(fieldHonorsPriority({ strategy: "most_specific", tie_breaker: "source_priority" })).toBe(
+      true
+    );
   });
 
   it("returns false for most_specific with tie_breaker: observed_at", () => {
-    expect(
-      fieldHonorsPriority({ strategy: "most_specific", tie_breaker: "observed_at" }),
-    ).toBe(false);
+    expect(fieldHonorsPriority({ strategy: "most_specific", tie_breaker: "observed_at" })).toBe(
+      false
+    );
   });
 
   it("returns false for most_specific without tie_breaker", () => {
@@ -372,6 +375,152 @@ describe("buildSourcePriorityIgnoredWarning message detail", () => {
       observationIndex: 0,
       entityType: "leaderboard_entry",
       entityId: "eid-6",
+    });
+    expect(warn).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SOURCE_PRIORITY_ESCALATION (#1838)
+// ---------------------------------------------------------------------------
+
+describe("priorityHonouringFields", () => {
+  it("lists only fields whose policy honours source_priority", () => {
+    const result = priorityHonouringFields({
+      writtenFields: { score: 42, note: "x", spec: "y" },
+      mergePolicies: {
+        score: { strategy: "highest_priority" },
+        note: { strategy: "last_write" },
+        spec: { strategy: "most_specific", tie_breaker: "source_priority" },
+      },
+    });
+    expect(result).toEqual([
+      { field: "score", strategy: "highest_priority" },
+      { field: "spec", strategy: "most_specific" },
+    ]);
+  });
+
+  it("returns [] when no field honours priority", () => {
+    expect(
+      priorityHonouringFields({
+        writtenFields: { note: "x" },
+        mergePolicies: { note: { strategy: "last_write" } },
+      })
+    ).toEqual([]);
+  });
+
+  it("returns [] when there are no merge policies (auto-discovered)", () => {
+    expect(
+      priorityHonouringFields({
+        writtenFields: { score: 1 },
+        mergePolicies: undefined,
+      })
+    ).toEqual([]);
+  });
+});
+
+describe("sourcePriorityMayEscalate", () => {
+  it("true: default priority 100 + highest_priority field", () => {
+    expect(
+      sourcePriorityMayEscalate({
+        sourcePriority: 100,
+        writtenFields: { score: 42 },
+        mergePolicies: { score: { strategy: "highest_priority" } },
+      })
+    ).toBe(true);
+  });
+
+  it("false: non-default priority (caller ranked intentionally)", () => {
+    expect(
+      sourcePriorityMayEscalate({
+        sourcePriority: 50,
+        writtenFields: { score: 42 },
+        mergePolicies: { score: { strategy: "highest_priority" } },
+      })
+    ).toBe(false);
+  });
+
+  it("false: priority 100 but no honouring field (last_write only)", () => {
+    expect(
+      sourcePriorityMayEscalate({
+        sourcePriority: 100,
+        writtenFields: { note: "x" },
+        mergePolicies: { note: { strategy: "last_write" } },
+      })
+    ).toBe(false);
+  });
+
+  it("false: priority 100 + highest_priority policy but that field not written", () => {
+    expect(
+      sourcePriorityMayEscalate({
+        sourcePriority: 100,
+        writtenFields: { note: "x" },
+        mergePolicies: {
+          score: { strategy: "highest_priority" },
+          note: { strategy: "last_write" },
+        },
+      })
+    ).toBe(false);
+  });
+
+  it("true: priority 100 + most_specific tie_breaker source_priority", () => {
+    expect(
+      sourcePriorityMayEscalate({
+        sourcePriority: 100,
+        writtenFields: { spec: "y" },
+        mergePolicies: { spec: { strategy: "most_specific", tie_breaker: "source_priority" } },
+      })
+    ).toBe(true);
+  });
+});
+
+describe("buildSourcePriorityEscalationWarning", () => {
+  it("builds a SOURCE_PRIORITY_ESCALATION warning for a default-100 write to a highest_priority field", () => {
+    const warn = buildSourcePriorityEscalationWarning({
+      sourcePriority: 100,
+      writtenFields: { score: 42, note: "ignored" },
+      mergePolicies: {
+        score: { strategy: "highest_priority" },
+        note: { strategy: "last_write" },
+      },
+      observationIndex: 3,
+      entityType: "leaderboard_entry",
+      entityId: "eid-esc-1",
+    });
+    expect(warn).not.toBeNull();
+    expect(warn!.code).toBe("SOURCE_PRIORITY_ESCALATION");
+    expect(warn!.observation_index).toBe(3);
+    expect(warn!.entity_type).toBe("leaderboard_entry");
+    expect(warn!.entity_id).toBe("eid-esc-1");
+    // Names the honouring field, not the last_write one.
+    expect(warn!.message).toContain("'score'");
+    expect(warn!.message).not.toContain("'note'");
+    expect(warn!.message).toContain("100");
+    expect(warn!.message.toLowerCase()).toContain("outrank");
+    // Documents the default-vs-explicit-100 limitation.
+    expect(warn!.message.toLowerCase()).toContain("indistinguishable");
+  });
+
+  it("returns null when priority is non-default (intentional ranking)", () => {
+    const warn = buildSourcePriorityEscalationWarning({
+      sourcePriority: 500,
+      writtenFields: { score: 42 },
+      mergePolicies: { score: { strategy: "highest_priority" } },
+      observationIndex: 0,
+      entityType: "leaderboard_entry",
+      entityId: "eid-esc-2",
+    });
+    expect(warn).toBeNull();
+  });
+
+  it("returns null when no written field honours priority", () => {
+    const warn = buildSourcePriorityEscalationWarning({
+      sourcePriority: 100,
+      writtenFields: { note: "x" },
+      mergePolicies: { note: { strategy: "last_write" } },
+      observationIndex: 0,
+      entityType: "contact",
+      entityId: "eid-esc-3",
     });
     expect(warn).toBeNull();
   });


### PR DESCRIPTION
## The footgun

`source_priority` defaults to **100** (`z.number().optional().default(100)` in `src/shared/action_schemas.ts`). On any field whose reducer policy is `highest_priority` (or `most_specific` with `tie_breaker: "source_priority"`), an **unprioritized** write silently inherits priority 100 — which **outranks** any prior observation written with an explicit priority ≤ 99 (e.g. a trusted import at 50). The unprioritized write wins the field. This is a silent **trust-escalation**: a caller who never thought about priority can override a value that was deliberately ranked lower.

Per the operator verdict on #1838, the **default value is unchanged** (lowering it would silently flip the winner of existing reductions everywhere — a breaking semantic change). The fix is **detection + docs**, not a new default.

## The fix (docs + warn only — no merge semantics change)

- **Docs:** new *"The default `source_priority = 100` footgun"* subsection in `docs/subsystems/conflict_resolution.md` (§5 Current Limitations) with a worked example and the mitigation: always pass an explicit `--source-priority` / `source_priority` for priority-semantic writes. Added a Related-Documents entry for #1838.
- **CLI:** `--source-priority` help on both `store` commands (`src/cli/index.ts`) now states the default-100 escalation edge and references `docs/subsystems/conflict_resolution.md`.
- **Warning:** new `buildSourcePriorityEscalationWarning(...)` in `src/services/source_priority_warning.ts` returns a `{ code: "SOURCE_PRIORITY_ESCALATION", message, ... }` (or `null`). Condition: `sourcePriority === 100` **and** at least one written field uses `highest_priority`. Wired into **both** store paths — `src/actions.ts` (HTTP/API `storeStructuredForApi`) and `src/server.ts` (MCP `store`) — right after the existing `buildSourcePriorityIgnoredWarning` call, pushed to `store_warnings[]`. Non-blocking; nothing is rejected.

### Limitation (default vs. explicit 100)

zod applies `.default(100)` before the request handler runs, so an explicit `source_priority: 100` is **indistinguishable** from an omitted value at write time. The advisory therefore fires on both, framed as "default/non-explicit 100". This is called out in the warning message, the docs subsection, and the code comments.

## Tests

- **Unit** (`tests/unit/source_priority_ignored_warning.test.ts`): `priorityHonouringFields`, `sourcePriorityMayEscalate`, and `buildSourcePriorityEscalationWarning` (fires on default-100 + highest_priority; null on non-default priority; null when no honouring field; `most_specific` tie-breaker case; message names the honouring field and documents the limitation).
- **Integration** (`tests/integration/store_source_priority_ignored_warning.test.ts`): asserts `SOURCE_PRIORITY_ESCALATION` fires on a **default-100 write to a `highest_priority` field on both the MCP and HTTP `/store` paths**, and does **not** fire on a non-default-priority write.
- Result: **52 tests green** (43 unit + 9 integration). `type-check`, `lint` (0 errors), `prettier --check`, `validate:test-catalog`, and `validate:doc-deps` all clean. No generated-file drift (openapi.yaml untouched; the docs audit lists paths only, no content/hash dependency).

Closes #1838

🤖 Generated with [Claude Code](https://claude.com/claude-code)
