### PR TITLE
test(ci): offline/local-transport parity gate

### DIFF
--- a/.github/workflows/ci_test_lanes.yml
+++ b/.github/workflows/ci_test_lanes.yml
@@ -131,6 +131,14 @@ jobs:
       - name: Run cross-surface contract-parity integration tests
         run: npm run test:contract-parity
 
+      # OFFLINE/local-transport parity gate. Curated behaviors that broke on the
+      # offline/HTTP path (#1819 at_ingested, #1840 dedup, #1839 null-cleared,
+      # #1842 issue-submit auth) are asserted through BOTH the MCP and offline
+      # transports, so a fix that lands on one surface but regresses on the other
+      # fails this PR-time lane. New infra (task ent_5850561116).
+      - name: Run offline/local-transport parity gate
+        run: npm run test:transport-parity
+
   frontend:
     runs-on: ubuntu-latest
     steps:

--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,8 +61,8 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **523**
-- Backend and repo Vitest files: **489**
+- Total automated test files: **524**
+- Backend and repo Vitest files: **490**
 - Frontend Vitest files: **9**
 - Playwright spec files: **25**
 
@@ -72,7 +72,7 @@ flowchart TD
 | Vitest unit tests | 146 |
 | Vitest service tests | 35 |
 | Source-adjacent tests | 64 |
-| Vitest integration tests | 149 |
+| Vitest integration tests | 150 |
 | Vitest CLI tests | 65 |
 | Vitest contract tests | 14 |
 | Vitest security tests | 4 |
@@ -375,7 +375,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm run test:integration` or `npx vitest run tests/integration`
 **Requirements:** Database configured; remote-dependent subsets additionally need `RUN_REMOTE_TESTS=1`.
-**Files (149):**
+**Files (150):**
 - `tests/integration/aauth_attribution_stamping.test.ts`
 - `tests/integration/aauth_mcp_capability_parity.test.ts`
 - `tests/integration/aauth_mcp_initialize_admission.test.ts`
@@ -518,6 +518,7 @@ flowchart TD
 - `tests/integration/subscription_list.test.ts`
 - `tests/integration/subscription_unsubscribe.test.ts`
 - `tests/integration/sync_webhook_inbound.test.ts`
+- `tests/integration/transport_parity_store_snapshot_auth.test.ts`
 - `tests/integration/tunnel_auth.test.ts`
 - `tests/integration/tunnel_discovery.test.ts`
 - `tests/integration/turn_summary_mcp_apps.test.ts`

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "test:cross-layer": "vitest run tests/integration/cli_to_mcp_store.test.ts tests/integration/cli_to_mcp_entities.test.ts tests/integration/cli_to_mcp_relationships.test.ts tests/integration/cli_to_mcp_schemas.test.ts",
     "test:parity": "vitest run tests/contract/contract_mcp_cli_parity.test.ts",
     "test:contract-parity": "vitest run --no-file-parallelism tests/integration/store_reference_source_parity.test.ts tests/integration/http_store_reference_source.test.ts tests/integration/mcp_store_reference_source.test.ts",
+    "test:transport-parity": "vitest run tests/integration/transport_parity_store_snapshot_auth.test.ts",
     "test:e2e:coverage": "npm run test:contract && npm run test:cross-layer",
     "test:agent-mcp": "vitest run tests/agent",
     "test:coverage": "vitest run --coverage",

--- a/tests/helpers/transport_parity_matrix.ts
+++ b/tests/helpers/transport_parity_matrix.ts
@@ -1,0 +1,323 @@
+/**
+ * Shared transport-parity matrix: drive the SAME behavioral assertion through
+ * BOTH the MCP tool-dispatch surface and the offline/local HTTP (Express) surface,
+ * and assert an IDENTICAL effect on each.
+ *
+ * Motivation. An external evaluator's regressions clustered in the offline/HTTP
+ * transport — the path the suite historically exercised less than MCP:
+ *   - #1819  at/at_ingested snapshot cutoffs were applied only on the MCP path;
+ *            the offline/HTTP `POST /get_entity_snapshot` silently ignored them.
+ *   - #1840  the dedup (idempotency-replay) store response lost its populated
+ *            `entity_snapshot_after` / `deduplicated` marker.
+ *   - #1842  issue-submit's local-loopback auth fallback was an HTTP-surface gap.
+ *
+ * This helper mirrors the structure of tests/helpers/store_reference_parity.ts
+ * (a surface × shape matrix), but instead of one feature across surfaces it
+ * encodes a CURATED set of behaviors that actually broke, each driven through
+ * both transports where the behavior is defined on both. Each cell asserts the
+ * EFFECT (observation count, reduced snapshot, warning emission, auth outcome),
+ * not merely that the input was accepted — per task_policy
+ * fixed_means_behavior_verified_not_contract_accepted (ent_db0b7855d47012084477fb00)
+ * and cross_surface_contract_parity_tested_all_surfaces (ent_2ad0677fe23c0c1878ae43e8).
+ *
+ * Transports:
+ *   - "mcp"     → NeotomaServer dispatch (the same path `/mcp` tools/call routes
+ *                 a tool into). No real auth token is needed; the test injects the
+ *                 authenticated user id.
+ *   - "offline" → the offline/local path IS the HTTP/Express path: a real
+ *                 `createServer(app)` over loopback, called with `POST /...`.
+ *                 Loopback with no Bearer resolves to LOCAL_DEV_USER_ID, exactly
+ *                 the offline-developer path the evaluator's bugs lived in.
+ *
+ * Where a behavior is genuinely single-transport by design (see NOTE comments in
+ * the scenario table), the cell documents WHY rather than forcing a parity claim
+ * the architecture does not make — forcing it would either be vacuous or red on a
+ * green main.
+ */
+
+import { createServer } from "node:http";
+import type { Server } from "node:http";
+import { randomUUID } from "node:crypto";
+
+import { expect } from "vitest";
+
+import { app } from "../../src/actions.js";
+import { db } from "../../src/db.js";
+import { NeotomaServer } from "../../src/server.js";
+import { LOCAL_DEV_USER_ID } from "../../src/services/local_auth.js";
+import { observationReducer } from "../../src/reducers/observation_reducer.js";
+
+export type Transport = "mcp" | "offline";
+
+/** Both transports resolve to the same local user, so a row written through one
+ *  is visible to the other — the precondition for a meaningful parity claim. */
+export const PARITY_USER_ID = LOCAL_DEV_USER_ID;
+
+// ---------------------------------------------------------------------------
+// Boot helpers
+// ---------------------------------------------------------------------------
+
+/** An MCP dispatch surface whose authenticated user is the shared local user. */
+export function makeMcpServer(): NeotomaServer {
+  const server = new NeotomaServer();
+  (server as unknown as { authenticatedUserId: string }).authenticatedUserId = PARITY_USER_ID;
+  return server;
+}
+
+/** A real Express server bound on an ephemeral loopback port (offline path). */
+export async function startOfflineServer(): Promise<{ server: Server; base: string }> {
+  const server = createServer(app);
+  await new Promise<void>((resolve, reject) => {
+    server.listen(0, "127.0.0.1", () => resolve());
+    server.once("error", reject);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("offline test server did not bind to a TCP port");
+  }
+  return { server, base: `http://127.0.0.1:${address.port}` };
+}
+
+export async function stopServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+}
+
+// ---------------------------------------------------------------------------
+// Low-level drivers — one per (action × transport)
+// ---------------------------------------------------------------------------
+
+/** MCP dispatch for snake_cased action methods on NeotomaServer (callMcp). */
+export async function callMcp(
+  server: NeotomaServer,
+  actionName: string,
+  params: unknown
+): Promise<Record<string, unknown>> {
+  const methodName = actionName.replace(/_([a-z])/g, (_m, c: string) => c.toUpperCase());
+  const result = (await (server as unknown as Record<string, (p: unknown) => Promise<{
+    content: Array<{ type: string; text: string }>;
+  }>>)[methodName](params)) as { content: Array<{ type: string; text: string }> };
+  return JSON.parse(result.content[0]!.text) as Record<string, unknown>;
+}
+
+/** Offline/HTTP POST against the Express app (callHttp). */
+export async function callHttp(
+  base: string,
+  routePath: string,
+  body: Record<string, unknown>,
+  extraHeaders: Record<string, string> = {}
+): Promise<{ status: number; json: Record<string, unknown>; text: string }> {
+  const resp = await fetch(`${base}${routePath}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...extraHeaders },
+    body: JSON.stringify(body),
+  });
+  const text = await resp.text();
+  let json: Record<string, unknown> = {};
+  try {
+    json = text ? (JSON.parse(text) as Record<string, unknown>) : {};
+  } catch {
+    /* non-JSON body (e.g. plain error) — leave json empty, keep text */
+  }
+  return { status: resp.status, json, text };
+}
+
+// ---------------------------------------------------------------------------
+// Effect inspectors (the EFFECT, read straight from the store)
+// ---------------------------------------------------------------------------
+
+/** Count observations for an entity under the shared user. */
+export async function observationCount(entityId: string): Promise<number> {
+  const { count } = await db
+    .from("observations")
+    .select("id", { count: "exact", head: true })
+    .eq("entity_id", entityId)
+    .eq("user_id", PARITY_USER_ID);
+  return count ?? 0;
+}
+
+/**
+ * Recompute an entity's snapshot directly from its persisted observations via
+ * the reducer. Embedding-free, so the assertion does not depend on a valid
+ * OPENAI_API_KEY (the materialized `entity_snapshots` row is gated on a
+ * successful embedding upsert, unavailable in key-less CI). Same approach the
+ * #1839 suite uses.
+ */
+export async function reduceSnapshot(entityId: string): Promise<Record<string, unknown>> {
+  const { data: obs } = await db
+    .from("observations")
+    .select("*")
+    .eq("entity_id", entityId)
+    .eq("user_id", PARITY_USER_ID)
+    .order("observed_at", { ascending: false });
+  const mapped = (obs ?? []).map((o: Record<string, unknown>) => ({
+    id: o.id,
+    entity_id: o.entity_id,
+    entity_type: o.entity_type,
+    schema_version: o.schema_version,
+    source_id: o.source_id || "",
+    observed_at: o.observed_at,
+    specificity_score: o.specificity_score,
+    source_priority: o.source_priority,
+    observation_source: o.observation_source ?? undefined,
+    fields: o.fields,
+    created_at: o.created_at,
+    user_id: o.user_id,
+  }));
+  const snap = await observationReducer.computeSnapshot(entityId, mapped as never);
+  return (snap?.snapshot as Record<string, unknown> | undefined) ?? {};
+}
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+export async function insertSource(tag: string): Promise<string> {
+  const { data: source, error } = await db
+    .from("sources")
+    .insert({
+      user_id: PARITY_USER_ID,
+      content_hash: `hash_parity_${tag}_${randomUUID()}`,
+      storage_url: `file:///test/transport_parity_${tag}.txt`,
+      mime_type: "text/plain",
+      file_size: 0,
+    })
+    .select()
+    .single();
+  if (error || !source) throw new Error(`insertSource failed: ${error?.message}`);
+  return source.id as string;
+}
+
+export async function insertObservation(opts: {
+  entityId: string;
+  sourceId: string;
+  observedAt: string;
+  createdAt: string;
+  fields: Record<string, unknown>;
+}): Promise<void> {
+  const { error } = await db.from("observations").insert({
+    entity_id: opts.entityId,
+    entity_type: "task",
+    schema_version: "1.0",
+    source_id: opts.sourceId,
+    user_id: PARITY_USER_ID,
+    observed_at: opts.observedAt,
+    created_at: opts.createdAt,
+    fields: opts.fields,
+  });
+  if (error) throw new Error(`insertObservation failed: ${error.message}`);
+}
+
+/** Resolve the snapshot for an entity at a cutoff through one transport. */
+export async function snapshotAtCutoff(
+  transport: Transport,
+  mcpServer: NeotomaServer,
+  offlineBase: string,
+  args: { entityId: string; at?: string; atIngested?: string }
+): Promise<{ observationCount: number; status: unknown }> {
+  if (transport === "mcp") {
+    const data = await callMcp(mcpServer, "retrieve_entity_snapshot", {
+      entity_id: args.entityId,
+      ...(args.at ? { at: args.at } : {}),
+      ...(args.atIngested ? { at_ingested: args.atIngested } : {}),
+      format: "json",
+    });
+    const snapshot = (data.snapshot as Record<string, unknown> | undefined) ?? {};
+    return { observationCount: data.observation_count as number, status: snapshot.status };
+  }
+  const { json } = await callHttp(offlineBase, "/get_entity_snapshot", {
+    entity_id: args.entityId,
+    ...(args.at ? { at: args.at } : {}),
+    ...(args.atIngested ? { at_ingested: args.atIngested } : {}),
+  });
+  const snapshot = (json.snapshot as Record<string, unknown> | undefined) ?? {};
+  return { observationCount: json.observation_count as number, status: snapshot.status };
+}
+
+// ---------------------------------------------------------------------------
+// assertIdenticalEffect
+// ---------------------------------------------------------------------------
+
+/**
+ * Assert that a behavior produced the byte-for-byte same effect on both
+ * transports. Used by the cross-transport cells: run the same setup against
+ * each transport and assert the inspected effect is equal (not just "each works
+ * in isolation").
+ */
+export function assertIdenticalEffect<T>(label: string, mcp: T, offline: T): void {
+  expect(
+    offline,
+    `${label}: offline/HTTP effect must equal the MCP effect (transport parity)`
+  ).toEqual(mcp);
+}
+
+// ---------------------------------------------------------------------------
+// Scenario table
+// ---------------------------------------------------------------------------
+
+/**
+ * A scenario is one curated behavior. `transports` lists the surfaces the
+ * behavior is defined on. For dual-transport behaviors the test loops both and
+ * calls assertIdenticalEffect; single-transport behaviors document WHY (`note`)
+ * and assert the effect on their one surface — the architecture does not expose
+ * the behavior on the other transport, so a parity claim there would be vacuous.
+ */
+export interface TransportParityScenario {
+  id: string;
+  issue: string;
+  label: string;
+  transports: Transport[];
+  note?: string;
+}
+
+export const TRANSPORT_PARITY_MATRIX: TransportParityScenario[] = [
+  {
+    id: "snapshot_at_ingested_cutoff",
+    issue: "#1819",
+    label: "at_ingested ingestion-time cutoff excludes a late-arriving backfill",
+    transports: ["mcp", "offline"],
+  },
+  {
+    id: "snapshot_at_event_time_cutoff",
+    issue: "#1819",
+    label: "at event-time cutoff excludes a future-observed observation",
+    transports: ["mcp", "offline"],
+  },
+  {
+    id: "store_dedup_observation_count",
+    issue: "#1840",
+    label: "identical re-store deduplicates (observation count stays 1; reduced snapshot stays populated)",
+    transports: ["mcp", "offline"],
+    note:
+      "Parity invariant asserted on BOTH transports: an identical re-store creates no new " +
+      "observation (count stays 1) and the reduced snapshot stays populated. The RESPONSE-ENVELOPE " +
+      "enrichment from the #1840 fix (deduplicated:true + populated entity_snapshot_after on the " +
+      "replayed entry) is asserted additionally on MCP; the offline/HTTP idempotency-replay path " +
+      "returns a stripped {entity_id,entity_type,observation_id} entry, so that envelope detail is " +
+      "MCP-only today. The effect that matters for data integrity (no duplicate observation; snapshot " +
+      "intact) is identical across transports and is what this cell locks in.",
+  },
+  {
+    id: "null_cleared_field_warning",
+    issue: "#1839",
+    label: "NULL_CLEARED_FIELD warning fires when a null wins under highest_priority",
+    transports: ["offline"],
+    note:
+      "Single-transport BY DESIGN. The offline/HTTP /store path persists a typed-field null as an " +
+      "observation, so the reducer can detect a null clearing a prior non-null and emit the warning. " +
+      "The MCP store path strips a typed-field null to raw_fragments (documented in " +
+      "store_null_cleared_field_warning.test.ts), so there is no observation-level null to warn on. " +
+      "Asserting the warning on MCP would be vacuous, so this cell exercises the offline path only.",
+  },
+  {
+    id: "issue_submit_local_auth_fallback",
+    issue: "#1842",
+    label: "issue-submit: local no-bearer allowed, remote no-bearer still rejected",
+    transports: ["offline"],
+    note:
+      "Single-transport BY DESIGN. The local-loopback auth fallback is an HTTP transport-layer " +
+      "concern (Express middleware decides whether a no-Bearer request resolves to the local user " +
+      "based on request locality). The MCP submit_issue handler receives an ALREADY-resolved userId " +
+      "and performs no such gating, so the remote-vs-local distinction does not exist on the MCP " +
+      "surface. This cell asserts both sides of the gate on the offline path.",
+  },
+];

--- a/tests/integration/transport_parity_store_snapshot_auth.test.ts
+++ b/tests/integration/transport_parity_store_snapshot_auth.test.ts
@@ -1,0 +1,379 @@
+/**
+ * OFFLINE/local-transport parity gate.
+ *
+ * An external evaluator's regressions clustered in the offline/HTTP transport —
+ * the path historically exercised less than MCP (#1842 issue-submit auth, #1840
+ * dedup snapshot, #1819 at_ingested cutoff). This curated suite runs the SAME
+ * behavioral assertions through BOTH the MCP dispatch surface and the
+ * offline/local HTTP (Express) surface, failing CI if a behavior passes on one
+ * transport and not the other. It is the teeth behind the `contract_parity` CI
+ * lane: a behavior that broke on the offline path before now has a cross-surface
+ * assertion locking the fix on both.
+ *
+ * Each cell asserts the EFFECT (observation count, reduced snapshot, warning
+ * emission, auth outcome) — never mere input acceptance — per task_policy
+ * fixed_means_behavior_verified_not_contract_accepted (ent_db0b7855d47012084477fb00)
+ * and cross_surface_contract_parity_tested_all_surfaces (ent_2ad0677fe23c0c1878ae43e8).
+ * New infra; ties to task ent_5850561116.
+ *
+ * The five curated behaviors (and the issues they lock in):
+ *   1. at_ingested ingestion-time snapshot cutoff           (#1819) — MCP + offline
+ *   2. at event-time snapshot cutoff                        (#1819) — MCP + offline
+ *   3. dedup store: identical re-store keeps obs count = 1  (#1840) — MCP + offline
+ *      (MCP additionally returns deduplicated:true + populated snapshot_after)
+ *   4. NULL_CLEARED_FIELD warning under highest_priority    (#1839) — offline (by design)
+ *   5. issue-submit local-loopback auth fallback            (#1842) — offline (by design)
+ *
+ * Behaviors 1–3 are true cross-transport parity cells (identical effect on both).
+ * Behaviors 4–5 are single-transport BY DESIGN; each documents in the matrix WHY
+ * the other transport does not expose the behavior (see transport_parity_matrix.ts).
+ */
+
+import type { Server } from "node:http";
+import { randomUUID } from "node:crypto";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { db } from "../../src/db.js";
+import { NeotomaServer } from "../../src/server.js";
+import { schemaRegistry } from "../../src/services/schema_registry.js";
+import { routeAllowsLocalIssueWriteFallback } from "../../src/actions.js";
+import {
+  PARITY_USER_ID,
+  TRANSPORT_PARITY_MATRIX,
+  assertIdenticalEffect,
+  callHttp,
+  callMcp,
+  insertObservation,
+  insertSource,
+  makeMcpServer,
+  observationCount,
+  reduceSnapshot,
+  snapshotAtCutoff,
+  startOfflineServer,
+  stopServer,
+} from "../helpers/transport_parity_matrix.js";
+
+describe("OFFLINE/local-transport parity gate (curated MCP↔offline behaviors)", () => {
+  let mcpServer: NeotomaServer;
+  let offline: { server: Server; base: string };
+
+  const createdEntityIds: string[] = [];
+  const createdSourceIds: string[] = [];
+  const createdSchemaTypes: string[] = [];
+
+  beforeAll(async () => {
+    mcpServer = makeMcpServer();
+    offline = await startOfflineServer();
+  });
+
+  afterAll(async () => {
+    if (createdSourceIds.length > 0) {
+      await db.from("raw_fragments").delete().in("source_id", createdSourceIds);
+      await db.from("observations").delete().in("source_id", createdSourceIds);
+      await db.from("sources").delete().in("id", createdSourceIds);
+    }
+    if (createdEntityIds.length > 0) {
+      await db.from("entity_snapshots").delete().in("entity_id", createdEntityIds);
+      await db.from("observations").delete().in("entity_id", createdEntityIds);
+      await db.from("entities").delete().in("id", createdEntityIds);
+    }
+    for (const t of createdSchemaTypes) {
+      await db.from("schema_registry").delete().eq("entity_type", t).eq("user_id", PARITY_USER_ID);
+    }
+    await stopServer(offline.server);
+  });
+
+  // Sanity: the matrix is the single source of truth for which behaviors this
+  // gate covers. If a cell is added/removed, this assertion documents the count.
+  it("matrix declares the five curated transport-parity behaviors", () => {
+    expect(TRANSPORT_PARITY_MATRIX.map((s) => s.id)).toEqual([
+      "snapshot_at_ingested_cutoff",
+      "snapshot_at_event_time_cutoff",
+      "store_dedup_observation_count",
+      "null_cleared_field_warning",
+      "issue_submit_local_auth_fallback",
+    ]);
+  });
+
+  // -------------------------------------------------------------------------
+  // Cell 1 (#1819) — at_ingested ingestion-time cutoff: MCP ↔ offline parity.
+  // -------------------------------------------------------------------------
+  it("at_ingested cutoff excludes a late backfill — IDENTICAL effect on MCP and offline (#1819)", async () => {
+    const entityId = `ent_parity_ingested_${randomUUID().replace(/-/g, "").slice(0, 12)}`;
+    createdEntityIds.push(entityId);
+    const sourceId = await insertSource("ingested");
+    createdSourceIds.push(sourceId);
+
+    const threeDaysAgo = new Date(Date.now() - 3 * 864e5).toISOString();
+    const twoDaysAgo = new Date(Date.now() - 2 * 864e5).toISOString();
+    const oneDayAgo = new Date(Date.now() - 1 * 864e5).toISOString();
+    const now = new Date().toISOString();
+
+    // obs_early: genuinely historical. obs_backfill: past event-time but ingested now.
+    await insertObservation({
+      entityId,
+      sourceId,
+      observedAt: threeDaysAgo,
+      createdAt: threeDaysAgo,
+      fields: { title: "Early", status: "pending" },
+    });
+    await insertObservation({
+      entityId,
+      sourceId,
+      observedAt: twoDaysAgo,
+      createdAt: now,
+      fields: { title: "Backfill", status: "done" },
+    });
+
+    // at_ingested = oneDayAgo: the backfill (created_at = now) must be excluded on
+    // BOTH transports → observation_count=1, status="pending".
+    const mcp = await snapshotAtCutoff("mcp", mcpServer, offline.base, {
+      entityId,
+      atIngested: oneDayAgo,
+    });
+    const off = await snapshotAtCutoff("offline", mcpServer, offline.base, {
+      entityId,
+      atIngested: oneDayAgo,
+    });
+
+    expect(mcp.observationCount).toBe(1);
+    expect(mcp.status).toBe("pending");
+    assertIdenticalEffect("at_ingested cutoff", mcp, off);
+  });
+
+  // -------------------------------------------------------------------------
+  // Cell 2 (#1819) — at event-time cutoff: MCP ↔ offline parity.
+  // -------------------------------------------------------------------------
+  it("at event-time cutoff excludes a future observation — IDENTICAL effect on MCP and offline (#1819)", async () => {
+    const entityId = `ent_parity_at_${randomUUID().replace(/-/g, "").slice(0, 12)}`;
+    createdEntityIds.push(entityId);
+    const sourceId = await insertSource("at");
+    createdSourceIds.push(sourceId);
+
+    const threeDaysAgo = new Date(Date.now() - 3 * 864e5).toISOString();
+    const yesterday = new Date(Date.now() - 1 * 864e5).toISOString();
+    const tomorrow = new Date(Date.now() + 1 * 864e5).toISOString();
+
+    await insertObservation({
+      entityId,
+      sourceId,
+      observedAt: threeDaysAgo,
+      createdAt: threeDaysAgo,
+      fields: { title: "Old", status: "pending" },
+    });
+    await insertObservation({
+      entityId,
+      sourceId,
+      observedAt: tomorrow,
+      createdAt: threeDaysAgo,
+      fields: { title: "Future", status: "done" },
+    });
+
+    // at = yesterday: the future-observed obs must be excluded on BOTH transports
+    // → observation_count=1, status="pending".
+    const mcp = await snapshotAtCutoff("mcp", mcpServer, offline.base, { entityId, at: yesterday });
+    const off = await snapshotAtCutoff("offline", mcpServer, offline.base, {
+      entityId,
+      at: yesterday,
+    });
+
+    expect(mcp.observationCount).toBe(1);
+    expect(mcp.status).toBe("pending");
+    assertIdenticalEffect("at event-time cutoff", mcp, off);
+  });
+
+  // -------------------------------------------------------------------------
+  // Cell 3 (#1840) — dedup: identical re-store keeps observation count at 1 and
+  // leaves the reduced snapshot populated on BOTH transports. MCP additionally
+  // returns the #1840 response enrichment (deduplicated:true + snapshot_after).
+  // -------------------------------------------------------------------------
+  it("identical re-store deduplicates — obs count stays 1 + snapshot intact on MCP and offline (#1840)", async () => {
+    const baseType = `parity_dedup_${randomUUID().replace(/-/g, "").slice(0, 8)}`;
+
+    // One schema, reused for both transports (distinct canonical_name per surface
+    // so the two surfaces target distinct entities — we compare the EFFECT shape,
+    // not a shared row).
+    await schemaRegistry.register({
+      entity_type: baseType,
+      schema_version: "1.0",
+      schema_definition: {
+        fields: { value: { type: "number", required: false }, label: { type: "string", required: true } },
+        identity_opt_out: "heuristic_canonical_name",
+      },
+      reducer_config: {
+        merge_policies: { value: { strategy: "last_write" }, label: { strategy: "last_write" } },
+      },
+      user_id: PARITY_USER_ID,
+      user_specific: true,
+      activate: true,
+    });
+    createdSchemaTypes.push(baseType);
+
+    // ---- MCP transport ----
+    const mcpKey = `parity-dedup-mcp-${randomUUID()}`;
+    const mcpEntity = { entity_type: baseType, canonical_name: `mcp-${Date.now()}`, label: "t", value: 42 };
+    const mcpStoreArgs = {
+      user_id: PARITY_USER_ID,
+      idempotency_key: mcpKey,
+      entities: [mcpEntity],
+      source_priority: 5,
+      observation_source: "sensor",
+    };
+    const mcpOne = await callMcp(mcpServer, "store", mcpStoreArgs);
+    const mcpEntryOne = (mcpOne.entities as Array<Record<string, unknown>>)[0]!;
+    const mcpEntityId = mcpEntryOne.entity_id as string;
+    createdEntityIds.push(mcpEntityId);
+    if (mcpOne.source_id) createdSourceIds.push(mcpOne.source_id as string);
+    expect(mcpEntryOne.entity_snapshot_after).toMatchObject({ value: 42, label: "t" });
+
+    const mcpTwo = await callMcp(mcpServer, "store", mcpStoreArgs);
+    const mcpEntryTwo = (mcpTwo.entities as Array<Record<string, unknown>>)[0]!;
+    if (mcpTwo.source_id) createdSourceIds.push(mcpTwo.source_id as string);
+
+    // ---- Offline/HTTP transport ----
+    const offKey = `parity-dedup-off-${randomUUID()}`;
+    const offEntity = { entity_type: baseType, canonical_name: `off-${Date.now()}`, label: "t", value: 42 };
+    const offBody = {
+      idempotency_key: offKey,
+      commit: true,
+      source_priority: 5,
+      observation_source: "sensor",
+      entities: [offEntity],
+    };
+    const offOne = await callHttp(offline.base, "/store", offBody);
+    expect(offOne.status).toBe(200);
+    const offEntryOne = (offOne.json.entities as Array<Record<string, unknown>>)[0]!;
+    const offEntityId = offEntryOne.entity_id as string;
+    createdEntityIds.push(offEntityId);
+    if (offOne.json.source_id) createdSourceIds.push(offOne.json.source_id as string);
+    expect(offEntryOne.entity_snapshot_after).toMatchObject({ value: 42, label: "t" });
+
+    const offTwo = await callHttp(offline.base, "/store", offBody);
+    expect(offTwo.status).toBe(200);
+
+    // ---- PARITY INVARIANT (the data-integrity effect), identical on both ----
+    // 1. The re-store created NO new observation: count stays 1 on each surface.
+    const mcpObs = await observationCount(mcpEntityId);
+    const offObs = await observationCount(offEntityId);
+    expect(mcpObs).toBe(1);
+    assertIdenticalEffect("dedup observation count", mcpObs, offObs);
+
+    // 2. The reduced snapshot stays populated (NOT lost) on each surface.
+    const mcpSnap = await reduceSnapshot(mcpEntityId);
+    const offSnap = await reduceSnapshot(offEntityId);
+    expect(mcpSnap).toMatchObject({ value: 42, label: "t" });
+    assertIdenticalEffect("dedup reduced snapshot", mcpSnap, offSnap);
+
+    // ---- MCP-only response enrichment from the #1840 fix ----
+    // The MCP replay response carries the deduplicated marker AND the populated
+    // entity_snapshot_after. (The offline/HTTP idempotency-replay path returns a
+    // stripped entry — a documented divergence; see the matrix note. The parity
+    // guarantee above covers the integrity-critical effect on both transports.)
+    expect(mcpEntryTwo.deduplicated).toBe(true);
+    expect(mcpEntryTwo.entity_snapshot_after).toMatchObject({ value: 42, label: "t" });
+  });
+
+  // -------------------------------------------------------------------------
+  // Cell 4 (#1839) — NULL_CLEARED_FIELD warning: offline path by design.
+  // -------------------------------------------------------------------------
+  it("NULL_CLEARED_FIELD warning fires on the offline /store path under highest_priority (#1839)", async () => {
+    const nullType = `parity_null_${randomUUID().replace(/-/g, "").slice(0, 8)}`;
+    await schemaRegistry.register({
+      entity_type: nullType,
+      schema_version: "1.0",
+      schema_definition: {
+        fields: { label: { type: "string", required: false }, value: { type: "number", required: false } },
+        identity_opt_out: "heuristic_canonical_name",
+      },
+      reducer_config: { merge_policies: { value: { strategy: "highest_priority" } } },
+      user_id: PARITY_USER_ID,
+      user_specific: true,
+      activate: true,
+    });
+    createdSchemaTypes.push(nullType);
+
+    const canonical = `parity-null-${Date.now()}`;
+
+    // Good value at source_priority 10 → reduced into the snapshot, no warning.
+    const good = await callHttp(offline.base, "/store", {
+      idempotency_key: `parity-null-good-${randomUUID()}`,
+      commit: true,
+      source_priority: 10,
+      observation_source: "sensor",
+      entities: [{ entity_type: nullType, canonical_name: canonical, label: "t", value: 0.18 }],
+    });
+    expect(good.status).toBe(200);
+    const goodEntities = good.json.entities as Array<Record<string, unknown>>;
+    const entityId = goodEntities[0]!.entity_id as string;
+    createdEntityIds.push(entityId);
+    expect((await reduceSnapshot(entityId)).value).toBe(0.18);
+    const goodWarnings = (good.json.store_warnings as Array<{ code: string }> | undefined) ?? [];
+    expect(goodWarnings.some((w) => w.code === "NULL_CLEARED_FIELD")).toBe(false);
+
+    // null at a HIGHER priority → wins selection, clears the field, AND warns.
+    const cleared = await callHttp(offline.base, "/store", {
+      idempotency_key: `parity-null-clear-${randomUUID()}`,
+      commit: true,
+      source_priority: 20,
+      observation_source: "sensor",
+      entities: [{ entity_type: nullType, canonical_name: canonical, label: "t", value: null }],
+    });
+    expect(cleared.status).toBe(200);
+
+    // Semantics unchanged: the field is cleared from the reduced snapshot.
+    const reduced = await reduceSnapshot(entityId);
+    expect(reduced.value === undefined || reduced.value === null).toBe(true);
+
+    // The warning fires with the correct shape.
+    const warnings =
+      (cleared.json.store_warnings as Array<{
+        code: string;
+        message: string;
+        entity_type: string;
+        entity_id: string;
+      }> | undefined) ?? [];
+    const warn = warnings.find((w) => w.code === "NULL_CLEARED_FIELD");
+    expect(warn).toBeDefined();
+    expect(warn!.entity_type).toBe(nullType);
+    expect(warn!.entity_id).toBe(entityId);
+    expect(warn!.message).toContain('"value"');
+    expect(warn!.message).toContain("highest_priority");
+  });
+
+  // -------------------------------------------------------------------------
+  // Cell 5 (#1842) — issue-submit local-loopback auth: offline path by design.
+  // Local no-Bearer must be ALLOWED; remote (untrusted X-Forwarded-For) no-Bearer
+  // must still be REJECTED with AUTH_REQUIRED.
+  // -------------------------------------------------------------------------
+  it("issue-submit: local no-bearer allowed, remote no-bearer still rejected (#1842)", async () => {
+    // The fallback is scoped to exactly the issue-write routes.
+    expect(routeAllowsLocalIssueWriteFallback({ method: "POST", path: "/issues/submit" })).toBe(true);
+    expect(routeAllowsLocalIssueWriteFallback({ method: "POST", path: "/store" })).toBe(false);
+
+    // Local request, NO Authorization header → must clear the auth gate.
+    const local = await callHttp(offline.base, "/issues/submit", {
+      title: `parity local issue ${Date.now()}`,
+      body: "Created locally with no Bearer token — must not require auth.",
+      visibility: "private",
+      reporter_git_sha: "0".repeat(40),
+      reporter_app_version: "0.0.0-test",
+    });
+    expect(local.status).not.toBe(401);
+    expect(local.text).not.toMatch(/AUTH_REQUIRED/);
+
+    // Remote request (untrusted X-Forwarded-For), NO Bearer → must be rejected.
+    const remote = await callHttp(
+      offline.base,
+      "/issues/submit",
+      {
+        title: `parity remote issue ${Date.now()}`,
+        body: "Remote caller with no Bearer must still get AUTH_REQUIRED.",
+        visibility: "private",
+      },
+      { "X-Forwarded-For": "203.0.113.7" }
+    );
+    expect(remote.status).toBe(401);
+    expect(remote.text).toMatch(/AUTH_REQUIRED/);
+  });
+});


### PR DESCRIPTION
## What this gate does

Adds a **blocking CI gate** that runs a curated set of behavioral assertions through **both** transports — the MCP tool-dispatch surface (`NeotomaServer`) and the offline/local **HTTP/Express** surface (`createServer(app)` + `POST /...`) — and fails a PR when a behavior passes on one transport but not the other.

Most of an external evaluator's regressions clustered in the **offline/HTTP transport**, the path the suite historically exercised less than MCP. This gate gives that path teeth: each previously-broken behavior now has a cross-surface assertion locking the fix on both transports. Each cell asserts the **EFFECT** (observation count, reduced snapshot, warning emission, auth outcome), not mere input acceptance.

New files:
- `tests/helpers/transport_parity_matrix.ts` — shared scenario table + drivers (`callMcp`, `callHttp`) + effect inspectors + `assertIdenticalEffect`, mirroring the structure of `tests/helpers/store_reference_parity.ts`.
- `tests/integration/transport_parity_store_snapshot_auth.test.ts` — loops the matrix.

## The 5 initial behaviors (and the issues they lock in)

| # | Behavior | Issue | Transports |
|---|----------|-------|------------|
| 1 | `at_ingested` ingestion-time snapshot cutoff excludes a late backfill | #1819 | MCP **and** offline — identical effect |
| 2 | `at` event-time snapshot cutoff excludes a future observation | #1819 | MCP **and** offline — identical effect |
| 3 | Identical re-store dedups: observation count stays 1, reduced snapshot stays populated | #1840 | MCP **and** offline — identical effect |
| 4 | `NULL_CLEARED_FIELD` warning fires when a null wins under `highest_priority` | #1839 | offline (by design) |
| 5 | issue-submit local-loopback auth: local no-bearer allowed, remote no-bearer rejected | #1842 | offline (by design) |

Behaviors 1–3 are **true cross-transport parity cells** — the same setup is driven through each surface and `assertIdenticalEffect` requires byte-for-byte equal effects.

Behaviors 4–5 are **single-transport by design**, documented in the matrix rather than forced:
- **#1839** — the offline/HTTP `/store` path persists a typed-field null as an observation (so the reducer can detect the clear and warn); the MCP store path strips a typed null to `raw_fragments`, so there is no observation-level null to warn on. Asserting it on MCP would be vacuous.
- **#1842** — the local-loopback auth fallback is an HTTP transport-layer concern (Express middleware decides locality); the MCP `submit_issue` handler receives an already-resolved `userId` and performs no such gating, so the remote-vs-local distinction does not exist on the MCP surface.

One documented partial divergence inside cell 3: the **#1840 response-envelope enrichment** (`deduplicated:true` + populated `entity_snapshot_after` on the replayed entry) is asserted additionally on MCP; the offline/HTTP idempotency-replay path returns a stripped `{entity_id,entity_type,observation_id}` entry today. The integrity-critical effect (no duplicate observation; reduced snapshot intact) **is** identical across transports and is what cell 3 locks in.

## How it wires into `contract_parity`

- `package.json`: new script `"test:transport-parity": "vitest run tests/integration/transport_parity_store_snapshot_auth.test.ts"`.
- `.github/workflows/ci_test_lanes.yml`: the existing **`contract_parity`** lane gains a step `npm run test:transport-parity` after `npm run test:contract-parity`, so it gates every PR on the same local SQLite backend the lane already uses.
- `docs/testing/automated_test_catalog.md` regenerated (`npm run generate:test-catalog`) — integration count 149 → 150 — so the baseline catalog-validation lane stays green.

## Verification

- `npm run test:transport-parity` → **6/6 pass** on `origin/main` (v0.18.4): all five behaviors are already fixed, so the suite locks the fixes in across both transports.
- `npm run validate:test-catalog` → up to date.
- `npm run type-check`, `eslint` on the new files → clean.

This is **new infra** (ties to task `ent_5850561116`); it does not close an issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)