### PR TITLE
chore(privacy): scrub real client/person names from public docs

### DIFF
--- a/docs/foundation/what_to_store.md
+++ b/docs/foundation/what_to_store.md
@@ -89,7 +89,7 @@ These before/after examples show what storage looks like in practice. "Before" i
 
 **Meeting from calendar:**
 - Before: Calendar events are siloed in Google Calendar. Your agent has no access to meeting context from last week.
-- After: Agent stores `{ entity_type: "event", title: "Q2 Planning with Nick", date: "2026-03-25", attendees: ["Nick Talwar", "Matt Kirk"] }` with REFERS_TO links to contact entities. When preparing for the next meeting, agent retrieves prior meeting context automatically.
+- After: Agent stores `{ entity_type: "event", title: "Q2 Planning with Alex", date: "2026-03-25", attendees: ["Alex Rivera", "Sam Chen"] }` with REFERS_TO links to contact entities. When preparing for the next meeting, agent retrieves prior meeting context automatically.
 
 ### Priority 3 — OS maturation (weeks 2-4)
 

--- a/docs/releases/in_progress/v0.18.8/github_release_supplement.md
+++ b/docs/releases/in_progress/v0.18.8/github_release_supplement.md
@@ -65,7 +65,7 @@ No routes, breaking schema changes, or removed/renamed fields.
 - **#1860** — offline/HTTP `/store` dedup-replay response missing `entity_snapshot_after` / `deduplicated: true` (already present on MCP transport).
 - **#1555** — agent-facing URL emitters still producing legacy `/inspector/...` links after the SPA prefix retirement.
 
-#1904, #1905, #1906, #1907 reported by an external evaluator (Nick Talwar, Bottega8) during onboarding, with independent repro. #1860 reported by an evaluator using Neotoma as an offline audit ledger. All fixes ship with an effect test (npm-pack contents, HTTP response shape, bytes+mtime unchanged, or transport-parity assertion).
+#1904, #1905, #1906, #1907 reported by an external evaluator during onboarding, with independent repro. #1860 reported by an evaluator using Neotoma as an offline audit ledger. All fixes ship with an effect test (npm-pack contents, HTTP response shape, bytes+mtime unchanged, or transport-parity assertion).
 
 ## Tests and validation
 


### PR DESCRIPTION
Removes third-party PII from two files on main:
- `docs/releases/in_progress/v0.18.8/github_release_supplement.md` — a named evaluator+org (also already scrubbed from the live GitHub Release body).
- `docs/foundation/what_to_store.md` — real personal names used as example data, replaced with neutral placeholders.

The public product repo must not carry third-party PII. Companion to #1924 (which scrubs the same identifiers from the leads-graph feature branch).