### PR TITLE
feat(schema): register issue_spec entity type for swarm issue-spec pipeline

### DIFF
--- a/src/services/schema_definitions.ts
+++ b/src/services/schema_definitions.ts
@@ -3339,6 +3339,81 @@ export const ENTITY_SCHEMAS: Record<string, EntitySchema> = {
     },
   },
 
+  issue_spec: {
+    entity_type: "issue_spec",
+    schema_version: "1.0",
+    metadata: {
+      label: "Issue Spec",
+      description:
+        "An additive, multi-agent specification for a single GitHub issue produced by the " +
+        "Ateles swarm's issue-spec pipeline. Each participating agent contributes its own " +
+        "section (PM, design, engineering, QA, security, legal); the entity accumulates them " +
+        "in place. Keyed by (repo, issue_number).",
+      category: "agent_runtime",
+      aliases: ["swarm_issue_spec", "issue_specification"],
+    },
+    schema_definition: {
+      fields: {
+        schema_version: { type: "string", required: false },
+        // Repository slug in owner/repo format (e.g. "markmhendrickson/neotoma").
+        repo: { type: "string", required: true },
+        // GitHub issue number — primary identifier within a repo.
+        issue_number: { type: "number", required: true },
+        // Human-readable composite key "<repo>#<number>"; mirrors the
+        // (repo, issue_number) identity and doubles as a fallback identity rule.
+        spec_key: { type: "string", required: false },
+        // Issue title.
+        title: { type: "string", required: false, preserveCase: true },
+        // Per-agent additive section markdown. Each agent corrects its own
+        // section in place as the spec progresses through the pipeline.
+        pm_section: { type: "string", required: false, preserveCase: true },
+        design_section: { type: "string", required: false, preserveCase: true },
+        eng_section: { type: "string", required: false, preserveCase: true },
+        qa_section: { type: "string", required: false, preserveCase: true },
+        security_section: { type: "string", required: false, preserveCase: true },
+        legal_section: { type: "string", required: false, preserveCase: true },
+        // Ordered list of completed section keys, tracking pipeline progress.
+        sequence_state: { type: "array", required: false },
+        // ISO-8601 timestamps. Strings (not date type) so lexicographic sort
+        // matches temporal order.
+        last_updated_at: { type: "string", required: false },
+        last_mirrored_at: { type: "string", required: false },
+      },
+      // An issue_spec is uniquely identified by its issue number within a repo.
+      // The composite [repo, issue_number] is the primary rule so two stores for
+      // the same repo#number resolve to the SAME entity (agents correct in
+      // place); spec_key ("<repo>#<number>") is a fallback for callers that only
+      // supply the pre-formed composite key.
+      canonical_name_fields: [{ composite: ["repo", "issue_number"] }, "spec_key"],
+      name_collision_policy: "reject",
+      agent_instructions:
+        "An issue_spec entity is the additive, multi-agent spec for one GitHub issue. " +
+        "Use repo and issue_number together as the primary identifier (spec_key = " +
+        '"<repo>#<number>" mirrors it). Each agent appends or corrects only its own ' +
+        "section field (pm_section, design_section, eng_section, qa_section, " +
+        "security_section, legal_section) and adds its section key to sequence_state; " +
+        "never overwrite another agent's section. Update last_updated_at on each write " +
+        "and last_mirrored_at when the spec is mirrored back to GitHub.",
+    },
+    reducer_config: {
+      merge_policies: {
+        repo: { strategy: "last_write" },
+        issue_number: { strategy: "last_write" },
+        spec_key: { strategy: "last_write" },
+        title: { strategy: "last_write" },
+        pm_section: { strategy: "last_write" },
+        design_section: { strategy: "last_write" },
+        eng_section: { strategy: "last_write" },
+        qa_section: { strategy: "last_write" },
+        security_section: { strategy: "last_write" },
+        legal_section: { strategy: "last_write" },
+        sequence_state: { strategy: "last_write" },
+        last_updated_at: { strategy: "last_write" },
+        last_mirrored_at: { strategy: "last_write" },
+      },
+    },
+  },
+
   usage_digest: {
     entity_type: "usage_digest",
     schema_version: "1.0",

--- a/tests/unit/issue_spec_schema.test.ts
+++ b/tests/unit/issue_spec_schema.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Unit tests for issue_spec entity schema registration.
+ *
+ * Backs ateles#178 (swarm issue-spec pipeline). Verifies that:
+ * - The `issue_spec` schema is present in ENTITY_SCHEMAS after bootstrap
+ * - `canonical_name_fields` has a composite rule for ["repo", "issue_number"]
+ *   and a "spec_key" fallback so two stores for the same repo#number resolve
+ *   to the SAME entity (agents correct in place)
+ * - Required fields (repo, issue_number) are declared as required
+ * - All expected per-agent section + bookkeeping fields are declared with
+ *   correct types
+ * - reducer_config has merge policies covering only declared fields
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  ENTITY_SCHEMAS,
+  getRegisteredEntityTypes,
+  getSchemaDefinition,
+} from "../../src/services/schema_definitions.js";
+import { deriveCanonicalNameFromFieldsWithTrace } from "../../src/services/entity_resolution.js";
+
+describe("issue_spec schema (ateles#178)", () => {
+  const schema = ENTITY_SCHEMAS["issue_spec"];
+
+  it("is registered in ENTITY_SCHEMAS", () => {
+    expect(schema).toBeDefined();
+    expect(schema.entity_type).toBe("issue_spec");
+  });
+
+  it("is retrievable via getSchemaDefinition", () => {
+    const result = getSchemaDefinition("issue_spec");
+    expect(result).not.toBeNull();
+    expect(result?.entity_type).toBe("issue_spec");
+  });
+
+  it("has repo declared as a required string field", () => {
+    const { fields } = schema.schema_definition;
+    expect(fields.repo).toBeDefined();
+    expect(fields.repo.type).toBe("string");
+    expect(fields.repo.required).toBe(true);
+  });
+
+  it("has issue_number declared as a required number field", () => {
+    const { fields } = schema.schema_definition;
+    expect(fields.issue_number).toBeDefined();
+    expect(fields.issue_number.type).toBe("number");
+    expect(fields.issue_number.required).toBe(true);
+  });
+
+  it("has all expected section + bookkeeping fields with correct types", () => {
+    const { fields } = schema.schema_definition;
+    expect(fields.spec_key?.type).toBe("string");
+    expect(fields.title?.type).toBe("string");
+    expect(fields.pm_section?.type).toBe("string");
+    expect(fields.design_section?.type).toBe("string");
+    expect(fields.eng_section?.type).toBe("string");
+    expect(fields.qa_section?.type).toBe("string");
+    expect(fields.security_section?.type).toBe("string");
+    expect(fields.legal_section?.type).toBe("string");
+    expect(fields.sequence_state?.type).toBe("array");
+    expect(fields.last_updated_at?.type).toBe("string");
+    expect(fields.last_mirrored_at?.type).toBe("string");
+  });
+
+  it("canonical_name_fields includes a composite rule for [repo, issue_number]", () => {
+    const cnf = schema.schema_definition.canonical_name_fields;
+    expect(cnf).toBeDefined();
+    expect(Array.isArray(cnf)).toBe(true);
+    const rules = cnf as Array<string | { composite: string[] }>;
+    const hasComposite = rules.some(
+      (r) =>
+        typeof r === "object" &&
+        "composite" in r &&
+        r.composite.includes("repo") &&
+        r.composite.includes("issue_number")
+    );
+    expect(hasComposite).toBe(true);
+  });
+
+  it("canonical_name_fields includes 'spec_key' as a fallback rule", () => {
+    const cnf = schema.schema_definition.canonical_name_fields;
+    const rules = cnf as Array<string | { composite: string[] }>;
+    expect(rules.some((r) => r === "spec_key")).toBe(true);
+  });
+
+  it("reducer_config has merge policies for only declared fields (no dangling policies)", () => {
+    const fields = schema.schema_definition.fields;
+    const policies = schema.reducer_config.merge_policies;
+    for (const key of Object.keys(policies)) {
+      expect(fields, `merge policy references undeclared field '${key}'`).toHaveProperty(key);
+    }
+  });
+
+  it("appears in list of registered entity types", () => {
+    const types: string[] = getRegisteredEntityTypes();
+    expect(types).toContain("issue_spec");
+  });
+
+  it("two stores for the same (repo, issue_number) derive the SAME canonical_name (identity dedup)", () => {
+    const base = {
+      repo: "markmhendrickson/neotoma",
+      issue_number: 178,
+      spec_key: "markmhendrickson/neotoma#178",
+    };
+    const a = deriveCanonicalNameFromFieldsWithTrace(
+      "issue_spec",
+      { ...base, pm_section: "first pass" },
+      { canonical_name_fields: schema.schema_definition.canonical_name_fields }
+    );
+    const b = deriveCanonicalNameFromFieldsWithTrace(
+      "issue_spec",
+      { ...base, eng_section: "later pass" },
+      { canonical_name_fields: schema.schema_definition.canonical_name_fields }
+    );
+    expect(a.canonicalName).toBeTruthy();
+    expect(a.canonicalName).toBe(b.canonicalName);
+    expect(a.identityBasis).toBe("schema_rule");
+  });
+
+  it("different issue numbers derive DIFFERENT canonical_names (distinct entities)", () => {
+    const a = deriveCanonicalNameFromFieldsWithTrace(
+      "issue_spec",
+      { repo: "markmhendrickson/neotoma", issue_number: 178 },
+      { canonical_name_fields: schema.schema_definition.canonical_name_fields }
+    );
+    const b = deriveCanonicalNameFromFieldsWithTrace(
+      "issue_spec",
+      { repo: "markmhendrickson/neotoma", issue_number: 179 },
+      { canonical_name_fields: schema.schema_definition.canonical_name_fields }
+    );
+    expect(a.canonicalName).not.toBe(b.canonicalName);
+  });
+});


### PR DESCRIPTION
## What

Registers a formal `issue_spec` entity schema in `src/services/schema_definitions.ts`, backing the Ateles swarm's issue-spec pipeline built in **ateles#178**. Until now the daemon relied on schema-inference plus O(n) dedup to keep one spec per issue; this gives the type a real schema with a deterministic identity key.

## Identity

```ts
canonical_name_fields: [{ composite: ["repo", "issue_number"] }, "spec_key"]
name_collision_policy: "reject"
```

- The **composite `(repo, issue_number)`** is the primary rule: two stores for the same repo#number resolve to the **same** entity, so each agent corrects its own section in place instead of minting a duplicate.
- **`spec_key`** (`"<repo>#<number>"`) is an ordered fallback for callers that only supply the pre-formed composite key.
- Different issue numbers resolve to distinct entities.

This mirrors the `pull_request` schema pattern seeded in #158 (composite `[pr_number, repo]` + a scalar fallback).

## Fields

`repo`, `issue_number` (required identity); `spec_key`, `title`; per-agent additive sections `pm_section` / `design_section` / `eng_section` / `qa_section` / `security_section` / `legal_section`; `sequence_state` (array of completed section keys); `last_updated_at`, `last_mirrored_at`. All section merges use `last_write` so each agent's in-place correction sticks.

## Additive / no migration

This is a brand-new entity type. Nothing changes for any existing entity type, and no existing rows require migration.

## Verification

- **11 unit tests** added (`tests/unit/issue_spec_schema.test.ts`): registration, retrieval, field types, composite + `spec_key` fallback in `canonical_name_fields`, no dangling merge policies, and identity dedup (same repo#number -> one `canonical_name`; different numbers -> distinct). All pass.
- `npm run type-check` - pass
- `npm run build` - pass
- `eslint` + `prettier --check` on changed files - pass
- `npm run validate:test-catalog` + `npm run validate:capability-manifest` - no generated-file drift
- Regression: `pull_request_schema`, `schema_definitions_agent_runtime`, `schema_definitions` suites (46 tests) - pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)