### PR TITLE
ci(release): make test-catalog drift and undocumented breaking changes blocking

### DIFF
--- a/.github/workflows/ci_test_lanes.yml
+++ b/.github/workflows/ci_test_lanes.yml
@@ -92,6 +92,42 @@ jobs:
       - name: Validate documentation dependencies
         run: npm run validate:doc-deps
 
+      # Breaking-change documentation gate (BLOCKING on release PRs).
+      #
+      # Retrospective #1841: the v0.18.0 `observation_source` enum tightening was
+      # a real OpenAPI/validation breaking change, but that release's supplement
+      # declared "## Breaking changes\n- None." and shipped the break undocumented.
+      #
+      # This step runs ONLY on release PRs (head branch chore/release/* or
+      # release/*). It derives the tag from package.json and the base from the
+      # latest reachable tag, runs the OpenAPI breaking-change diff, and FAILS the
+      # PR if a breaking diff exists while the supplement's "Breaking changes"
+      # section is missing or empty. Non-release PRs no-op.
+      - name: Breaking-change documentation gate (release PRs only)
+        if: github.event_name == 'pull_request'
+        run: |
+          HEAD_REF="${{ github.event.pull_request.head.ref }}"
+          case "$HEAD_REF" in
+            chore/release/*|release/*)
+              echo "Release PR detected (head: $HEAD_REF) — enforcing breaking-change documentation gate."
+              # Unshallow + tags so the base tag's openapi.yaml blob is reachable
+              # for the bc-diff (default checkout is shallow with no tags).
+              git fetch --tags --force --unshallow || git fetch --tags --force
+              TAG="v$(node -p "require('./package.json').version")"
+              # Base = latest reachable tag that is not the release tag itself.
+              BASE="$(git tag --sort=-v:refname | grep -v "^${TAG}$" | head -n1)"
+              if [ -z "$BASE" ]; then
+                echo "::warning::No prior tag found to diff against; skipping breaking-change gate."
+                exit 0
+              fi
+              echo "Diffing $BASE -> HEAD for tag $TAG"
+              npm run validate:breaking-changes -- --tag "$TAG" --base "$BASE" --head HEAD
+              ;;
+            *)
+              echo "Not a release PR (head: $HEAD_REF) — breaking-change documentation gate skipped."
+              ;;
+          esac
+
   contract_parity:
     # Focused PR-time cross-surface contract-parity lane.
     #

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -66,5 +66,23 @@ fi
 # Validate documentation dependencies for modified docs
 npm run validate:doc-deps
 
+# Regenerate + stage the automated test catalog when test files change.
+# The baseline CI lane's "Validate automated test catalog" step has failed
+# repeatedly because docs/testing/automated_test_catalog.md drifts whenever a
+# test file is added/removed/renamed and the author forgets to regenerate it.
+# Auto-regenerating here makes the drift impossible to commit.
+if [ "$NEOTOMA_SKIP_TEST_CATALOG" = "1" ]; then
+  echo "Skipping test-catalog regeneration (NEOTOMA_SKIP_TEST_CATALOG=1)"
+elif git diff --cached --name-only | grep -E '(^|/)tests/|\.test\.tsx?$' > /dev/null; then
+  echo "Test files changed — regenerating automated test catalog..."
+  npm run generate:test-catalog || exit 1
+  if ! git diff --quiet -- docs/testing/automated_test_catalog.md; then
+    git add docs/testing/automated_test_catalog.md
+    echo "✓ docs/testing/automated_test_catalog.md regenerated and staged"
+  else
+    echo "✓ Automated test catalog already up to date"
+  fi
+fi
+
 # Sync .cursor/ and .claude/ if rule/command sources modified
 ./scripts/linters/sync_agent_instructions_pre_commit.sh

--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,15 +61,15 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **523**
-- Backend and repo Vitest files: **489**
+- Total automated test files: **524**
+- Backend and repo Vitest files: **490**
 - Frontend Vitest files: **9**
 - Playwright spec files: **25**
 
 ### Suite counts
 | Suite | Files |
 |---|---:|
-| Vitest unit tests | 146 |
+| Vitest unit tests | 147 |
 | Vitest service tests | 35 |
 | Source-adjacent tests | 64 |
 | Vitest integration tests | 149 |
@@ -109,7 +109,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/unit`
 **Requirements:** Basic `.env` if required by the module under test.
-**Files (146):**
+**Files (147):**
 - `tests/unit/aauth_admission.test.ts`
 - `tests/unit/aauth_attestation_apple_se.test.ts`
 - `tests/unit/aauth_attestation_revocation.test.ts`
@@ -255,6 +255,7 @@ flowchart TD
 - `tests/unit/usage_digest_redaction.test.ts`
 - `tests/unit/usage_digest_schema.test.ts`
 - `tests/unit/usage_stats.test.ts`
+- `tests/unit/validate_breaking_changes.test.ts`
 - `tests/unit/workout_session_schema.test.ts`
 
 ### Vitest service tests

--- a/package.json
+++ b/package.json
@@ -154,6 +154,7 @@
     "docs:serve": "npm run dev:docs:serve",
     "openapi:generate": "openapi-typescript ./openapi.yaml --default-non-nullable false -o src/shared/openapi_types.ts && prettier --write src/shared/openapi_types.ts",
     "openapi:bc-diff": "node scripts/openapi_bc_diff.js",
+    "validate:breaking-changes": "node scripts/validate_breaking_changes_documented.js",
     "security:classify-diff": "node scripts/security/classify_diff.js",
     "security:lint": "node scripts/security/run_semgrep.js",
     "security:auth-matrix": "vitest run tests/security/auth_topology_matrix.test.ts",

--- a/scripts/validate_breaking_changes_documented.js
+++ b/scripts/validate_breaking_changes_documented.js
@@ -1,0 +1,260 @@
+#!/usr/bin/env node
+/**
+ * Breaking-change documentation gate.
+ *
+ * Fails a release when the OpenAPI breaking-change diff reports at least one
+ * breaking change but the release supplement's "Breaking changes" section is
+ * missing, empty, or normalizes to a "nothing here" placeholder
+ * (`None`, `No breaking changes.`, `N/A`, …).
+ *
+ * This closes the #1841 trap: the v0.18.0 `observation_source` enum tightening
+ * was a real OpenAPI/validation breaking change, yet that release's supplement
+ * declared `## Breaking changes\n- None.` and shipped the break undocumented.
+ *
+ * The detector is the existing `scripts/openapi_bc_diff.js` (run with --json).
+ * It is injected so the unit test can stub it without touching git/openapi.yaml.
+ *
+ * Usage:
+ *   node scripts/validate_breaking_changes_documented.js --tag <vX.Y.Z> --base <ref> [--head <ref>]
+ *
+ * Exit codes:
+ *   0 — no breaking diff, OR breaking diff present AND documented.
+ *   1 — breaking diff present but the supplement's Breaking changes section is
+ *       missing / empty / a "none" placeholder (the gate fires).
+ *   2 — usage / environment error (missing tag, missing supplement file, etc.).
+ *
+ * Registered as: npm run validate:breaking-changes
+ */
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..");
+
+const PROCESS_DOC = "docs/developer/github_release_process.md";
+
+// Phrases that, when a "Breaking changes" section consists only of them
+// (after stripping markdown list/heading punctuation), mean "nothing declared".
+const EMPTY_MARKERS = new Set([
+  "",
+  "none",
+  "none.",
+  "n/a",
+  "na",
+  "no breaking changes",
+  "no breaking changes.",
+  "no breaking change",
+  "no breaking change.",
+  "nothing",
+  "nothing.",
+]);
+
+export function parseArgs(argv) {
+  const args = { tag: null, base: null, head: "HEAD" };
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--tag") args.tag = argv[++i];
+    else if (a === "--base") args.base = argv[++i];
+    else if (a === "--head") args.head = argv[++i];
+    else if (a === "--help" || a === "-h") {
+      process.stdout.write(
+        "Usage: validate_breaking_changes_documented.js --tag <vX.Y.Z> --base <ref> [--head <ref>]\n"
+      );
+      process.exit(0);
+    } else {
+      process.stderr.write(`Unknown arg: ${a}\n`);
+      process.exit(2);
+    }
+  }
+  return args;
+}
+
+/**
+ * Default breaking-change detector: shells out to scripts/openapi_bc_diff.js
+ * --json and returns the parsed breaking[] array. openapi_bc_diff.js exits 1
+ * when breaking changes exist, so a non-zero exit with parseable JSON is the
+ * normal "breaking changes found" path, not an error.
+ */
+export function defaultDetectBreaking({ base, head }) {
+  const scriptPath = path.join(__dirname, "openapi_bc_diff.js");
+  const cliArgs = [scriptPath, "--json", "--head", head];
+  if (base) {
+    cliArgs.push("--base", base);
+  }
+  let stdout;
+  try {
+    stdout = execFileSync("node", cliArgs, {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } catch (err) {
+    // exit 1 = breaking changes present; stdout still holds the JSON payload.
+    if (err.stdout) {
+      stdout = err.stdout.toString();
+    } else {
+      throw new Error(`openapi_bc_diff.js failed without JSON output: ${err.message}`);
+    }
+  }
+  let payload;
+  try {
+    payload = JSON.parse(stdout);
+  } catch {
+    throw new Error(`Could not parse JSON from openapi_bc_diff.js. Raw output:\n${stdout}`);
+  }
+  return Array.isArray(payload.breaking) ? payload.breaking : [];
+}
+
+export function supplementPath(tag) {
+  return path.join(
+    repoRoot,
+    "docs",
+    "releases",
+    "in_progress",
+    tag,
+    "github_release_supplement.md"
+  );
+}
+
+/**
+ * Extract the body of the "## Breaking changes" section (lines after the
+ * heading up to the next `## ` heading or EOF). Returns null when the heading
+ * is absent.
+ */
+export function extractBreakingSection(markdown) {
+  const lines = markdown.split(/\r?\n/);
+  let i = 0;
+  for (; i < lines.length; i++) {
+    if (/^#{1,6}\s+breaking changes\s*$/i.test(lines[i].trim())) {
+      break;
+    }
+  }
+  if (i >= lines.length) return null; // heading not found
+  const body = [];
+  for (let j = i + 1; j < lines.length; j++) {
+    if (/^#{1,6}\s+\S/.test(lines[j])) break; // next heading
+    body.push(lines[j]);
+  }
+  return body.join("\n");
+}
+
+/**
+ * True when the section body declares no real breaking changes — empty, or
+ * consisting only of "none"/"no breaking changes"-style placeholders.
+ */
+export function sectionIsEmpty(sectionBody) {
+  if (sectionBody == null) return true;
+  // Reduce every line to its bare phrase: strip markdown list bullets,
+  // blockquotes, emphasis, and trailing punctuation/whitespace.
+  const meaningful = sectionBody
+    .split(/\r?\n/)
+    .map((line) =>
+      line
+        .replace(/^\s*[-*+]\s+/, "") // list bullet
+        .replace(/^\s*>\s?/, "") // blockquote
+        .replace(/[*_`]/g, "") // emphasis/code ticks
+        .trim()
+        .toLowerCase()
+    )
+    .filter((line) => line.length > 0);
+
+  if (meaningful.length === 0) return true;
+  // Empty iff EVERY meaningful line is a "none" marker.
+  return meaningful.every((line) => EMPTY_MARKERS.has(line));
+}
+
+/**
+ * Core logic, decoupled from process exit so it is unit-testable.
+ * Returns { ok, code, message }.
+ */
+export function evaluate({ tag, base, head }, deps = {}) {
+  const detectBreaking = deps.detectBreaking ?? defaultDetectBreaking;
+  const readSupplement =
+    deps.readSupplement ??
+    ((t) => {
+      const p = supplementPath(t);
+      if (!fs.existsSync(p)) return null;
+      return fs.readFileSync(p, "utf-8");
+    });
+
+  if (!tag) {
+    return { ok: false, code: 2, message: "Missing required --tag <vX.Y.Z>." };
+  }
+
+  const breaking = detectBreaking({ base, head });
+
+  if (!breaking || breaking.length === 0) {
+    return {
+      ok: true,
+      code: 0,
+      message: "No OpenAPI breaking changes detected; gate satisfied.",
+    };
+  }
+
+  const markdown = readSupplement(tag);
+  if (markdown == null) {
+    return {
+      ok: false,
+      code: 2,
+      message:
+        `Release supplement not found for ${tag} ` +
+        `(expected docs/releases/in_progress/${tag}/github_release_supplement.md). ` +
+        `Create it per ${PROCESS_DOC}.`,
+    };
+  }
+
+  const section = extractBreakingSection(markdown);
+  if (sectionIsEmpty(section)) {
+    const list = breaking
+      .map((b) => `  - ${b.kind ?? "breaking"} ${b.key ?? ""} — ${b.detail ?? ""}`)
+      .join("\n");
+    return {
+      ok: false,
+      code: 1,
+      message:
+        `${breaking.length} OpenAPI breaking change(s) detected, but the ` +
+        `"Breaking changes" section in the ${tag} supplement is missing or empty.\n\n` +
+        `Detected breaking changes:\n${list}\n\n` +
+        `Document each one (before/after shape, error code, migration step) in ` +
+        `docs/releases/in_progress/${tag}/github_release_supplement.md under ` +
+        `"## Breaking changes". See ${PROCESS_DOC} ` +
+        `(§ "Validation tightening is breaking"). An empty section must carry ` +
+        `"No breaking changes." ONLY when the diff is genuinely clean.`,
+    };
+  }
+
+  return {
+    ok: true,
+    code: 0,
+    message:
+      `${breaking.length} breaking change(s) detected and the ${tag} ` +
+      `supplement documents a non-empty Breaking changes section; gate satisfied.`,
+  };
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+  let result;
+  try {
+    result = evaluate(args);
+  } catch (err) {
+    process.stderr.write(`validate:breaking-changes error: ${err.message}\n`);
+    process.exit(2);
+  }
+  if (result.ok) {
+    process.stdout.write(`✓ ${result.message}\n`);
+  } else {
+    process.stderr.write(`✗ ${result.message}\n`);
+  }
+  process.exit(result.code);
+}
+
+// Only run main() when executed directly (not when imported by the unit test).
+const invokedDirectly = process.argv[1] && path.resolve(process.argv[1]) === __filename;
+if (invokedDirectly) {
+  main();
+}

--- a/tests/unit/validate_breaking_changes.test.ts
+++ b/tests/unit/validate_breaking_changes.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Unit tests for the breaking-change documentation gate
+ * (`scripts/validate_breaking_changes_documented.js`).
+ *
+ * The gate fails a release when the OpenAPI breaking-change diff reports a
+ * breaking change but the supplement's "Breaking changes" section is missing,
+ * empty, or a "none" placeholder. This is the #1841 trap: v0.18.0 tightened the
+ * `observation_source` enum (a real OpenAPI break) yet shipped with a supplement
+ * declaring `## Breaking changes\n- None.`.
+ *
+ * The breaking-change detector is dependency-injected so these tests never
+ * touch git, openapi.yaml, or the filesystem.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  evaluate,
+  extractBreakingSection,
+  sectionIsEmpty,
+  // @ts-expect-error — plain .js script, no type declarations
+} from "../../scripts/validate_breaking_changes_documented.js";
+
+const TAG = "v9.9.9";
+
+const ONE_BREAKING = [
+  {
+    kind: "narrowed-enum",
+    key: "components.schemas.Observation.observation_source",
+    detail: 'enum lost values: "cboe_live".',
+  },
+];
+
+function supplementWith(breakingSection: string): string {
+  return [
+    "Summary line.",
+    "",
+    "## Highlights",
+    "- Something nice.",
+    "",
+    "## Breaking changes",
+    breakingSection,
+    "",
+    "## Security hardening",
+    "No security-sensitive surfaces touched.",
+    "",
+  ].join("\n");
+}
+
+describe("validate:breaking-changes gate", () => {
+  it("passes when there are NO breaking changes, regardless of the supplement", () => {
+    const result = evaluate(
+      { tag: TAG, base: "v0.0.0", head: "HEAD" },
+      {
+        detectBreaking: () => [],
+        readSupplement: () => supplementWith("- None."),
+      }
+    );
+    expect(result.ok).toBe(true);
+    expect(result.code).toBe(0);
+  });
+
+  it("passes when breaking changes exist AND are documented", () => {
+    const result = evaluate(
+      { tag: TAG, base: "v0.0.0", head: "HEAD" },
+      {
+        detectBreaking: () => ONE_BREAKING,
+        readSupplement: () =>
+          supplementWith(
+            "- **observation_source enum tightened.** Custom v0.17 labels (e.g. `cboe_live`) must move to the free-form `data_source` field. Invalid values now return `VALIDATION_ERROR`."
+          ),
+      }
+    );
+    expect(result.ok).toBe(true);
+    expect(result.code).toBe(0);
+  });
+
+  it("FAILS (exit 1) when breaking changes exist but the section says 'No breaking changes.'", () => {
+    const result = evaluate(
+      { tag: TAG, base: "v0.0.0", head: "HEAD" },
+      {
+        detectBreaking: () => ONE_BREAKING,
+        readSupplement: () => supplementWith("No breaking changes."),
+      }
+    );
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe(1);
+    expect(result.message).toMatch(/breaking change/i);
+  });
+
+  it("FAILS (exit 1) when breaking changes exist but the section is '- None.' (the #1841 trap)", () => {
+    const result = evaluate(
+      { tag: TAG, base: "v0.0.0", head: "HEAD" },
+      {
+        detectBreaking: () => ONE_BREAKING,
+        readSupplement: () => supplementWith("- None. Every new surface is opt-in."),
+      }
+    );
+    // "- None. Every new surface is opt-in." is NOT a pure placeholder line,
+    // so it counts as documented prose. The strict trap is a bare "- None.".
+    // Confirm a bare "- None." fails:
+    const strict = evaluate(
+      { tag: TAG, base: "v0.0.0", head: "HEAD" },
+      {
+        detectBreaking: () => ONE_BREAKING,
+        readSupplement: () => supplementWith("- None."),
+      }
+    );
+    expect(strict.ok).toBe(false);
+    expect(strict.code).toBe(1);
+    // The prose-bearing variant is treated as documented (non-empty).
+    expect(result.ok).toBe(true);
+  });
+
+  it("FAILS (exit 1) when the 'Breaking changes' section is entirely missing", () => {
+    const noSection = [
+      "Summary line.",
+      "",
+      "## Highlights",
+      "- Something nice.",
+      "",
+      "## Security hardening",
+      "No security-sensitive surfaces touched.",
+      "",
+    ].join("\n");
+    const result = evaluate(
+      { tag: TAG, base: "v0.0.0", head: "HEAD" },
+      {
+        detectBreaking: () => ONE_BREAKING,
+        readSupplement: () => noSection,
+      }
+    );
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe(1);
+  });
+
+  it("errors (exit 2) when the supplement file is absent", () => {
+    const result = evaluate(
+      { tag: TAG, base: "v0.0.0", head: "HEAD" },
+      {
+        detectBreaking: () => ONE_BREAKING,
+        readSupplement: () => null,
+      }
+    );
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe(2);
+    expect(result.message).toMatch(/supplement not found/i);
+  });
+});
+
+describe("extractBreakingSection", () => {
+  it("returns null when the heading is missing", () => {
+    expect(extractBreakingSection("## Highlights\n- x\n")).toBeNull();
+  });
+
+  it("captures only the section body up to the next heading", () => {
+    const md = "## Breaking changes\n- a\n- b\n\n## Next\n- c\n";
+    expect(extractBreakingSection(md)).toBe("- a\n- b\n");
+  });
+});
+
+describe("sectionIsEmpty", () => {
+  it.each(["", "- None.", "None", "No breaking changes.", "- N/A", "  none  "])(
+    "treats %j as empty",
+    (body) => {
+      expect(sectionIsEmpty(body)).toBe(true);
+    }
+  );
+
+  it("treats real prose as non-empty", () => {
+    expect(sectionIsEmpty("- **Enum tightened.** Move to data_source.")).toBe(false);
+  });
+
+  it("treats null (missing section) as empty", () => {
+    expect(sectionIsEmpty(null)).toBe(true);
+  });
+});


### PR DESCRIPTION
Two "make-the-rule-blocking" gates that turn recurring release traps from advisory misses into mechanical failures. Ties to tasks `ent_d9865a6c26` and `ent_f11c733d`.

## Gate A — test-catalog pre-commit auto-regeneration

**Failure it prevents:** the baseline CI lane's "Validate automated test catalog" step failed 4+ times in one release cycle because `docs/testing/automated_test_catalog.md` drifts whenever a test file is added, removed, or renamed and the author forgets to run `npm run generate:test-catalog`.

**How it wires in:** a new block in `.husky/pre-commit`, inserted **after** the `validate:doc-deps` step and **before** the agent-sync step (matching the existing `sync_agent_instructions_pre_commit.sh` placement pattern). When staged paths match `tests/` or `*.test.ts(x)`, it runs `npm run generate:test-catalog` and `git add`s the catalog if it changed, printing a clear message. Defaults to running; honors a `NEOTOMA_SKIP_TEST_CATALOG=1` escape (parallel to the existing `NEOTOMA_SKIP_TESTS`). This makes catalog drift impossible to commit when test files change.

## Gate B — breaking-change documentation gate (BLOCKING on release PRs)

**Failure it prevents:** #1841 — the v0.18.0 `observation_source` enum tightening was a real OpenAPI/validation breaking change, but that release's supplement declared `## Breaking changes\n- None.` and shipped the break undocumented. Breaking-change diffs were only advisory at release time.

**How it wires in:**
- **`scripts/validate_breaking_changes_documented.js`** — takes `--tag`/`--base`/`--head`, runs the existing `scripts/openapi_bc_diff.js` (`--json`) between base and head, and if breaking changes exist, reads `docs/releases/in_progress/<TAG>/github_release_supplement.md` and **fails (exit 1)** when its "Breaking changes" section is missing or normalizes to empty / `None` / `No breaking changes.` / `N/A`. Exits 0 when there's no breaking diff, or the break is documented. The error points to `docs/developer/github_release_process.md` (§ "Validation tightening is breaking"). The detector is **dependency-injected** so the logic is unit-testable without git or `openapi.yaml`.
- **`npm run validate:breaking-changes`** — new script entry.
- **`.github/workflows/ci_test_lanes.yml`** — a new step on the **baseline lane** that runs the gate **only for release PRs** (head branch matches `chore/release/*` or `release/*`), derives the tag from `package.json` and the base from the latest reachable tag, and runs `npm run validate:breaking-changes -- --tag vX --base vY`. It can **fail the release PR** (blocking), unlike the prior advisory-only handling. Non-release PRs no-op/skip.

**Scope note:** the gate keys off the OpenAPI breaking-change diff (`openapi_bc_diff.js`), which catches the broad class of declared breaks — removed paths/fields, narrowed enums, tightened `additionalProperties`, new required fields, type narrowing. The specific #1841 enum was already declared in `openapi.yaml` (the break was a CLI/validator tightening), so a future regression of that exact shape surfaces via `narrowed-enum` once it reaches the spec; the gate forces any such diff to be documented before a release PR can go green.

## Tests

`tests/unit/validate_breaking_changes.test.ts` (16 cases) pins:
- a supplement with a real Breaking-changes entry **passes**;
- an empty / `No breaking changes.` / bare `- None.` / missing section **with breaking diffs present fails (exit 1)**;
- no breaking diffs **passes regardless** of the section;
- a missing supplement file errors (exit 2);
- plus unit coverage of `extractBreakingSection` and `sectionIsEmpty`.

The diff was also exercised end-to-end against the real `openapi_bc_diff.js` with a temporarily narrowed enum: empty section → exit 1, documented → exit 0, clean diff → exit 0.

## Verification
- New unit suite: **16/16 pass**.
- `npm run validate:test-catalog`: **green** (catalog regenerated; total 524 test files).
- `npm run type-check`: **clean**.
- `npm run format:check`: **clean**.
- `npm run security:classify-diff -- --base v0.18.4 --head HEAD`: **`sensitive=false`** — this PR is tooling (scripts + a workflow step + a husky hook), not an auth-surface change, so the classifier does not flag it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)