### PR TITLE
fix(inspector): render graph edges + fit viewport (blank-canvas bug)

### DIFF
--- a/inspector/src/components/shared/graph_auto_fit.tsx
+++ b/inspector/src/components/shared/graph_auto_fit.tsx
@@ -1,0 +1,84 @@
+import { useEffect } from "react";
+import { useReactFlow, useStoreApi } from "@xyflow/react";
+
+/**
+ * Forces a node-internals measurement pass + `fitView` after the rendered node
+ * set changes, retrying until React Flow reports the nodes as measured.
+ *
+ * Why this exists — the blank-canvas bug (Jeroen repro, embed task
+ * ent_a876f38dd8ed65eb2ad331ee): on some environments React Flow v12's
+ * per-node `ResizeObserver` never fires its initial measurement callback, so
+ * every node's `measured` stays `{}` and `nodesInitialized` stays `false`.
+ * With no measured dimensions:
+ *   - `getFitViewNodes()` treats every node as invisible → `fitView` is a
+ *     no-op and the viewport sits at the identity transform, and
+ *   - `getEdgePosition()` bails for every edge → edges silently never draw.
+ * The visible result is a graph whose nodes render un-fitted with no edges,
+ * or — for a neighborhood laid out off the initial viewport — a fully blank
+ * canvas, with ZERO console errors (measurement failing is silent).
+ *
+ * We call the store's `updateNodeInternals` directly with each node's DOM
+ * element (`force: true`). That re-reads `offsetWidth`/`offsetHeight` from the
+ * DOM and writes `measured`, bypassing the (silently unfired) ResizeObserver.
+ * We retry on a `setTimeout` cadence (not `requestAnimationFrame`, which is
+ * paused in background/hidden tabs) because the node DOM may not be laid out
+ * yet when the effect first runs, then `fitView` once bounds are real.
+ * Rendered as a child of `<ReactFlow>` so the hooks resolve against its store.
+ * Shared by the standalone `/graph` explorer and the chrome-less
+ * `/embed/graph` route, so both are fixed by the one component.
+ */
+const MAX_ATTEMPTS = 30;
+const RETRY_MS = 16;
+
+export function GraphAutoFit({ nodeIds }: { nodeIds: string[] }) {
+  const store = useStoreApi();
+  const { fitView } = useReactFlow();
+  // Re-run only when the actual membership changes, not on every render.
+  const key = nodeIds.join("|");
+
+  useEffect(() => {
+    if (nodeIds.length === 0) return;
+    let cancelled = false;
+    let attempts = 0;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const measureAll = (): boolean => {
+      const { domNode, nodeLookup, updateNodeInternals } = store.getState();
+      if (!domNode) return false;
+      const updates = new Map<string, { id: string; nodeElement: Element; force: true }>();
+      for (const id of nodeIds) {
+        const nodeElement = domNode.querySelector(`.react-flow__node[data-id="${CSS.escape(id)}"]`);
+        if (nodeElement) updates.set(id, { id, nodeElement, force: true });
+      }
+      if (updates.size > 0) {
+        // Direct store action — synchronously writes `measured` from the DOM.
+        (updateNodeInternals as (u: typeof updates) => void)(updates);
+      }
+      return nodeIds.every((id) => {
+        const measured = nodeLookup.get(id)?.measured;
+        return !!(measured && measured.width && measured.height);
+      });
+    };
+
+    const tick = () => {
+      if (cancelled) return;
+      attempts += 1;
+      const done = measureAll();
+      if (done || attempts >= MAX_ATTEMPTS) {
+        void fitView({ padding: 0.2 });
+        return;
+      }
+      timer = setTimeout(tick, RETRY_MS);
+    };
+
+    tick();
+    return () => {
+      cancelled = true;
+      if (timer !== null) clearTimeout(timer);
+    };
+    // Intentionally keyed on the node-id membership string only: `store` and
+    // `fitView` are stable, and `nodeIds` is re-derived every render.
+  }, [key]);
+
+  return null;
+}

--- a/inspector/src/lib/graph_layout.test.ts
+++ b/inspector/src/lib/graph_layout.test.ts
@@ -24,7 +24,11 @@ describe("graph_layout", () => {
         entity: { id: "ent_focus", canonical_name: "neotoma", entity_type: "company" },
         related_entities: [{ id: "ent_a", canonical_name: "Plan A", entity_type: "plan" }],
         relationships: [
-          { source_entity_id: "ent_a", target_entity_id: "ent_focus", relationship_type: "REFERS_TO" },
+          {
+            source_entity_id: "ent_a",
+            target_entity_id: "ent_focus",
+            relationship_type: "REFERS_TO",
+          },
         ],
       },
       "ent_focus"
@@ -55,13 +59,77 @@ describe("graph_layout", () => {
     expect(child1.y).toBeLessThan(child2.y);
   });
 
+  // Regression for the Inspector blank-canvas bug (Jeroen repro / embed task
+  // ent_a876f38dd8ed65eb2ad331ee): React Flow silently drops edges and no-ops
+  // `fitView` when nodes have no dimensions. `graphSpecToFlow` must emit
+  // `initialWidth`/`initialHeight` on every node so edge geometry and
+  // `getNodesBounds` have a fallback before measurement, and every edge must
+  // reference two node ids that actually exist in the flow node set. Shared by
+  // the standalone /graph explorer and /embed/graph.
+  it("emits finite positions, dimension hints, and edges wired to real nodes for Jeroen's shape", () => {
+    // Exact server response shape (from prod retrieve_graph_neighborhood):
+    // `entity` + `related_entities` are `entities` rows (field `id`);
+    // `relationships` are `relationship_snapshots` rows.
+    const spec = buildGraphFromNeighborhood(
+      {
+        node_id: "ent_focus_contact",
+        node_type: "entity",
+        entity: {
+          id: "ent_focus_contact",
+          entity_type: "contact",
+          canonical_name: "Naresh Sital",
+        },
+        relationships: [
+          {
+            source_entity_id: "ent_msg_a",
+            target_entity_id: "ent_focus_contact",
+            relationship_type: "REFERS_TO",
+          },
+          {
+            source_entity_id: "ent_msg_b",
+            target_entity_id: "ent_focus_contact",
+            relationship_type: "REFERS_TO",
+          },
+        ],
+        related_entities: [
+          { id: "ent_msg_a", entity_type: "conversation_message", canonical_name: "msg a" },
+          { id: "ent_msg_b", entity_type: "conversation_message", canonical_name: "msg b" },
+        ],
+      },
+      "ent_focus_contact"
+    );
+
+    const { flowNodes, flowEdges } = graphSpecToFlow(spec, "tree", null);
+
+    expect(flowNodes).toHaveLength(3);
+    expect(flowEdges).toHaveLength(2);
+
+    for (const node of flowNodes) {
+      expect(Number.isFinite(node.position.x)).toBe(true);
+      expect(Number.isFinite(node.position.y)).toBe(true);
+      // Dimension hints back edge geometry + fitView bounds before measurement.
+      expect(node.initialWidth).toBeGreaterThan(0);
+      expect(node.initialHeight).toBeGreaterThan(0);
+    }
+
+    const nodeIds = new Set(flowNodes.map((n) => n.id));
+    for (const edge of flowEdges) {
+      expect(nodeIds.has(edge.source)).toBe(true);
+      expect(nodeIds.has(edge.target)).toBe(true);
+    }
+  });
+
   it("hides edge labels until hovered", () => {
     const spec = buildGraphFromNeighborhood(
       {
         entity: { id: "ent_focus" },
         related_entities: [{ id: "ent_a" }],
         relationships: [
-          { source_entity_id: "ent_a", target_entity_id: "ent_focus", relationship_type: "REFERS_TO" },
+          {
+            source_entity_id: "ent_a",
+            target_entity_id: "ent_focus",
+            relationship_type: "REFERS_TO",
+          },
         ],
       },
       "ent_focus"

--- a/inspector/src/lib/graph_layout.ts
+++ b/inspector/src/lib/graph_layout.ts
@@ -26,6 +26,15 @@ export interface GraphSpec {
   edges: GraphEdgeSpec[];
 }
 
+/**
+ * Fallback node dimensions used as `initialWidth`/`initialHeight` on every
+ * flow node. They match the default React Flow node box (≈150×40) closely
+ * enough for `fitView` bounds and edge-path geometry to be correct before the
+ * ResizeObserver reports the real measured size. See `graphSpecToFlow`.
+ */
+const NODE_INITIAL_WIDTH = 150;
+const NODE_INITIAL_HEIGHT = 40;
+
 const TREE_ORIGIN_X = 40;
 const TREE_CHILD_X = 360;
 const TREE_ROW_SPACING = 72;
@@ -143,9 +152,7 @@ export function applyGraphLayout(
   const focus = spec.nodes.find((n) => n.id === spec.focusId || n.kind === "focus");
   const focusId = focus?.id ?? spec.focusId;
 
-  const neighbors = spec.nodes
-    .filter((n) => n.id !== focusId)
-    .sort(compareGraphNodeSpecs);
+  const neighbors = spec.nodes.filter((n) => n.id !== focusId).sort(compareGraphNodeSpecs);
 
   if (mode === "tree") {
     const totalHeight = Math.max(neighbors.length - 1, 0) * TREE_ROW_SPACING;
@@ -235,6 +242,15 @@ export function graphSpecToFlow(
     position: positions.get(node.id) ?? { x: 0, y: 0 },
     data: { label: node.label, raw: node.raw },
     style: nodeStyle(node.kind),
+    // Dimension hints so edge geometry and `getNodesBounds` have a fallback
+    // before React Flow's per-node measurement populates `measured`. React
+    // Flow overrides these with the real measured size once it observes the
+    // DOM node, so labels of any size still render normally. This alone is
+    // NOT sufficient — `fitView` strictly requires `measured` — which is why
+    // the graph pages also force a node-internals measurement pass after the
+    // nodes mount (see GraphAutoFit). Shared by /graph and /embed/graph.
+    initialWidth: NODE_INITIAL_WIDTH,
+    initialHeight: NODE_INITIAL_HEIGHT,
   }));
 
   const flowEdges: Edge[] = spec.edges.map((edge) => ({

--- a/inspector/src/pages/embed_graph.tsx
+++ b/inspector/src/pages/embed_graph.tsx
@@ -50,6 +50,7 @@ import {
   graphSpecToFlow,
   type GraphLayoutMode,
 } from "@/lib/graph_layout";
+import { GraphAutoFit } from "@/components/shared/graph_auto_fit";
 import { ApiBaseProvider } from "@/contexts/api_base_context";
 
 const LAYOUT_STORAGE_KEY = "inspector_graph_layout_mode";
@@ -234,6 +235,7 @@ function EmbedGraphView({ initialNodeId }: { initialNodeId: string }) {
             fitViewOptions={{ padding: 0.2 }}
             proOptions={{ hideAttribution: true }}
           >
+            <GraphAutoFit nodeIds={nodes.map((n) => n.id)} />
             <Background />
             <Controls />
             <MiniMap />

--- a/inspector/src/pages/graph_explorer.tsx
+++ b/inspector/src/pages/graph_explorer.tsx
@@ -20,6 +20,7 @@ import {
   graphSpecToFlow,
   type GraphLayoutMode,
 } from "@/lib/graph_layout";
+import { GraphAutoFit } from "@/components/shared/graph_auto_fit";
 const LAYOUT_STORAGE_KEY = "inspector_graph_layout_mode";
 
 function readStoredLayoutMode(): GraphLayoutMode {
@@ -173,6 +174,7 @@ export default function GraphExplorerPage() {
               fitViewOptions={{ padding: 0.2 }}
               proOptions={{ hideAttribution: true }}
             >
+              <GraphAutoFit nodeIds={nodes.map((n) => n.id)} />
               <Background />
               <Controls />
               <MiniMap />


### PR DESCRIPTION
## Summary

The Inspector graph viewer received valid neighborhood data (nodes, edges, correct ids) yet rendered a **blank/partial canvas**: nodes drew at raw layout coordinates, edges never appeared, and `fitView` was a no-op (viewport stuck at the identity transform), with **zero console errors**. For a neighborhood laid out off the initial viewport the result is a fully blank pane.

Reproduced on the shipped **v0.18.5 production bundle**, same-origin against prod data, on **both** the standalone `/graph` explorer **and** `/embed/graph` — confirming the cause is in **shared** graph-render code, not embed-specific. (Answers the evaluator's diagnostic question: our own standalone Inspector does NOT correctly render the neighborhood on 0.18.5 — nodes appear but edges/fit do not.)

## Root cause

React Flow v12's per-node `ResizeObserver` never fires its initial measurement callback in this environment, so every node's `measured` stays `{}` and `nodesInitialized` stays `false`. With no measured dimensions:

- `getFitViewNodes()` treats every node as invisible → `fitView` is a no-op (identity viewport transform), and
- `getEdgePosition()` bails for every edge → edges silently never draw.

Confirmed by inspecting the live React Flow store in the browser: `nodesInitialized: false`, `measured: {}` for all nodes, while the DOM node elements had real non-zero `offsetWidth`/`offsetHeight`. Forcing `updateNodeInternals` (which re-reads offset dimensions from the DOM) immediately populated `measured`, drew all edges, and made `fitView` work.

This is **not** the old #1837 refetch loop (that stays fixed — exactly one neighborhood call), not a container-height issue (blank at full viewport too), and not a field mismatch (node ids and edge endpoints match exactly).

## Fix

Shared, so both routes are fixed by one change:

- **New `GraphAutoFit` helper** rendered inside `<ReactFlow>`. When the rendered node set changes, it forces `updateNodeInternals` with each node's DOM element (`force: true`), re-reading offset dimensions to populate `measured` (bypassing the unfired ResizeObserver), then calls `fitView`. Retries on a `setTimeout` cadence (not `requestAnimationFrame`, which is paused in background/hidden tabs) until every node reports measured dimensions.
- **`graphSpecToFlow`** now sets `initialWidth`/`initialHeight` on each node as a dimension fallback for edge geometry and bounds before measurement. React Flow still overrides these with the real measured size once it observes the node, so labels of any size render normally.

## Verification

In a real browser on the **v0.18.5 prod bundle** against prod data:
- **Before:** a 3-node / 2-edge neighborhood rendered 3 nodes but **0 edges** with an un-fitted (identity) viewport.
- **After:** the same neighborhood renders **3 nodes + 2 edges** with the viewport correctly fitted.

## Test

`inspector/src/lib/graph_layout.test.ts` adds an effect test that, given the evaluator's exact `retrieve_graph_neighborhood` response shape (1 entity + 2 related_entities + 2 relationships), asserts the render pipeline emits 3 nodes with **finite numeric positions**, **dimension hints** (`initialWidth`/`initialHeight`), and 2 edges each **wired to real node ids**. It **fails before** the fix (missing dimension hints) and **passes after**. Full inspector suite green; lint + type-check green on the changed files.

Note: the inspector `.test.ts` lane runs in the Node environment (no jsdom/React Flow store), so the render-layer measurement fix (`GraphAutoFit`) is verified in-browser rather than in a unit test; the unit test guards the pipeline-level invariants that back it.

Refs embed task `ent_a876f38dd8ed65eb2ad331ee` and evaluator repro node `ent_97adf029`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)