### PR TITLE
chore(release): bump version to v0.18.8 + supplement

### DIFF
--- a/docs/releases/in_progress/v0.18.8/github_release_supplement.md
+++ b/docs/releases/in_progress/v0.18.8/github_release_supplement.md
@@ -1,0 +1,58 @@
+Four onboarding/install fixes reported by an external evaluator running a fresh global npm install of Neotoma against Claude Code. All target the "does the published artifact work, coherently, on a clean machine" class — the kind of gap only visible against the packed tarball on a fresh machine, not a repo checkout.
+
+## Highlights
+
+- **`neotoma hooks install` / `neotoma setup --tool claude-code` now work from a global npm install (#1904).** The hook installers copy templates from `packages/{claude-code-plugin,codex-hooks,cursor-hooks}`, but those directories were absent from the npm `files` allowlist, so a global install failed with *"Could not locate the Neotoma package root … hook packages were not published with this install."* Real per-turn auto-capture is now achievable from a normal `npm install -g neotoma`.
+- **`get_authenticated_user` surfaces the active environment (#1905).** On a fresh install the CLI local transport defaults to production while the server/API default to development, so an unflagged CLI query can silently hit an empty prod DB and return nothing/401. The `storage` block now includes `environment`, so an agent can confirm which graph (dev vs prod) it is on before writing instead of discovering the split via silent-empty results.
+- **`neotoma setup` no longer rewrites `settings.local.json` on a pure reformat (#1906).** Running setup to diagnose an error could rewrite a user's tracked config even when nothing meaningful changed (a whitespace-only diff), because the change check compared the pretty-printed serialization against the raw on-disk bytes. A semantic no-op guard now leaves the file untouched when only formatting differs.
+- **Documented the Bash-tool gap in path-based deny rules (#1907).** Declarative `Read`/`Glob`/`Grep` deny rules do not stop a raw `cat`/`grep`/`find`/`ls` via the agent's Bash tool from reaching the same paths. The Claude Code hooks doc now documents this explicitly and ships a fail-closed `PreToolUse` reference hook (with its known limits) for users hardening a scoped install against sensitive sibling directories.
+
+## What changed for npm package users
+
+**Packaging**
+
+- `packages/claude-code-plugin`, `packages/codex-hooks`, `packages/cursor-hooks` are now in the published tarball, so the hook installers find their templates.
+
+**Tools / API**
+
+- `get_authenticated_user` response `storage` block gains an `environment` field (`"development"` | `"production"`) for the local backend. Additive; existing fields unchanged.
+
+**CLI**
+
+- `neotoma setup` is now a true no-op on `settings.local.json` when the effective content is unchanged (no whitespace-only reformat).
+
+**Docs**
+
+- `docs/integrations/hooks/claude_code.md` gains a "Path-based isolation and the Bash-tool gap" section + a reference `PreToolUse` hook.
+
+## API surface & contracts
+
+Additive only: `get_authenticated_user` gains `storage.environment`. No routes, schema, or breaking contract changes.
+
+## Behavior changes
+
+- `neotoma setup` no longer reformats `settings.local.json` when content is unchanged. No other behavior changes. (The larger "default to read-only preview / `--apply`" UX redesign for `setup`, and flipping the CLI default env to match the server, are intentionally deferred as separate, riskier behavior changes.)
+
+## Fixes
+
+- **#1904** — hook packages not shipped with the npm install (`neotoma hooks install` / `setup --tool claude-code` fail on a global install).
+- **#1905** — dev/prod DB default mismatch is now observable via `get_authenticated_user.storage.environment` (observability half; the CLI-default coherence fix is tracked separately).
+- **#1906** — `neotoma setup` rewrote `settings.local.json` on a formatting-only difference.
+- **#1907** — documented the Read/Glob/Grep-vs-Bash isolation gap + shipped a reference hook.
+
+All four reported by an external evaluator (Nick Talwar, Bottega8) during onboarding, with independent repro. Fixes each ship with an effect test (npm-pack contents, HTTP response shape, bytes+mtime unchanged).
+
+## Tests and validation
+
+- `tests/contract/package_contents.test.ts` — asserts (via `npm pack --dry-run`) the hook installer templates ship in the tarball (#1904).
+- `tests/integration/get_authenticated_user_environment.test.ts` — asserts the `storage.environment` field is present over HTTP (#1905).
+- `tests/cli/cli_doctor_setup.test.ts` — asserts a differently-formatted-but-equivalent `settings.local.json` is not rewritten (bytes + mtime unchanged) (#1906).
+- `security:classify-diff` (base v0.18.7): see [security_review.md](security_review.md).
+
+## Security hardening
+
+Not security-sensitive in the exploit sense. The #1907 docs change is security-*relevant* (it documents an isolation-expectation gap and provides a fail-closed mitigation). See [security_review.md](security_review.md).
+
+## Breaking changes
+
+None. Additive packaging/tool/doc fixes plus one no-op-write correction. Patch bump is correct per SemVer.

--- a/docs/releases/in_progress/v0.18.8/security_review.md
+++ b/docs/releases/in_progress/v0.18.8/security_review.md
@@ -1,0 +1,25 @@
+# Security review — v0.18.8
+
+**Base:** v0.18.7 · **Head:** release/v0.18.8
+**`npm run security:classify-diff -- --base v0.18.7 --head HEAD`:** `sensitive=true`
+**Flagged surface:** `auth-middleware: src/actions.ts`
+**Verdict: ship — no security regression.**
+
+## Why the classifier flagged `sensitive=true`
+
+The diff since v0.18.7 touches `src/actions.ts`, which the classifier treats as auth-middleware-adjacent. The changes in that file across this release window are:
+
+1. **#1905 (this release's onboarding batch):** adds a single read-only field, `environment`, to the `storage` block returned by `get_authenticated_user`. It exposes `config.environment` (`"development"` | `"production"`) — a non-secret, already-derivable value (the DB path already differs: `neotoma.db` vs `neotoma.prod.db`). No change to authentication, authorization, token handling, or the resolved `user_id`. It is strictly additive observability so a caller can confirm which graph it is on before writing.
+2. **#1860/#1878 (merged to main before this batch):** the offline/HTTP `/store` dedup-replay path now surfaces the current snapshot in `entity_snapshot_after` and marks replayed entries `deduplicated: true`, mirroring the MCP transport. This is a response-shape parity fix on the store path; it reads a persisted snapshot on an idempotency replay and writes no new observation. No auth-surface change.
+
+## Assessment per changed area
+
+- **`get_authenticated_user`** — adds a non-secret environment string to an already-authenticated response. No new data exposure (the value is inferable from the DB path), no auth-logic change. Safe.
+- **`/store` replay path** — response-completeness fix; no privilege, no new write, no cross-user surface. Safe.
+- **Packaging (#1904)** — `packages/*` added to the npm `files` allowlist. Ships hook *templates* (Python/JS the user opts to install); no server code. The templates are inert until a user runs `hooks install`. Safe.
+- **`neotoma setup` no-op guard (#1906)** — narrows when a local config file is written (fewer writes). Strictly reduces filesystem side effects. Safe.
+- **Docs (#1907)** — documents a Read/Glob/Grep-vs-Bash isolation gap and ships a **fail-closed** reference `PreToolUse` hook. Security-positive: it closes a user expectation gap and the example denies on parse failure.
+
+## Conclusion
+
+No middleware, route-guard, token, or authorization logic changed. The `sensitive=true` flag is driven by the `actions.ts` path heuristic, not by an actual auth-surface modification. The batch is additive/observability + a response-parity fix + packaging/docs. **Ship.**

--- a/docs/releases/in_progress/v0.18.8/test_coverage_review.md
+++ b/docs/releases/in_progress/v0.18.8/test_coverage_review.md
@@ -1,0 +1,23 @@
+# Test coverage review — v0.18.8
+
+Each fix in this batch ships with an **effect test** — asserting the observable outcome the issue describes, not merely that a contract validates.
+
+| Fix | Effect test | Asserts |
+|---|---|---|
+| #1904 (hook packages in npm) | `tests/contract/package_contents.test.ts` | `npm pack --dry-run` output contains `packages/claude-code-plugin/hooks/session_start.py`, `packages/codex-hooks/scripts/install.mjs`, `packages/cursor-hooks/scripts/install.mjs` — i.e. the installer templates actually ship in the tarball. Would have failed before the `files` change. |
+| #1905 (active env) | `tests/integration/get_authenticated_user_environment.test.ts` | POST `/get_authenticated_user` returns `storage.environment` ∈ {development, production} for the local backend, over real HTTP. |
+| #1906 (no-op reformat) | `tests/cli/cli_doctor_setup.test.ts` | A compact/reordered-but-semantically-equal `settings.local.json` yields `changed === false`, on-disk **bytes** unchanged, and **mtime** unchanged (not just the `changed` flag — the bug was a silent rewrite). |
+| #1907 (Bash-deny docs) | — | Documentation + reference hook; no code path to unit-test. The reference hook is fail-closed by construction (denies on unparseable input). |
+
+## Class-level guard
+
+These are the fresh-install / runtime-file-completeness class (retrospective `ent_e5e2778500c522178d1ea9d0`). The #1904 test runs `npm pack` against the real tarball, so it guards not just this instance but the class: any file the CLI resolves at runtime but that is missing from `files` would fail it. A broader fresh-install test lane is tracked as a follow-up (#1908).
+
+## Not covered (intentional, tracked)
+
+- The #1905 **CLI-default coherence** fix (flip the CLI local-transport default to match the server, or fail loud) is deferred as a separate behavior change; this release ships only the observability half.
+- The #1906 fuller `setup` UX redesign (default read-only preview, `--apply`) is deferred.
+
+## Regression risk
+
+Low. All changes are additive (a field, tarball entries), a narrowed write condition, or docs. Existing `patchClaudeCodeProject` idempotency and merge tests continue to pass unmodified, confirming the no-op guard does not regress the already-covered content-change path.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neotoma",
-  "version": "0.18.7",
+  "version": "0.18.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neotoma",
-      "version": "0.18.7",
+      "version": "0.18.8",
       "license": "MIT",
       "dependencies": {
         "@hellocoop/httpsig": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neotoma",
-  "version": "0.18.7",
+  "version": "0.18.8",
   "description": "MCP server for structured personal data memory with unified source ingestion",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
## v0.18.8 — onboarding/install fixes

Patch release bundling four fixes reported by an external evaluator (Nick Talwar, Bottega8) during a fresh global npm install against Claude Code. All in the "does the published artifact work coherently on a clean machine" class.

| Issue | PR | Fix |
|---|---|---|
| #1904 | #1910 | ship `packages/*` hook templates in the npm tarball so `hooks install` / `setup --tool claude-code` work from a global install |
| #1905 | #1913 | surface active `environment` in `get_authenticated_user` (observability half of the dev/prod default mismatch) |
| #1906 | #1912 | don't rewrite `settings.local.json` on a pure reformat |
| #1907 | #1914 | document the Read/Glob/Grep-vs-Bash isolation gap + ship a fail-closed `PreToolUse` reference hook |

All four already merged to main. Each shipped with an effect test (see `test_coverage_review.md`).

## Security

`security:classify-diff` (base v0.18.7): `sensitive=true` on `src/actions.ts` — reviewed as a path heuristic, not an actual auth-surface change (a read-only `environment` field add + a previously-merged store-replay response-parity fix). Verdict: ship. See `security_review.md`.

## Breaking changes

None. Additive packaging/tool/doc fixes + one no-op-write correction. Patch bump per SemVer.

## Publish

Merging this bumps the version on main. **Publishing to npm is a separate, gated step** — creating the GitHub Release (tag `v0.18.8`) triggers the publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)