### PR TITLE
fix(reducer): warn (NULL_CLEARED_FIELD) when a null clears a highest_priority field

### DIFF
--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,18 +61,18 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **518**
-- Backend and repo Vitest files: **484**
+- Total automated test files: **520**
+- Backend and repo Vitest files: **486**
 - Frontend Vitest files: **9**
 - Playwright spec files: **25**
 
 ### Suite counts
 | Suite | Files |
 |---|---:|
-| Vitest unit tests | 144 |
+| Vitest unit tests | 145 |
 | Vitest service tests | 35 |
 | Source-adjacent tests | 64 |
-| Vitest integration tests | 146 |
+| Vitest integration tests | 147 |
 | Vitest CLI tests | 65 |
 | Vitest contract tests | 14 |
 | Vitest security tests | 4 |
@@ -109,7 +109,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/unit`
 **Requirements:** Basic `.env` if required by the module under test.
-**Files (144):**
+**Files (145):**
 - `tests/unit/aauth_admission.test.ts`
 - `tests/unit/aauth_attestation_apple_se.test.ts`
 - `tests/unit/aauth_attestation_revocation.test.ts`
@@ -200,6 +200,7 @@ flowchart TD
 - `tests/unit/mirror_writeback_integration.test.ts`
 - `tests/unit/mirror_writeback.test.ts`
 - `tests/unit/neotoma_entity_id.test.ts`
+- `tests/unit/null_cleared_field_warning.test.ts`
 - `tests/unit/observation_reducer_converters.test.ts`
 - `tests/unit/observation_reducer_merge_array_correction.test.ts`
 - `tests/unit/observation_reducer_merge_array_stringified.test.ts`
@@ -373,7 +374,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm run test:integration` or `npx vitest run tests/integration`
 **Requirements:** Database configured; remote-dependent subsets additionally need `RUN_REMOTE_TESTS=1`.
-**Files (146):**
+**Files (147):**
 - `tests/integration/aauth_attribution_stamping.test.ts`
 - `tests/integration/aauth_mcp_capability_parity.test.ts`
 - `tests/integration/aauth_mcp_initialize_admission.test.ts`
@@ -502,6 +503,7 @@ flowchart TD
 - `tests/integration/store_exercise_log_device_schema.test.ts`
 - `tests/integration/store_explicit_canonical_name.test.ts`
 - `tests/integration/store_external_link_schema.test.ts`
+- `tests/integration/store_null_cleared_field_warning.test.ts`
 - `tests/integration/store_prefix_duplicate_candidates.test.ts`
 - `tests/integration/store_reference_source_parity.test.ts`
 - `tests/integration/store_registered_schema_alias_precedence.test.ts`

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -7047,6 +7047,13 @@ export async function storeStructuredForApi(params: {
     entity_snapshot_after: Record<string, unknown> | null;
   }> = [];
 
+  // Issue #1839: capture each entity's prior and post-reduction snapshot so the
+  // store_warnings loop below can detect a NULL_CLEARED_FIELD event (an incoming
+  // null clearing a prior non-null value under highest_priority). Keyed by
+  // entity_id.
+  const priorSnapshotByEntityId = new Map<string, Record<string, unknown>>();
+  const newSnapshotByEntityId = new Map<string, Record<string, unknown>>();
+
   for (const r of resolved) {
     let observation_id: string | null = null;
     let snapshotAfter: Record<string, unknown> | null = null;
@@ -7060,6 +7067,7 @@ export async function storeStructuredForApi(params: {
         .maybeSingle();
       const priorSnapshot =
         (priorSnapRow?.snapshot as Record<string, unknown> | null | undefined) ?? {};
+      priorSnapshotByEntityId.set(r.entity_id, priorSnapshot);
 
       const obsData = await createObservation({
         entity_id: r.entity_id,
@@ -7084,6 +7092,7 @@ export async function storeStructuredForApi(params: {
         const snap = await recomputeSnapshot(r.entity_id, userId);
         snapshotAfter =
           (snap as { snapshot?: Record<string, unknown> } | null | undefined)?.snapshot ?? null;
+        if (snapshotAfter) newSnapshotByEntityId.set(r.entity_id, snapshotAfter);
       } catch (snapshotErr) {
         logger.warn(`Snapshot recompute failed for ${r.entity_id}: ${snapshotErr}`);
       }
@@ -7482,6 +7491,34 @@ export async function storeStructuredForApi(params: {
           entityId: r.entity_id,
         });
         if (spWarn) schemaStoreWarnings.push(spWarn);
+      }
+
+      // Issue #1839: NULL_CLEARED_FIELD — non-blocking advisory warning when an
+      // incoming null clears a prior non-null value under a `highest_priority`
+      // field. The clear is by design (null is an explicit tombstone), but it
+      // is silent today; this surfaces the data-loss vector. Warn-only: no
+      // change to snapshot computation or clearing semantics.
+      {
+        const mergePolicies = schemaEntry?.reducer_config?.merge_policies;
+        if (mergePolicies) {
+          const priorSnapshot = priorSnapshotByEntityId.get(r.entity_id) ?? {};
+          const newSnapshot = newSnapshotByEntityId.get(r.entity_id) ?? {};
+          const { buildNullClearedFieldWarning } =
+            await import("./services/null_cleared_field_warning.js");
+          for (const field of Object.keys(r.fields)) {
+            const nullWarn = buildNullClearedFieldWarning({
+              field,
+              strategy: mergePolicies[field]?.strategy,
+              prior_value: priorSnapshot[field],
+              incoming_value: r.fields[field],
+              new_value: newSnapshot[field],
+              observation_index: r.observation_index,
+              entity_type: r.entity_type,
+              entity_id: r.entity_id,
+            });
+            if (nullWarn) schemaStoreWarnings.push(nullWarn);
+          }
+        }
       }
     }
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -5868,6 +5868,11 @@ export class NeotomaServer {
 
     // Compute and store snapshots for all entities
     const snapshotByEntityId = new Map<string, Record<string, unknown>>();
+    // Issue #1839: capture each entity's prior and post-reduction snapshot so
+    // the store_warnings loop below can detect a NULL_CLEARED_FIELD event (an
+    // incoming null clearing a prior non-null value under highest_priority).
+    const priorSnapshotByEntityId = new Map<string, Record<string, unknown>>();
+    const newSnapshotByEntityId = new Map<string, Record<string, unknown>>();
     const { observationReducer } = await import("./reducers/observation_reducer.js");
     for (const createdEntity of createdEntities) {
       try {
@@ -5879,6 +5884,7 @@ export class NeotomaServer {
           .maybeSingle();
         const priorSnapshot =
           (priorSnapRow?.snapshot as Record<string, unknown> | null | undefined) ?? {};
+        priorSnapshotByEntityId.set(createdEntity.entityId, priorSnapshot);
 
         // Get all observations for entity, scoped to the current user so
         // cross-user data does not bleed into this user's snapshot.
@@ -5923,6 +5929,14 @@ export class NeotomaServer {
           if (!snapshot) {
             continue; // Skip snapshot and timeline derivation if snapshot computation failed
           }
+
+          // Issue #1839: record the post-reduction snapshot before the embedding
+          // upsert, so the NULL_CLEARED_FIELD warning's "field actually cleared"
+          // check is independent of embedding availability.
+          newSnapshotByEntityId.set(
+            snapshot.entity_id,
+            (snapshot.snapshot as Record<string, unknown>) || {}
+          );
 
           const rowWithEmbedding = await prepareEntitySnapshotWithEmbedding({
             entity_id: snapshot.entity_id,
@@ -6255,6 +6269,34 @@ export class NeotomaServer {
           entityId: e.entityId,
         });
         if (spWarn) schemaStoreWarnings.push(spWarn);
+      }
+
+      // Issue #1839: NULL_CLEARED_FIELD — non-blocking advisory warning when an
+      // incoming null clears a prior non-null value under a `highest_priority`
+      // field. The clear is by design (null is an explicit tombstone), but it
+      // is silent today; this surfaces the data-loss vector. Warn-only: no
+      // change to snapshot computation or clearing semantics.
+      {
+        const mergePolicies = schemaEntry?.reducer_config?.merge_policies;
+        if (mergePolicies) {
+          const priorSnapshot = priorSnapshotByEntityId.get(e.entityId) ?? {};
+          const newSnapshot = newSnapshotByEntityId.get(e.entityId) ?? {};
+          const { buildNullClearedFieldWarning } =
+            await import("./services/null_cleared_field_warning.js");
+          for (const field of Object.keys(entityFields)) {
+            const nullWarn = buildNullClearedFieldWarning({
+              field,
+              strategy: mergePolicies[field]?.strategy,
+              prior_value: priorSnapshot[field],
+              incoming_value: entityFields[field],
+              new_value: newSnapshot[field],
+              observation_index: i,
+              entity_type: e.entityType,
+              entity_id: e.entityId,
+            });
+            if (nullWarn) schemaStoreWarnings.push(nullWarn);
+          }
+        }
       }
     }
 

--- a/src/services/null_cleared_field_warning.ts
+++ b/src/services/null_cleared_field_warning.ts
@@ -1,0 +1,113 @@
+/**
+ * null_cleared_field_warning.ts
+ *
+ * Pure helper for the NULL_CLEARED_FIELD write-time warning (#1839).
+ *
+ * Under the `highest_priority` reducer, a `null` observation is an explicit
+ * tombstone: when it wins selection for a field, it clears that field from the
+ * snapshot. This is BY DESIGN (only `undefined` is dropped/ignored by the
+ * reducer; `null` is a deliberate clear). The gap reported in #1839 is that the
+ * clear happens SILENTLY — a transient data-source failure that writes `null`
+ * at the same-or-higher source_priority can erase a good historical value with
+ * no signal to the caller.
+ *
+ * The fix is warn-only: emit a non-blocking `NULL_CLEARED_FIELD` store_warning
+ * when an incoming `null` clears a prior non-null value under a field whose
+ * merge policy is `highest_priority`. The clearing semantics are unchanged.
+ *
+ * This module exposes:
+ *  - `buildNullClearedFieldWarning(opts)` — constructs the structured
+ *    store_warnings[] entry, or `null` when no warning is warranted.
+ *
+ * The export is intentionally pure (no I/O) so it can be unit-tested without
+ * mocking the database or schema registry.
+ */
+
+import type { ReducerConfig } from "./schema_registry.js";
+
+export type MergePolicy = ReducerConfig["merge_policies"][string];
+
+/**
+ * The shape of one store_warnings[] entry emitted by the NULL_CLEARED_FIELD
+ * code path. Mirrors the shape expected by both the HTTP and MCP store handlers.
+ */
+export type NullClearedFieldWarning = {
+  code: "NULL_CLEARED_FIELD";
+  message: string;
+  observation_index: number;
+  entity_type: string;
+  entity_id: string;
+};
+
+/**
+ * Returns a structured store_warnings[] entry when an incoming `null` value is
+ * the resolved winner for a `highest_priority` field and clears a prior
+ * non-null value, or `null` when no warning is warranted.
+ *
+ * Conditions (all must hold):
+ *  1. The incoming value for the field is exactly `null` (not `undefined` — an
+ *     omitted field is ignored by the reducer and clears nothing).
+ *  2. The prior snapshot value for the field was non-null and non-undefined
+ *     (i.e. there is a good value to lose). Clearing an already-empty field is
+ *     not a data-loss event and warrants no warning.
+ *  3. The newly-recomputed snapshot value for the field is null/undefined — the
+ *     field was ACTUALLY cleared. This guards against false positives on store
+ *     paths that strip a typed-field null before it becomes an observation (so
+ *     the prior value is in fact retained, not cleared): no real clear, no
+ *     warning.
+ *  4. The field's merge policy strategy is `highest_priority`. Only this
+ *     strategy lets a same/higher-priority null win selection in the way #1839
+ *     describes. (`last_write` reaches the same clear, but the warning scope is
+ *     deliberately limited to highest_priority per the approved fix.)
+ *
+ * Warn-only: this never alters the snapshot or the clearing semantics.
+ */
+export function buildNullClearedFieldWarning(opts: {
+  field: string;
+  strategy: string | undefined;
+  prior_value: unknown;
+  incoming_value: unknown;
+  new_value: unknown;
+  observation_index: number;
+  entity_type: string;
+  entity_id: string;
+}): NullClearedFieldWarning | null {
+  const {
+    field,
+    strategy,
+    prior_value,
+    incoming_value,
+    new_value,
+    observation_index,
+    entity_type,
+    entity_id,
+  } = opts;
+
+  // Condition 1: incoming value is an explicit null tombstone.
+  if (incoming_value !== null) return null;
+
+  // Condition 2: there was a prior non-null/undefined value to lose.
+  if (prior_value === null || prior_value === undefined) return null;
+
+  // Condition 3: the field was actually cleared in the new snapshot.
+  if (new_value !== null && new_value !== undefined) return null;
+
+  // Condition 4: the field is reduced under highest_priority.
+  if (strategy !== "highest_priority") return null;
+
+  return {
+    code: "NULL_CLEARED_FIELD",
+    message:
+      `${entity_type} field "${field}" was cleared by a null observation under ` +
+      "`highest_priority` reduction. A null value at the same or higher source_priority " +
+      "is an explicit tombstone and wins selection, clearing the prior non-null value. " +
+      "This is by design, but it is a data-loss vector when the null represents " +
+      '"data unavailable" (e.g. an upstream timeout or solver failure). ' +
+      "To retain the last-good value, omit the field entirely instead of sending null " +
+      "(omitted fields are ignored by the reducer), or correct() the field back to a " +
+      "non-null value.",
+    observation_index,
+    entity_type,
+    entity_id,
+  };
+}

--- a/tests/integration/store_null_cleared_field_warning.test.ts
+++ b/tests/integration/store_null_cleared_field_warning.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Integration tests for the NULL_CLEARED_FIELD store warning (#1839).
+ *
+ * Under the `highest_priority` reducer, a `null` observation is an explicit
+ * tombstone: at the same-or-higher source_priority it wins selection and clears
+ * the field from the snapshot. This is BY DESIGN (only `undefined` is ignored by
+ * the reducer). The gap reported in #1839 is that the clear is SILENT — a
+ * transient upstream failure that writes `null` can erase a good historical
+ * value with no signal.
+ *
+ * This suite asserts the warn-only fix on the HTTP `/store` path (which
+ * persists a typed-field null as an observation, unlike the MCP path that
+ * strips it to raw_fragments):
+ *  1. Store a good non-null value under a `highest_priority` field.
+ *  2. Store a `null` at a higher source_priority → the snapshot field IS
+ *     cleared (semantics unchanged) AND a `NULL_CLEARED_FIELD` store_warning
+ *     fires with the correct code/observation_index/entity_type/entity_id.
+ *  3. Storing the good value alone → no NULL_CLEARED_FIELD warning.
+ *  4. Storing a null over an already-empty field → no warning (nothing lost).
+ */
+
+import { createServer } from "node:http";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { app } from "../../src/actions.js";
+import { schemaRegistry } from "../../src/services/schema_registry.js";
+import { LOCAL_DEV_USER_ID } from "../../src/services/local_auth.js";
+import { cleanupEntityType, cleanupTestSchema } from "../helpers/cleanup_helpers.js";
+import { db } from "../../src/db.js";
+import { observationReducer } from "../../src/reducers/observation_reducer.js";
+
+const TEST_USER_ID = LOCAL_DEV_USER_ID;
+
+// Registered schema type whose `value` field uses `highest_priority`, so a null
+// at the same/higher priority wins selection and clears the field.
+const NULL_TYPE = "test_null_cleared_priority_type";
+
+const API_PORT = 18251;
+const API_BASE = `http://127.0.0.1:${API_PORT}`;
+
+type StoreWarning = {
+  code: string;
+  message: string;
+  observation_index: number;
+  entity_type: string;
+  entity_id: string;
+};
+
+type StoreResponse = {
+  entities?: Array<{ entity_id: string; entity_type: string }>;
+  store_warnings?: StoreWarning[];
+  error?: unknown;
+};
+
+/**
+ * Recompute an entity's snapshot directly from its persisted observations via
+ * the reducer. Embedding-free, so the assertion does not depend on a valid
+ * OPENAI_API_KEY (entity_snapshot_after in the store response is gated on a
+ * successful embedding upsert, unavailable in key-less test environments).
+ */
+async function reduceSnapshot(entityId: string, userId: string) {
+  const { data: obs } = await db
+    .from("observations")
+    .select("*")
+    .eq("entity_id", entityId)
+    .eq("user_id", userId)
+    .order("observed_at", { ascending: false });
+  const mapped = (obs ?? []).map((o: any) => ({
+    id: o.id,
+    entity_id: o.entity_id,
+    entity_type: o.entity_type,
+    schema_version: o.schema_version,
+    source_id: o.source_id || "",
+    observed_at: o.observed_at,
+    specificity_score: o.specificity_score,
+    source_priority: o.source_priority,
+    observation_source: o.observation_source ?? undefined,
+    fields: o.fields,
+    created_at: o.created_at,
+    user_id: o.user_id,
+  }));
+  const snap = await observationReducer.computeSnapshot(entityId, mapped as any);
+  return (snap?.snapshot as Record<string, unknown> | undefined) ?? {};
+}
+
+async function httpStore(body: Record<string, unknown>): Promise<StoreResponse> {
+  const res = await fetch(`${API_BASE}/store`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  expect(res.status).toBe(200);
+  return (await res.json()) as StoreResponse;
+}
+
+describe("store_warnings: NULL_CLEARED_FIELD (#1839)", () => {
+  let httpServer: ReturnType<typeof createServer>;
+
+  beforeAll(async () => {
+    httpServer = createServer(app);
+    await new Promise<void>((resolve, reject) => {
+      httpServer.listen(API_PORT, "127.0.0.1", () => resolve());
+      httpServer.once("error", reject);
+    });
+
+    if (!(await schemaRegistry.loadActiveSchema(NULL_TYPE, TEST_USER_ID))) {
+      await schemaRegistry.register({
+        entity_type: NULL_TYPE,
+        schema_version: "1.0",
+        schema_definition: {
+          fields: {
+            label: { type: "string", required: false },
+            value: { type: "number", required: false },
+          },
+          identity_opt_out: "heuristic_canonical_name",
+        },
+        reducer_config: {
+          merge_policies: {
+            value: { strategy: "highest_priority" },
+          },
+        },
+        user_id: TEST_USER_ID,
+        user_specific: true,
+        activate: true,
+      });
+    }
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+    await cleanupEntityType(NULL_TYPE, TEST_USER_ID);
+    await cleanupTestSchema(NULL_TYPE, TEST_USER_ID);
+  });
+
+  it("warns and still clears when a null wins over a prior non-null value under highest_priority", async () => {
+    const canonical = `null-cleared-${Date.now()}`;
+
+    // Step 1: store a good value at source_priority 10.
+    const goodBody = await httpStore({
+      idempotency_key: `null-good-${Date.now()}`,
+      commit: true,
+      source_priority: 10,
+      observation_source: "sensor",
+      entities: [
+        {
+          entity_type: NULL_TYPE,
+          canonical_name: canonical,
+          label: "t",
+          value: 0.18,
+        },
+      ],
+    });
+    expect(goodBody.error).toBeUndefined();
+    expect(goodBody.entities && goodBody.entities.length).toBe(1);
+    const entityId = goodBody.entities![0].entity_id;
+    // Good value is reduced into the snapshot.
+    expect((await reduceSnapshot(entityId, TEST_USER_ID)).value).toBe(0.18);
+    // No NULL_CLEARED_FIELD on the first (non-null) write.
+    expect((goodBody.store_warnings ?? []).some((w) => w.code === "NULL_CLEARED_FIELD")).toBe(
+      false
+    );
+
+    // Step 2: store null at a HIGHER source_priority → deterministically wins
+    // selection and clears the field. (Same-priority null also wins per the
+    // reducer, but two stores in one test can collide on observed_at to the
+    // millisecond, making the id tie-break nondeterministic; a higher priority
+    // removes that flakiness while still exercising the exact #1839 path.)
+    const clearedBody = await httpStore({
+      idempotency_key: `null-clear-${Date.now()}`,
+      commit: true,
+      source_priority: 20,
+      observation_source: "sensor",
+      entities: [
+        {
+          entity_type: NULL_TYPE,
+          canonical_name: canonical,
+          label: "t",
+          value: null,
+        },
+      ],
+    });
+    expect(clearedBody.error).toBeUndefined();
+    expect(clearedBody.entities && clearedBody.entities.length).toBe(1);
+    expect(clearedBody.entities![0].entity_id).toBe(entityId);
+
+    // Semantics unchanged: the field is cleared from the reduced snapshot.
+    const reduced = await reduceSnapshot(entityId, TEST_USER_ID);
+    expect(reduced.value === undefined || reduced.value === null).toBe(true);
+
+    // The warning fires.
+    const warn = (clearedBody.store_warnings ?? []).find((w) => w.code === "NULL_CLEARED_FIELD");
+    expect(warn).toBeDefined();
+    expect(warn!.entity_type).toBe(NULL_TYPE);
+    expect(warn!.entity_id).toBe(entityId);
+    expect(warn!.observation_index).toBe(0);
+    expect(warn!.message).toContain('"value"');
+    expect(warn!.message).toContain("highest_priority");
+  });
+
+  it("does not warn when a null is stored over an already-empty field (nothing lost)", async () => {
+    const canonical = `null-empty-${Date.now()}`;
+
+    // First write carries only label; value was never set.
+    const firstBody = await httpStore({
+      idempotency_key: `null-empty-first-${Date.now()}`,
+      commit: true,
+      source_priority: 10,
+      observation_source: "sensor",
+      entities: [
+        {
+          entity_type: NULL_TYPE,
+          canonical_name: canonical,
+          label: "t",
+        },
+      ],
+    });
+    expect(firstBody.error).toBeUndefined();
+
+    // Now store value: null — there is no prior non-null value to clear.
+    const nulledBody = await httpStore({
+      idempotency_key: `null-empty-null-${Date.now()}`,
+      commit: true,
+      source_priority: 20,
+      observation_source: "sensor",
+      entities: [
+        {
+          entity_type: NULL_TYPE,
+          canonical_name: canonical,
+          label: "t",
+          value: null,
+        },
+      ],
+    });
+    expect(nulledBody.error).toBeUndefined();
+    expect((nulledBody.store_warnings ?? []).some((w) => w.code === "NULL_CLEARED_FIELD")).toBe(
+      false
+    );
+  });
+});

--- a/tests/unit/null_cleared_field_warning.test.ts
+++ b/tests/unit/null_cleared_field_warning.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Unit tests for the NULL_CLEARED_FIELD write-time warning (#1839).
+ *
+ * Tests the pure helper `buildNullClearedFieldWarning` in
+ * `src/services/null_cleared_field_warning.ts` that drives the warning logic in
+ * `src/actions.ts`.
+ *
+ * Under `highest_priority`, a null observation is an explicit tombstone that
+ * clears a field when it wins selection. The clear is by design, but #1839 asks
+ * that it stop being silent: warn when an incoming null clears a prior non-null
+ * value under highest_priority. Warn-only — no semantic change.
+ */
+
+import { describe, it, expect } from "vitest";
+import { buildNullClearedFieldWarning } from "../../src/services/null_cleared_field_warning.js";
+
+describe("buildNullClearedFieldWarning", () => {
+  const base = {
+    field: "value",
+    // new_value: undefined models the common case where the null cleared the
+    // field (the field is absent from the recomputed snapshot). Individual
+    // cases override it where the field was NOT actually cleared.
+    new_value: undefined as unknown,
+    observation_index: 0,
+    entity_type: "null_test",
+    entity_id: "ent_0123456789abcdef01234567",
+  };
+
+  it("fires when an incoming null clears a prior non-null value under highest_priority", () => {
+    const warn = buildNullClearedFieldWarning({
+      ...base,
+      strategy: "highest_priority",
+      prior_value: 0.18,
+      incoming_value: null,
+      new_value: undefined,
+    });
+    expect(warn).not.toBeNull();
+    expect(warn?.code).toBe("NULL_CLEARED_FIELD");
+    expect(warn?.entity_type).toBe("null_test");
+    expect(warn?.entity_id).toBe(base.entity_id);
+    expect(warn?.observation_index).toBe(0);
+    expect(warn?.message).toContain('"value"');
+    expect(warn?.message).toContain("highest_priority");
+  });
+
+  it("does not fire when the incoming value is not null (a real value, no clear)", () => {
+    expect(
+      buildNullClearedFieldWarning({
+        ...base,
+        strategy: "highest_priority",
+        prior_value: 0.18,
+        incoming_value: 0.42,
+      })
+    ).toBeNull();
+  });
+
+  it("does not fire when the incoming value is undefined (field omitted, reducer ignores it)", () => {
+    expect(
+      buildNullClearedFieldWarning({
+        ...base,
+        strategy: "highest_priority",
+        prior_value: 0.18,
+        incoming_value: undefined,
+      })
+    ).toBeNull();
+  });
+
+  it("does not fire when there was no prior value (prior null — nothing lost)", () => {
+    expect(
+      buildNullClearedFieldWarning({
+        ...base,
+        strategy: "highest_priority",
+        prior_value: null,
+        incoming_value: null,
+      })
+    ).toBeNull();
+  });
+
+  it("does not fire when there was no prior value (prior undefined — field absent before)", () => {
+    expect(
+      buildNullClearedFieldWarning({
+        ...base,
+        strategy: "highest_priority",
+        prior_value: undefined,
+        incoming_value: null,
+      })
+    ).toBeNull();
+  });
+
+  it("does not fire for last_write (scope is limited to highest_priority)", () => {
+    expect(
+      buildNullClearedFieldWarning({
+        ...base,
+        strategy: "last_write",
+        prior_value: 0.18,
+        incoming_value: null,
+      })
+    ).toBeNull();
+  });
+
+  it("does not fire when the field has no declared merge policy strategy", () => {
+    expect(
+      buildNullClearedFieldWarning({
+        ...base,
+        strategy: undefined,
+        prior_value: 0.18,
+        incoming_value: null,
+      })
+    ).toBeNull();
+  });
+
+  it("fires when clearing a falsy-but-non-null prior value (0)", () => {
+    const warn = buildNullClearedFieldWarning({
+      ...base,
+      strategy: "highest_priority",
+      prior_value: 0,
+      incoming_value: null,
+      new_value: undefined,
+    });
+    expect(warn).not.toBeNull();
+    expect(warn?.code).toBe("NULL_CLEARED_FIELD");
+  });
+
+  it("does not fire when the field was not actually cleared (null stripped, prior value retained)", () => {
+    // Some store paths strip a typed-field null before it becomes an
+    // observation, so the prior value survives. No real clear → no warning,
+    // even though the caller passed null.
+    expect(
+      buildNullClearedFieldWarning({
+        ...base,
+        strategy: "highest_priority",
+        prior_value: 0.18,
+        incoming_value: null,
+        new_value: 0.18,
+      })
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
## The gap (#1839)

Under the `highest_priority` reducer, a `null` observation is an explicit tombstone: at the same-or-higher `source_priority` it wins selection and **clears the field** from the snapshot. This is **by design** — only `undefined` is dropped/ignored by the reducer; `null` is a deliberate clear.

The problem reported in #1839 is that the clear is **silent**. A transient upstream failure that writes `null` (an API timeout, a solver returning no value) at same/higher priority can erase a good historical value from the snapshot with no `store_warning`, the opposite of what `highest_priority` is meant to protect. There is no signal to make the failure mode discoverable.

## The fix (warn-only)

Emit a new non-blocking `NULL_CLEARED_FIELD` `store_warning` when an incoming `null` **actually clears** a prior non-null value under a `highest_priority` field. **No change to clearing semantics or snapshot computation** — `null` remains an explicit tombstone, exactly as before.

- New pure helper `src/services/null_cleared_field_warning.ts` (`buildNullClearedFieldWarning`), mirroring the `SOURCE_PRIORITY_IGNORED` helper pattern. It returns a warning only when **all** hold:
  1. the incoming value is exactly `null` (not `undefined` — omitted fields are ignored and clear nothing),
  2. the **prior** snapshot value was non-null/undefined (a good value to lose),
  3. the **recomputed** snapshot value is now cleared — this guards against the store path that strips a typed-field `null` to `raw_fragments` (where the prior value is in fact retained), so the warning never false-positives, and
  4. the field's merge strategy is `highest_priority`.
- Wired into **both** store paths, immediately after the existing `SOURCE_PRIORITY_IGNORED` block, each comparing the prior snapshot to the post-reduction snapshot: `src/actions.ts` (HTTP `/store`) and `src/server.ts` (MCP `store`). The insertions are minimal and self-contained (one import + one small block each, plus a prior/new snapshot map) to avoid conflicting with parallel work near this area.

## Tests

- `tests/unit/null_cleared_field_warning.test.ts` — unit-tests the helper across the fire and all no-fire cases (non-null incoming, omitted field, no prior value, `last_write`, undeclared strategy, falsy-but-non-null prior, and the not-actually-cleared/null-stripped case).
- `tests/integration/store_null_cleared_field_warning.test.ts` — exercises the HTTP `/store` path end to end: a winning `null` over a prior non-null value under `highest_priority` **still clears the field** (asserted via the reducer) **and** returns a `NULL_CLEARED_FIELD` warning; a `null` over an already-empty field emits no warning.

All run green locally (11 new tests), alongside the adjacent `SOURCE_PRIORITY_IGNORED` and store-warning suites. `type-check`, `lint`, and `format:check` pass with 0 errors. No contract/generated files touched (warn-only helper).

Closes #1839

🤖 Generated with [Claude Code](https://claude.com/claude-code)