### PR TITLE
chore(release): v0.18.5 — official cross-origin Inspector embed mode (#1861)

### DIFF
--- a/docs/releases/in_progress/v0.18.5/github_release_supplement.md
+++ b/docs/releases/in_progress/v0.18.5/github_release_supplement.md
@@ -1,0 +1,48 @@
+Official cross-origin embed support for the Inspector graph: an allowlisted host can now iframe `/embed/graph` directly and let its browser fetch the two graph read endpoints cross-origin, without running a same-origin reverse proxy. Opt-in and secure-by-default.
+
+## Highlights
+
+- **Cross-origin Inspector graph embed, natively.** A new `NEOTOMA_EMBED_ALLOWED_ORIGINS` env config lists the host origins allowed to embed. For those origins only, Neotoma emits `Content-Security-Policy: frame-ancestors 'self' <origins>` and drops `X-Frame-Options` on the `/embed/*` shell, and answers scoped CORS on the two graph read endpoints. An embedding host no longer needs to reverse-proxy the shell, rewrite the CSP, strip `X-Frame-Options`, or re-host the data path. Implemented in `src/services/embed_cross_origin.ts` (pure helpers) + `src/actions.ts` (opt-in middleware).
+- **Secure by default.** With `NEOTOMA_EMBED_ALLOWED_ORIGINS` unset or empty, the embed middleware is inert and every response is byte-identical to the prior locked-down `'self'` / `SAMEORIGIN` posture. Nothing changes for anyone who does not opt in.
+
+## What changed for npm package users
+
+**Runtime / config**
+
+- New env var `NEOTOMA_EMBED_ALLOWED_ORIGINS` (comma-separated origins, scheme + host + optional port, no path). Invalid or path-bearing entries are dropped. Unset = today's behavior.
+- When configured, two response behaviors change **only for allowlisted traffic**:
+  1. `/embed/*` shell responses carry `frame-ancestors 'self' <origins>` and no `X-Frame-Options`, so an allowlisted host can frame them.
+  2. The two graph read endpoints `POST /entities/query` and `POST /retrieve_graph_neighborhood` receive scoped CORS (exact-origin echo, never `*`, no credentials, `POST`/`OPTIONS` only) and preflight handling.
+- Write endpoints (`/store`, `/correct`, `/submit`, …) are **never** CORS-enabled by this middleware, so a browser on an allowlisted origin can never reach them cross-origin.
+
+**Shipped artifacts**
+
+- `openapi.yaml` — unchanged; no new routes. The middleware only adds response headers on existing routes. Protected-routes manifest unchanged (115 routes).
+- `dist/` — updated for the new service + middleware.
+
+## API surface & contracts
+
+No new routes and no request/response body changes. The change is purely additive response headers, gated on config + origin. `docs/subsystems/inspector_embed_cross_origin.md` documents the embed data contract (the two read endpoints, the `?apiBase=` shell parameter, the `<meta name="neotoma-api-base">` injection point) so embedding hosts can build against a stable, versioned contract.
+
+## Behavior changes
+
+- With an allowlist configured, allowlisted origins gain the two behaviors above. Everything else is unchanged. With no allowlist configured, there is no behavior change at all.
+
+## Fixes / features
+
+- **Official cross-origin Inspector embed mode** (PR #1861, epic #1606). Replaces the same-origin reverse-proxy pattern an external evaluator (Jeroen van 't Hoff, OPSCHUDDING) had built to embed the graph in his app. All four pieces of that proxy hack — `X-Frame-Options` strip, `frame-ancestors` rewrite, same-origin data proxy, and `crossorigin`/api-base shell rewrite — are obviated natively (the last because framing Neotoma directly serves its assets same-origin). Read-only embed auth reuses Neotoma's existing read-only guest/access machinery rather than a new token type.
+
+## Tests and validation
+
+- `tests/services/embed_cross_origin.test.ts` — 21 unit assertions on the pure helpers (origin allowlist parsing/canonicalization, `frame-ancestors` build/rewrite, scoped CORS header construction, read-endpoint + shell-path matching).
+- `tests/integration/embed_cross_origin_http.test.ts` — 6 HTTP effect assertions against the real Express app: an allowlisted origin gets `frame-ancestors` + its origin and no `X-Frame-Options`; non-embed paths keep the locked-down `X-Frame-Options` (secure-by-default); CORS preflight from an allowlisted origin on both read endpoints is answered with scoped CORS and no credentials; a non-allowlisted origin gets no CORS; and write endpoints get no CORS even from an allowlisted origin.
+- Ran in the PR-gating `contract_parity` and `baseline` lanes; both green on merge.
+- Security gates: G1 (`security:classify-diff`) flagged `src/actions.ts` as auth-adjacent; manual adversarial review (see security_review.md) confirmed secure-by-default, no wildcard CORS, no credentialed CORS, and write endpoints unreachable cross-origin. G2 (`security:lint`) 0 errors. G3 (`security:manifest:check` 115 routes in sync + `test:security:auth-matrix` 18 passed / 1 skipped) passed.
+
+## Security hardening
+
+This release adds an **opt-in** relaxation of cross-origin framing and fetch for explicitly-allowlisted host origins. It is off by default and, when on, is bounded to the configured origins and the two read endpoints. See [docs/releases/in_progress/v0.18.5/security_review.md](security_review.md) — verdict: **yes** (secure-by-default; bounded relaxation; write path unreachable cross-origin).
+
+## Breaking changes
+
+None. No OpenAPI changes, no request-shape changes. Additive, config-gated response headers. Secure-by-default. Patch bump is correct per SemVer.

--- a/docs/releases/in_progress/v0.18.5/security_review.md
+++ b/docs/releases/in_progress/v0.18.5/security_review.md
@@ -1,0 +1,69 @@
+# Security review — v0.18.5
+
+Manual adversarial security review. The diff classifier flagged this release sensitive because it adds an opt-in relaxation of cross-origin framing and fetch. This review records the adversarial pass and the verdict. The supplement's `Security hardening` section links it.
+
+## Scope
+
+- Base ref: `v0.18.4`
+- Head ref: `HEAD`
+- Diff classifier: **sensitive** (`sensitive=true`) — reason: `auth-middleware: src/actions.ts` (the embed middleware lives there; it relaxes framing/CORS, which is genuinely security-relevant).
+- Protected routes manifest: 115 routes, **unchanged** (the change adds no routes, only response headers).
+- Changed files: 9 (2 embed source, 1 config, 1 design doc, 2 test, 1 generated catalog, 2 skill docs).
+
+## Adversarial review prompt
+
+Treat the diff as if you were an attacker. For each concern, name a concrete request that exercises the failure mode, then confirm the gate catches it.
+
+1. **Default posture.** With no allowlist configured, does anything change vs. today's locked-down `'self'`/`SAMEORIGIN`?
+2. **Framing relaxation scope.** Can a non-allowlisted origin frame `/embed/graph`? Can an allowlisted origin frame anything beyond `/embed/*`?
+3. **CORS wildcard / credentials.** Does the CORS ever emit `Access-Control-Allow-Origin: *` or `Access-Control-Allow-Credentials: true`?
+4. **Origin spoofing.** Can a forged `Origin` header not on the allowlist obtain CORS?
+5. **Write reachability.** Can a browser on an allowlisted origin reach `/store`, `/correct`, or any write endpoint cross-origin?
+6. **Preflight-before-auth.** The OPTIONS preflight is answered before the auth stack. Does that leak anything or bypass auth on the actual data request?
+7. **Config injection.** Can a malformed `NEOTOMA_EMBED_ALLOWED_ORIGINS` value widen the surface (path-bearing entry, `null`, wildcard)?
+
+## Findings
+
+1. **Secure by default (concern 1).** `parseAllowedEmbedOrigins(process.env[…])` yields `[]` when unset/empty; the middleware's first line is `if (embedAllowedOrigins.length === 0) return next();`. No config → inert → byte-identical to prior behavior. Confirmed by `test:security:auth-matrix` (18 pass / 1 skipped, unchanged) and the manifest check (115 routes unchanged). No default-posture change.
+
+2. **Framing relaxation is bounded (concern 2).** The `frame-ancestors` rewrite is applied only on `isEmbedShellPath(reqPath)` (`/embed` or `/embed/*`), and the emitted directive is `frame-ancestors 'self' <configured origins>` — it lists only the configured allowlist, so emitting it grants nothing beyond the allowlist. A non-allowlisted origin trying to frame `/embed/graph` is refused by the browser against that CSP. A non-`/embed` path never has its `X-Frame-Options`/CSP touched. Concern 2 closed. (Test: "non-embed paths keep the locked-down X-Frame-Options".)
+
+3. **No wildcard, no credentials (concern 3).** `embedCorsHeaders(origin)` sets `Access-Control-Allow-Origin: <exact canonical origin>`, never `*`, and emits no `Access-Control-Allow-Credentials` header at all. Methods are limited to `POST, OPTIONS`. (Test: preflight asserts `access-control-allow-credentials` is null and the origin is echoed exactly.)
+
+4. **Origin spoofing gets nothing (concern 4).** CORS headers are set only when `isOriginAllowed(requestOrigin, embedAllowedOrigins)` is true; that canonicalizes the request Origin and checks membership. A forged Origin not on the allowlist receives no CORS. `"null"`/opaque origins are explicitly rejected. (Test: "a NON-allowlisted origin gets NO embed CORS".)
+
+5. **Write path unreachable cross-origin (concern 5).** CORS is gated on `isEmbedReadEndpoint(reqPath)`, whose set is exactly `/entities/query` + `/retrieve_graph_neighborhood`. No write endpoint is ever in that set, so `/store`,`/correct`,`/submit` receive no `Access-Control-Allow-Origin` even from an allowlisted origin — the browser blocks the cross-origin write. (Test: "write endpoints never get embed CORS even from an allowlisted origin".) This is the browser-enforced equivalent of the evaluator's default-deny POST allowlist.
+
+6. **Preflight-before-auth is correct (concern 6).** The middleware answers `OPTIONS` with `204` before the auth stack, as browsers require (preflight must not need a bearer). This leaks nothing: the preflight response carries only CORS headers, no data. The *actual* data `POST` still flows through the unchanged auth stack after this middleware calls `next()` — so server-side authorization on `/entities/query` and `/retrieve_graph_neighborhood` is unchanged. CORS is an additional browser-side gate, not a replacement for auth.
+
+7. **Config injection resisted (concern 7).** `parseAllowedEmbedOrigins` validates each entry with the URL parser, requires `http:`/`https:`, rejects any entry with a path/query/fragment, reduces to canonical `origin`, and de-duplicates. A wildcard, a path-bearing entry, or a malformed value is dropped, not honored. There is no way to express `*` as an allowed origin.
+
+- **G2 security:lint:** 0 errors, 125 warnings (all pre-existing; none in the changed lines).
+- **G3 security:manifest:check + test:security:auth-matrix:** both passed (115 routes in sync; 18 passed / 1 skipped).
+
+## Suggested negative tests
+
+The added `embed_cross_origin_http.test.ts` already encodes the key negatives (non-allowlisted origin gets no CORS; write endpoints get no CORS; non-embed paths stay locked down; secure-by-default). No additional negative test is required for this diff.
+
+## Residual risks
+
+- The relaxation is real but opt-in and bounded: an operator who configures `NEOTOMA_EMBED_ALLOWED_ORIGINS` is explicitly allowing those origins to frame the graph and read via the two endpoints. That is the intended capability. Operators should set the allowlist to exactly the host origins they trust and no broader. Documented in `.env.example` and `docs/subsystems/inspector_embed_cross_origin.md`.
+- A self-contained Neotoma-minted short-TTL embed token is deferred; the current model reuses existing read-only guest/access machinery. This does not widen the surface — it is a usability follow-up, not a security gap.
+
+## Sign-off
+
+| Reviewer | Verdict | Date |
+|----------|---------|------|
+| ateles-agent (manual) | yes | 2026-06-30 |
+
+Verdict `yes` — opt-in, secure-by-default, bounded to configured origins and the two read endpoints; no wildcard/credentialed CORS; write path unreachable cross-origin; server-side auth unchanged. No block.
+
+## Diff appendix
+
+- `src/services/embed_cross_origin.ts`
+- `src/actions.ts`
+- `.env.example`
+- `docs/subsystems/inspector_embed_cross_origin.md`
+- `tests/integration/embed_cross_origin_http.test.ts`
+- `tests/services/embed_cross_origin.test.ts`
+- `docs/testing/automated_test_catalog.md`

--- a/docs/releases/in_progress/v0.18.5/test_coverage_review.md
+++ b/docs/releases/in_progress/v0.18.5/test_coverage_review.md
@@ -1,0 +1,38 @@
+# Test coverage review — v0.18.5
+
+## Scope
+
+Release diff: `v0.18.4..HEAD`. One feature (official cross-origin Inspector embed mode, PR #1861) plus two skill-doc updates (`/status`, `/end` whole-session coverage) that carry no runtime behavior.
+
+## Code review
+
+The feature is an opt-in, config-gated middleware plus a pure helper module. It adds response headers on existing routes; it adds no routes, no request/response body changes, no schema changes, no migrations. The security-sensitive surface (CORS + frame-ancestors relaxation) is covered by the security review; this review covers behavioral test adequacy.
+
+Verdict: **ADVISORY only** — no BLOCKING gaps. The feature ships with effect-level HTTP tests that assert the observable outcome on the real Express app, plus unit tests on the brittle header-manipulation helpers.
+
+## Surface coverage
+
+### `src/services/embed_cross_origin.ts` — pure helpers
+
+- **Change:** origin-allowlist parsing/canonicalization, `frame-ancestors` directive build + CSP rewrite, scoped CORS header construction, read-endpoint + embed-shell-path matching.
+- **Classification:** pure logic; the provably-brittle header manipulation.
+- **Coverage:** `tests/services/embed_cross_origin.test.ts` — 21 unit assertions covering allowlist parsing (valid/invalid/path-bearing/duplicate/empty), origin matching (canonical, `null`, opaque), `frame-ancestors` build + rewrite (present/absent directive), and the CORS header shape. All pass.
+
+### `src/actions.ts` — opt-in middleware
+
+- **Change:** wires the helpers into an Express middleware after Helmet, before global `cors()` and the auth stack; secure-by-default early-return when no allowlist.
+- **Classification:** user-observable HTTP behavior; security-sensitive.
+- **Coverage:** `tests/integration/embed_cross_origin_http.test.ts` — 6 HTTP effect assertions against the real app: (1) allowlisted origin gets `frame-ancestors` + its origin, X-Frame-Options dropped; (2) non-embed paths keep locked-down X-Frame-Options (secure-by-default); (3) CORS preflight on `/entities/query` answered with scoped CORS, no credentials; (4) same for `/retrieve_graph_neighborhood`; (5) non-allowlisted origin gets no CORS; (6) write endpoints get no CORS even from an allowlisted origin. These assert the EFFECT, not just that config is accepted — the exact discipline required by the fixed-means-effect policy. All pass. Ran in the PR-gating `contract_parity` and `baseline` lanes.
+
+## Surfaces that do NOT apply to this release
+
+- Destructive / data-mutating operations: none.
+- External file-shape parsers: none.
+- New CLI commands or flags: none.
+- New HTTP/MCP routes: none (headers only; manifest unchanged at 115 routes).
+- Migrations: none.
+- Skill-doc changes (`/status`, `/end`): documentation only, no runtime code.
+
+## Verdict
+
+No BLOCKING coverage gaps. The feature has both unit coverage on the brittle helpers and end-to-end HTTP coverage asserting the observable security-relevant effects, including the negative cases (non-allowlisted origin, write endpoints, non-embed paths). Release may proceed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neotoma",
-  "version": "0.18.4",
+  "version": "0.18.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neotoma",
-      "version": "0.18.4",
+      "version": "0.18.5",
       "license": "MIT",
       "dependencies": {
         "@hellocoop/httpsig": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neotoma",
-  "version": "0.18.4",
+  "version": "0.18.5",
   "description": "MCP server for structured personal data memory with unified source ingestion",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
Patch release shipping the official cross-origin Inspector graph embed mode (#1861, epic #1606), which merged to main after v0.18.4 was cut and is therefore not yet in any published release.

## What ships
- **Cross-origin Inspector embed** — `NEOTOMA_EMBED_ALLOWED_ORIGINS`-gated `frame-ancestors` + scoped CORS on the two graph read endpoints (`/entities/query`, `/retrieve_graph_neighborhood`), so an allowlisted host can iframe `/embed/graph` directly without a same-origin reverse proxy.
- **Opt-in, secure-by-default** — unset allowlist = byte-identical to today's `'self'`/`SAMEORIGIN`. No wildcard CORS, no credentialed CORS, write endpoints never CORS-reachable cross-origin.

## Origin
Requested by evaluator Jeroen van 't Hoff (OPSCHUDDING), who had built a same-origin reverse-proxy hack to embed the graph. All four pieces of that hack are now obviated natively.

## Release artifacts
- `docs/releases/in_progress/v0.18.5/github_release_supplement.md`
- `docs/releases/in_progress/v0.18.5/security_review.md` — verdict **yes** (manual adversarial review of the CORS/frame-ancestors relaxation; secure-by-default, bounded, write path unreachable)
- `docs/releases/in_progress/v0.18.5/test_coverage_review.md`

## Gates
- `security:classify-diff`: sensitive=true (opt-in cross-origin relaxation); manual review = secure-by-default, no wildcard/credentialed CORS, writes unreachable
- `security:lint`: 0 errors · `security:manifest:check`: 115 routes in sync (no new routes) · `test:security:auth-matrix`: 18 passed / 1 skipped
- Feature tests (27: 21 unit + 6 HTTP effect) merged green via #1861 in the `contract_parity` + `baseline` lanes

🤖 Generated with [Claude Code](https://claude.com/claude-code)