### PR TITLE
chore(release): v0.18.6 — Inspector graph blank-canvas fix (#1863)

### DIFF
--- a/docs/releases/in_progress/v0.18.6/github_release_supplement.md
+++ b/docs/releases/in_progress/v0.18.6/github_release_supplement.md
@@ -1,0 +1,43 @@
+A single targeted fix: the Inspector graph viewer now renders its nodes, edges, and viewport again. On v0.18.5 the graph could receive valid data yet paint a blank canvas; this release restores rendering on both the standalone explorer and the embedded graph.
+
+## Highlights
+
+- **Inspector graph no longer renders blank.** On v0.18.5, a graph neighborhood could load valid data (correct nodes and relationships, exactly one fetch, no console error) yet the canvas stayed empty: edges did not draw and the viewport never fit to the graph. Root cause: in the production bundle, React Flow v12's per-node `ResizeObserver` never fires its initial measurement callback, so every node's `measured` dimensions stay empty and `nodesInitialized` stays `false`. With no measured dimensions, `fitView` treats every node as invisible and bails, and edge positions can't be computed, so edges never draw. Fixed in `inspector/src/components/shared/graph_auto_fit.tsx` (new) + the two graph pages. Affects both the standalone `/graph` explorer and the embedded `/embed/graph`.
+
+## What changed for npm package users
+
+**Inspector**
+
+- A new `GraphAutoFit` helper, mounted inside the graph's `<ReactFlow>`, forces a node-internals measurement pass (reading real DOM dimensions directly, bypassing the unfired ResizeObserver) whenever the rendered node set changes, then calls `fitView` once nodes report real bounds, retrying on a short cadence until measured. `graphSpecToFlow` also sets `initialWidth`/`initialHeight` as dimension fallbacks.
+- Net effect: exploring an entity's neighborhood renders its nodes and edges and fits them into view, on both graph routes.
+
+**Shipped artifacts**
+
+- `openapi.yaml` — unchanged; this is an Inspector-only (frontend) fix. No routes, schema, or server behavior changed.
+- The Inspector bundle is rebuilt with the fix.
+
+## API surface & contracts
+
+No API, schema, or contract changes. The data pipeline (`buildGraphFromNeighborhood` / `applyGraphLayout` / `graphSpecToFlow`) was already correct — it emitted valid nodes with finite positions and edges wired to real node ids. The bug was purely in the render/measurement layer.
+
+## Behavior changes
+
+- The Inspector graph renders again. No other behavior changes.
+
+## Fixes
+
+- **Blank-canvas render regression in the Inspector graph viewer.** Valid neighborhood data produced an empty canvas on v0.18.5 because React Flow v12 node measurement did not initialize in the production bundle. `GraphAutoFit` forces measurement + fit. Reported by an external evaluator (Jeroen van 't Hoff, OPSCHUDDING), who isolated it end to end: every layer green (shell 200, render chunk loaded, one neighborhood fetch, valid body, zero console errors) except the drawing, and blank on both the embedded panel and the standalone explorer — confirming a shared render bug, not an embed-specific one.
+
+## Tests and validation
+
+- `inspector/src/lib/graph_layout.test.ts` — a case built from the reporter's exact neighborhood shape (1 entity + 2 related_entities + 2 relationships) asserts the pipeline emits nodes with finite numeric positions, dimension hints, and edges wired to existing node ids. It fails before the fix's pipeline changes and passes after.
+- The render-layer fix (measurement + fitView) was verified in a real browser against the production bundle: before = nodes present but 0 edges and an un-fitted viewport (blank); after = edges drawn and viewport fitted. The Inspector unit lane runs in Node without a DOM/React Flow store, so the measurement fix is browser-verified rather than unit-asserted; the unit test guards the pipeline invariants that back it.
+- Full inspector test suite green; `security:classify-diff` reports `sensitive=false` (Inspector-only, no auth/route/schema surface).
+
+## Security hardening
+
+Not security-sensitive. `npm run security:classify-diff -- --base v0.18.5 --head HEAD` reported `sensitive=false` (5 changed files, all under `inspector/src/`; no middleware, auth, route, or schema paths). See [docs/releases/in_progress/v0.18.6/security_review.md](security_review.md) — verdict: **yes** (frontend-only render fix).
+
+## Breaking changes
+
+None. Frontend-only, additive render fix. Patch bump is correct per SemVer.

--- a/docs/releases/in_progress/v0.18.6/security_review.md
+++ b/docs/releases/in_progress/v0.18.6/security_review.md
@@ -1,0 +1,37 @@
+# Security review — v0.18.6
+
+## Scope
+
+- Base ref: `v0.18.5`
+- Head ref: `HEAD`
+- Diff classifier: **not sensitive** (`sensitive=false`).
+- Changed files: 5, all under `inspector/src/` (frontend render/layout only).
+- Protected routes manifest: unchanged (no routes touched).
+
+## Findings
+
+- **No auth-path changes.** The diff adds an Inspector render helper (`inspector/src/components/shared/graph_auto_fit.tsx`) that forces React Flow node measurement + `fitView`, plus two-line mounts in the two graph pages and dimension-fallback fields in `graph_layout.ts`. No server code, middleware, route registration, schema, or access-policy path is touched.
+- **No new routes / no manifest change.** `security:manifest:check` unaffected; the change is client-side only.
+- **No data-exposure change.** The fix changes only how already-fetched neighborhood data is measured and laid out for display. It does not alter what data the graph endpoints return or who can call them.
+- **No proxy-trust, local-dev-widening, guest-access, or AAuth changes.**
+- `security:classify-diff` (base v0.18.5): `sensitive=false`.
+
+## Residual risks
+
+None. Frontend-only render fix confined to the Inspector graph view.
+
+## Sign-off
+
+| Reviewer | Verdict | Date |
+|----------|---------|------|
+| ateles-agent (automated) | yes | 2026-07-01 |
+
+Verdict `yes` — not security-sensitive (Inspector render/layout only). No block.
+
+## Diff appendix
+
+- `inspector/src/components/shared/graph_auto_fit.tsx`
+- `inspector/src/lib/graph_layout.ts`
+- `inspector/src/lib/graph_layout.test.ts`
+- `inspector/src/pages/embed_graph.tsx`
+- `inspector/src/pages/graph_explorer.tsx`

--- a/docs/releases/in_progress/v0.18.6/test_coverage_review.md
+++ b/docs/releases/in_progress/v0.18.6/test_coverage_review.md
@@ -1,0 +1,35 @@
+# Test coverage review — v0.18.6
+
+## Scope
+
+Release diff: `v0.18.5..HEAD`. One fix (Inspector graph blank-canvas render regression, PR #1863). 5 files, all under `inspector/src/`.
+
+## Code review
+
+The fix is a client-side render/layout change: a new `GraphAutoFit` component that forces React Flow node measurement + `fitView`, mounted in both graph pages, plus dimension-fallback fields in the layout builder. No server, schema, route, or contract surface. No migrations.
+
+Verdict: **ADVISORY only** — no BLOCKING gaps.
+
+## Surface coverage
+
+### `inspector/src/lib/graph_layout.ts` — pipeline + dimension fallbacks
+
+- **Change:** `graphSpecToFlow` now sets `initialWidth`/`initialHeight`; pipeline otherwise unchanged.
+- **Coverage:** `inspector/src/lib/graph_layout.test.ts` — a case built from the reporter's exact neighborhood shape (1 entity + 2 related_entities + 2 relationships) asserts the pipeline emits nodes with finite numeric positions, dimension hints, and edges wired to existing node ids. Fails before the pipeline change, passes after. Full inspector suite green.
+
+### `inspector/src/components/shared/graph_auto_fit.tsx` — the render-layer fix
+
+- **Change:** forces `updateNodeInternals` (reads real DOM dimensions, populating `measured`, bypassing the unfired ResizeObserver) then `fitView`, retrying until measured.
+- **Classification:** UI render behavior; the root-cause layer.
+- **Coverage:** verified in a real browser against the production bundle (before = nodes present, 0 edges, un-fitted/blank; after = edges drawn, viewport fitted). The Inspector `.test.ts` lane runs in Node without jsdom/a React Flow store, so this measurement behavior cannot be unit-asserted in-lane; it is browser-verified, and the unit test guards the pipeline invariants that back it. This is an honest, documented coverage boundary, not a gap in the fix.
+
+## Surfaces that do NOT apply
+
+- Destructive / data-mutating operations: none.
+- New CLI/MCP/HTTP routes: none.
+- Schema / migrations: none.
+- Server behavior: none (frontend only).
+
+## Verdict
+
+No BLOCKING coverage gaps. The data-pipeline invariant is unit-tested (failing→passing on the reporter's shape); the render/measurement fix is browser-verified against the prod bundle, with the Node-lane limitation stated explicitly. Release may proceed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neotoma",
-  "version": "0.18.5",
+  "version": "0.18.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neotoma",
-      "version": "0.18.5",
+      "version": "0.18.6",
       "license": "MIT",
       "dependencies": {
         "@hellocoop/httpsig": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neotoma",
-  "version": "0.18.5",
+  "version": "0.18.6",
   "description": "MCP server for structured personal data memory with unified source ingestion",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
Patch release shipping the Inspector graph render fix from #1863 (already merged to main).

## What ships
- **Blank-canvas fix**: on v0.18.5 the Inspector graph could load valid data yet render nothing — React Flow v12's per-node ResizeObserver never fired in the prod bundle, so `measured` stayed empty, `fitView` bailed, and edges never drew. `GraphAutoFit` forces a measurement pass + fitView. Fixes both `/graph` (standalone) and `/embed/graph`.
- Frontend-only; no API/schema/route changes.

## Origin
Reported by evaluator Jeroen van 't Hoff (OPSCHUDDING), isolated end-to-end; blank on both routes confirmed it was shared render code, not embed-specific.

## Release artifacts
- `docs/releases/in_progress/v0.18.6/github_release_supplement.md`
- `docs/releases/in_progress/v0.18.6/security_review.md` — verdict **yes** (sensitive=false, Inspector-only)
- `docs/releases/in_progress/v0.18.6/test_coverage_review.md`

## Verification
Fix verified rendering in a browser (before: 0 edges/blank; after: edges drawn + viewport fitted). Pipeline unit test on the reporter's exact neighborhood shape fails-before/passes-after. All CI lanes green on #1863.

🤖 Generated with [Claude Code](https://claude.com/claude-code)