### PR TITLE
fix(inspector): embed graph blank canvas — resolve container height (v0.18.7)

### DIFF
--- a/docs/releases/in_progress/v0.18.7/github_release_supplement.md
+++ b/docs/releases/in_progress/v0.18.7/github_release_supplement.md
@@ -1,0 +1,44 @@
+A single targeted fix: the Inspector embedded graph (`/embed/graph`) now paints again. On v0.18.6 the standalone `/graph` explorer rendered correctly, but the embed shell showed a blank canvas even with a fully healthy graph — because its canvas container had a min-height but no resolved height, collapsing React Flow to zero painted pixels.
+
+## Highlights
+
+- **Embedded graph (`/embed/graph`) no longer renders blank.** On v0.18.6, the embed graph could lay out perfectly — nodes measured with real dimensions, edges with real path data, the viewport transform applied (so `fitView` ran) — yet paint zero pixels, with `document.elementFromPoint()` at a node's center hitting the page background instead of the node. Root cause: the graph canvas container used `flex-1 min-h-[calc(100dvh-5rem)]` — a **min**-height with no definite height. React Flow's root element needs `height:100%`, which resolves against the parent's computed `auto` height → `0px`; React Flow's `overflow:hidden` then clips the correctly-laid-out graph to nothing. The standalone `/graph` was unaffected because its wrapper is `h-[600px]` (a definite height). Fixed in `inspector/src/pages/embed_graph.tsx`. This is a **separate** bug from the v0.18.6 measurement fix (`GraphAutoFit`), which remains correct and is confirmed working.
+
+## What changed for npm package users
+
+**Inspector**
+
+- The embed graph shell now establishes a definite height context so React Flow fills it: the root shell is `h-dvh` (was `min-h-screen`) and the canvas container is a flex column that lets React Flow flex to fill (`flex flex-col flex-1 min-h-0`, was `flex-1 min-h-[calc(100dvh-5rem)]`). This is the flex-column approach rather than a hard `calc()` height, so it stays correct when the controls bar wraps to two rows at narrow widths.
+- Net effect: exploring an entity's neighborhood in the embedded panel renders and paints its nodes and edges, matching the standalone explorer.
+
+**Shipped artifacts**
+
+- `openapi.yaml` — unchanged; Inspector-only (frontend) fix. No routes, schema, or server behavior changed.
+- The Inspector bundle is rebuilt with the fix.
+
+## API surface & contracts
+
+No API, schema, or contract changes. The data pipeline and the render/measurement layer were already correct as of v0.18.6; this was purely a CSS layout collapse in the embed shell.
+
+## Behavior changes
+
+- The embedded graph renders again. No other behavior changes.
+
+## Fixes
+
+- **Blank embedded graph in the Inspector (`/embed/graph`).** The canvas container had a min-height but no resolved height, so React Flow's `height:100%` collapsed to `0px` and `overflow:hidden` clipped the graph. Reported and root-caused end to end by an external evaluator (Jeroen van 't Hoff, OPSCHUDDING), who isolated it precisely: DOM fully healthy (nodes measured, edges with path data, viewport transform applied) but zero pixels painting and `elementFromPoint` at a node center hitting the background — and pinned the cause to the percentage-height-against-`auto` collapse, distinguishing it from the standalone route's explicit `h-[600px]`.
+
+## Tests and validation
+
+- `inspector/src/lib/embed_graph.test.ts` — 12/12 pass (unchanged; the pipeline invariants are unaffected).
+- The CSS layout fix was verified in a real browser against the built production bundle: reproducing the exact class chain, the old container left React Flow's `clientHeight` collapsed while the new class chain resolves it to the full available height (viewport minus the controls bar), swept across viewport widths including a wrapped two-row controls bar. The Inspector unit lane runs in Node without a real viewport, so the height-resolution behavior is browser-verified rather than unit-asserted.
+- A follow-up hardening item (tracked): the PR-gating render smoke test must assert **paint at the pixel level** on `/embed/graph` (e.g. `elementFromPoint` at a node center returns a `.react-flow__node`, or a screenshot-not-blank check), not merely nodes-in-DOM + a fitted viewport — because this bug had both of those true while painting nothing.
+- `security:classify-diff` (base v0.18.6): `sensitive=false`.
+
+## Security hardening
+
+Not security-sensitive. `npm run security:classify-diff -- --base v0.18.6 --head HEAD` reported `sensitive=false` (1 changed file under `inspector/src/`; no middleware, auth, route, or schema surface). See [docs/releases/in_progress/v0.18.7/security_review.md](security_review.md) — verdict: **yes** (frontend-only CSS layout fix).
+
+## Breaking changes
+
+None. Frontend-only, additive layout fix. Patch bump is correct per SemVer.

--- a/docs/releases/in_progress/v0.18.7/security_review.md
+++ b/docs/releases/in_progress/v0.18.7/security_review.md
@@ -1,0 +1,33 @@
+# Security review — v0.18.7
+
+## Scope
+
+- Base ref: `v0.18.6`
+- Head ref: `HEAD`
+- Diff classifier: **not sensitive** (`sensitive=false`).
+- Changed files: 1 (`inspector/src/pages/embed_graph.tsx`, frontend CSS/className only), plus the release version bump + supplement docs.
+- Protected routes manifest: unchanged (no routes touched).
+
+## Findings
+
+- **No auth-path changes.** The diff changes two `className` strings on the embed graph page so the graph canvas container has a resolved height (root `min-h-screen` → `h-dvh`; canvas `flex-1 min-h-[calc(100dvh-5rem)]` → `flex flex-col flex-1 min-h-0`). No server code, middleware, route registration, schema, or access-policy path is touched.
+- **No new routes / no manifest change.** The change is client-side only.
+- **No data-exposure change.** The fix changes only how already-fetched neighborhood data is laid out for display (the container's height). It does not alter what data the graph endpoints return or who can call them. The embed CORS/frame-ancestors gating shipped in v0.18.5 is unchanged.
+- **No proxy-trust, local-dev-widening, guest-access, or AAuth changes.**
+- `security:classify-diff` (base v0.18.6): `sensitive=false`.
+
+## Residual risks
+
+None. Frontend-only CSS layout fix confined to the Inspector embed graph view.
+
+## Sign-off
+
+| Reviewer | Verdict | Date |
+|----------|---------|------|
+| ateles-agent (automated) | yes | 2026-07-02 |
+
+Verdict `yes` — not security-sensitive (Inspector embed layout/CSS only). No block.
+
+## Diff appendix
+
+- `inspector/src/pages/embed_graph.tsx`

--- a/docs/releases/in_progress/v0.18.7/test_coverage_review.md
+++ b/docs/releases/in_progress/v0.18.7/test_coverage_review.md
@@ -1,0 +1,34 @@
+# Test coverage review — v0.18.7
+
+## Scope
+
+Release diff: `v0.18.6..HEAD`. One fix (Inspector `/embed/graph` blank-canvas height collapse). 1 code file changed (`inspector/src/pages/embed_graph.tsx`), className-only.
+
+## Code review
+
+The fix is a client-side CSS/layout change: two `className` edits so the embed graph canvas has a resolved height and React Flow fills it (root `min-h-screen` → `h-dvh`; canvas container → `flex flex-col flex-1 min-h-0`). No server, schema, route, or contract surface. No migrations.
+
+Verdict: **ADVISORY only** — no BLOCKING gaps.
+
+## Surface coverage
+
+### `inspector/src/pages/embed_graph.tsx` — embed graph container height
+
+- **Change:** the graph canvas container now establishes a definite height context (flex column with `min-h-0` under an `h-dvh` root) instead of a min-height-only container, so React Flow's `height:100%` resolves instead of collapsing to `0px`.
+- **Classification:** UI layout/render behavior; the root-cause layer.
+- **Coverage:** `inspector/src/lib/embed_graph.test.ts` (12/12 pass) guards the pipeline invariants that back the page; it does not assert layout. The height-resolution behavior was verified in a real browser against the built production bundle: with the OLD class chain React Flow's `clientHeight` stayed collapsed, and with the NEW chain it resolved to the full available height (viewport minus the controls bar), swept across viewport widths including a wrapped two-row controls bar. The Inspector `.test.ts` lane runs in Node without a real viewport, so this height behavior cannot be unit-asserted in-lane; it is browser-verified. This is an honest, documented coverage boundary, not a gap in the fix.
+
+## Coverage follow-up (tracked, not blocking this release)
+
+The PR-gating render smoke test (task ent_6636601b50fc2d43b21d5174) is being extended so the `/embed/graph` assertion is **pixel-level** — `document.elementFromPoint()` at a node center returns a `.react-flow__node`, and `.react-flow` has non-zero `clientHeight`, or a screenshot-not-blank check — because this exact bug had nodes-in-DOM and a fitted viewport both true while painting nothing. A DOM-only assertion would not have caught it. This is the structural prevention for the class; it lands with the render-smoke-test task, not in this patch.
+
+## Surfaces that do NOT apply
+
+- Destructive / data-mutating operations: none.
+- New CLI/MCP/HTTP routes: none.
+- Schema / migrations: none.
+- Server behavior: none (frontend only).
+
+## Verdict
+
+No BLOCKING coverage gaps. The pipeline invariant is unit-tested; the layout fix is browser-verified against the prod bundle with the Node-lane limitation stated explicitly; the pixel-level render smoke test that would have caught this class is tracked as a follow-up. Release may proceed.

--- a/inspector/src/pages/embed_graph.tsx
+++ b/inspector/src/pages/embed_graph.tsx
@@ -141,7 +141,7 @@ function EmbedGraphView({ initialNodeId }: { initialNodeId: string }) {
 
   return (
     <div
-      className="flex flex-col min-h-screen w-full"
+      className="flex flex-col h-dvh w-full"
       data-testid="embed-graph-root"
       data-embed="graph"
     >
@@ -205,7 +205,7 @@ function EmbedGraphView({ initialNodeId }: { initialNodeId: string }) {
       </div>
 
       {/* Graph canvas — fills remaining height */}
-      <div className="flex-1 bg-background min-h-[calc(100dvh-5rem)]">
+      <div className="flex flex-col flex-1 min-h-0 bg-background">
         {showInitialQuerySkeleton(graph) ? (
           <GraphAreaSkeleton />
         ) : graph.error && activeNodeId ? (

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neotoma",
-  "version": "0.18.6",
+  "version": "0.18.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neotoma",
-      "version": "0.18.6",
+      "version": "0.18.7",
       "license": "MIT",
       "dependencies": {
         "@hellocoop/httpsig": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neotoma",
-  "version": "0.18.6",
+  "version": "0.18.7",
   "description": "MCP server for structured personal data memory with unified source ingestion",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
## Summary

The Inspector embedded graph (`/embed/graph`) rendered a **blank canvas** on v0.18.6, even though the graph laid out correctly (nodes measured, edges with path data, `fitView` ran). Zero pixels painted; `elementFromPoint` at a node center hit the page background.

**Root cause:** the graph canvas container used `flex-1 min-h-[calc(100dvh-5rem)]` — a min-height with no definite height. React Flow's root needs `height:100%`, which resolves against the parent's computed `auto` height → `0px`, and React Flow's `overflow:hidden` clips the graph to nothing. The standalone `/graph` was unaffected because its wrapper is `h-[600px]` (definite). This is a **separate** bug from the v0.18.6 `GraphAutoFit` measurement fix, which remains correct.

## The fix (2 lines, `inspector/src/pages/embed_graph.tsx`)

- Root shell `min-h-screen` → `h-dvh` (definite height for the flex column).
- Canvas container `flex-1 min-h-[calc(100dvh-5rem)]` → `flex flex-col flex-1 min-h-0` (flex child that lets React Flow fill it).

Flex-column approach rather than a hard `calc()`, so it stays correct when the controls bar wraps at narrow widths.

## Verification

- Build succeeds; `inspector/src/lib/embed_graph.test.ts` 12/12 pass.
- **Browser-verified against the built prod bundle:** reproducing the exact class chain, the OLD container left React Flow's `clientHeight` collapsed (~21px) while the NEW chain resolves it to the full available height (viewport − controls bar), across viewport widths including a wrapped two-row bar.
- `security:classify-diff` (base v0.18.6): `sensitive=false`.

## Follow-up (tracked, not in this PR)

The PR-gating render smoke test is being extended so `/embed/graph` asserts **paint at the pixel level** (`elementFromPoint` at a node center hits `.react-flow__node`; non-zero `.react-flow` clientHeight) — because this bug had nodes-in-DOM + a fitted viewport both true while painting nothing.

## Credit

Reported and root-caused end to end by external evaluator Jeroen van 't Hoff (OPSCHUDDING).

🤖 Generated with [Claude Code](https://claude.com/claude-code)