### PR TITLE
fix(cli): global npm install setup --tool claude-code writes .mcp.json

### DIFF
--- a/src/cli/harness_configure.ts
+++ b/src/cli/harness_configure.ts
@@ -3,7 +3,12 @@ import {
   scanAgentInstructions,
   type CliInstructionsScope,
 } from "./agent_instructions_scan.js";
-import { offerInstall, scanForMcpConfigs, type McpTransportChoice } from "./mcp_config_scan.js";
+import {
+  offerInstall,
+  scanForMcpConfigs,
+  type McpHookHarness,
+  type McpTransportChoice,
+} from "./mcp_config_scan.js";
 
 export type HarnessInstallScope = "project" | "user" | "both";
 export type HarnessMcpEnv = "dev" | "prod" | "both";
@@ -25,6 +30,8 @@ export interface ConfigureMcpServersOptions {
   silent?: boolean;
   boxAlreadyShown?: boolean;
   skipProjectSync?: boolean;
+  /** Target harness (e.g. from `setup --tool <harness>`); steers project-config file choice. */
+  harness?: McpHookHarness;
 }
 
 export async function configureMcpServers(options: ConfigureMcpServersOptions): Promise<{
@@ -55,6 +62,7 @@ export async function configureMcpServers(options: ConfigureMcpServersOptions): 
     silent: options.silent,
     boxAlreadyShown: options.boxAlreadyShown,
     skipProjectSync: options.skipProjectSync,
+    harness: options.harness,
   });
   return { ...result, repoRoot };
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -9697,7 +9697,16 @@ program
     }
     const { runSetup } = await import("./setup.js");
     const { createDefaultSetupRunners } = await import("./setup_runners.js");
+    const { toHookHarness } = await import("./hooks_detect.js");
     const cwd = process.cwd();
+    // Narrow the target tool to an MCP-config-capable harness so a project-scoped
+    // Claude Code install writes a project-root .mcp.json (vs. the Cursor default),
+    // which is what unblocks global npm installs of `setup --tool claude-code`.
+    const hookHarness = toHookHarness(opts.tool);
+    const mcpHarness =
+      hookHarness === "claude-code" || hookHarness === "cursor" || hookHarness === "codex"
+        ? hookHarness
+        : undefined;
     const report = await runSetup({
       tool: opts.tool ?? null,
       dryRun: Boolean(opts.dryRun),
@@ -9717,6 +9726,7 @@ program
         rewriteExistingNeotoma: Boolean(opts.rewriteNeotomaMcp),
         skipHooks: Boolean(opts.skipHooks),
         allHarnesses: Boolean(opts.allHarnesses),
+        harness: mcpHarness,
       }),
     });
     const exitCode = report.overall_ok ? 0 : 1;

--- a/src/cli/mcp_config_scan.ts
+++ b/src/cli/mcp_config_scan.ts
@@ -548,6 +548,28 @@ function resolveMcpLaunchTarget(repoRoot: string): { root: string; mode: "script
   return { root: repoRoot, mode: "scripts" };
 }
 
+/**
+ * Resolve a root usable for GENERATING launch entries and OFFERING a project-level
+ * `.mcp.json` write, even when the caller has no Neotoma source checkout (repoRoot null).
+ *
+ * A global/built npm install has no source checkout on the cwd path, so findRepoRoot
+ * returns null — but getInstalledCliRoot() still points at the installed package, which
+ * carries either the MCP shim scripts or a `dist/index.js` entrypoint. Either is enough
+ * to launch a local stdio Neotoma MCP server. Returns null only when no launchable
+ * Neotoma install can be found at all (neither a source checkout nor a built package).
+ *
+ * NOTE: this root is for entry generation only. Repo-only side effects (npm run
+ * sync:mcp) must still gate on a real source checkout, not on this value.
+ */
+function resolveEffectiveInstallRoot(repoRoot: string | null): string | null {
+  if (repoRoot) return repoRoot;
+  const installedRoot = getInstalledCliRoot();
+  if (hasRequiredMcpScripts(installedRoot) || hasDistMcpEntrypoint(installedRoot)) {
+    return installedRoot;
+  }
+  return null;
+}
+
 export function neotomaServerEntries(
   repoRoot: string,
   _sessionPorts?: SessionPorts
@@ -1562,10 +1584,15 @@ export async function offerFix(
     return { fixed: false, message: "No misconfigurations detected.", updatedPaths: [] };
   }
 
-  if (!repoRoot) {
+  // A globally installed CLI has no source checkout on the cwd path (repoRoot null),
+  // but can still launch a local stdio MCP server from its built package. Only bail
+  // when no launchable Neotoma install is resolvable at all.
+  const effectiveRoot = resolveEffectiveInstallRoot(repoRoot);
+  if (!effectiveRoot) {
     return {
       fixed: false,
-      message: "Cannot fix: Neotoma source root not found. Run from a Neotoma source checkout.",
+      message:
+        "Cannot fix: no Neotoma install found. Install neotoma (npm i -g neotoma) or run from a source checkout.",
       updatedPaths: [],
     };
   }
@@ -1705,6 +1732,12 @@ export async function offerInstall(
     assumeYes?: boolean;
     /** When true, do not run sync:mcp (avoids writing project-level MCP configs). */
     skipProjectSync?: boolean;
+    /**
+     * Target harness for this install (e.g. from `setup --tool <harness>`). When
+     * "claude-code" and creating a fresh project-level config, write a project-root
+     * `.mcp.json` (Claude Code's config location) instead of `.cursor/mcp.json`.
+     */
+    harness?: McpHookHarness;
   }
 ): Promise<{
   installed: boolean;
@@ -1721,12 +1754,20 @@ export async function offerInstall(
       ? { devPort: options.devPort, prodPort: options.prodPort }
       : undefined;
 
-  if (!repoRoot) {
+  // `installRoot` is the root used to GENERATE launch entries (scripts or dist/index.js).
+  // A global/built install has no source checkout on the cwd path (repoRoot null) but is
+  // still launchable via getInstalledCliRoot(); only bail when nothing launchable exists.
+  const installRoot = resolveEffectiveInstallRoot(repoRoot);
+  if (!installRoot) {
     const message =
-      "Cannot install: Neotoma source root not found. Run from a Neotoma source checkout or set NEOTOMA_REPO_ROOT.";
+      "Cannot install: no Neotoma install found. Install neotoma (npm i -g neotoma) or run from a source checkout, or set NEOTOMA_REPO_ROOT.";
     if (!silent) process.stderr.write(message + "\n");
     return { installed: false, message };
   }
+  // `projectScopeRoot` is where a project-level config (.mcp.json / .cursor/mcp.json)
+  // would live for the CURRENT project. In a source checkout this equals repoRoot; for a
+  // global install it is the user's project root, resolved from cwd.
+  const projectScopeRoot = repoRoot ?? (await getProjectRoot(cwd));
 
   const getMissingConfigs = (env: "dev" | "prod" | null): ConfigStatus[] =>
     env
@@ -1734,10 +1775,10 @@ export async function offerInstall(
       : configs.filter((c) => !c.hasDev || !c.hasProd);
   const getConfigsForScope = (allConfigs: ConfigStatus[]): ConfigStatus[] => {
     if (options?.autoInstallScope === "user") {
-      return filterConfigsByInstallChoice(allConfigs, "user_all", repoRoot);
+      return filterConfigsByInstallChoice(allConfigs, "user_all", projectScopeRoot);
     }
     if (options?.autoInstallScope === "project") {
-      return filterConfigsByInstallChoice(allConfigs, "project_all", repoRoot);
+      return filterConfigsByInstallChoice(allConfigs, "project_all", projectScopeRoot);
     }
     return allConfigs;
   };
@@ -1833,14 +1874,21 @@ export async function offerInstall(
     }
 
     process.stdout.write("No MCP config files found.\n");
+    // For a project-scoped Claude Code install, the canonical target is a project-root
+    // `.mcp.json` (local stdio server), not `.cursor/mcp.json`. Other harnesses keep the
+    // Cursor default. This is the path a global install of `setup --tool claude-code` hits.
+    const createClaudeCodeProjectMcp =
+      options?.harness === "claude-code" &&
+      (options?.autoInstallScope === "project" || options?.autoInstallScope === undefined);
+    const promptText = createClaudeCodeProjectMcp
+      ? "Create user-level (~/.cursor/mcp.json) or project-level (.mcp.json in current project)? (u/p)"
+      : "Create user-level (~/.cursor/mcp.json) or project-level (.cursor/mcp.json in current project)? (u/p)";
     const choice =
       options?.autoInstallScope === "user"
         ? "user"
         : options?.autoInstallScope === "project"
           ? "project"
-          : await promptUserOrProject(
-              "Create user-level (~/.cursor/mcp.json) or project-level (.cursor/mcp.json in current project)? (u/p)"
-            );
+          : await promptUserOrProject(promptText);
     if (choice === null) {
       return { installed: false, message: "Installation cancelled." };
     }
@@ -1849,14 +1897,21 @@ export async function offerInstall(
     }
     await ensureAAuthKeysForSignedTransport(selectedTransport, silent);
 
-    const cursorDir =
-      choice === "user"
-        ? path.join(os.homedir(), ".cursor")
-        : path.join(await getProjectRoot(cwd), ".cursor");
-    const configPath = path.join(cursorDir, "mcp.json");
+    let configPath: string;
+    if (choice === "project" && createClaudeCodeProjectMcp) {
+      // Claude Code reads a project-root .mcp.json.
+      configPath = path.join(await getProjectRoot(cwd), ".mcp.json");
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+    } else {
+      const cursorDir =
+        choice === "user"
+          ? path.join(os.homedir(), ".cursor")
+          : path.join(await getProjectRoot(cwd), ".cursor");
+      configPath = path.join(cursorDir, "mcp.json");
+      await fs.mkdir(cursorDir, { recursive: true });
+    }
 
-    await fs.mkdir(cursorDir, { recursive: true });
-    const entries = neotomaServerEntriesForTransport(repoRoot, sessionPorts, selectedTransport);
+    const entries = neotomaServerEntriesForTransport(installRoot, sessionPorts, selectedTransport);
     const mcpServers =
       selectedEnv === "dev"
         ? { "neotoma-dev": entries["neotoma-dev"] }
@@ -1866,10 +1921,16 @@ export async function offerInstall(
     const newConfig = { mcpServers };
     await fs.writeFile(configPath, JSON.stringify(newConfig, null, 2) + "\n");
 
-    if (choice === "project" && configPath.startsWith(repoRoot) && !options?.skipProjectSync) {
+    // sync:mcp only exists in a source checkout; skip it for global installs.
+    if (
+      choice === "project" &&
+      repoRoot &&
+      configPath.startsWith(repoRoot) &&
+      !options?.skipProjectSync
+    ) {
       await runSyncMcp(repoRoot);
     }
-    await attemptCursorMcpReload(configPath);
+    if (!createClaudeCodeProjectMcp) await attemptCursorMcpReload(configPath);
 
     const createdMsg = selectedEnv
       ? `Created ${configPath} with ${selectedEnv} server.`
@@ -1894,8 +1955,12 @@ export async function offerInstall(
   if (!boxAlreadyShown && !silent) {
     process.stdout.write("\n" + formatMcpStatusBox(scopedTargetConfigs) + "\n");
   }
-  const runningFromSourceCheckout = cwd === repoRoot || cwd.startsWith(repoRoot + path.sep);
-  const includeProjectOptions = runningFromSourceCheckout;
+  const runningFromSourceCheckout =
+    !!repoRoot && (cwd === repoRoot || cwd.startsWith(repoRoot + path.sep));
+  // Project-level configs are offered from a source checkout OR whenever we can launch a
+  // built/global install (installRoot resolved above) — the latter writes a project-root
+  // .mcp.json that points at the installed dist entrypoint, no checkout required.
+  const includeProjectOptions = runningFromSourceCheckout || !!installRoot;
 
   const installChoice: InstallTargetChoice =
     options?.autoInstallScope === "project"
@@ -1919,11 +1984,11 @@ export async function offerInstall(
   let selectedMissingConfigs = filterConfigsByInstallChoice(
     configsForInstallTargets,
     installChoice,
-    repoRoot
+    projectScopeRoot
   );
   if (!includeProjectOptions) {
     selectedMissingConfigs = selectedMissingConfigs.filter(
-      (c) => !isProjectLevelConfig(c.path, repoRoot)
+      (c) => !isProjectLevelConfig(c.path, projectScopeRoot)
     );
   }
   if (selectedMissingConfigs.length === 0) {
@@ -1934,7 +1999,7 @@ export async function offerInstall(
     };
   }
 
-  const entries = neotomaServerEntriesForTransport(repoRoot, sessionPorts, selectedTransport);
+  const entries = neotomaServerEntriesForTransport(installRoot, sessionPorts, selectedTransport);
   const updatedPaths: string[] = [];
   const selectedIncludesCodex = selectedMissingConfigs.some((c) => isCodexConfigPath(c.path));
   const forceRewriteNeotoma = options?.rewriteExistingNeotoma ?? false;

--- a/src/cli/mcp_config_scan.ts
+++ b/src/cli/mcp_config_scan.ts
@@ -1078,6 +1078,21 @@ export type ConfigStatus = {
 
 export type McpHookHarness = "cursor" | "claude-code" | "codex";
 
+/** Canonical list of `McpHookHarness` values, for runtime validation of untyped input. */
+const MCP_HOOK_HARNESSES: readonly McpHookHarness[] = ["cursor", "claude-code", "codex"];
+
+/**
+ * Runtime type guard for `McpHookHarness`. `offerInstall`'s `options.harness` is typed as
+ * `McpHookHarness | undefined` at compile time, but callers may thread through an untyped or
+ * externally-sourced string (e.g. from a future harness added to `HookHarnessId` in
+ * hooks_detect.ts before `McpHookHarness` is updated to match, or from a caller that skips
+ * `toHookHarness`'s narrowing). Validate here so an unsupported value can't silently reach the
+ * `.mcp.json`-vs-`.cursor/mcp.json` decision below as if it were a real, supported harness.
+ */
+export function isMcpHookHarness(value: unknown): value is McpHookHarness {
+  return typeof value === "string" && (MCP_HOOK_HARNESSES as readonly string[]).includes(value);
+}
+
 /** Infer hook-capable harnesses from MCP config paths that already contain a Neotoma server. */
 export function inferHookHarnessesFromMcpConfigs(configs: ConfigStatus[]): McpHookHarness[] {
   const harnesses = new Set<McpHookHarness>();
@@ -1875,10 +1890,15 @@ export async function offerInstall(
 
     process.stdout.write("No MCP config files found.\n");
     // For a project-scoped Claude Code install, the canonical target is a project-root
-    // `.mcp.json` (local stdio server), not `.cursor/mcp.json`. Other harnesses keep the
-    // Cursor default. This is the path a global install of `setup --tool claude-code` hits.
+    // `.mcp.json` (local stdio server), not `.cursor/mcp.json`. Other harnesses — including
+    // any value that fails `isMcpHookHarness` (e.g. an unsupported/future harness id passed
+    // through an untyped caller) — fall back to the Cursor default `.cursor/mcp.json`. This
+    // fallback is deliberate and safe: `.cursor/mcp.json` is the harness-agnostic default this
+    // function used before the Claude Code carve-out existed. This is the path a global install
+    // of `setup --tool claude-code` hits.
     const createClaudeCodeProjectMcp =
-      options?.harness === "claude-code" &&
+      isMcpHookHarness(options?.harness) &&
+      options.harness === "claude-code" &&
       (options?.autoInstallScope === "project" || options?.autoInstallScope === undefined);
     const promptText = createClaudeCodeProjectMcp
       ? "Create user-level (~/.cursor/mcp.json) or project-level (.mcp.json in current project)? (u/p)"

--- a/src/cli/setup_runners.ts
+++ b/src/cli/setup_runners.ts
@@ -10,6 +10,7 @@ import {
 import {
   inferHookHarnessesFromMcpConfigs,
   scanForMcpConfigs,
+  type McpHookHarness,
   type McpTransportChoice,
 } from "./mcp_config_scan.js";
 import type { RunSetupOptions, SetupStepResult } from "./setup.js";
@@ -24,6 +25,8 @@ export interface DefaultSetupRunnerOptions {
   rewriteExistingNeotoma?: boolean;
   skipHooks?: boolean;
   allHarnesses?: boolean;
+  /** Target harness (from `setup --tool <harness>`); steers project MCP config placement. */
+  harness?: McpHookHarness;
 }
 
 function runInitSubprocess(cwd: string): Promise<SetupStepResult> {
@@ -112,6 +115,7 @@ export function createDefaultSetupRunners(
         mcpTransport: options.mcpTransport,
         assumeYes: options.yes,
         rewriteExistingNeotoma: options.rewriteExistingNeotoma,
+        harness: options.harness,
       });
       return {
         id: "mcp-configure",

--- a/tests/cli/cli_mcp_commands.test.ts
+++ b/tests/cli/cli_mcp_commands.test.ts
@@ -11,6 +11,8 @@ import {
   findMcpConfigPaths,
   inferHookHarnessesFromMcpConfigs,
   ensureAAuthKeysForSignedTransport,
+  isMcpHookHarness,
+  type McpHookHarness,
   neotomaServerEntriesForTransport,
   neotomaServerEntries,
   offerInstall,
@@ -304,6 +306,61 @@ describe("CLI MCP and instruction commands", () => {
       } finally {
         await fs.rm(tmpProject, { recursive: true, force: true });
       }
+    });
+
+    it("falls back to .cursor/mcp.json for an unsupported harness value", async () => {
+      // A caller that bypasses toHookHarness's narrowing (e.g. a future harness id, or an
+      // untyped/externally-sourced string) must not be treated as "claude-code" by offerInstall.
+      // isMcpHookHarness rejects it and the project-level default (.cursor/mcp.json) is used —
+      // this documents and locks in that runtime fallback behavior.
+      const tmpProject = await fs.mkdtemp(path.join(os.tmpdir(), "neotoma-unsupported-harness-"));
+      try {
+        await fs.writeFile(
+          path.join(tmpProject, "package.json"),
+          JSON.stringify({ name: "some-user-app", version: "1.0.0" }, null, 2)
+        );
+
+        const result = await offerInstall([], /* repoRoot */ null, {
+          silent: false,
+          cwd: tmpProject,
+          autoInstallScope: "project",
+          autoInstallEnv: "both",
+          // Cast: "vscode" is not a valid McpHookHarness. This exercises the runtime guard
+          // that protects offerInstall from an untyped caller passing an unsupported value.
+          harness: "vscode" as unknown as McpHookHarness,
+          skipProjectSync: true,
+        });
+
+        expect(result.installed).toBe(true);
+        const cursorMcpPath = path.join(tmpProject, ".cursor", "mcp.json");
+        const rootMcpPath = path.join(tmpProject, ".mcp.json");
+        expect(result.updatedPaths).toContain(cursorMcpPath);
+        expect(result.updatedPaths).not.toContain(rootMcpPath);
+        await expect(fs.access(rootMcpPath)).rejects.toThrow();
+        const parsed = JSON.parse(await fs.readFile(cursorMcpPath, "utf-8")) as {
+          mcpServers?: Record<string, unknown>;
+        };
+        expect(parsed.mcpServers?.["neotoma-dev"]).toBeDefined();
+        expect(parsed.mcpServers?.neotoma).toBeDefined();
+      } finally {
+        await fs.rm(tmpProject, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe("isMcpHookHarness", () => {
+    it("accepts only the supported McpHookHarness values", () => {
+      expect(isMcpHookHarness("claude-code")).toBe(true);
+      expect(isMcpHookHarness("cursor")).toBe(true);
+      expect(isMcpHookHarness("codex")).toBe(true);
+    });
+
+    it("rejects unsupported or malformed values", () => {
+      expect(isMcpHookHarness("vscode")).toBe(false);
+      expect(isMcpHookHarness("")).toBe(false);
+      expect(isMcpHookHarness(undefined)).toBe(false);
+      expect(isMcpHookHarness(null)).toBe(false);
+      expect(isMcpHookHarness(123)).toBe(false);
     });
   });
 

--- a/tests/cli/cli_mcp_commands.test.ts
+++ b/tests/cli/cli_mcp_commands.test.ts
@@ -239,6 +239,74 @@ describe("CLI MCP and instruction commands", () => {
     });
   });
 
+  describe("global install (no source checkout) claude-code project .mcp.json", () => {
+    it("writes a project-root .mcp.json pointing at the installed CLI when repoRoot is null", async () => {
+      // Simulates a global npm install: findRepoRoot(cwd) returns null (no neotoma
+      // package.json above the user's project). Previously offerInstall bailed with
+      // "source root not found" and wrote nothing. It must now fall back to the
+      // installed CLI root and create <project>/.mcp.json for Claude Code.
+      const tmpProject = await fs.mkdtemp(path.join(os.tmpdir(), "neotoma-global-install-cc-"));
+      try {
+        // Give the scratch dir a project marker so getProjectRoot resolves to it.
+        await fs.writeFile(
+          path.join(tmpProject, "package.json"),
+          JSON.stringify({ name: "some-user-app", version: "1.0.0" }, null, 2)
+        );
+
+        const result = await offerInstall([], /* repoRoot */ null, {
+          silent: false,
+          cwd: tmpProject,
+          autoInstallScope: "project",
+          autoInstallEnv: "both",
+          harness: "claude-code",
+          skipProjectSync: true,
+        });
+
+        expect(result.installed).toBe(true);
+        const mcpJsonPath = path.join(tmpProject, ".mcp.json");
+        expect(result.updatedPaths).toContain(mcpJsonPath);
+        const parsed = JSON.parse(await fs.readFile(mcpJsonPath, "utf-8")) as {
+          mcpServers?: Record<string, { command?: string; args?: string[] }>;
+        };
+        // Both dev and prod neotoma servers should be present and launchable
+        // (either script shims or a node dist/index.js entrypoint from the install root).
+        expect(parsed.mcpServers?.["neotoma-dev"]).toBeDefined();
+        expect(parsed.mcpServers?.neotoma).toBeDefined();
+        const prod = parsed.mcpServers?.neotoma;
+        const serialized = JSON.stringify(prod);
+        // The launcher must be a real Neotoma stdio entrypoint from the install root
+        // (a run_neotoma_mcp_*.sh shim, or a node dist/index.js for a built package),
+        // never a stale/empty path — this is the whole point of the global-install fix.
+        expect(
+          serialized.includes("run_neotoma_mcp") || serialized.includes("dist/index.js")
+        ).toBe(true);
+      } finally {
+        await fs.rm(tmpProject, { recursive: true, force: true });
+      }
+    });
+
+    it("does not bail with 'source root not found' for a resolvable install", async () => {
+      const tmpProject = await fs.mkdtemp(path.join(os.tmpdir(), "neotoma-global-install-msg-"));
+      try {
+        await fs.writeFile(
+          path.join(tmpProject, "package.json"),
+          JSON.stringify({ name: "some-user-app", version: "1.0.0" }, null, 2)
+        );
+        const result = await offerInstall([], /* repoRoot */ null, {
+          silent: true,
+          cwd: tmpProject,
+          autoInstallScope: "project",
+          autoInstallEnv: "both",
+          harness: "claude-code",
+          skipProjectSync: true,
+        });
+        expect(result.message.toLowerCase()).not.toContain("source root not found");
+      } finally {
+        await fs.rm(tmpProject, { recursive: true, force: true });
+      }
+    });
+  });
+
   describe("mcp hook harness inference", () => {
     it("infers hook-capable harnesses only from configured Neotoma MCP paths", () => {
       const result = inferHookHarnessesFromMcpConfigs([


### PR DESCRIPTION
## Problem

`neotoma setup --tool claude-code --yes` on a **global npm install** completes init / permissions / skills / CLI-instruction rules but silently **skips mcp-configure** (`repoRoot: null`) — no `.mcp.json` and no hooks are written. The CLI itself works fully. Reported by an evaluator on `neotoma@0.18.7`:

> `neotoma mcp config` → "source root not found." Setting `NEOTOMA_REPO_ROOT` cleared that but that command only targets Claude-desktop/Codex (never claude-code). Re-running `neotoma setup --tool claude-code --yes` with the path configured still skipped mcp-configure (repoRoot: null, wrote nothing).

## Root cause

`scanForMcpConfigs` resolves `repoRoot` via `findRepoRoot(cwd)`, which walks up from cwd looking for a `package.json` whose `name === "neotoma"`. For a global install run inside an arbitrary user project, that never matches → `repoRoot = null`. `offerInstall` and `offerFix` then **early-return** `"Neotoma source root not found"` before ever reaching `getInstalledCliRoot()` / `resolveMcpLaunchTarget()` / the dist-mode `neotomaServerEntries` branch — which **already** resolve a launchable entrypoint for globally-installed/built packages (`{ command: node, args: [<installedRoot>/dist/index.js] }`, or the `run_neotoma_mcp_*.sh` shims). The install path just never got there. A second gap: the "no configs found" create-branch was Cursor-only and never emitted a project `.mcp.json` for Claude Code.

## Fix

- **`resolveEffectiveInstallRoot()`** — falls back to `getInstalledCliRoot()` when `findRepoRoot` is null and the installed package carries MCP scripts or a `dist/index.js`. `offerInstall`/`offerFix` bail only when nothing launchable exists.
- **Separate the two roots** — `installRoot` (launch-entry generation) vs `projectScopeRoot` (= `getProjectRoot(cwd)` for global installs; where a project `.mcp.json` lives).
- **Offer project-level configs** whenever a launchable install resolves, not only from a source checkout; guard `runningFromSourceCheckout` against null `repoRoot`.
- **Thread a `harness` hint** (`setup --tool`) through `configureMcpServers` → `offerInstall` so a project-scoped **Claude Code** install creates a project-root `.mcp.json` (local stdio server) instead of `.cursor/mcp.json`.
- **Keep `runSyncMcp` / codex-sync gated on a true source checkout** (`npm run sync:mcp` only exists there).

## Tests

Adds a `cli_mcp_commands` cell proving a global install (`repoRoot=null`, `harness: "claude-code"`, project scope) writes `<project>/.mcp.json` with launchable neotoma dev+prod entries and no longer reports "source root not found". Full `tsc`, targeted vitest (cli_mcp_commands, cli_doctor_setup, cli_init_*, cli_onboarding, mcp_proxy, cli_bug_fixes — 129 tests), and eslint on changed core files all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #1881
