### PR TITLE
docs(skills): make /status and /end cover the whole session

### DIFF
--- a/skills/end/SKILL.md
+++ b/skills/end/SKILL.md
@@ -47,11 +47,18 @@ Before Phase 1, decide whether context is whole-session or partial. Treat it as 
 
 When partial, reconstruct the full arc from the transcript **before** auditing:
 
-1. **Locate the transcript JSONL.** It lives under `~/.claude/projects/<project-slug>/<session-id>.jsonl`. The compaction summary names the exact path; otherwise pick the most recently modified `.jsonl` in that project dir.
-2. **Do not read the whole file into context** — it can be multiple MB. Extract a skeleton with a small script: pull genuine user messages (filter out `tool_result` payloads, `<system-reminder>` / `<command-*>` / `<local-command-*>` blocks, and "Continue from where you left off."), plus the assistant's short summary lines and any entity IDs / PR numbers mentioned. This recovers the full request arc and the set of entities surfaced, cheaply.
+1. **Locate the transcript JSONL — by identity, not recency.** Resolve the path in this strict order, stopping at the first that yields exactly one file:
+   1. The exact path named in the compaction/summary block in context — use it directly.
+   2. The harness-provided session id (a `<session-id>` / transcript path in environment context) → `~/.claude/projects/<project-slug>/<session-id>.jsonl`.
+   3. Only if neither is available: list `~/.claude/projects/<project-slug>/*.jsonl`. If exactly one exists, use it. **Do not** silently pick "the most recently modified" when several exist — a concurrent or prior-day session in the same project would make recency select the wrong file. If multiple remain and the session id can't disambiguate, treat it as *transcript unresolved* (see not-found handling) rather than guessing — filing tasks against the wrong session is worse than flagging tail-only.
+2. **Do not read the whole file into context** — it can be multiple MB. Extract a skeleton deterministically: parse the JSONL line by line; keep entries where `type`/`role` is `user` **and** the text does **not** match `^\s*<(system-reminder|command-name|command-message|local-command)`; drop `tool_result` content entirely; drop standalone "Continue from where you left off." lines; keep short assistant summary lines and any entity IDs / PR numbers mentioned. The "filter out tool_result" rule targets the `tool_result` *content type*, not user-pasted log/test output inside a genuine user message. This recovers the full request arc and the set of entities surfaced, cheaply.
 3. **Feed that whole-session skeleton into Phases 1 and 2** — the remaining-work audit and the storage audit must both cover the entire session, not just the in-context tail.
 
-If the transcript can't be found or read, proceed from context but state in the final report that coverage may be tail-only, so the user knows earlier work might be unaudited. When context is already whole-session (short, no compaction boundary), skip the transcript read.
+If the transcript can't be resolved or read (not found, ambiguous, parse error, or zero user messages after filtering), proceed from context but lead the final report with one explicit, prefixed caveat line naming the reason and that coverage is tail-only — so the user knows earlier work might be unaudited and unfiled, e.g.:
+
+> ⚠️ Whole-session transcript unavailable (<reason>) — audit coverage is tail-only; trackable work and storage gaps before the boundary may be missed.
+
+When context is already whole-session (short, no compaction boundary), skip the transcript read. (Attaching the transcript itself as a `source_id` is out of scope here — Phase 2.3 already covers source-linking for files the session actually ingested; the transcript is a read aid, not an audited artifact.)
 
 ## Phase 1: Remaining-work audit
 

--- a/skills/end/SKILL.md
+++ b/skills/end/SKILL.md
@@ -35,9 +35,27 @@ Applies once per session, at user request. Does not modify code. Files Neotoma e
 - The only thing it never auto-executes is `do-now` code work unless the user explicitly asked for it in-session; those are filed as tasks like any other `track` item.
 - PII MUST still be stripped from any filed issues per the `feedback_issue_pii` memory, and standing constraints (Neotoma prod, never mark yoga/therapy done, etc.) still apply.
 
+## Phase 0: Whole-session coverage (read the transcript when context is partial)
+
+`/end` must audit the **whole session**, not just the portion currently in context. This matters more here than for `/status`: a partial scan silently *fails to file* trackable work and *misses storage gaps* from the earlier session, defeating the skill's purpose.
+
+Before Phase 1, decide whether context is whole-session or partial. Treat it as **partial** whenever any of these hold:
+
+- A compaction/summary boundary is present in context (a "This session is being continued…" summary block, or an injected session-summary).
+- The session spans multiple days or many turns.
+- The user signals earlier work was missed.
+
+When partial, reconstruct the full arc from the transcript **before** auditing:
+
+1. **Locate the transcript JSONL.** It lives under `~/.claude/projects/<project-slug>/<session-id>.jsonl`. The compaction summary names the exact path; otherwise pick the most recently modified `.jsonl` in that project dir.
+2. **Do not read the whole file into context** — it can be multiple MB. Extract a skeleton with a small script: pull genuine user messages (filter out `tool_result` payloads, `<system-reminder>` / `<command-*>` / `<local-command-*>` blocks, and "Continue from where you left off."), plus the assistant's short summary lines and any entity IDs / PR numbers mentioned. This recovers the full request arc and the set of entities surfaced, cheaply.
+3. **Feed that whole-session skeleton into Phases 1 and 2** — the remaining-work audit and the storage audit must both cover the entire session, not just the in-context tail.
+
+If the transcript can't be found or read, proceed from context but state in the final report that coverage may be tail-only, so the user knows earlier work might be unaudited. When context is already whole-session (short, no compaction boundary), skip the transcript read.
+
 ## Phase 1: Remaining-work audit
 
-Scan the current conversation and identify every follow-up under these headings:
+Scan the whole session (per Phase 0 — the transcript skeleton when context is partial, otherwise the in-context conversation) and identify every follow-up under these headings:
 
 1. **Open work** — TODOs the assistant introduced, partial implementations, files modified but not verified, tests not run, lint/type-check skipped, PRs/commits not made.
 2. **Decisions or proposals not acted on** — recommendations the user accepted that have not been executed; designs sketched but not implemented.
@@ -51,7 +69,7 @@ For each item, classify: `do-now` (trivially finishable inline only if the user 
 
 Determine what should be in Neotoma from this session and what already is.
 
-1. **Per-turn lifecycle compliance** — confirm each turn this session followed the Neotoma turn lifecycle (user message + assistant message stored, PART_OF + REFERS_TO edges). If any turn was skipped (which is forbidden), note it for repair.
+1. **Per-turn lifecycle compliance** — confirm each turn this session followed the Neotoma turn lifecycle (user message + assistant message stored, PART_OF + REFERS_TO edges). Use the Phase 0 transcript skeleton to enumerate turns when context is partial, so turns from before a compaction boundary are checked too. If any turn was skipped (which is forbidden), note it for repair.
 2. **Substantive entities surfaced** — list every concrete entity discussed or produced this session: plans, decisions, skills, rules, bugs, contacts, transactions, events, code artifacts, etc. For each, check via `retrieve_entity_by_identifier` or `retrieve_entities` whether it is already stored.
 3. **Files or attachments** — any files the user pasted, screenshots, transcripts, or external URLs fetched. Check whether each has a corresponding `source_id` / content-addressed source row.
 4. **Memory-worthy facts** — items that should be written to the auto-memory directory (`~/.claude/projects/.../memory/`) per the auto-memory protocol.
@@ -96,6 +114,7 @@ Both `/end` and `store-neotoma` MUST emit a **succinct affected-records list** i
 
 ## Constraints
 
+- MUST audit the whole session: when context is partial (a compaction boundary is present, the session is multi-day / many-turn, or the user flags missed work), reconstruct the full arc from the transcript JSONL (Phase 0) before Phases 1–2, so trackable work and storage gaps from before the boundary are not missed. If the transcript is unreadable, proceed but state in the final report that coverage may be tail-only.
 - MUST file `track` items as task entities **before** rendering the remaining-work bullets, so the bullets reflect stored state.
 - MUST NOT request confirmation before filing tasks, storing entities, or invoking `store-neotoma`.
 - MUST NOT skip the storage audit even if the user only asks about remaining work, and vice versa.

--- a/skills/status/SKILL.md
+++ b/skills/status/SKILL.md
@@ -38,11 +38,18 @@ Before composing the report, decide whether context is whole-session or partial.
 
 When partial, reconstruct the full arc from the transcript **before** reporting:
 
-1. **Locate the transcript JSONL.** It lives under `~/.claude/projects/<project-slug>/<session-id>.jsonl`. The compaction summary names the exact path; otherwise pick the most recently modified `.jsonl` in that project dir.
-2. **Do not read the whole file into context** — it can be multiple MB. Extract a skeleton with a small script: pull genuine user messages (filter out `tool_result` payloads, `<system-reminder>` / `<command-*>` / `<local-command-*>` blocks, and "Continue from where you left off."), and optionally the assistant's short summary lines. This recovers the session's request arc cheaply.
+1. **Locate the transcript JSONL — by identity, not recency.** Resolve the path in this strict order, stopping at the first that yields exactly one file:
+   1. The exact path named in the compaction/summary block in context (it almost always states it verbatim) — use it directly.
+   2. The harness-provided session id (e.g. a `<session-id>` / transcript path in environment context) → `~/.claude/projects/<project-slug>/<session-id>.jsonl`.
+   3. Only if neither is available: list `~/.claude/projects/<project-slug>/*.jsonl`. If exactly one exists, use it. **Do not** silently pick "the most recently modified" when several exist — a concurrent or prior-day session in the same project would make recency select the wrong file. If multiple remain and none can be disambiguated by the session id, treat it as *transcript unresolved* (see the not-found handling below) rather than guessing.
+2. **Do not read the whole file into context** — it can be multiple MB. Extract a skeleton deterministically: parse the JSONL line by line; keep entries where `type`/`role` is `user` **and** the text does **not** match `^\s*<(system-reminder|command-name|command-message|local-command)`; drop `tool_result` content entirely; drop standalone "Continue from where you left off." lines; optionally keep short assistant summary lines. The "filter out tool_result" rule targets the `tool_result` *content type*, not user-pasted log/test output inside a genuine user message — keep the latter. This yields the session's request arc in a few hundred chars.
 3. **Compose Achieved / Remaining from that whole-session skeleton**, not just the in-context tail.
 
-If the transcript can't be found or read, say so in one line and report from context with an explicit caveat that coverage may be tail-only — don't present a partial read-out as complete. When context is already whole-session (short, no compaction boundary), skip the transcript read.
+If the transcript can't be resolved or read (not found, ambiguous, parse error, or zero user messages after filtering), do not present a partial read-out as complete. Lead the report with one explicit, prefixed caveat line naming the reason and that coverage is tail-only, e.g.:
+
+> ⚠️ Whole-session transcript unavailable (<reason: not found / multiple candidates / parse error>) — coverage is tail-only; earlier work may be under-reported. Re-run with the session id if you have it.
+
+Then report from context. When context is already whole-session (short, no compaction boundary), skip the transcript read.
 
 ## Modes
 

--- a/skills/status/SKILL.md
+++ b/skills/status/SKILL.md
@@ -26,6 +26,24 @@ This skill is **user-level** (`~/.claude/skills/status/`), so it is available in
 - **`/status` is read-only.** It does NOT store entities, file tasks, write memory, invoke `store-neotoma`, or render the `🧠 Neotoma` turn report. It just reports. (Read-only retrieval of an existing plan is allowed — see Project-aware mode — but it never writes.)
 - **`/end` is the closing audit** — it files and persists. Reach for `/end` at the natural close of a session; reach for `/status` any time mid-session to check in.
 
+## Whole-session coverage (read the transcript when context is partial)
+
+`/status` must report on the **whole session**, not just the portion currently in context. Long sessions get compacted: the active context window may hold only a recent slice (a pre-compaction summary plus the last few turns), so reporting from context alone silently under-represents earlier work.
+
+Before composing the report, decide whether context is whole-session or partial. Treat it as **partial** whenever any of these hold:
+
+- A compaction/summary boundary is present in context (a "This session is being continued…" summary block, or an injected session-summary).
+- The session spans multiple days or many turns.
+- The user signals the read-out missed earlier work.
+
+When partial, reconstruct the full arc from the transcript **before** reporting:
+
+1. **Locate the transcript JSONL.** It lives under `~/.claude/projects/<project-slug>/<session-id>.jsonl`. The compaction summary names the exact path; otherwise pick the most recently modified `.jsonl` in that project dir.
+2. **Do not read the whole file into context** — it can be multiple MB. Extract a skeleton with a small script: pull genuine user messages (filter out `tool_result` payloads, `<system-reminder>` / `<command-*>` / `<local-command-*>` blocks, and "Continue from where you left off."), and optionally the assistant's short summary lines. This recovers the session's request arc cheaply.
+3. **Compose Achieved / Remaining from that whole-session skeleton**, not just the in-context tail.
+
+If the transcript can't be found or read, say so in one line and report from context with an explicit caveat that coverage may be tail-only — don't present a partial read-out as complete. When context is already whole-session (short, no compaction boundary), skip the transcript read.
+
 ## Modes
 
 `/status` has one default behavior and two optional modifiers, which compose:
@@ -110,7 +128,8 @@ If no plan is found, silently fall back to the session-only report — do not an
 
 ## Constraints
 
-- MUST be read-only: no `store`, no task filing, no memory writes, no `store-neotoma`, no `🧠 Neotoma` turn report. Project-aware mode may *read* a plan but MUST NOT correct or write it (that's `/update-plan`).
+- MUST report on the whole session: when context is partial (a compaction boundary is present, the session is multi-day / many-turn, or the user flags missed work), reconstruct the full arc from the transcript JSONL *before* reporting; never present a tail-only read-out as complete. If the transcript is unreadable, report from context with an explicit coverage caveat.
+- MUST be read-only: no `store`, no task filing, no memory writes, no `store-neotoma`, no `🧠 Neotoma` turn report. Project-aware mode may *read* a plan but MUST NOT correct or write it (that's `/update-plan`). Reading the transcript JSONL is a read and is allowed.
 - MUST keep technical detail light — anchors for navigation only, never logs or diffs — in both default and verbose modes.
 - MUST separate genuinely-completed work from outstanding/in-progress work; do not report attempts as achievements.
 - Default `/status` MUST stay succinct; resist turning the report into a full audit (that's `/end`). `verbose` adds context, never mechanics.


### PR DESCRIPTION
## Summary

Long sessions get compacted: the active context window may hold only a recent slice (a pre-compaction summary plus the last few turns). Both `/status` and `/end` previously scanned "the current conversation," so on a compacted session they silently under-reported — and `/end` could *fail to file* trackable work and *miss storage gaps* from before the boundary.

This adds a **whole-session coverage** step to both skills: when context is partial (compaction boundary present, multi-day / many-turn session, or the user flags missed work), reconstruct the full arc from the transcript JSONL (`~/.claude/projects/<slug>/<session-id>.jsonl`) via a cheap user-message skeleton — not a full multi-MB read — before reporting/auditing.

- **`/status`**: new "Whole-session coverage" section + matching constraint. Reading the transcript is explicitly allowed (it's a read; the skill stays read-only).
- **`/end`**: new **Phase 0** that feeds the skeleton into Phase 1 (remaining-work audit) and Phase 2.1 (per-turn lifecycle compliance), plus a matching constraint and a tail-only caveat for the final report when the transcript is unreadable.

Motivation: in a real multi-day session, a `/status` run reported only the last day's work; reconstructing from the transcript recovered the full Jun 2–10 arc.

## Test plan

- [ ] On a compacted session, `/status` reconstructs and reports the full arc, not just the tail
- [ ] `/end` Phase 0 enumerates pre-compaction turns for the storage audit
- [ ] On a short, uncompacted session, both skills skip the transcript read (no added cost)

🤖 Generated with [Claude Code](https://claude.com/claude-code)