### PR TITLE
test(inspector): pixel-level graph render smoke gate on prod bundle

### DIFF
--- a/.github/workflows/ci_test_lanes.yml
+++ b/.github/workflows/ci_test_lanes.yml
@@ -149,6 +149,48 @@ jobs:
       - name: Run frontend Vitest suite
         run: npm run test:frontend
 
+  graph_render_smoke:
+    # PR-gating PIXEL-LEVEL render smoke gate for the Inspector graph.
+    #
+    # Retrospective ent_c4359aa810a5c5e6550cd631 / policy
+    # render_effect_is_the_rendered_output_tested_on_prod_bundle
+    # (ent_aa78b25af71561a203bde840): the Inspector graph shipped BLANK twice to an
+    # external evaluator (v0.18.5 React-Flow measurement never fired; v0.18.6
+    # /embed/graph container collapsed to 0px). Both had a healthy DOM (nodes +
+    # edges present, viewport fitted) yet painted ZERO pixels, so DOM-only checks
+    # were insufficient and the one existing "graph" e2e is a DATA-integrity test.
+    #
+    # This lane runs playwright/tests/inspector/inspector-graph-render.spec.ts
+    # against the BUILT/minified Inspector bundle (both bugs are prod-bundle-only),
+    # opening /graph AND /embed/graph and asserting at the PIXEL level:
+    # elementFromPoint at a node center hits a .react-flow__node and .react-flow has
+    # non-zero clientHeight. A failure blocks the PR (task ent_6636601b50fc2d43b21d5174).
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build server (Playwright e2e boots the in-process dev:server)
+        run: npm run build:server
+
+      - name: Build Inspector prod bundle (render bugs reproduce only in the built bundle)
+        run: npm run build:inspector
+
+      - name: Install Playwright browser (Chromium)
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Inspector graph render smoke gate (pixel-level, prod bundle)
+        run: npm run test:e2e:graph-render
+
   site_export:
     runs-on: ubuntu-latest
     steps:

--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,10 +61,10 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **525**
+- Total automated test files: **526**
 - Backend and repo Vitest files: **491**
 - Frontend Vitest files: **9**
-- Playwright spec files: **25**
+- Playwright spec files: **26**
 
 ### Suite counts
 | Suite | Files |
@@ -83,7 +83,7 @@ flowchart TD
 | Vitest shared-environment tests | 1 |
 | Frontend Vitest tests | 9 |
 | Playwright E2E tests | 22 |
-| Playwright Inspector E2E tests | 3 |
+| Playwright Inspector E2E tests | 4 |
 | Tests Performance | 1 |
 | Tests Scripts | 2 |
 
@@ -703,7 +703,7 @@ flowchart TD
 - `playwright/tests/entity-detail.spec.ts`
 - `playwright/tests/entity-list.spec.ts`
 - `playwright/tests/floating-settings-button.spec.ts`
-- `playwright/tests/graph-integrity.spec.ts`
+- `playwright/tests/graph-data-integrity.spec.ts`
 - `playwright/tests/interpretations.spec.ts`
 - `playwright/tests/mcp-configuration.spec.ts`
 - `playwright/tests/mcp-relationships.spec.ts`
@@ -726,8 +726,9 @@ flowchart TD
 **Runner:** `playwright`
 **Command:** `npm run test:e2e:inspector`
 **Requirements:** Inspector bundle built before execution.
-**Files (3):**
+**Files (4):**
 - `playwright/tests/inspector/inspector-entity-detail.spec.ts`
+- `playwright/tests/inspector/inspector-graph-render.spec.ts`
 - `playwright/tests/inspector/inspector-issues.spec.ts`
 - `playwright/tests/inspector/inspector-sandbox-pack-picker.spec.ts`
 

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "test:e2e": "cross-env PLAYWRIGHT_USE_MOCK_API=1 PLAYWRIGHT_TEST_SEED=ci npx playwright test",
     "test:e2e:headed": "cross-env PLAYWRIGHT_USE_MOCK_API=1 PLAYWRIGHT_TEST_SEED=ci npx playwright test --headed",
     "test:e2e:inspector": "npm run build:inspector && cross-env PLAYWRIGHT_USE_MOCK_API=1 PLAYWRIGHT_TEST_SEED=ci npx playwright test playwright/tests/inspector",
+    "test:e2e:graph-render": "npm run build:inspector && cross-env PLAYWRIGHT_USE_MOCK_API=1 PLAYWRIGHT_TEST_SEED=ci npx playwright test playwright/tests/inspector/inspector-graph-render.spec.ts --project=chromium",
     "generate:capability-manifest": "tsx scripts/generate-capability-manifest.ts",
     "validate:capability-manifest": "tsx scripts/generate-capability-manifest.ts --check",
     "generate:test-catalog": "tsx scripts/generate-automated-test-catalog.ts",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -17,7 +17,7 @@ const legacySpecFiles = [
   'entity-detail.spec.ts',
   'entity-list.spec.ts',
   'floating-settings-button.spec.ts',
-  'graph-integrity.spec.ts',
+  'graph-data-integrity.spec.ts',
   'interpretations.spec.ts',
   'mcp-configuration.spec.ts',
   'mcp-relationships.spec.ts',

--- a/playwright/tests/coverage-map.json
+++ b/playwright/tests/coverage-map.json
@@ -30,10 +30,10 @@
     "specFile": "floating-settings-button.spec.ts"
   },
   "graphIntegrity": {
-    "description": "Graph integrity UI coverage.",
+    "description": "Graph DATA-integrity coverage (orphans/cycles/deletion). NOT render coverage — the graph render smoke gate is playwright/tests/inspector/inspector-graph-render.spec.ts.",
     "components": ["GraphIntegrityView"],
     "states": ["inspect graph checks"],
-    "specFile": "graph-integrity.spec.ts"
+    "specFile": "graph-data-integrity.spec.ts"
   },
   "interpretations": {
     "description": "Interpretation page coverage.",
@@ -143,4 +143,3 @@
     "specFile": "upload-flow.spec.ts"
   }
 }
-

--- a/playwright/tests/graph-data-integrity.spec.ts
+++ b/playwright/tests/graph-data-integrity.spec.ts
@@ -1,7 +1,17 @@
 /**
- * E2E Test: Graph Integrity Checks
- * 
- * Tests orphan detection and cycle prevention in the graph.
+ * E2E Test: Graph DATA-Integrity Checks
+ *
+ * ⚠️ THIS IS NOT RENDER COVERAGE. This test exercises the graph DATA MODEL only —
+ * orphan detection, cycle prevention, and entity-deletion behavior — by querying
+ * the database directly. It never opens the graph viewer and asserts NOTHING about
+ * whether the graph actually paints in the browser.
+ *
+ * The v0.18.5 blank-canvas and v0.18.6 /embed/graph height-collapse render bugs
+ * both shipped while this "graph" test was green, because "graph coverage" was
+ * misread as "render coverage." Pixel-level render coverage lives in
+ * playwright/tests/inspector/inspector-graph-render.spec.ts (task
+ * ent_6636601b50fc2d43b21d5174, policy ent_aa78b25af71561a203bde840). Do NOT
+ * extend this file for render assertions.
  */
 
 import { expect } from "@playwright/test";
@@ -85,7 +95,7 @@ async function detectCycles() {
   };
 }
 
-test.describe("E2E-009: Graph Integrity Checks", () => {
+test.describe("E2E-009: Graph DATA-Integrity Checks (NOT render coverage)", () => {
   const testUserId = "test-user-graph-integrity";
   const createdEntityIds: string[] = [];
   const createdSourceIds: string[] = [];

--- a/playwright/tests/inspector/inspector-graph-render.spec.ts
+++ b/playwright/tests/inspector/inspector-graph-render.spec.ts
@@ -1,0 +1,256 @@
+/**
+ * E2E: Inspector graph RENDER smoke gate (prod bundle, PIXEL-LEVEL).
+ *
+ * WHAT THIS GUARDS
+ * ----------------
+ * This is the ship-gate for the whole class of "graph is in the DOM but paints
+ * nothing" bugs that an external evaluator (Jeroen) caught twice:
+ *   - v0.18.5 blank-canvas: React Flow v12's per-node ResizeObserver never fired
+ *     its initial measurement, so nodes stayed unmeasured, fitView no-op'd, and
+ *     edges never drew. Prod-bundle-only.
+ *   - v0.18.6 /embed/graph height-collapse: the canvas container had a MIN height
+ *     but no resolved height, so React Flow's root computed clientHeight = 0px and
+ *     overflow:hidden clipped a correctly-laid-out graph to zero painted pixels.
+ * BOTH shipped with a healthy DOM (nodes present, edges present, viewport fitted)
+ * yet painted nothing. So DOM-only assertions are INSUFFICIENT — this spec asserts
+ * at the PIXEL level: document.elementFromPoint() at a rendered node's center must
+ * hit an element inside `.react-flow__node` (not the page background/body), AND the
+ * `.react-flow` root must have non-zero clientHeight.
+ *
+ * WHY IT RUNS AGAINST THE BUILT BUNDLE
+ * ------------------------------------
+ * Both bugs reproduce ONLY in the minified prod bundle / embed shell — a dev-server
+ * or jsdom render passes while prod is broken. This spec loads the built Inspector
+ * SPA served by the Neotoma HTTP server at `/inspector/` (dist/inspector, produced
+ * by `npm run build:inspector`). When dist is missing, the whole file skips.
+ *
+ * Enforces task_policy render_effect_is_the_rendered_output_tested_on_prod_bundle
+ * (ent_aa78b25af71561a203bde840): "rendered" means PAINTED, not present-in-DOM.
+ * Task ent_6636601b50fc2d43b21d5174 / retrospective ent_c4359aa810a5c5e6550cd631.
+ */
+
+import { LOCAL_DEV_USER_ID } from "../../../src/services/local_auth.js";
+import { expect, test } from "../../fixtures/servers.js";
+import { isInspectorDistBuilt } from "../../utils/inspector_e2e.js";
+
+test.skip(!isInspectorDistBuilt(), "Inspector SPA not built; run npm run build:inspector");
+
+type StoreResponse = {
+  structured?: { entities?: Array<{ entity_id: string }> };
+  entities?: Array<{ entity_id: string }>;
+};
+
+async function storeEntity(
+  origin: string,
+  bearer: string,
+  entity: Record<string, unknown>,
+  idempotencyKey: string
+): Promise<string> {
+  const res = await fetch(`${origin}/store`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${bearer}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      user_id: LOCAL_DEV_USER_ID,
+      entities: [entity],
+      idempotency_key: idempotencyKey,
+    }),
+  });
+  const text = await res.text();
+  if (!res.ok) {
+    throw new Error(`POST /store failed: ${res.status} ${text.slice(0, 800)}`);
+  }
+  const body = JSON.parse(text) as StoreResponse;
+  const id = body.structured?.entities?.[0]?.entity_id ?? body.entities?.[0]?.entity_id;
+  if (!id) throw new Error(`No entity_id in /store response: ${text.slice(0, 400)}`);
+  return id;
+}
+
+async function createRelationship(
+  origin: string,
+  bearer: string,
+  sourceId: string,
+  targetId: string
+): Promise<void> {
+  const res = await fetch(`${origin}/create_relationship`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${bearer}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      user_id: LOCAL_DEV_USER_ID,
+      relationship_type: "PART_OF",
+      source_entity_id: sourceId,
+      target_entity_id: targetId,
+    }),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`POST /create_relationship failed: ${res.status} ${text.slice(0, 800)}`);
+  }
+}
+
+/**
+ * Seed a focus entity linked to >=2 neighbors so the neighborhood graph renders
+ * >=3 nodes and >=1 edge. Returns the focus entity id to explore.
+ */
+async function seedGraph(origin: string, bearer: string): Promise<string> {
+  const stamp = Date.now();
+  const focusId = await storeEntity(
+    origin,
+    bearer,
+    {
+      entity_type: "company",
+      name: `PWGraphFocus${stamp}`,
+      data_source: "playwright_graph_render_e2e",
+    },
+    `pw-graph-focus-${stamp}`
+  );
+  const neighborIds: string[] = [];
+  for (let i = 0; i < 2; i++) {
+    neighborIds.push(
+      await storeEntity(
+        origin,
+        bearer,
+        {
+          entity_type: "person",
+          name: `PWGraphNeighbor${i}_${stamp}`,
+          data_source: "playwright_graph_render_e2e",
+        },
+        `pw-graph-neighbor-${i}-${stamp}`
+      )
+    );
+  }
+  // focus PART_OF neighbor0, neighbor1 PART_OF focus -> 2 edges, 3 nodes total.
+  await createRelationship(origin, bearer, focusId, neighborIds[0]!);
+  await createRelationship(origin, bearer, neighborIds[1]!, focusId);
+  return focusId;
+}
+
+/**
+ * Assert the graph actually PAINTS: the React Flow root has non-zero clientHeight
+ * and elementFromPoint at a rendered node's center returns an element inside a
+ * `.react-flow__node` (not the page background / body). This is the assertion that
+ * fails on the v0.18.5 blank-canvas and v0.18.6 height-collapse bugs and passes on
+ * the fix. Runs in the page so it reads the real painted layout.
+ */
+async function assertGraphPaints(page: import("@playwright/test").Page): Promise<void> {
+  // Wait for React Flow to mount + fit before probing pixels.
+  await page.waitForSelector(".react-flow__node", { timeout: 45_000 });
+  await expect
+    .poll(async () => page.locator(".react-flow__node").count(), { timeout: 20_000 })
+    .toBeGreaterThanOrEqual(3);
+  await expect
+    .poll(async () => page.locator(".react-flow__edge").count(), { timeout: 20_000 })
+    .toBeGreaterThanOrEqual(1);
+
+  const result = await page.evaluate(() => {
+    const root = document.querySelector(".react-flow") as HTMLElement | null;
+    const viewport = document.querySelector(".react-flow__viewport") as HTMLElement | null;
+    const node = document.querySelector(".react-flow__node") as HTMLElement | null;
+    if (!root || !node) {
+      return {
+        ok: false,
+        reason: "missing .react-flow root or node",
+        rootHeight: root?.clientHeight ?? -1,
+      };
+    }
+
+    const rootHeight = root.clientHeight;
+
+    // fitView must have fired: the viewport transform is non-identity. Identity is
+    // `matrix(1, 0, 0, 1, 0, 0)` / no transform; a fitted graph translates+scales.
+    const transform = viewport ? getComputedStyle(viewport).transform : "none";
+    const viewportFitted = transform !== "none" && transform !== "matrix(1, 0, 0, 1, 0, 0)";
+
+    // PIXEL-LEVEL: hit-test the center of a rendered node. On the two shipped bugs
+    // this returns the page background/body because the graph painted 0 pixels.
+    const rect = node.getBoundingClientRect();
+    const cx = Math.round(rect.left + rect.width / 2);
+    const cy = Math.round(rect.top + rect.height / 2);
+    const hit = document.elementFromPoint(cx, cy);
+    const hitInsideNode = !!(hit && hit.closest(".react-flow__node") !== null);
+
+    return {
+      ok: rootHeight > 0 && viewportFitted && hitInsideNode,
+      rootHeight,
+      transform,
+      viewportFitted,
+      hitInsideNode,
+      hitTag: hit ? `${hit.tagName}.${hit.className}` : null,
+      nodeRect: { x: cx, y: cy, w: Math.round(rect.width), h: Math.round(rect.height) },
+    };
+  });
+
+  // Rich failure message so a red run tells you *which* paint invariant broke.
+  expect(
+    result.rootHeight,
+    `.react-flow clientHeight must be > 0 (height-collapse guard). Got ${result.rootHeight}. ${JSON.stringify(result)}`
+  ).toBeGreaterThan(0);
+  expect(
+    result.viewportFitted,
+    `viewport transform must be non-identity (fitView must fire). transform=${result.transform}. ${JSON.stringify(result)}`
+  ).toBe(true);
+  expect(
+    result.hitInsideNode,
+    `elementFromPoint at a node center must hit a .react-flow__node, not the page background (blank-paint guard). hit=${result.hitTag}. ${JSON.stringify(result)}`
+  ).toBe(true);
+}
+
+test.describe("Inspector graph render smoke (prod bundle, pixel-level)", () => {
+  test("/graph paints a fitted graph with >=3 nodes and >=1 edge", async ({
+    page,
+    bearerToken,
+    neotomaHttpOrigin,
+    inspectorSpaUrl,
+  }) => {
+    // Same-origin Inspector + local SQLite: omit Bearer so the API uses the dev
+    // user; clear any scoped auth/api-url so the SPA defaults to the server-injected
+    // same-origin `<meta name="neotoma-api-base">`.
+    await page.addInitScript(() => {
+      for (const k of [
+        "neotoma_inspector_auth_token_dev",
+        "neotoma_inspector_auth_token_prod",
+        "neotoma_inspector_api_url_dev",
+        "neotoma_inspector_api_url_prod",
+      ]) {
+        try {
+          localStorage.removeItem(k);
+        } catch {
+          /* ignore */
+        }
+      }
+    });
+
+    const focusId = await seedGraph(neotomaHttpOrigin, bearerToken);
+
+    await page.goto(`${inspectorSpaUrl}graph?node=${encodeURIComponent(focusId)}`, {
+      waitUntil: "domcontentloaded",
+    });
+
+    await assertGraphPaints(page);
+  });
+
+  test("/embed/graph paints a fitted graph with >=3 nodes and >=1 edge", async ({
+    page,
+    bearerToken,
+    neotomaHttpOrigin,
+    inspectorSpaUrl,
+  }) => {
+    const focusId = await seedGraph(neotomaHttpOrigin, bearerToken);
+
+    // The embed route reads its API origin from `?apiBase=` (the `WithBase` graph
+    // hook), and the focus node from `?node=`.
+    const embedUrl =
+      `${inspectorSpaUrl}embed/graph` +
+      `?apiBase=${encodeURIComponent(neotomaHttpOrigin)}` +
+      `&node=${encodeURIComponent(focusId)}`;
+
+    await page.goto(embedUrl, { waitUntil: "domcontentloaded" });
+
+    await assertGraphPaints(page);
+  });
+});


### PR DESCRIPTION
## What

Adds a **PR-gating, pixel-level render smoke test** for the Inspector graph, run against the **built/minified prod bundle**, plus CI wiring, a relabel of the misleading data-integrity spec, and the regenerated test catalog.

Task `ent_6636601b50fc2d43b21d5174`; enforces policy `render_effect_is_the_rendered_output_tested_on_prod_bundle` (`ent_aa78b25af71561a203bde840`); retrospective `ent_c4359aa810a5c5e6550cd631`.

## The two bugs it closes

An external evaluator (Jeroen) caught the Inspector graph shipping **blank** twice. Both had a **healthy DOM** (nodes measured, edges with path data, viewport fitted) yet painted **zero pixels** — so DOM-only assertions give false confidence:

- **v0.18.5 blank-canvas** — React Flow v12's per-node `ResizeObserver` never fired its initial measurement pass, so nodes stayed unmeasured, `fitView` no-op'd, and edges never drew. Prod-bundle-only.
- **v0.18.6 `/embed/graph` height-collapse** — the canvas container had a `min-height` but no *resolved* height, so React Flow's root computed `clientHeight = 0px` and `overflow:hidden` clipped a correctly-laid-out graph to nothing.

## What the gate asserts

`playwright/tests/inspector/inspector-graph-render.spec.ts` runs against the **built** Inspector SPA (served by the Neotoma HTTP server at `/inspector/` — both bugs are prod-bundle-only), seeds a focus entity with 2 neighbors, opens **both** `/graph` **and** `/embed/graph`, and on each asserts:

- `.react-flow__node` count >= 3 and `.react-flow__edge` count >= 1
- viewport transform is **non-identity** (fitView fired)
- **PIXEL-LEVEL:** `.react-flow` has non-zero `clientHeight`, **and** `document.elementFromPoint()` at a rendered node's center returns an element inside `.react-flow__node` (not the page background/body)

## Green-on-fixed / red-on-broken proof

- **GREEN** on current `main` (v0.18.7 fix): both `/graph` and `/embed/graph` pass.
- **RED** when the v0.18.6 embed height-collapse is reintroduced (revert `h-dvh`→`min-h-screen` + canvas `flex flex-col flex-1 min-h-0`→`flex-1 min-h-[calc(100dvh-5rem)]`), rebuild, run: the `/embed/graph` case FAILS with `rootHeight: 0`, `hitInsideNode: false` (elementFromPoint hit the collapsed `DIV.flex-1 bg-background min-h-[calc(100dvh-5rem)]`), while `viewportFitted: true` — i.e. the DOM-only checks still passed and only the pixel-level check caught it. Fix then restored.

## Relabel

Renamed `graph-integrity.spec.ts` → `graph-data-integrity.spec.ts` with a header banner + describe rename. It is a **DATA-integrity** test (orphans/cycles/deletion) that never opens the viewer — so "graph coverage" is never again misread as "render coverage."

## CI wiring / required check

Adds a `graph_render_smoke` job to `.github/workflows/ci_test_lanes.yml` that runs on `pull_request`: builds the server + Inspector prod bundle, installs Chromium, runs `npm run test:e2e:graph-render`. A failure fails the job and blocks merge once the check is required.

**Operator step (branch protection):** to make this a *required* check, add the status check named **`graph_render_smoke`** (job name in `CI test lanes`) to the `main` branch protection rule in GitHub repo settings → Branches. Getting it running in the PR lane is done here; marking it required is the one operator step.

## Verification run locally

- Green-on-fixed: `npm run test:e2e:graph-render` — 2 passed.
- Red-on-broken: reintroduced v0.18.6 embed bug → `/embed/graph` failed on the pixel-level assertion; restored fix.
- `npm run type-check`, `npm run lint` (0 errors), `npm run validate:coverage`, `npm run validate:test-catalog`, `npm run test:frontend` (69 passed), inspector `embed_graph`+`graph_layout` unit tests (17 passed) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)