### PR TITLE
docs(hooks): document the Bash-tool gap in path-based deny rules (#1907)

### DIFF
--- a/docs/integrations/hooks/claude_code.md
+++ b/docs/integrations/hooks/claude_code.md
@@ -50,3 +50,54 @@ Every hook above also accretes onto a single `conversation_turn` keyed by `(sess
 ## Coexistence with MCP
 
 MCP and the plugin share idempotency keys — `conversation-{session_id}-{turn_id}-user` etc. — so a user message captured by the plugin and then enriched by the agent via MCP lands on the same `agent_message` observation, not a duplicate.
+
+## Path-based isolation and the Bash-tool gap
+
+If you scope a local Neotoma install to a working directory and want to keep an
+agent out of *sensitive sibling directories* (accounting, legal, client files,
+etc.), be aware of an important limitation of Claude Code's declarative
+permission rules:
+
+> **Declarative `Read` / `Glob` / `Grep` deny rules do NOT stop a raw
+> `cat` / `grep` / `find` / `ls` run through the agent's `Bash` tool.** The
+> path-based deny list only governs the dedicated file tools; a shell command
+> that reads the same file bypasses it.
+
+So a `deny` entry like `Read(//Users/you/Private/**)` protects the `Read` tool,
+but `Bash(cat /Users/you/Private/secret.txt)` still succeeds. If a broad allow
+such as `Read(//Users/you/**)` is also present, that widens the exposure
+further (deny overrides allow for the file tools, but Bash is unaffected).
+
+### Recommended: a fail-closed `PreToolUse` hook
+
+To actually enforce path-based isolation against the Bash tool, add a
+`PreToolUse` hook (matcher `Bash`) that inspects the command and blocks reads
+into denied paths. Make it **fail-closed**: if the command can't be parsed,
+deny rather than allow. A minimal shape:
+
+```python
+#!/usr/bin/env python3
+# .claude/hooks/scope-guard.py  (register under hooks.PreToolUse, matcher "Bash")
+import json, sys
+
+DENY_SUBSTRINGS = ["/Accounting/", "/LEGAL/", "/Equity/"]  # your sensitive paths
+
+try:
+    event = json.load(sys.stdin)
+    command = event.get("tool_input", {}).get("command", "")
+except Exception:
+    # Unparseable input -> fail closed.
+    print(json.dumps({"decision": "block", "reason": "scope-guard: unparseable"}))
+    sys.exit(0)
+
+if ".." in command or any(s in command for s in DENY_SUBSTRINGS):
+    print(json.dumps({"decision": "block", "reason": "scope-guard: denied path"}))
+else:
+    print(json.dumps({"decision": "approve"}))
+sys.exit(0)
+```
+
+Known limits of the pattern approach: a regex/substring check cannot catch
+computed paths, symlinks, or `$(…)` command substitution. Treat the hook as one
+layer; keep the declarative `Read`/`Glob`/`Grep` denies for the file tools, and
+keep genuinely sensitive data out of the scoped tree entirely where possible.

--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,15 +61,15 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **527**
-- Backend and repo Vitest files: **492**
+- Total automated test files: **528**
+- Backend and repo Vitest files: **493**
 - Frontend Vitest files: **9**
 - Playwright spec files: **26**
 
 ### Suite counts
 | Suite | Files |
 |---|---:|
-| Vitest unit tests | 146 |
+| Vitest unit tests | 147 |
 | Vitest service tests | 36 |
 | Source-adjacent tests | 64 |
 | Vitest integration tests | 151 |
@@ -109,7 +109,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/unit`
 **Requirements:** Basic `.env` if required by the module under test.
-**Files (146):**
+**Files (147):**
 - `tests/unit/aauth_admission.test.ts`
 - `tests/unit/aauth_attestation_apple_se.test.ts`
 - `tests/unit/aauth_attestation_revocation.test.ts`
@@ -182,6 +182,7 @@ flowchart TD
 - `tests/unit/i18n_routing.test.ts`
 - `tests/unit/inspector_admin_unlock_url.test.ts`
 - `tests/unit/inspector_skin.test.ts`
+- `tests/unit/issue_spec_schema.test.ts`
 - `tests/unit/keepalive_timeout.test.ts`
 - `tests/unit/list_timeline_events_unknown_type.test.ts`
 - `tests/unit/manage_bundles_tool.test.ts`


### PR DESCRIPTION
## Problem (#1907)

Declarative `Read`/`Glob`/`Grep` deny rules in Claude Code do **not** stop a raw `cat`/`grep`/`find`/`ls` via the agent's Bash tool from reaching the same paths — the deny list only governs the dedicated file tools. A user scoping a local Neotoma install to keep an agent out of sensitive sibling directories (accounting, legal, client files) may believe those paths are protected when a Bash read still reaches them.

An external evaluator hit exactly this and had to write their own fail-closed PreToolUse hook.

## Fix

Document the gap explicitly in `docs/integrations/hooks/claude_code.md`, and provide a **fail-closed PreToolUse reference hook** that blocks Bash reads into denied paths — with its honest limits (computed paths, symlinks, `$(…)` substitution) and a recommendation to layer it with the declarative denies rather than rely on either alone.

Closes #1907

🤖 Generated with [Claude Code](https://claude.com/claude-code)