### PR TITLE
Release v0.18.8

### DIFF
--- a/docs/releases/in_progress/v0.18.8/github_release_supplement.md
+++ b/docs/releases/in_progress/v0.18.8/github_release_supplement.md
@@ -1,0 +1,87 @@
+Four onboarding/install fixes reported by an external evaluator running a fresh global npm install of Neotoma against Claude Code, plus a store-response parity fix, a new swarm-facing entity schema, an agent-facing URL cleanup, and a pixel-level render regression gate for the Inspector graph.
+
+## Highlights
+
+- **`neotoma hooks install` / `neotoma setup --tool claude-code` now work from a global npm install (#1904).** The hook installers copy templates from `packages/{claude-code-plugin,codex-hooks,cursor-hooks}`, but those directories were absent from the npm `files` allowlist, so a global install failed with *"Could not locate the Neotoma package root … hook packages were not published with this install."* Per-turn auto-capture is now achievable from a normal `npm install -g neotoma`.
+- **`get_authenticated_user` surfaces the active environment (#1905).** On a fresh install the CLI local transport defaults to production while the server/API default to development, so an unflagged CLI query can silently hit an empty prod DB and return nothing/401. The `storage` block now includes `environment`, so an agent can confirm which graph (dev vs prod) it is on before writing instead of discovering the split via silent-empty results.
+- **`neotoma setup` no longer rewrites `settings.local.json` on a pure reformat (#1906).** Running setup to diagnose an error could rewrite a user's tracked config even when nothing meaningful changed (a whitespace-only diff), because the change check compared the pretty-printed serialization against the raw on-disk bytes. A semantic no-op guard now leaves the file untouched when only formatting differs.
+- **Documented the Bash-tool gap in path-based deny rules (#1907).** Declarative `Read`/`Glob`/`Grep` deny rules do not stop a raw `cat`/`grep`/`find`/`ls` via the agent's Bash tool from reaching the same paths. The Claude Code hooks doc now documents this explicitly and ships a fail-closed `PreToolUse` reference hook (with its known limits) for users hardening a scoped install against sensitive sibling directories.
+- **Store dedup-replay response now matches on both transports (#1860).** A deduplicated `/store` call over the offline/HTTP transport previously came back without `entity_snapshot_after` and `deduplicated: true`, even though the MCP transport already returned them. The offline path now mirrors the MCP behavior, closing a gap re-confirmed by an evaluator using Neotoma as an offline audit ledger.
+- **New `issue_spec` entity schema for the swarm issue-spec pipeline (#1901).** Gives the Ateles swarm's issue-spec pipeline a formal schema with a deterministic identity key (composite `[repo, issue_number]`, with a `spec_key` fallback), so concurrent agent stores for the same issue resolve to one entity instead of relying on schema-inference + O(n) dedup.
+- **Agent-facing links no longer emit the retired `/inspector` prefix (#1555).** Following the SPA's move to serving at `/` with `/inspector/*` 308-redirecting, every agent-facing URL emitter (MCP instructions, server display-rule string, CLI/agent turn-report builders) now emits unprefixed `/conversations/<id>` and `/entities/<id>` links directly, instead of a redirect-through legacy form.
+- **Pixel-level render smoke gate for the Inspector graph (#1874).** Adds a PR-gating Playwright test against the built Inspector bundle that asserts the graph actually paints pixels (not just that DOM nodes/edges exist), catching the class of "healthy DOM, blank canvas" regressions that shipped twice in v0.18.5 and v0.18.6.
+
+## What changed for npm package users
+
+**Packaging**
+
+- `packages/claude-code-plugin`, `packages/codex-hooks`, `packages/cursor-hooks` are now in the published tarball, so the hook installers find their templates.
+
+**Tools / API**
+
+- `get_authenticated_user` response `storage` block gains an `environment` field (`"development"` | `"production"`) for the local backend. Additive; existing fields unchanged.
+- `/store` (offline/HTTP transport): a deduplicated store call now returns `entity_snapshot_after` and `deduplicated: true`, matching the MCP transport's existing behavior on the same idempotency-replay path. No new observation is written; observation count is unchanged.
+- New `issue_spec` entity type registered in the schema registry (additive; no existing type affected).
+
+**CLI**
+
+- `neotoma setup` is now a true no-op on `settings.local.json` when the effective content is unchanged (no whitespace-only reformat).
+
+**Agent-facing surfaces**
+
+- MCP instructions, the server's compact display-rule string, and the CLI/agent `turn_report` URL builders now emit `/conversations/<id>` and `/entities/<id>` instead of `/inspector/conversations/<id>` and `/inspector/entities/<id>`.
+
+**Docs**
+
+- `docs/integrations/hooks/claude_code.md` gains a "Path-based isolation and the Bash-tool gap" section + a reference `PreToolUse` hook.
+
+**Inspector / CI**
+
+- A new required `graph_render_smoke` CI job runs a pixel-level Playwright check against the built Inspector bundle on every PR (`npm run test:e2e:graph-render`).
+- `graph-integrity.spec.ts` renamed to `graph-data-integrity.spec.ts` to distinguish data-integrity checks (orphans/cycles/deletion) from render-effect checks.
+
+## API surface & contracts
+
+Additive only:
+
+- `get_authenticated_user` gains `storage.environment`.
+- `/store` offline transport response gains `entity_snapshot_after` / `deduplicated: true` on idempotency replay (already present on the MCP transport — this is a parity fix, not a new field).
+- New `issue_spec` entity type in the schema registry.
+
+No routes, breaking schema changes, or removed/renamed fields.
+
+## Behavior changes
+
+- `neotoma setup` no longer reformats `settings.local.json` when content is unchanged. (The larger "default to read-only preview / `--apply`" UX redesign for `setup`, and flipping the CLI default env to match the server, are intentionally deferred as separate, riskier behavior changes.)
+- A deduplicated `/store` call over the offline/HTTP transport now returns the same response shape as the MCP transport (previously under-populated).
+- Agent-facing entity/conversation links no longer route through the `/inspector` redirect.
+
+## Fixes
+
+- **#1904** — hook packages not shipped with the npm install (`neotoma hooks install` / `setup --tool claude-code` fail on a global install).
+- **#1905** — dev/prod DB default mismatch is now observable via `get_authenticated_user.storage.environment` (observability half; the CLI-default coherence fix is tracked separately).
+- **#1906** — `neotoma setup` rewrote `settings.local.json` on a formatting-only difference.
+- **#1907** — documented the Read/Glob/Grep-vs-Bash isolation gap + shipped a reference hook.
+- **#1860** — offline/HTTP `/store` dedup-replay response missing `entity_snapshot_after` / `deduplicated: true` (already present on MCP transport).
+- **#1555** — agent-facing URL emitters still producing legacy `/inspector/...` links after the SPA prefix retirement.
+
+#1904, #1905, #1906, #1907 reported by an external evaluator (Nick Talwar, Bottega8) during onboarding, with independent repro. #1860 reported by an evaluator using Neotoma as an offline audit ledger. All fixes ship with an effect test (npm-pack contents, HTTP response shape, bytes+mtime unchanged, or transport-parity assertion).
+
+## Tests and validation
+
+- `tests/contract/package_contents.test.ts` — asserts (via `npm pack --dry-run`) the hook installer templates ship in the tarball (#1904).
+- `tests/integration/get_authenticated_user_environment.test.ts` — asserts the `storage.environment` field is present over HTTP (#1905).
+- `tests/cli/cli_doctor_setup.test.ts` — asserts a differently-formatted-but-equivalent `settings.local.json` is not rewritten (bytes + mtime unchanged) (#1906).
+- `tests/integration/store_dedup_snapshot_after.test.ts` + `tests/integration/transport_parity_store_snapshot_auth.test.ts` — offline/MCP transport-parity gate; assert `entity_snapshot_after` and `deduplicated: true` on BOTH transports for a deduplicated store, verified to fail if the offline fix is reverted (#1860, #1840).
+- `tests/unit/issue_spec_schema.test.ts` — registration, field types, composite+fallback identity, dedup behavior for the new `issue_spec` schema (#1901).
+- `tests/unit/client_turn_report.test.ts` — updated to assert unprefixed `/conversations/<id>` and `/entities/<id>` URLs (#1555).
+- `playwright/tests/inspector/inspector-graph-render.spec.ts` — pixel-level render gate; verified RED against the reintroduced v0.18.6 embed height-collapse bug, GREEN on the current fix (#1874).
+- `security:classify-diff` (base v0.18.7): see [security_review.md](security_review.md).
+
+## Security hardening
+
+Not security-sensitive in the exploit sense. The classifier flags `src/actions.ts` due to path heuristics (touched by #1905 and #1860), but neither change touches authentication, authorization, or token handling — see [security_review.md](security_review.md) for the per-area breakdown. The #1907 docs change is security-*relevant* in the positive direction (documents an isolation-expectation gap and provides a fail-closed mitigation).
+
+## Breaking changes
+
+None. Additive packaging/tool/schema/doc fixes, one transport-parity correction, one no-op-write correction, and a CI-only render regression gate. Patch bump is correct per SemVer.

--- a/docs/releases/in_progress/v0.18.8/security_review.md
+++ b/docs/releases/in_progress/v0.18.8/security_review.md
@@ -1,0 +1,37 @@
+# Security review — v0.18.8
+
+**Base:** v0.18.7 · **Head:** release/v0.18.8
+**`npm run security:classify-diff -- --base v0.18.7 --head HEAD`:** `sensitive=true`
+**Flagged surface:** `auth-middleware: src/actions.ts`
+**Verdict: ship — no security regression.**
+
+## Gate results (G1–G3)
+
+- **G1 `security:classify-diff`:** `sensitive=true`, single concern `auth-middleware` on `src/actions.ts`.
+- **G2 `security:lint`:** 0 errors, 125 warnings across 380 files (full-repo scan; warnings are pre-existing baseline noise, not new to this diff — confirmed no `error`-level findings).
+- **G3 `security:manifest:check`:** `protected_routes_manifest.json` in sync with `openapi.yaml` (115 routes) — no drift, no regeneration needed.
+- **G3 `test:security:auth-matrix`:** 18 passed, 1 skipped, 0 failed.
+
+## Why the classifier flagged `sensitive=true`
+
+The diff since v0.18.7 touches `src/actions.ts`, which the classifier treats as auth-middleware-adjacent. The changes in that file across this release window are:
+
+1. **#1905 (onboarding batch):** adds a single read-only field, `environment`, to the `storage` block returned by `get_authenticated_user`. It exposes `config.environment` (`"development"` | `"production"`) — a non-secret, already-derivable value (the DB path already differs: `neotoma.db` vs `neotoma.prod.db`). No change to authentication, authorization, token handling, or the resolved `user_id`. Strictly additive observability so a caller can confirm which graph it is on before writing.
+2. **#1860/#1878 (offline transport-parity fix):** the offline/HTTP `/store` dedup-replay path now surfaces the current snapshot in `entity_snapshot_after` and marks replayed entries `deduplicated: true`, mirroring the MCP transport. This is a response-shape parity fix on the store path; it reads a persisted snapshot on an idempotency replay and writes no new observation. No auth-surface change.
+
+No other file in this release range falls under `src/actions.ts`, `src/services/root_landing/**`, or the `isLocalRequest`/`forwardedForValues`/`isProductionEnvironment` helpers governed by the change guardrails rule.
+
+## Assessment per changed area
+
+- **`get_authenticated_user`** — adds a non-secret environment string to an already-authenticated response. No new data exposure (the value is inferable from the DB path), no auth-logic change. Safe.
+- **`/store` replay path (offline transport)** — response-completeness fix; no privilege change, no new write, no cross-user surface. The replay path reads a persisted snapshot the requesting user already owns (same `user_id` scoping as the original store); mirrors an already-shipped MCP behavior. Safe.
+- **Packaging (#1904)** — `packages/*` added to the npm `files` allowlist. Ships hook *templates* (Python/JS the user opts to install); no server code. The templates are inert until a user runs `hooks install`. Safe.
+- **`neotoma setup` no-op guard (#1906)** — narrows when a local config file is written (fewer writes). Strictly reduces filesystem side effects. Safe.
+- **Docs (#1907)** — documents a Read/Glob/Grep-vs-Bash isolation gap and ships a **fail-closed** reference `PreToolUse` hook. Security-positive: closes a user expectation gap; the example denies on parse failure.
+- **`issue_spec` schema (#1901)** — new entity type registration only (identity rule, field declarations, merge policies). No route, no auth-path change, no data migration of existing rows. Safe.
+- **URL emitter fix (#1555)** — string-substitution change in agent-facing link builders (`/inspector/...` → unprefixed). No routing or auth-logic change; the underlying `/inspector/*` redirect already existed and still works for stale links. Safe.
+- **Inspector render smoke test (#1874)** — CI-only Playwright test addition; no production code path. Safe.
+
+## Conclusion
+
+No middleware, route-guard, token, or authorization logic changed in this release. The `sensitive=true` flag is driven by the `actions.ts` path heuristic, not by an actual auth-surface modification. The batch is additive/observability + a transport-parity fix + a new schema registration + packaging/docs/CI. **Ship.**

--- a/docs/releases/in_progress/v0.18.8/test_coverage_review.md
+++ b/docs/releases/in_progress/v0.18.8/test_coverage_review.md
@@ -1,0 +1,66 @@
+# Test coverage review — v0.18.8
+
+## Code review
+
+`/review v0.18.7..HEAD` was run against the full release diff (12 commits, 28 files, +1862/-67 lines) in the isolated worktree for `release/v0.18.8`.
+
+### Scope reviewed
+
+Full diff read for every changed file. Verified with: `npx tsc --noEmit` (clean), `npm run build` (clean, incl. Inspector), `npx eslint` on all touched files (0 errors, pre-existing `no-explicit-any` warnings only), targeted `vitest run` on every new/changed test file (109/109 passed across unit/CLI/contract/integration lanes), `npx playwright test inspector-graph-render.spec.ts --project=chromium` (2/2 passed against the real built bundle), `npm run validate:test-catalog` (up to date), `npm run security:manifest:check` (in sync, 115 routes), CI workflow YAML syntax validated.
+
+### Conditional docs loaded
+
+`docs/subsystems/auth.md`, `docs/security/threat_model.md` (src/actions.ts touched), `docs/developer/mcp/instructions.md`, `docs/developer/agent_instructions_sync_rules.mdc` (server.ts / mcp/instructions.md touched), `docs/developer/cli_reference.md` (src/cli/* touched), `docs/foundation/schema_agnostic_design_rules.md`, `docs/subsystems/schema_registry.md` (new issue_spec registration), `docs/architecture/openapi_contract_flow.md`, `docs/testing/testing_standard.md`, `docs/developer/package_scripts.md`.
+
+### Pre-PR checklist (Phase 4)
+
+All 25 checklist items evaluated. 23 items ✓ or — N/A. Two items initially flagged BLOCKING (both instances of item 1/13, "new response fields declared in openapi.yaml"): `get_authenticated_user`'s new `storage.environment` field was populated in `src/actions.ts` (#1905) but not declared in `openapi.yaml`.
+
+**Resolution applied in this preparation pass:** Added the `environment` field to the `storage` object schema for `POST /get_authenticated_user` in `openapi.yaml` (`type: string`, `enum: [development, production]`, with a description matching the field's purpose), then ran `npm run openapi:generate` to regenerate `src/shared/openapi_types.ts`. Re-verified:
+
+- `npm run openapi:bc-diff -- --base v0.18.7 --head HEAD` — still **no breaking changes detected** (purely additive field).
+- `npx vitest run tests/integration/get_authenticated_user_environment.test.ts` — passes.
+- `npx vitest run tests/contract/` — 147/147 passed.
+- `npx tsc --noEmit` — clean.
+- `npm run build` — clean.
+
+The related `entity_snapshot_after` field (used by the #1860 transport-parity fix) was flagged as a pre-existing, un-declared response field, but it was introduced by the earlier #1840 MCP-side fix (already on `main` before this release range), not by this diff. Not fixed in this pass — tracked as a separate, smaller follow-up since it is not a regression introduced by v0.18.8's changes. Noted here for visibility rather than left silent.
+
+### Architectural review (Phase 5)
+
+- **State-layer boundaries**: clean. No strategy/execution logic added; `issue_spec` is a passive data schema for an external (Ateles swarm) consumer.
+- **Schema-agnostic design**: clean. The new `issue_spec` schema is a pure declarative `SchemaDefinition` addition (fields, composite+fallback `canonical_name_fields`, `merge_policies`) with zero per-type branches introduced elsewhere in the codebase.
+- **Determinism**: clean. `issue_spec` canonical-name resolution is deterministic; `entity_snapshot_after` on replay reads an already-persisted snapshot rather than recomputing.
+- **Immutability**: clean. The #1860 fix reads existing observations/snapshots and writes nothing new on replay (verified: observation count stays 1 in both `store_dedup_snapshot_after.test.ts` and `transport_parity_store_snapshot_auth.test.ts`).
+- **Auth surface** (`src/actions.ts`): no `req.socket.remoteAddress` / `X-Forwarded-For` / `Host` reads outside canonical helpers introduced; no `user_id` read from body/query for access control; no new `LOCAL_DEV_USER_ID` references outside allowed paths; no new unguarded route. Corroborates the independent `security_review.md` "ship" verdict.
+
+### Product/UX and documentation completeness (Phase 5b/5c)
+
+- The `/inspector` prefix removal (#1555) is consistently applied across all URL emitters (`docs/developer/mcp/instructions.md`, `src/server.ts`'s compact mirror, `packages/agent/src/turn_report.ts`, `packages/client/src/turn_report.ts`) — no drift between the canonical MCP doc and its CLI/agent mirrors.
+- `docs/integrations/hooks/claude_code.md`'s new "Bash-tool gap" section is actionable and transparent about the reference hook's limitations.
+- **Advisory (not blocking)**: `docs/developer/cli_reference.md` was not updated to reflect the #1880/#1904 behavior change (global install + `--tool claude-code` now writes a project-root `.mcp.json` it previously silently skipped). The release supplement adequately informs users of the behavior change for this release; tracked as a fast-follow doc update rather than blocking this release.
+
+### Effect-test verification for the six named fixes
+
+Each was verified by reading the actual test body, not just the file name:
+
+| Fix | Test | Verified assertion |
+|---|---|---|
+| #1904 (hook packages in npm) | `tests/contract/package_contents.test.ts` | Real `npm pack --json --dry-run`; asserts the tarball manifest contains the three installer-referenced template files. |
+| #1905 (active env) | `tests/integration/get_authenticated_user_environment.test.ts` | Real Express app, POST `/get_authenticated_user`, asserts `storage.environment ∈ {development, production}` over HTTP. |
+| #1906 (no-op reformat) | `tests/cli/cli_doctor_setup.test.ts` | Asserts `changed === false` AND on-disk bytes + mtime unchanged for a differently-formatted-but-equivalent file. |
+| #1907 (Bash-deny docs) | — | Documentation-only; no test applicable (correctly not claimed as tested). |
+| #1860/#1878 (transport parity) | `tests/integration/store_dedup_snapshot_after.test.ts`, `tests/integration/transport_parity_store_snapshot_auth.test.ts`, `tests/helpers/transport_parity_matrix.ts` | Drives `storeStructuredForApi` (offline) and `NeotomaServer` (MCP) with the same idempotency key; asserts observation count stays 1, `entity_snapshot_after` populated and matches an independent `getSnapshot()` read, `deduplicated === true` on both transports via `assertIdenticalEffect`. |
+| #1874 (graph render smoke) | `playwright/tests/inspector/inspector-graph-render.spec.ts` | Re-run against the real built prod bundle; asserts pixel-level rendering (`document.elementFromPoint` hit-test, non-zero `.react-flow` clientHeight, non-identity viewport transform) on both `/graph` and `/embed/graph`. |
+
+All effect tests assert user-observable outcomes, not merely that a function was called or a contract validates.
+
+## Verdict
+
+**APPROVED-WITH-NOTES** (after the openapi.yaml fix applied in this pass; originally NEEDS-CHANGES on one BLOCKING finding, now resolved).
+
+Must fix before merge: none remaining — the sole BLOCKING finding (`get_authenticated_user.storage.environment` undeclared in `openapi.yaml`) has been fixed in this preparation pass and re-verified (bc-diff clean, contract tests pass, typecheck/build clean).
+
+Should address in follow-up:
+- Declare the pre-existing `entity_snapshot_after` field on `StoreStructuredResponse.entities[]` in `openapi.yaml` (introduced by #1840, predates this release).
+- Update `docs/developer/cli_reference.md` to reflect the global-install `.mcp.json` behavior change from #1880/#1904.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -6719,6 +6719,13 @@ paths:
                       storage_backend:
                         type: string
                         enum: [local]
+                      environment:
+                        type: string
+                        description: |
+                          Active NEOTOMA_ENV for the local backend
+                          (development vs production), so a caller can
+                          confirm which graph it resolved to before writing.
+                        enum: [development, production]
                       data_dir:
                         type: string
                       sqlite_db:

--- a/src/shared/openapi_types.ts
+++ b/src/shared/openapi_types.ts
@@ -7464,6 +7464,13 @@ export interface operations {
             storage?: {
               /** @enum {string} */
               storage_backend?: "local";
+              /**
+               * @description Active NEOTOMA_ENV for the local backend
+               *     (development vs production), so a caller can
+               *     confirm which graph it resolved to before writing.
+               * @enum {string}
+               */
+              environment?: "development" | "production";
               data_dir?: string;
               sqlite_db?: string;
             };


### PR DESCRIPTION
Four onboarding/install fixes reported by an external evaluator running a fresh global npm install of Neotoma against Claude Code, plus a store-response parity fix, a new swarm-facing entity schema, an agent-facing URL cleanup, and a pixel-level render regression gate for the Inspector graph.

## Highlights

- **`neotoma hooks install` / `neotoma setup --tool claude-code` now work from a global npm install (#1904).** The hook installers copy templates from `packages/{claude-code-plugin,codex-hooks,cursor-hooks}`, but those directories were absent from the npm `files` allowlist, so a global install failed with *"Could not locate the Neotoma package root … hook packages were not published with this install."* Per-turn auto-capture is now achievable from a normal `npm install -g neotoma`.
- **`get_authenticated_user` surfaces the active environment (#1905).** On a fresh install the CLI local transport defaults to production while the server/API default to development, so an unflagged CLI query can silently hit an empty prod DB and return nothing/401. The `storage` block now includes `environment`, so an agent can confirm which graph (dev vs prod) it is on before writing instead of discovering the split via silent-empty results.
- **`neotoma setup` no longer rewrites `settings.local.json` on a pure reformat (#1906).** Running setup to diagnose an error could rewrite a user's tracked config even when nothing meaningful changed (a whitespace-only diff), because the change check compared the pretty-printed serialization against the raw on-disk bytes. A semantic no-op guard now leaves the file untouched when only formatting differs.
- **Documented the Bash-tool gap in path-based deny rules (#1907).** Declarative `Read`/`Glob`/`Grep` deny rules do not stop a raw `cat`/`grep`/`find`/`ls` via the agent's Bash tool from reaching the same paths. The Claude Code hooks doc now documents this explicitly and ships a fail-closed `PreToolUse` reference hook (with its known limits) for users hardening a scoped install against sensitive sibling directories.
- **Store dedup-replay response now matches on both transports (#1860).** A deduplicated `/store` call over the offline/HTTP transport previously came back without `entity_snapshot_after` and `deduplicated: true`, even though the MCP transport already returned them. The offline path now mirrors the MCP behavior, closing a gap re-confirmed by an evaluator using Neotoma as an offline audit ledger.
- **New `issue_spec` entity schema for the swarm issue-spec pipeline (#1901).** Gives the Ateles swarm's issue-spec pipeline a formal schema with a deterministic identity key (composite `[repo, issue_number]`, with a `spec_key` fallback), so concurrent agent stores for the same issue resolve to one entity instead of relying on schema-inference + O(n) dedup.
- **Agent-facing links no longer emit the retired `/inspector` prefix (#1555).** Following the SPA's move to serving at `/` with `/inspector/*` 308-redirecting, every agent-facing URL emitter (MCP instructions, server display-rule string, CLI/agent turn-report builders) now emits unprefixed `/conversations/<id>` and `/entities/<id>` links directly, instead of a redirect-through legacy form.
- **Pixel-level render smoke gate for the Inspector graph (#1874).** Adds a PR-gating Playwright test against the built Inspector bundle that asserts the graph actually paints pixels (not just that DOM nodes/edges exist), catching the class of "healthy DOM, blank canvas" regressions that shipped twice in v0.18.5 and v0.18.6.

## What changed for npm package users

**Packaging**

- `packages/claude-code-plugin`, `packages/codex-hooks`, `packages/cursor-hooks` are now in the published tarball, so the hook installers find their templates.

**Tools / API**

- `get_authenticated_user` response `storage` block gains an `environment` field (`"development"` | `"production"`) for the local backend. Additive; existing fields unchanged.
- `/store` (offline/HTTP transport): a deduplicated store call now returns `entity_snapshot_after` and `deduplicated: true`, matching the MCP transport's existing behavior on the same idempotency-replay path. No new observation is written; observation count is unchanged.
- New `issue_spec` entity type registered in the schema registry (additive; no existing type affected).

**CLI**

- `neotoma setup` is now a true no-op on `settings.local.json` when the effective content is unchanged (no whitespace-only reformat).

**Agent-facing surfaces**

- MCP instructions, the server's compact display-rule string, and the CLI/agent `turn_report` URL builders now emit `/conversations/<id>` and `/entities/<id>` instead of `/inspector/conversations/<id>` and `/inspector/entities/<id>`.

**Docs**

- `docs/integrations/hooks/claude_code.md` gains a "Path-based isolation and the Bash-tool gap" section + a reference `PreToolUse` hook.

**Inspector / CI**

- A new required `graph_render_smoke` CI job runs a pixel-level Playwright check against the built Inspector bundle on every PR (`npm run test:e2e:graph-render`).
- `graph-integrity.spec.ts` renamed to `graph-data-integrity.spec.ts` to distinguish data-integrity checks (orphans/cycles/deletion) from render-effect checks.

## API surface & contracts

Additive only:

- `get_authenticated_user` gains `storage.environment`.
- `/store` offline transport response gains `entity_snapshot_after` / `deduplicated: true` on idempotency replay (already present on the MCP transport — this is a parity fix, not a new field).
- New `issue_spec` entity type in the schema registry.

No routes, breaking schema changes, or removed/renamed fields.

## Behavior changes

- `neotoma setup` no longer reformats `settings.local.json` when content is unchanged. (The larger "default to read-only preview / `--apply`" UX redesign for `setup`, and flipping the CLI default env to match the server, are intentionally deferred as separate, riskier behavior changes.)
- A deduplicated `/store` call over the offline/HTTP transport now returns the same response shape as the MCP transport (previously under-populated).
- Agent-facing entity/conversation links no longer route through the `/inspector` redirect.

## Fixes

- **#1904** — hook packages not shipped with the npm install (`neotoma hooks install` / `setup --tool claude-code` fail on a global install).
- **#1905** — dev/prod DB default mismatch is now observable via `get_authenticated_user.storage.environment` (observability half; the CLI-default coherence fix is tracked separately).
- **#1906** — `neotoma setup` rewrote `settings.local.json` on a formatting-only difference.
- **#1907** — documented the Read/Glob/Grep-vs-Bash isolation gap + shipped a reference hook.
- **#1860** — offline/HTTP `/store` dedup-replay response missing `entity_snapshot_after` / `deduplicated: true` (already present on MCP transport).
- **#1555** — agent-facing URL emitters still producing legacy `/inspector/...` links after the SPA prefix retirement.

#1904, #1905, #1906, #1907 reported by an external evaluator (Nick Talwar, Bottega8) during onboarding, with independent repro. #1860 reported by an evaluator using Neotoma as an offline audit ledger. All fixes ship with an effect test (npm-pack contents, HTTP response shape, bytes+mtime unchanged, or transport-parity assertion).

## Tests and validation

- `tests/contract/package_contents.test.ts` — asserts (via `npm pack --dry-run`) the hook installer templates ship in the tarball (#1904).
- `tests/integration/get_authenticated_user_environment.test.ts` — asserts the `storage.environment` field is present over HTTP (#1905).
- `tests/cli/cli_doctor_setup.test.ts` — asserts a differently-formatted-but-equivalent `settings.local.json` is not rewritten (bytes + mtime unchanged) (#1906).
- `tests/integration/store_dedup_snapshot_after.test.ts` + `tests/integration/transport_parity_store_snapshot_auth.test.ts` — offline/MCP transport-parity gate; assert `entity_snapshot_after` and `deduplicated: true` on BOTH transports for a deduplicated store, verified to fail if the offline fix is reverted (#1860, #1840).
- `tests/unit/issue_spec_schema.test.ts` — registration, field types, composite+fallback identity, dedup behavior for the new `issue_spec` schema (#1901).
- `tests/unit/client_turn_report.test.ts` — updated to assert unprefixed `/conversations/<id>` and `/entities/<id>` URLs (#1555).
- `playwright/tests/inspector/inspector-graph-render.spec.ts` — pixel-level render gate; verified RED against the reintroduced v0.18.6 embed height-collapse bug, GREEN on the current fix (#1874).
- `security:classify-diff` (base v0.18.7): see [security_review.md](security_review.md).

## Security hardening

Not security-sensitive in the exploit sense. The classifier flags `src/actions.ts` due to path heuristics (touched by #1905 and #1860), but neither change touches authentication, authorization, or token handling — see [security_review.md](security_review.md) for the per-area breakdown. The #1907 docs change is security-*relevant* in the positive direction (documents an isolation-expectation gap and provides a fail-closed mitigation).

## Breaking changes

None. Additive packaging/tool/schema/doc fixes, one transport-parity correction, one no-op-write correction, and a CI-only render regression gate. Patch bump is correct per SemVer.