### PR TITLE
chore(release): bump version to v0.18.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neotoma",
-  "version": "0.18.7",
+  "version": "0.18.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neotoma",
-      "version": "0.18.7",
+      "version": "0.18.8",
       "license": "MIT",
       "dependencies": {
         "@hellocoop/httpsig": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neotoma",
-  "version": "0.18.7",
+  "version": "0.18.8",
   "description": "MCP server for structured personal data memory with unified source ingestion",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
Adds the package.json/package-lock.json version bump (0.18.7 → 0.18.8) that the v0.18.8 release tag requires. The supplement/security/test-coverage docs already landed via RC PR #1921; this cycle's prepare produced them in a supplement-only commit without the bump, so main sat at 0.18.7. This closes that gap so `publish.py` tags + publishes the correct version.

Ships #1904/#1905/#1906/#1907 (Nick's fresh-install fixes) + #1860/#1901/#1555/#1874.

🤖 Generated with [Claude Code](https://claude.com/claude-code)