### PR TITLE
feat(auth): surface active environment in get_authenticated_user (#1905)

### DIFF
--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,8 +61,8 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **528**
-- Backend and repo Vitest files: **493**
+- Total automated test files: **529**
+- Backend and repo Vitest files: **494**
 - Frontend Vitest files: **9**
 - Playwright spec files: **26**
 
@@ -72,7 +72,7 @@ flowchart TD
 | Vitest unit tests | 147 |
 | Vitest service tests | 36 |
 | Source-adjacent tests | 64 |
-| Vitest integration tests | 151 |
+| Vitest integration tests | 152 |
 | Vitest CLI tests | 65 |
 | Vitest contract tests | 14 |
 | Vitest security tests | 4 |
@@ -377,7 +377,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm run test:integration` or `npx vitest run tests/integration`
 **Requirements:** Database configured; remote-dependent subsets additionally need `RUN_REMOTE_TESTS=1`.
-**Files (151):**
+**Files (152):**
 - `tests/integration/aauth_attribution_stamping.test.ts`
 - `tests/integration/aauth_mcp_capability_parity.test.ts`
 - `tests/integration/aauth_mcp_initialize_admission.test.ts`
@@ -420,6 +420,7 @@ flowchart TD
 - `tests/integration/field_converters.test.ts`
 - `tests/integration/fixture_mcp_store_replay.test.ts`
 - `tests/integration/gdpr_deletion.test.ts`
+- `tests/integration/get_authenticated_user_environment.test.ts`
 - `tests/integration/graph_neighborhood_pagination.test.ts`
 - `tests/integration/graph_neighborhood_source_branch.test.ts`
 - `tests/integration/guest_invalid_bearer_routes.test.ts`

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -10546,6 +10546,14 @@ app.post("/get_authenticated_user", async (req, res) => {
       config.storageBackend === "local"
         ? {
             storage_backend: "local" as const,
+            // Surface the active environment + DB so an agent can confirm it is
+            // on the intended graph before writing (#1905). On a fresh npm
+            // install the CLI local transport defaults to production while the
+            // server defaults to development; exposing `environment` here lets
+            // a caller detect the split (e.g. writing to dev while an unflagged
+            // CLI reads empty prod) instead of discovering it via silent-empty
+            // results.
+            environment: config.environment,
             data_dir: config.dataDir,
             sqlite_db: config.sqlitePath,
           }

--- a/tests/integration/get_authenticated_user_environment.test.ts
+++ b/tests/integration/get_authenticated_user_environment.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Effect test for #1905: `get_authenticated_user` surfaces the active
+ * environment so a caller can confirm which graph (dev vs prod) it is on
+ * before writing.
+ *
+ * Background: on a fresh npm install the CLI local transport defaults to
+ * production while the server/API default to development, so an unflagged CLI
+ * query can silently hit an empty prod DB. Exposing `environment` in the
+ * storage block lets an agent detect that split instead of discovering it via
+ * silent-empty results.
+ */
+import type { AddressInfo } from "node:net";
+import type express from "express";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+describe("get_authenticated_user surfaces active environment (#1905)", () => {
+  let server: ReturnType<express.Application["listen"]>;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    const { app } = await import("../../src/actions.js");
+    server = app.listen(0);
+    const addr = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${addr.port}`;
+  });
+
+  afterAll(() => {
+    server?.close();
+  });
+
+  it("includes storage.environment in the response for a local backend", async () => {
+    const res = await fetch(`${baseUrl}/get_authenticated_user`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      user_id?: string;
+      storage?: { storage_backend?: string; environment?: string; sqlite_db?: string };
+    };
+    // Local (SQLite) backend must report which environment it resolved to.
+    expect(body.storage?.storage_backend).toBe("local");
+    expect(body.storage?.environment).toBeDefined();
+    expect(["development", "production"]).toContain(body.storage?.environment);
+    // The db path should be consistent with the reported environment (dev DB
+    // is neotoma.db; prod DB is neotoma.prod.db) — this is the split a caller
+    // needs to see.
+    expect(body.storage?.sqlite_db).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Problem (#1905)

On a fresh `npm install -g neotoma`, the CLI local transport defaults to **production** while the server/API default to **development**. So the MCP server writes to the dev DB, but an unflagged CLI query resolves to the empty, unauthenticated prod DB → returns nothing or 401 with **no signal** that the caller is on the wrong graph. An external evaluator lost real debugging time to this silent split.

## Fix (the non-breaking, high-value half)

Add `environment` to the `storage` block returned by `get_authenticated_user`, so an agent can **confirm which graph it's on before writing** — exactly the reporter's suggested fix (b): *surface the active env in a tool response*. The db path already differs (`neotoma.db` vs `neotoma.prod.db`); this makes the environment explicit and queryable.

Effect test asserts the field is present over HTTP.

## Scope note

This PR is the **observability** half. Flipping the CLI default to match the server (fix (a): make the default coherent / fail-loud) is a behavior change tracked separately under #1905 so it can be reviewed on its own risk profile.

Refs #1905

🤖 Generated with [Claude Code](https://claude.com/claude-code)