### PR TITLE
fix(npm): ship hook packages so 'hooks install' works from a global install (#1904)

### DIFF
--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,15 +61,15 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **527**
-- Backend and repo Vitest files: **492**
+- Total automated test files: **528**
+- Backend and repo Vitest files: **493**
 - Frontend Vitest files: **9**
 - Playwright spec files: **26**
 
 ### Suite counts
 | Suite | Files |
 |---|---:|
-| Vitest unit tests | 146 |
+| Vitest unit tests | 147 |
 | Vitest service tests | 36 |
 | Source-adjacent tests | 64 |
 | Vitest integration tests | 151 |
@@ -109,7 +109,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/unit`
 **Requirements:** Basic `.env` if required by the module under test.
-**Files (146):**
+**Files (147):**
 - `tests/unit/aauth_admission.test.ts`
 - `tests/unit/aauth_attestation_apple_se.test.ts`
 - `tests/unit/aauth_attestation_revocation.test.ts`
@@ -182,6 +182,7 @@ flowchart TD
 - `tests/unit/i18n_routing.test.ts`
 - `tests/unit/inspector_admin_unlock_url.test.ts`
 - `tests/unit/inspector_skin.test.ts`
+- `tests/unit/issue_spec_schema.test.ts`
 - `tests/unit/keepalive_timeout.test.ts`
 - `tests/unit/list_timeline_events_unknown_type.test.ts`
 - `tests/unit/manage_bundles_tool.test.ts`

--- a/package.json
+++ b/package.json
@@ -257,6 +257,9 @@
     "openapi.yaml",
     "openclaw.plugin.json",
     "skills",
+    "packages/claude-code-plugin",
+    "packages/codex-hooks",
+    "packages/cursor-hooks",
     "LICENSE",
     "README.md"
   ],

--- a/tests/contract/package_contents.test.ts
+++ b/tests/contract/package_contents.test.ts
@@ -30,4 +30,34 @@ describe("npm package contents", () => {
 
     expect(filePaths).toContain("openapi.yaml");
   });
+
+  // Regression for #1904: `neotoma hooks install` / `neotoma setup --tool
+  // claude-code` copy hook templates from packages/*, but those directories
+  // were absent from the npm `files` allowlist, so a global npm install failed
+  // with "Could not locate the Neotoma package root". Assert the hook package
+  // templates the installers reference (src/cli/hooks.ts) actually ship.
+  it("includes the hook packages the installers copy at runtime (#1904)", () => {
+    const result = spawnSync("npm", ["pack", "--json", "--dry-run"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    expect(result.status, result.stderr || result.stdout).toBe(0);
+
+    const parsed = parseNpmPackJsonOutput(result.stdout.trim());
+    const filePaths = (parsed[0]?.files ?? [])
+      .map((file) => file.path)
+      .filter(Boolean) as string[];
+
+    // The Claude Code plugin hooks (installer target for --tool claude-code)
+    // and the codex/cursor installer entry points must be in the tarball.
+    const required = [
+      "packages/claude-code-plugin/hooks/session_start.py",
+      "packages/codex-hooks/scripts/install.mjs",
+      "packages/cursor-hooks/scripts/install.mjs",
+    ];
+    for (const path of required) {
+      expect(filePaths, `missing from npm pack: ${path}`).toContain(path);
+    }
+  });
 });


### PR DESCRIPTION
## Problem (#1904)

`neotoma hooks install` and `neotoma setup --tool claude-code` copy hook templates from `packages/{claude-code-plugin,codex-hooks,cursor-hooks}` (see `src/cli/hooks.ts`), but those directories were **not** in the npm `files` allowlist. On a global `npm install -g neotoma`, `packages/` isn't in the tarball, so the installers fail:

> Could not locate the Neotoma package root … hook packages were not published with this install.

Reported by an external evaluator on 0.18.7 (latest). Real per-turn auto-capture is therefore unachievable from a normal npm install today.

## Fix

- Add `packages/claude-code-plugin`, `packages/codex-hooks`, `packages/cursor-hooks` to `package.json` `files`.
- Add a `package_contents` contract test that runs `npm pack --dry-run --json` and asserts the installer-referenced templates ship in the tarball (would have failed before this change).

## Why a test, not just the one-line fix

This is the **fresh-install runtime-file-completeness** bug class (retrospective `ent_e5e2778500c522178d1ea9d0`): any file the CLI resolves at runtime but that's missing from `files` fails silently in production. The test guards the class, not just this instance.

Closes #1904

🤖 Generated with [Claude Code](https://claude.com/claude-code)