### PR TITLE
fix(store): mirror #1840 dedup-replay snapshot fix onto the offline/HTTP transport (#1860)

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -6701,10 +6701,38 @@ export async function storeStructuredForApi(params: {
     const { listObservationsForSource } = await import("./services/observation_storage.js");
     const existingObs = await listObservationsForSource(existingSource.id, userId);
 
+    // Issue #1860 (mirrors the #1840 MCP-path fix in src/server.ts): on a
+    // deduplicated (idempotency-replay) store, the early return must still
+    // surface the current snapshot in `entity_snapshot_after` and mark each
+    // entry `deduplicated: true` — matching the MCP transport. Previously the
+    // offline/HTTP path omitted both, so callers validating writes by
+    // inspecting the response saw a false empty snapshot even though
+    // getSnapshot returned the real one. No new observation is written, so we
+    // read the persisted snapshot directly.
+    const { getSnapshot: getSnapshotForReplay } =
+      await import("./services/snapshot_computation.js");
+    const replaySnapshotByEntityId = new Map<string, Record<string, unknown>>();
+    for (const replayEntityId of new Set<string>(existingObs.map((obs) => obs.entity_id))) {
+      try {
+        const snap = await getSnapshotForReplay(replayEntityId, userId);
+        if (snap?.snapshot) {
+          replaySnapshotByEntityId.set(replayEntityId, snap.snapshot as Record<string, unknown>);
+        }
+      } catch (snapErr) {
+        logger.warn(
+          `store replay: snapshot fetch failed for ${replayEntityId}: ${
+            snapErr instanceof Error ? snapErr.message : String(snapErr)
+          }`
+        );
+      }
+    }
+
     const existingEntities = existingObs.map((obs) => ({
       entity_id: obs.entity_id,
       entity_type: obs.entity_type,
       observation_id: obs.id,
+      entity_snapshot_after: replaySnapshotByEntityId.get(obs.entity_id) ?? null,
+      deduplicated: true,
     }));
 
     // Idempotency replay: the source row already exists for

--- a/tests/integration/store_dedup_snapshot_after.test.ts
+++ b/tests/integration/store_dedup_snapshot_after.test.ts
@@ -8,11 +8,18 @@
  * count stays 1) but the store response must still return the current,
  * populated snapshot in `entity_snapshot_after` and mark the entity entry with
  * `deduplicated: true`.
+ *
+ * Issue #1860: the #1840 fix was applied only to the MCP path (src/server.ts).
+ * The offline/HTTP path (storeStructuredForApi in src/actions.ts) still stripped
+ * the snapshot on replay. The second test below asserts transport parity: the
+ * offline path returns the same populated `entity_snapshot_after` +
+ * `deduplicated: true` as the MCP path.
  */
 
 import { describe, it, expect, afterEach } from "vitest";
 import { db } from "../../src/db.js";
 import { NeotomaServer } from "../../src/server.js";
+import { storeStructuredForApi } from "../../src/actions.js";
 import { randomUUID } from "crypto";
 import { cleanupTestEntityType } from "../helpers/test_schema_helpers.js";
 import { getSnapshot } from "../../src/services/snapshot_computation.js";
@@ -125,5 +132,89 @@ describe("store: dedup replay populates entity_snapshot_after (#1840)", () => {
     // It must match what getEntitySnapshot returns directly.
     const direct = await getSnapshot(entityId, TEST_USER_ID);
     expect(entryTwo.entity_snapshot_after).toEqual(direct?.snapshot);
+  });
+
+  it("offline/HTTP transport replay populates snapshot + deduplicated marker (#1860 parity)", async () => {
+    await db.from("schema_registry").insert({
+      entity_type: entityType,
+      schema_version: "1.0",
+      schema_definition: {
+        fields: {
+          value: { type: "number", required: false },
+          label: { type: "string", required: true },
+        },
+      },
+      reducer_config: {
+        merge_policies: {
+          value: { strategy: "last_write" },
+          label: { strategy: "last_write" },
+        },
+      },
+      active: true,
+      scope: "user",
+      user_id: TEST_USER_ID,
+    });
+
+    const entities = [
+      {
+        entity_type: entityType,
+        name: "offline-test",
+        label: "t",
+        value: 42,
+      },
+    ];
+    const sharedIdempotencyKey = `test-1860-${randomUUID()}`;
+
+    // First store over the offline/HTTP path (storeStructuredForApi).
+    const first = await storeStructuredForApi({
+      userId: TEST_USER_ID,
+      entities,
+      sourcePriority: 5,
+      idempotencyKey: sharedIdempotencyKey,
+      observationSource: "sensor",
+    });
+    expect(first.entities.length).toBeGreaterThan(0);
+    const firstEntry = first.entities[0] as {
+      entity_id: string;
+      entity_snapshot_after?: Record<string, unknown> | null;
+    };
+    const entityId = firstEntry.entity_id;
+    createdEntityIds.push(entityId);
+    if (first.source_id) createdSourceIds.push(first.source_id);
+    expect(firstEntry.entity_snapshot_after).toMatchObject({ value: 42, label: "t" });
+
+    // Second identical store, same key → offline idempotency-replay dedup.
+    const second = await storeStructuredForApi({
+      userId: TEST_USER_ID,
+      entities,
+      sourcePriority: 5,
+      idempotencyKey: sharedIdempotencyKey,
+      observationSource: "sensor",
+    });
+    if (second.source_id) createdSourceIds.push(second.source_id);
+    expect((second as { replayed?: boolean }).replayed).toBe(true);
+    expect(second.entities).toHaveLength(1);
+    const secondEntry = second.entities[0] as {
+      entity_snapshot_after?: Record<string, unknown> | null;
+      deduplicated?: boolean;
+    };
+
+    // Observation count stays at 1 (dedup worked).
+    const { count: obsCount } = await db
+      .from("observations")
+      .select("id", { count: "exact", head: true })
+      .eq("entity_id", entityId)
+      .eq("user_id", TEST_USER_ID);
+    expect(obsCount).toBe(1);
+
+    // #1860: the offline replay must return a POPULATED snapshot (not absent/{})
+    // and the deduplicated marker — matching the MCP path above.
+    expect(secondEntry.entity_snapshot_after).toBeTruthy();
+    expect(secondEntry.entity_snapshot_after).toMatchObject({ value: 42, label: "t" });
+    expect(secondEntry.deduplicated).toBe(true);
+
+    // And it must equal what getSnapshot returns directly (transport parity).
+    const direct = await getSnapshot(entityId, TEST_USER_ID);
+    expect(secondEntry.entity_snapshot_after).toEqual(direct?.snapshot);
   });
 });


### PR DESCRIPTION
## Summary

Closes #1860. The #1840 fix (PR #1852, commit `1289cc123`) populated `entity_snapshot_after` + `deduplicated: true` on the idempotency-replay early-return, **but only in the MCP path** (`src/server.ts`). The offline/HTTP path (`storeStructuredForApi` in `src/actions.ts`) still returned a stripped entry, so a deduplicated store over the offline transport came back with `entity_snapshot_after` absent.

This is the exact gap the reporter — running Neotoma as an **offline audit ledger** (`neotoma store --offline`) — re-confirmed on **v0.18.7** in [#1860's comment](https://github.com/markmhendrickson/neotoma/issues/1860#issuecomment-4881734473). `#1840` reported fixed in v0.18.4; it was fixed on MCP, not on the reporter's actual transport.

## The fix

Mirror the `src/server.ts` pattern into the offline replay early-return:
- On a deduplicated (idempotency-replay) store, read each entity's persisted snapshot via `getSnapshot` and populate `entity_snapshot_after`.
- Mark each entry `deduplicated: true`, matching the MCP transport.
- No new observation is written, so the snapshot is read directly; observation count stays 1.

## Test

Adds an offline-transport parity case to the existing `#1840` regression test (`tests/integration/store_dedup_snapshot_after.test.ts`) that calls `storeStructuredForApi` directly and asserts the replay returns a populated `entity_snapshot_after` (equal to `getSnapshot`) + `deduplicated: true`.

**Verified to fail without the fix** (`expected undefined to be truthy` — the reporter's exact symptom) and pass with it. Type-check, lint (0 errors), prettier, and test-catalog all pass.

## Acceptance (from the issue / Pavo's PM gate)

- [x] Deduplicated store over the offline/HTTP path returns a populated `entity_snapshot_after` (equals `getSnapshot`)
- [x] Response includes `deduplicated: true` on the replay
- [x] Observation count remains 1
- [x] Implementation in `src/actions.ts` mirrors the `src/server.ts` pattern from #1840 with no unrequested scope

## Follow-up (not in this PR)

The offline-transport-parity CI gate (PR #1858) currently *documents* the dedup-cell divergence as "MCP-only" rather than failing. It should be promoted to a hard MCP↔offline assertion so this class of transport-only fix can't regress — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)