### PR TITLE
feat(db): concurrent backend — async driver contract + libsql/worker backend (event-loop blocking fix)

### DIFF
--- a/.github/workflows/ci_test_lanes.yml
+++ b/.github/workflows/ci_test_lanes.yml
@@ -131,6 +131,17 @@ jobs:
       - name: Run cross-surface contract-parity integration tests
         run: npm run test:contract-parity
 
+      # Concurrent-backend (PR #1944) effect-verified regressions. These two
+      # tests existed but ran in NO PR lane (test:unit excludes tests/integration
+      # and tests/scripts; only a hand-picked contract-parity subset ran here),
+      # so the async-transaction-rollback proof for entity_merge.ts and the
+      # libsql migration-validator's own detection logic passed locally but never
+      # gated a merge. Wiring them here closes that gap under the same
+      # fixed_means_behavior_verified_not_contract_accepted policy
+      # (ent_db0b7855d47012084477fb00) this lane already enforces.
+      - name: Run concurrent-backend effect-verified regressions (merge rollback + migration validator)
+        run: npx vitest run --no-file-parallelism tests/integration/merge_repoint_relationship_edges.test.ts tests/scripts/validate_libsql_migration.test.ts
+
       # OFFLINE/local-transport parity gate. Curated behaviors that broke on the
       # offline/HTTP path (#1819 at_ingested, #1840 dedup, #1839 null-cleared,
       # #1842 issue-submit auth) are asserted through BOTH the MCP and offline

--- a/docs/infrastructure/deployment.md
+++ b/docs/infrastructure/deployment.md
@@ -633,7 +633,7 @@ flyctl releases rollback
 
 ## SQLite concurrency and the multi-writer model
 
-Neotoma's default storage backend is SQLite (`better-sqlite3`), configured in `src/repositories/sqlite/sqlite_client.ts`. For anyone running a single hosted instance that serves multiple users, the concurrency envelope is:
+Neotoma's default storage backend is SQLite (`better-sqlite3` / `node:sqlite`), configured in `src/repositories/sqlite/sqlite_client.ts`. For hosted or agent-heavy instances, set `NEOTOMA_DB_BACKEND=libsql` to switch to the concurrent backend (same on-disk format — validate with `scripts/validate_libsql_migration.ts`, then flip the env var): statements execute off the Node event loop (worker-hosted driver for local files: one writer plus `NEOTOMA_DB_READER_WORKERS` read-only readers under WAL; genuinely-async @libsql/client for remote sqld/Turso URLs), so one slow query no longer blocks health checks, the web UI, or other callers' requests. For anyone running a single hosted instance that serves multiple users on the default backend, the concurrency envelope is:
 
 **What is configured today**
 

--- a/docs/infrastructure/deployment.md
+++ b/docs/infrastructure/deployment.md
@@ -633,7 +633,11 @@ flyctl releases rollback
 
 ## SQLite concurrency and the multi-writer model
 
-Neotoma's default storage backend is SQLite (`better-sqlite3` / `node:sqlite`), configured in `src/repositories/sqlite/sqlite_client.ts`. For hosted or agent-heavy instances, set `NEOTOMA_DB_BACKEND=libsql` to switch to the concurrent backend (same on-disk format — validate with `scripts/validate_libsql_migration.ts`, then flip the env var): statements execute off the Node event loop (worker-hosted driver for local files: one writer plus `NEOTOMA_DB_READER_WORKERS` read-only readers under WAL; genuinely-async @libsql/client for remote sqld/Turso URLs), so one slow query no longer blocks health checks, the web UI, or other callers' requests. For anyone running a single hosted instance that serves multiple users on the default backend, the concurrency envelope is:
+Neotoma's default storage backend is SQLite (`better-sqlite3` / `node:sqlite`), configured in `src/repositories/sqlite/sqlite_client.ts`. For hosted or agent-heavy instances, set `NEOTOMA_DB_BACKEND=libsql` to switch to the concurrent backend (same on-disk format — validate with `scripts/validate_libsql_migration.ts`, then flip the env var): statements execute off the Node event loop (worker-hosted driver for local files: one writer plus `NEOTOMA_DB_READER_WORKERS` read-only readers under WAL; genuinely-async @libsql/client for remote sqld/Turso URLs), so one slow query no longer blocks health checks, the web UI, or other callers' requests.
+
+**Decision trigger:** switch when you've observed (or expect) a slow query blocking other requests on a shared instance — the concrete case that motivated this backend was a deep-offset `include_snapshots` contact query blocking a hosted instance for 4.8–7.5s per page — or when the database moves to a remote sqld/Turso URL, which requires `libsql` regardless of load. Staying on the default `sqlite` backend is correct for single-user/local/CLI-driven deployments. See `docs/operations/configuration.md` § When to opt into `NEOTOMA_DB_BACKEND=libsql` for the operator-facing summary.
+
+For anyone running a single hosted instance that serves multiple users on the default backend, the concurrency envelope is:
 
 **What is configured today**
 

--- a/docs/infrastructure/multi_tenant_deployment_topology.md
+++ b/docs/infrastructure/multi_tenant_deployment_topology.md
@@ -27,9 +27,16 @@ Related:
 These are the constraints any topology choice has to start from, verified against
 `src/repositories/sqlite/sqlite_client.ts` and the server entrypoint:
 
-- **Backend is SQLite** (`better-sqlite3`). The repository layer defines storage
-  interfaces (`src/repositories/interfaces.ts`), so a second backend is a real seam,
-  but only the SQLite binding exists today — there is no Postgres adapter.
+- **Backend is SQLite by default** (`better-sqlite3` / `node:sqlite`), selected via
+  `NEOTOMA_DB_BACKEND` (`sqlite` | `libsql`). All call sites go through the async
+  driver contract in `src/repositories/db/driver.ts`. The `libsql` backend (same
+  file format and SQL dialect) executes statements **off the Node event loop** —
+  local files via worker threads hosting the synchronous driver (one writer + a
+  read-only reader pool under WAL; every local Node binding, including
+  @libsql/client's `file:` protocol, is synchronous on the calling thread), remote
+  sqld/Turso URLs via the genuinely-async @libsql/client — so a slow query cannot
+  freeze health checks or concurrent MCP requests. Recommended for
+  hosted/agent-heavy/shared instances. There is no Postgres adapter yet.
 - **WAL is enabled** (`journal_mode = WAL`), and `foreign_keys = ON`. WAL allows
   concurrent readers alongside a single writer.
 - **`busy_timeout` is set** (default 5000ms, override `NEOTOMA_SQLITE_BUSY_TIMEOUT_MS`).

--- a/docs/operations/configuration.md
+++ b/docs/operations/configuration.md
@@ -29,6 +29,10 @@ Resolution order for the data directory and variables: a project-local `.env`, t
 | `NEOTOMA_ENV` | `development` or `production` | `development` |
 | `NEOTOMA_DATA_DIR` | Root data directory | local `data/` |
 | `NEOTOMA_SQLITE_PATH` | Explicit database file path | `{dataDir}/neotoma.db` (dev) |
+| `NEOTOMA_DB_BACKEND` | DB driver: `sqlite` (synchronous, zero-config) or `libsql` (concurrent — statements run off the event loop via worker-hosted driver for local files, or @libsql/client for remote sqld/Turso, so slow queries can't freeze the server; recommended for hosted/agent-heavy/shared instances) | `sqlite` |
+| `NEOTOMA_DB_URL` | libsql connection URL (`file:` for embedded local, `http(s)://`/`libsql://` for remote sqld/Turso) | `file:{NEOTOMA_SQLITE_PATH}` |
+| `NEOTOMA_DB_AUTH_TOKEN` | Auth token for remote libsql connections | unset |
+| `NEOTOMA_DB_READER_WORKERS` | Read-only worker connections for the local `libsql` backend (WAL lets them run concurrently with the writer) | `2` |
 | `NEOTOMA_RAW_STORAGE_DIR` | Content-addressed source files | `{dataDir}/sources` |
 | `NEOTOMA_LOGS_DIR` / `NEOTOMA_EVENT_LOG_PATH` | Log directory and event log file | under `{dataDir}/logs` |
 | `NEOTOMA_HOST_URL` / `NEOTOMA_PUBLIC_BASE_URL` | Public URL of this instance | auto-discovered or unset |

--- a/docs/operations/configuration.md
+++ b/docs/operations/configuration.md
@@ -37,6 +37,15 @@ Resolution order for the data directory and variables: a project-local `.env`, t
 | `NEOTOMA_LOGS_DIR` / `NEOTOMA_EVENT_LOG_PATH` | Log directory and event log file | under `{dataDir}/logs` |
 | `NEOTOMA_HOST_URL` / `NEOTOMA_PUBLIC_BASE_URL` | Public URL of this instance | auto-discovered or unset |
 
+### When to opt into `NEOTOMA_DB_BACKEND=libsql`
+
+Stay on the default `sqlite` backend until you have a concrete reason to switch. Switch to `libsql` when **either** of these is true:
+
+- You operate a **hosted, multi-user, or agent-heavy instance** where a single slow query (e.g. a deep-offset paginated query) has been observed to block health checks or other callers — this was the production symptom that motivated the concurrent backend (see `docs/infrastructure/deployment.md` § SQLite concurrency and the multi-writer model).
+- You are moving a database file to a **remote sqld/Turso URL** (`NEOTOMA_DB_URL=libsql://...` or `http(s)://...`), which requires the `libsql` backend regardless of load.
+
+Before flipping the variable on an existing database, run `npx tsx scripts/validate_libsql_migration.ts <path-to-db>` — it proves the file adopts safely under libsql (integrity check, per-table row-count parity, snapshot hydration spot check) without mutating the original file.
+
 ## Server and ports
 
 | Variable | Purpose | Default |

--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,19 +61,19 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **555**
-- Backend and repo Vitest files: **520**
+- Total automated test files: **551**
+- Backend and repo Vitest files: **516**
 - Frontend Vitest files: **9**
 - Playwright spec files: **26**
 
 ### Suite counts
 | Suite | Files |
 |---|---:|
-| Vitest unit tests | 151 |
-| Vitest service tests | 42 |
+| Vitest unit tests | 156 |
+| Vitest service tests | 39 |
 | Source-adjacent tests | 65 |
-| Vitest integration tests | 159 |
-| Vitest CLI tests | 72 |
+| Vitest integration tests | 157 |
+| Vitest CLI tests | 67 |
 | Vitest contract tests | 15 |
 | Vitest security tests | 4 |
 | Vitest subscription tests | 5 |
@@ -85,7 +85,7 @@ flowchart TD
 | Playwright E2E tests | 22 |
 | Playwright Inspector E2E tests | 4 |
 | Tests Performance | 1 |
-| Tests Scripts | 2 |
+| Tests Scripts | 3 |
 
 ## Primary validation commands
 - `npm test`
@@ -109,7 +109,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/unit`
 **Requirements:** Basic `.env` if required by the module under test.
-**Files (151):**
+**Files (156):**
 - `tests/unit/aauth_admission.test.ts`
 - `tests/unit/aauth_attestation_apple_se.test.ts`
 - `tests/unit/aauth_attestation_revocation.test.ts`
@@ -150,6 +150,7 @@ flowchart TD
 - `tests/unit/client_turn_report.test.ts`
 - `tests/unit/compliance_scorecard.test.ts`
 - `tests/unit/config_data_dir_resolution.test.ts`
+- `tests/unit/config_db_backend.test.ts`
 - `tests/unit/config_sqlite_path.test.ts`
 - `tests/unit/content_field_store_warning.test.ts`
 - `tests/unit/conversation_schema_bootstrap.test.ts`
@@ -157,6 +158,10 @@ flowchart TD
 - `tests/unit/cursor_hooks_context.test.ts`
 - `tests/unit/cursor_hooks_external_data.test.ts`
 - `tests/unit/cursor_hooks_small_model.test.ts`
+- `tests/unit/db_driver_contract.test.ts`
+- `tests/unit/db_idempotency_concurrency.test.ts`
+- `tests/unit/db_libsql_nonblocking.test.ts`
+- `tests/unit/db_worker_file_database.test.ts`
 - `tests/unit/docs_sidebar_nav.test.ts`
 - `tests/unit/docs/index_builder_deprecation.test.ts`
 - `tests/unit/drift_comparison.test.ts`
@@ -267,13 +272,12 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/services`
 **Requirements:** Basic `.env` if required by the module under test.
-**Files (42):**
+**Files (39):**
 - `tests/services/auto_enhancement_converter_detection.test.ts`
 - `tests/services/auto_enhancement_processor.test.ts`
 - `tests/services/capability_registry.test.ts`
 - `tests/services/company_resolution.test.ts`
 - `tests/services/converter_detection_unit.test.ts`
-- `tests/services/deploy_seed_wiring.test.ts`
 - `tests/services/embed_cross_origin.test.ts`
 - `tests/services/encryption_service.test.ts`
 - `tests/services/entity_id_tenant_scope_resolution.test.ts`
@@ -296,14 +300,12 @@ flowchart TD
 - `tests/services/payload_schema.test.ts`
 - `tests/services/peer_sync_batch.test.ts`
 - `tests/services/raw_fragments_isolation.test.ts`
-- `tests/services/raw_storage_mime_map.test.ts`
 - `tests/services/raw_storage.test.ts`
 - `tests/services/schema_definitions_agent_runtime.test.ts`
 - `tests/services/schema_definitions.test.ts`
 - `tests/services/schema_recommendation.test.ts`
 - `tests/services/schema_reference_fields_resolve_target_validation.test.ts`
 - `tests/services/schema_reference_linking.test.ts`
-- `tests/services/schema_registry_bootstrap.test.ts`
 - `tests/services/schema_registry_incremental.test.ts`
 - `tests/services/schema_seeding_fresh_instance_gap.test.ts`
 - `tests/services/summary.test.ts`
@@ -388,7 +390,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm run test:integration` or `npx vitest run tests/integration`
 **Requirements:** Database configured; remote-dependent subsets additionally need `RUN_REMOTE_TESTS=1`.
-**Files (159):**
+**Files (157):**
 - `tests/integration/aauth_attribution_stamping.test.ts`
 - `tests/integration/aauth_mcp_capability_parity.test.ts`
 - `tests/integration/aauth_mcp_initialize_admission.test.ts`
@@ -426,7 +428,6 @@ flowchart TD
 - `tests/integration/docs_route.test.ts`
 - `tests/integration/embed_cross_origin_http.test.ts`
 - `tests/integration/entity_identifier_handler.test.ts`
-- `tests/integration/entity_queries_contains_word.test.ts`
 - `tests/integration/entity_queries_cursor.test.ts`
 - `tests/integration/entity_queries_status_column.test.ts`
 - `tests/integration/entity_queries.test.ts`
@@ -517,7 +518,6 @@ flowchart TD
 - `tests/integration/sandbox_seed_token_bypass.test.ts`
 - `tests/integration/sandbox_stale_bearer_fallback.test.ts`
 - `tests/integration/schema_recommendation_integration.test.ts`
-- `tests/integration/seed_then_works_at_e2e.test.ts`
 - `tests/integration/session_introspection.test.ts`
 - `tests/integration/snapshot_ingestion_cutoff.test.ts`
 - `tests/integration/store_builtin_identity_opt_out_schemas.test.ts`
@@ -554,7 +554,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/cli`
 **Requirements:** Basic `.env`; some tests provision temp config homes automatically.
-**Files (72):**
+**Files (67):**
 - `tests/cli/api_client_offline_fallback.test.ts`
 - `tests/cli/backup_verify.test.ts`
 - `tests/cli/cli_access_commands.test.ts`
@@ -609,9 +609,6 @@ flowchart TD
 - `tests/cli/discover_to_parse_roundtrip.test.ts`
 - `tests/cli/discovery_harness.test.ts`
 - `tests/cli/extract_user_cli_args.test.ts`
-- `tests/cli/instance_scripts.test.ts`
-- `tests/cli/instance_skills_client.test.ts`
-- `tests/cli/instance_skills.test.ts`
 - `tests/cli/issues_import.test.ts`
 - `tests/cli/issues_message.test.ts`
 - `tests/cli/onboarding_import_transcripts.test.ts`
@@ -622,8 +619,6 @@ flowchart TD
 - `tests/cli/schemas_describe.test.ts`
 - `tests/cli/schemas_repair_plural_types.test.ts`
 - `tests/cli/skills_mirror.test.ts`
-- `tests/cli/skills_sync_instance_cli.test.ts`
-- `tests/cli/sources_content_cli.test.ts`
 - `tests/cli/test_command_detection.test.ts`
 - `tests/cli/test_debug_tty.test.ts`
 - `tests/cli/transcript_parser.test.ts`
@@ -774,9 +769,10 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npx vitest run tests/scripts`
 **Requirements:** Basic `.env` if required by the module under test.
-**Files (2):**
+**Files (3):**
 - `tests/scripts/bundles_scaffold.test.ts`
 - `tests/scripts/launchd_cli_sync_tooling.test.ts`
+- `tests/scripts/validate_libsql_migration.test.ts`
 
 ### Python unit tests
 **Directory:** `packages/client-python/tests/`

--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,19 +61,19 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **551**
-- Backend and repo Vitest files: **516**
+- Total automated test files: **558**
+- Backend and repo Vitest files: **523**
 - Frontend Vitest files: **9**
 - Playwright spec files: **26**
 
 ### Suite counts
 | Suite | Files |
 |---|---:|
-| Vitest unit tests | 156 |
-| Vitest service tests | 39 |
+| Vitest unit tests | 157 |
+| Vitest service tests | 40 |
 | Source-adjacent tests | 65 |
 | Vitest integration tests | 157 |
-| Vitest CLI tests | 67 |
+| Vitest CLI tests | 72 |
 | Vitest contract tests | 15 |
 | Vitest security tests | 4 |
 | Vitest subscription tests | 5 |
@@ -109,7 +109,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/unit`
 **Requirements:** Basic `.env` if required by the module under test.
-**Files (156):**
+**Files (157):**
 - `tests/unit/aauth_admission.test.ts`
 - `tests/unit/aauth_attestation_apple_se.test.ts`
 - `tests/unit/aauth_attestation_revocation.test.ts`
@@ -161,6 +161,7 @@ flowchart TD
 - `tests/unit/db_driver_contract.test.ts`
 - `tests/unit/db_idempotency_concurrency.test.ts`
 - `tests/unit/db_libsql_nonblocking.test.ts`
+- `tests/unit/db_url_misconfig_guard.test.ts`
 - `tests/unit/db_worker_file_database.test.ts`
 - `tests/unit/docs_sidebar_nav.test.ts`
 - `tests/unit/docs/index_builder_deprecation.test.ts`
@@ -272,7 +273,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/services`
 **Requirements:** Basic `.env` if required by the module under test.
-**Files (39):**
+**Files (40):**
 - `tests/services/auto_enhancement_converter_detection.test.ts`
 - `tests/services/auto_enhancement_processor.test.ts`
 - `tests/services/capability_registry.test.ts`
@@ -300,6 +301,7 @@ flowchart TD
 - `tests/services/payload_schema.test.ts`
 - `tests/services/peer_sync_batch.test.ts`
 - `tests/services/raw_fragments_isolation.test.ts`
+- `tests/services/raw_storage_mime_map.test.ts`
 - `tests/services/raw_storage.test.ts`
 - `tests/services/schema_definitions_agent_runtime.test.ts`
 - `tests/services/schema_definitions.test.ts`
@@ -554,7 +556,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/cli`
 **Requirements:** Basic `.env`; some tests provision temp config homes automatically.
-**Files (67):**
+**Files (72):**
 - `tests/cli/api_client_offline_fallback.test.ts`
 - `tests/cli/backup_verify.test.ts`
 - `tests/cli/cli_access_commands.test.ts`
@@ -609,6 +611,9 @@ flowchart TD
 - `tests/cli/discover_to_parse_roundtrip.test.ts`
 - `tests/cli/discovery_harness.test.ts`
 - `tests/cli/extract_user_cli_args.test.ts`
+- `tests/cli/instance_scripts.test.ts`
+- `tests/cli/instance_skills_client.test.ts`
+- `tests/cli/instance_skills.test.ts`
 - `tests/cli/issues_import.test.ts`
 - `tests/cli/issues_message.test.ts`
 - `tests/cli/onboarding_import_transcripts.test.ts`
@@ -619,6 +624,8 @@ flowchart TD
 - `tests/cli/schemas_describe.test.ts`
 - `tests/cli/schemas_repair_plural_types.test.ts`
 - `tests/cli/skills_mirror.test.ts`
+- `tests/cli/skills_sync_instance_cli.test.ts`
+- `tests/cli/sources_content_cli.test.ts`
 - `tests/cli/test_command_detection.test.ts`
 - `tests/cli/test_debug_tty.test.ts`
 - `tests/cli/transcript_parser.test.ts`

--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,18 +61,18 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **558**
-- Backend and repo Vitest files: **523**
+- Total automated test files: **563**
+- Backend and repo Vitest files: **528**
 - Frontend Vitest files: **9**
 - Playwright spec files: **26**
 
 ### Suite counts
 | Suite | Files |
 |---|---:|
-| Vitest unit tests | 157 |
-| Vitest service tests | 40 |
+| Vitest unit tests | 158 |
+| Vitest service tests | 42 |
 | Source-adjacent tests | 65 |
-| Vitest integration tests | 157 |
+| Vitest integration tests | 159 |
 | Vitest CLI tests | 72 |
 | Vitest contract tests | 15 |
 | Vitest security tests | 4 |
@@ -109,7 +109,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/unit`
 **Requirements:** Basic `.env` if required by the module under test.
-**Files (157):**
+**Files (158):**
 - `tests/unit/aauth_admission.test.ts`
 - `tests/unit/aauth_attestation_apple_se.test.ts`
 - `tests/unit/aauth_attestation_revocation.test.ts`
@@ -161,6 +161,7 @@ flowchart TD
 - `tests/unit/db_driver_contract.test.ts`
 - `tests/unit/db_idempotency_concurrency.test.ts`
 - `tests/unit/db_libsql_nonblocking.test.ts`
+- `tests/unit/db_libsql_remote_class.test.ts`
 - `tests/unit/db_url_misconfig_guard.test.ts`
 - `tests/unit/db_worker_file_database.test.ts`
 - `tests/unit/docs_sidebar_nav.test.ts`
@@ -273,12 +274,13 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/services`
 **Requirements:** Basic `.env` if required by the module under test.
-**Files (40):**
+**Files (42):**
 - `tests/services/auto_enhancement_converter_detection.test.ts`
 - `tests/services/auto_enhancement_processor.test.ts`
 - `tests/services/capability_registry.test.ts`
 - `tests/services/company_resolution.test.ts`
 - `tests/services/converter_detection_unit.test.ts`
+- `tests/services/deploy_seed_wiring.test.ts`
 - `tests/services/embed_cross_origin.test.ts`
 - `tests/services/encryption_service.test.ts`
 - `tests/services/entity_id_tenant_scope_resolution.test.ts`
@@ -308,6 +310,7 @@ flowchart TD
 - `tests/services/schema_recommendation.test.ts`
 - `tests/services/schema_reference_fields_resolve_target_validation.test.ts`
 - `tests/services/schema_reference_linking.test.ts`
+- `tests/services/schema_registry_bootstrap.test.ts`
 - `tests/services/schema_registry_incremental.test.ts`
 - `tests/services/schema_seeding_fresh_instance_gap.test.ts`
 - `tests/services/summary.test.ts`
@@ -392,7 +395,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm run test:integration` or `npx vitest run tests/integration`
 **Requirements:** Database configured; remote-dependent subsets additionally need `RUN_REMOTE_TESTS=1`.
-**Files (157):**
+**Files (159):**
 - `tests/integration/aauth_attribution_stamping.test.ts`
 - `tests/integration/aauth_mcp_capability_parity.test.ts`
 - `tests/integration/aauth_mcp_initialize_admission.test.ts`
@@ -430,6 +433,7 @@ flowchart TD
 - `tests/integration/docs_route.test.ts`
 - `tests/integration/embed_cross_origin_http.test.ts`
 - `tests/integration/entity_identifier_handler.test.ts`
+- `tests/integration/entity_queries_contains_word.test.ts`
 - `tests/integration/entity_queries_cursor.test.ts`
 - `tests/integration/entity_queries_status_column.test.ts`
 - `tests/integration/entity_queries.test.ts`
@@ -520,6 +524,7 @@ flowchart TD
 - `tests/integration/sandbox_seed_token_bypass.test.ts`
 - `tests/integration/sandbox_stale_bearer_fallback.test.ts`
 - `tests/integration/schema_recommendation_integration.test.ts`
+- `tests/integration/seed_then_works_at_e2e.test.ts`
 - `tests/integration/session_introspection.test.ts`
 - `tests/integration/snapshot_ingestion_cutoff.test.ts`
 - `tests/integration/store_builtin_identity_opt_out_schemas.test.ts`

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@hellocoop/httpsig": "^1.4.0",
         "@hookform/resolvers": "^5.2.2",
+        "@libsql/client": "^0.17.4",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@noble/curves": "^2.0.1",
         "@noble/hashes": "^2.0.1",
@@ -51,6 +52,7 @@
         "idb-keyval": "^6.2.2",
         "jose": "^6.2.2",
         "js-yaml": "^4.1.1",
+        "libsql": "^0.5.29",
         "lucide-react": "^0.344.0",
         "morgan": "^1.10.0",
         "next-themes": "^0.4.6",
@@ -2277,6 +2279,165 @@
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
       "license": "MIT"
     },
+    "node_modules/@libsql/client": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@libsql/client/-/client-0.17.4.tgz",
+      "integrity": "sha512-lYayFWasDV78A+TjlEhr6ubb3odBV6OHjb+wdp8VQcyWWAEIjuwbCHaraEUS4m4yWoo0BvZo96It4VdzZRmRWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@libsql/core": "^0.17.4",
+        "@libsql/hrana-client": "^0.10.0",
+        "js-base64": "^3.7.5",
+        "libsql": "^0.5.28",
+        "promise-limit": "^2.7.0"
+      }
+    },
+    "node_modules/@libsql/core": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@libsql/core/-/core-0.17.4.tgz",
+      "integrity": "sha512-LqF9gIvnJ38nmAH1y/ChizHqDO/MO1wLgA96XrraulEEbqXxLjleSH92YWTolbuJKgPUmGu4aJk9W3UnAcxLOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "js-base64": "^3.7.5"
+      }
+    },
+    "node_modules/@libsql/darwin-arm64": {
+      "version": "0.5.29",
+      "resolved": "https://registry.npmjs.org/@libsql/darwin-arm64/-/darwin-arm64-0.5.29.tgz",
+      "integrity": "sha512-K+2RIB1OGFPYQbfay48GakLhqf3ArcbHqPFu7EZiaUcRgFcdw8RoltsMyvbj5ix2fY0HV3Q3Ioa/ByvQdaSM0A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@libsql/darwin-x64": {
+      "version": "0.5.29",
+      "resolved": "https://registry.npmjs.org/@libsql/darwin-x64/-/darwin-x64-0.5.29.tgz",
+      "integrity": "sha512-OtT+KFHsKFy1R5FVadr8FJ2Bb1mghtXTyJkxv0trocq7NuHntSki1eUbxpO5ezJesDvBlqFjnWaYYY516QNLhQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@libsql/hrana-client": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@libsql/hrana-client/-/hrana-client-0.10.0.tgz",
+      "integrity": "sha512-OoA4EMqRAC7kn7V2P6EQqRcpZf2W+AjsNIyCizBg339Tq/aMC7sRnzs3SklderhmQWAqEzvv8A2vhxVmWpkVvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@libsql/isomorphic-ws": "^0.1.5",
+        "js-base64": "^3.7.5"
+      }
+    },
+    "node_modules/@libsql/isomorphic-ws": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@libsql/isomorphic-ws/-/isomorphic-ws-0.1.5.tgz",
+      "integrity": "sha512-DtLWIH29onUYR00i0GlQ3UdcTRC6EP4u9w/h9LxpUZJWRMARk6dQwZ6Jkd+QdwVpuAOrdxt18v0K2uIYR3fwFg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ws": "^8.5.4",
+        "ws": "^8.13.0"
+      }
+    },
+    "node_modules/@libsql/linux-arm-gnueabihf": {
+      "version": "0.5.29",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-arm-gnueabihf/-/linux-arm-gnueabihf-0.5.29.tgz",
+      "integrity": "sha512-CD4n4zj7SJTHso4nf5cuMoWoMSS7asn5hHygsDuhRl8jjjCTT3yE+xdUvI4J7zsyb53VO5ISh4cwwOtf6k2UhQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@libsql/linux-arm-musleabihf": {
+      "version": "0.5.29",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-arm-musleabihf/-/linux-arm-musleabihf-0.5.29.tgz",
+      "integrity": "sha512-2Z9qBVpEJV7OeflzIR3+l5yAd4uTOLxklScYTwpZnkm2vDSGlC1PRlueLaufc4EFITkLKXK2MWBpexuNJfMVcg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@libsql/linux-arm64-gnu": {
+      "version": "0.5.29",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-arm64-gnu/-/linux-arm64-gnu-0.5.29.tgz",
+      "integrity": "sha512-gURBqaiXIGGwFNEaUj8Ldk7Hps4STtG+31aEidCk5evMMdtsdfL3HPCpvys+ZF/tkOs2MWlRWoSq7SOuCE9k3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@libsql/linux-arm64-musl": {
+      "version": "0.5.29",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-arm64-musl/-/linux-arm64-musl-0.5.29.tgz",
+      "integrity": "sha512-fwgYZ0H8mUkyVqXZHF3mT/92iIh1N94Owi/f66cPVNsk9BdGKq5gVpoKO+7UxaNzuEH1roJp2QEwsCZMvBLpqg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@libsql/linux-x64-gnu": {
+      "version": "0.5.29",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-x64-gnu/-/linux-x64-gnu-0.5.29.tgz",
+      "integrity": "sha512-y14V0vY0nmMC6G0pHeJcEarcnGU2H6cm21ZceRkacWHvQAEhAG0latQkCtoS2njFOXiYIg+JYPfAoWKbi82rkg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@libsql/linux-x64-musl": {
+      "version": "0.5.29",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-x64-musl/-/linux-x64-musl-0.5.29.tgz",
+      "integrity": "sha512-gquqwA/39tH4pFl+J9n3SOMSymjX+6kZ3kWgY3b94nXFTwac9bnFNMffIomgvlFaC4ArVqMnOZD3nuJ3H3VO1w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@libsql/win32-x64-msvc": {
+      "version": "0.5.29",
+      "resolved": "https://registry.npmjs.org/@libsql/win32-x64-msvc/-/win32-x64-msvc-0.5.29.tgz",
+      "integrity": "sha512-4/0CvEdhi6+KjMxMaVbFM2n2Z44escBRoEYpR+gZg64DdetzGnYm8mcNLcoySaDJZNaBd6wz5DNdgRmcI4hXcg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@mdx-js/mdx": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-3.1.1.tgz",
@@ -2852,6 +3013,12 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/@neon-rs/load": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@neon-rs/load/-/load-0.0.4.tgz",
+      "integrity": "sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw==",
+      "license": "MIT"
     },
     "node_modules/@noble/ciphers": {
       "version": "1.3.0",
@@ -5108,7 +5275,6 @@
       "version": "20.19.30",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.30.tgz",
       "integrity": "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==",
-      "dev": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -5248,7 +5414,6 @@
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
       "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -9261,6 +9426,12 @@
       "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
       "dev": true
     },
+    "node_modules/js-base64": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.9.1.tgz",
+      "integrity": "sha512-U73qptcvf/HIOauFOmqT3a0mDUp0MYlfd15oqoe9kqZt5XhiXVb+HG09sLvI9PQ9tZIBFS4nlErai8zbWazP0g==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/js-levenshtein": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
@@ -9429,6 +9600,47 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/libsql": {
+      "version": "0.5.29",
+      "resolved": "https://registry.npmjs.org/libsql/-/libsql-0.5.29.tgz",
+      "integrity": "sha512-8lMP8iMgiBzzoNbAPQ59qdVcj6UaE/Vnm+fiwX4doX4Narook0a4GPKWBEv+CR8a1OwbfkgL18uBfBjWdF0Fzg==",
+      "cpu": [
+        "x64",
+        "arm64",
+        "wasm32",
+        "arm"
+      ],
+      "license": "MIT",
+      "os": [
+        "darwin",
+        "linux",
+        "win32"
+      ],
+      "dependencies": {
+        "@neon-rs/load": "^0.0.4",
+        "detect-libc": "2.0.2"
+      },
+      "optionalDependencies": {
+        "@libsql/darwin-arm64": "0.5.29",
+        "@libsql/darwin-x64": "0.5.29",
+        "@libsql/linux-arm-gnueabihf": "0.5.29",
+        "@libsql/linux-arm-musleabihf": "0.5.29",
+        "@libsql/linux-arm64-gnu": "0.5.29",
+        "@libsql/linux-arm64-musl": "0.5.29",
+        "@libsql/linux-x64-gnu": "0.5.29",
+        "@libsql/linux-x64-musl": "0.5.29",
+        "@libsql/win32-x64-msvc": "0.5.29"
+      }
+    },
+    "node_modules/libsql/node_modules/detect-libc": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.2.tgz",
+      "integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/lilconfig": {
@@ -12176,6 +12388,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/promise-limit": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/promise-limit/-/promise-limit-2.7.0.tgz",
+      "integrity": "sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw==",
+      "license": "ISC"
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -14379,8 +14597,7 @@
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
     },
     "node_modules/unicode-properties": {
       "version": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -267,6 +267,7 @@
   "dependencies": {
     "@hellocoop/httpsig": "^1.4.0",
     "@hookform/resolvers": "^5.2.2",
+    "@libsql/client": "^0.17.4",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@noble/curves": "^2.0.1",
     "@noble/hashes": "^2.0.1",
@@ -307,6 +308,7 @@
     "idb-keyval": "^6.2.2",
     "jose": "^6.2.2",
     "js-yaml": "^4.1.1",
+    "libsql": "^0.5.29",
     "lucide-react": "^0.344.0",
     "morgan": "^1.10.0",
     "next-themes": "^0.4.6",

--- a/scripts/validate_libsql_migration.ts
+++ b/scripts/validate_libsql_migration.ts
@@ -1,0 +1,132 @@
+/**
+ * Validate that an existing Neotoma SQLite database opens and reads correctly
+ * under the libSQL backend (concurrent-backend plan, migration step).
+ *
+ * libSQL uses the same on-disk format and SQL dialect as SQLite, so "migration"
+ * is adopting the file in place — this script proves that adoption is safe for
+ * a specific database before flipping NEOTOMA_DB_BACKEND=libsql:
+ *
+ *   1. Copies the source DB to a temp file (never touches the original).
+ *   2. Opens the copy with @libsql/client and runs PRAGMA integrity_check.
+ *   3. Compares per-table row counts between the SQLite driver's view of the
+ *      source and the libSQL driver's view of the copy.
+ *   4. Runs a snapshot-hydration spot check (SELECT with JSON columns) through
+ *      both drivers and compares results.
+ *
+ * Usage:
+ *   npx tsx scripts/validate_libsql_migration.ts /path/to/neotoma.prod.db
+ *
+ * Exits 0 when every check passes, 1 otherwise.
+ */
+
+import { copyFileSync, existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { AsyncSqliteDatabase } from "../src/repositories/sqlite/sqlite_driver.js";
+import { openLibsqlDatabase } from "../src/repositories/libsql/libsql_driver.js";
+import type { DbDatabase } from "../src/repositories/db/driver.js";
+
+const TABLES = [
+  "sources",
+  "interpretations",
+  "observations",
+  "entities",
+  "entity_snapshots",
+  "timeline_events",
+  "relationship_observations",
+  "relationship_snapshots",
+  "raw_fragments",
+  "schema_registry",
+];
+
+async function tableCount(db: DbDatabase, table: string): Promise<number | null> {
+  try {
+    const row = (await db.prepare(`SELECT COUNT(*) AS n FROM ${table}`).get()) as
+      | { n: number }
+      | undefined;
+    return row?.n ?? 0;
+  } catch {
+    return null; // Table absent in this DB.
+  }
+}
+
+async function main(): Promise<void> {
+  const source = process.argv[2];
+  if (!source || !existsSync(source)) {
+    console.error("Usage: npx tsx scripts/validate_libsql_migration.ts <path-to-sqlite-db>");
+    process.exit(1);
+  }
+
+  const workDir = mkdtempSync(path.join(tmpdir(), "neotoma-libsql-validate-"));
+  const copyPath = path.join(workDir, path.basename(source));
+  copyFileSync(source, copyPath);
+  const sidecars = ["-wal", "-shm"];
+  for (const suffix of sidecars) {
+    if (existsSync(source + suffix)) copyFileSync(source + suffix, copyPath + suffix);
+  }
+
+  let failed = false;
+  const sqlite = new AsyncSqliteDatabase(source);
+  const libsql = openLibsqlDatabase(`file:${copyPath}`);
+
+  try {
+    // 1. Integrity check under libSQL.
+    const integrity = (await libsql.pragma("integrity_check")) as Array<
+      Record<string, unknown>
+    >;
+    const verdict = String(Object.values(integrity[0] ?? {})[0] ?? "");
+    if (verdict === "ok") {
+      console.log("✅ integrity_check: ok");
+    } else {
+      console.error(`❌ integrity_check failed: ${JSON.stringify(integrity).slice(0, 500)}`);
+      failed = true;
+    }
+
+    // 2. Row-count parity across core tables.
+    for (const table of TABLES) {
+      const a = await tableCount(sqlite, table);
+      const b = await tableCount(libsql, table);
+      if (a === null && b === null) continue;
+      if (a === b) {
+        console.log(`✅ ${table}: ${a} rows (parity)`);
+      } else {
+        console.error(`❌ ${table}: sqlite=${a} libsql=${b}`);
+        failed = true;
+      }
+    }
+
+    // 3. Spot check: newest entity snapshot hydrates identically.
+    const probe = `SELECT entity_id, entity_type, snapshot FROM entity_snapshots
+                   ORDER BY computed_at DESC LIMIT 5`;
+    try {
+      const fromSqlite = (await sqlite.prepare(probe).all()) as Record<string, unknown>[];
+      const fromLibsql = (await libsql.prepare(probe).all()) as Record<string, unknown>[];
+      const same = JSON.stringify(fromSqlite) === JSON.stringify(fromLibsql);
+      if (same) {
+        console.log(`✅ snapshot spot check: ${fromSqlite.length} rows identical`);
+      } else {
+        console.error("❌ snapshot spot check: rows differ between drivers");
+        failed = true;
+      }
+    } catch (error) {
+      console.log(`ℹ️ snapshot spot check skipped: ${(error as Error).message}`);
+    }
+  } finally {
+    await sqlite.close();
+    await libsql.close();
+    rmSync(workDir, { recursive: true, force: true });
+  }
+
+  if (failed) {
+    console.error("\nValidation FAILED — do not switch this database to libsql yet.");
+    process.exit(1);
+  }
+  console.log(
+    "\nValidation passed. Set NEOTOMA_DB_BACKEND=libsql (optionally NEOTOMA_DB_URL) and restart."
+  );
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/validate_libsql_migration.ts
+++ b/scripts/validate_libsql_migration.ts
@@ -22,6 +22,7 @@
 import { copyFileSync, existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { AsyncSqliteDatabase } from "../src/repositories/sqlite/sqlite_driver.js";
 import { openLibsqlDatabase } from "../src/repositories/libsql/libsql_driver.js";
 import type { DbDatabase } from "../src/repositories/db/driver.js";
@@ -50,6 +51,71 @@ async function tableCount(db: DbDatabase, table: string): Promise<number | null>
   }
 }
 
+export interface MigrationValidationResult {
+  passed: boolean;
+  messages: string[];
+  /** Tables whose row counts diverged between the sqlite and libsql views. */
+  failedTables: string[];
+}
+
+/**
+ * Runs the integrity check, per-table row-count parity, and snapshot
+ * spot-check against an already-open sqlite/libsql pair. Extracted from
+ * `main()` so tests can inject a deliberately corrupted copy without going
+ * through the CLI/process.exit path.
+ */
+export async function validateMigration(
+  sqlite: DbDatabase,
+  libsql: DbDatabase
+): Promise<MigrationValidationResult> {
+  const messages: string[] = [];
+  const failedTables: string[] = [];
+  let failed = false;
+
+  // 1. Integrity check under libSQL.
+  const integrity = (await libsql.pragma("integrity_check")) as Array<Record<string, unknown>>;
+  const verdict = String(Object.values(integrity[0] ?? {})[0] ?? "");
+  if (verdict === "ok") {
+    messages.push("✅ integrity_check: ok");
+  } else {
+    messages.push(`❌ integrity_check failed: ${JSON.stringify(integrity).slice(0, 500)}`);
+    failed = true;
+  }
+
+  // 2. Row-count parity across core tables.
+  for (const table of TABLES) {
+    const a = await tableCount(sqlite, table);
+    const b = await tableCount(libsql, table);
+    if (a === null && b === null) continue;
+    if (a === b) {
+      messages.push(`✅ ${table}: ${a} rows (parity)`);
+    } else {
+      messages.push(`❌ ${table}: sqlite=${a} libsql=${b}`);
+      failedTables.push(table);
+      failed = true;
+    }
+  }
+
+  // 3. Spot check: newest entity snapshot hydrates identically.
+  const probe = `SELECT entity_id, entity_type, snapshot FROM entity_snapshots
+                 ORDER BY computed_at DESC LIMIT 5`;
+  try {
+    const fromSqlite = (await sqlite.prepare(probe).all()) as Record<string, unknown>[];
+    const fromLibsql = (await libsql.prepare(probe).all()) as Record<string, unknown>[];
+    const same = JSON.stringify(fromSqlite) === JSON.stringify(fromLibsql);
+    if (same) {
+      messages.push(`✅ snapshot spot check: ${fromSqlite.length} rows identical`);
+    } else {
+      messages.push("❌ snapshot spot check: rows differ between drivers");
+      failed = true;
+    }
+  } catch (error) {
+    messages.push(`ℹ️ snapshot spot check skipped: ${(error as Error).message}`);
+  }
+
+  return { passed: !failed, messages, failedTables };
+}
+
 async function main(): Promise<void> {
   const source = process.argv[2];
   if (!source || !existsSync(source)) {
@@ -65,59 +131,20 @@ async function main(): Promise<void> {
     if (existsSync(source + suffix)) copyFileSync(source + suffix, copyPath + suffix);
   }
 
-  let failed = false;
   const sqlite = new AsyncSqliteDatabase(source);
   const libsql = openLibsqlDatabase(`file:${copyPath}`);
+  let result: MigrationValidationResult;
 
   try {
-    // 1. Integrity check under libSQL.
-    const integrity = (await libsql.pragma("integrity_check")) as Array<
-      Record<string, unknown>
-    >;
-    const verdict = String(Object.values(integrity[0] ?? {})[0] ?? "");
-    if (verdict === "ok") {
-      console.log("✅ integrity_check: ok");
-    } else {
-      console.error(`❌ integrity_check failed: ${JSON.stringify(integrity).slice(0, 500)}`);
-      failed = true;
-    }
-
-    // 2. Row-count parity across core tables.
-    for (const table of TABLES) {
-      const a = await tableCount(sqlite, table);
-      const b = await tableCount(libsql, table);
-      if (a === null && b === null) continue;
-      if (a === b) {
-        console.log(`✅ ${table}: ${a} rows (parity)`);
-      } else {
-        console.error(`❌ ${table}: sqlite=${a} libsql=${b}`);
-        failed = true;
-      }
-    }
-
-    // 3. Spot check: newest entity snapshot hydrates identically.
-    const probe = `SELECT entity_id, entity_type, snapshot FROM entity_snapshots
-                   ORDER BY computed_at DESC LIMIT 5`;
-    try {
-      const fromSqlite = (await sqlite.prepare(probe).all()) as Record<string, unknown>[];
-      const fromLibsql = (await libsql.prepare(probe).all()) as Record<string, unknown>[];
-      const same = JSON.stringify(fromSqlite) === JSON.stringify(fromLibsql);
-      if (same) {
-        console.log(`✅ snapshot spot check: ${fromSqlite.length} rows identical`);
-      } else {
-        console.error("❌ snapshot spot check: rows differ between drivers");
-        failed = true;
-      }
-    } catch (error) {
-      console.log(`ℹ️ snapshot spot check skipped: ${(error as Error).message}`);
-    }
+    result = await validateMigration(sqlite, libsql);
+    for (const message of result.messages) console.log(message);
   } finally {
     await sqlite.close();
     await libsql.close();
     rmSync(workDir, { recursive: true, force: true });
   }
 
-  if (failed) {
+  if (!result.passed) {
     console.error("\nValidation FAILED — do not switch this database to libsql yet.");
     process.exit(1);
   }
@@ -126,7 +153,12 @@ async function main(): Promise<void> {
   );
 }
 
-main().catch((error) => {
-  console.error(error);
-  process.exit(1);
-});
+// Run only when invoked directly (not when imported by tests).
+const invokedDirectly =
+  process.argv[1] !== undefined && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (invokedDirectly) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -145,7 +145,7 @@ import { getSandboxTermsResponse } from "./services/sandbox/terms.js";
 import { resolveSandboxReportTransport } from "./services/sandbox/transport.js";
 import type { SandboxReportReason } from "./services/sandbox/types.js";
 import type { SubstrateEvent } from "./events/types.js";
-import { getSqliteDb } from "./repositories/sqlite/sqlite_client.js";
+import { getDb } from "./repositories/db/connection.js";
 import { getMcpAuthToken } from "./crypto/mcp_auth_token.js";
 import {
   isOauthKeyCredentialValid,
@@ -443,7 +443,7 @@ if (isSandboxMode()) {
   const createAndSeedSession = async (
     packId: string
   ): Promise<{ session: SandboxSession; seedStatus: SeedStatus }> => {
-    const session = createSandboxSession(packId);
+    const session = await createSandboxSession(packId);
     const pack = getSandboxPack(session.packId);
     // Packs with seedPolicy "none" (e.g. the empty pack) legitimately seed
     // nothing — that is "skipped", not a failure.
@@ -493,14 +493,14 @@ if (isSandboxMode()) {
     }
   });
 
-  app.post("/sandbox/session/redeem", (req, res) => {
+  app.post("/sandbox/session/redeem", async (req, res) => {
     try {
       const code = typeof req.body?.code === "string" ? req.body.code : "";
       if (!code) {
         res.status(400).json({ error_code: "MISSING_CODE", message: "code is required" });
         return;
       }
-      const result = redeemOneTimeCode(code);
+      const result = await redeemOneTimeCode(code);
       if (!result) {
         res
           .status(404)
@@ -527,8 +527,8 @@ if (isSandboxMode()) {
     }
   });
 
-  app.get("/sandbox/session", (req, res) => {
-    const session = resolveSessionFromRequest(req);
+  app.get("/sandbox/session", async (req, res) => {
+    const session = await resolveSessionFromRequest(req);
     if (!session) {
       res.status(401).json({ error_code: "NO_SESSION", message: "No active sandbox session" });
       return;
@@ -542,13 +542,13 @@ if (isSandboxMode()) {
   });
 
   app.post("/sandbox/session/reset", async (req, res) => {
-    const session = resolveSessionFromRequest(req);
+    const session = await resolveSessionFromRequest(req);
     if (!session) {
       res.status(401).json({ error_code: "NO_SESSION", message: "No active sandbox session" });
       return;
     }
     const packId = typeof req.body?.pack_id === "string" ? req.body.pack_id : undefined;
-    purgeSessionUserData(session.userId);
+    await purgeSessionUserData(session.userId);
     const { session: newSession, seedStatus } = await createAndSeedSession(
       packId ?? session.packId
     );
@@ -566,24 +566,29 @@ if (isSandboxMode()) {
     });
   });
 
-  app.delete("/sandbox/session", (req, res) => {
-    const session = resolveSessionFromRequest(req);
+  app.delete("/sandbox/session", async (req, res) => {
+    const session = await resolveSessionFromRequest(req);
     if (!session) {
       res.status(401).json({ error_code: "NO_SESSION", message: "No active sandbox session" });
       return;
     }
-    revokeSession(session.userId);
-    purgeSessionUserData(session.userId);
+    await revokeSession(session.userId);
+    await purgeSessionUserData(session.userId);
     res.clearCookie(SESSION_COOKIE_NAME, { path: "/" });
     res.json({ ok: true });
   });
 
   setInterval(
     () => {
-      const purged = sweepExpiredSessions();
-      if (purged > 0) {
-        logger.info(`[Sandbox] Swept ${purged} expired session(s)`);
-      }
+      sweepExpiredSessions()
+        .then((purged) => {
+          if (purged > 0) {
+            logger.info(`[Sandbox] Swept ${purged} expired session(s)`);
+          }
+        })
+        .catch((err) => {
+          logger.error(`[Sandbox] session sweep failed: ${(err as Error).message}`);
+        });
     },
     15 * 60 * 1000
   );
@@ -3074,7 +3079,7 @@ app.get("/mcp/oauth/local-login", async (req, res) => {
     // (no Google session on this cookie — the default, and the only
     // possibility when the Google feature flag is off) is unchanged.
     const googleUserId = getGoogleVerifiedUserId(req);
-    const resolvedUserId = googleUserId ?? ensureLocalDevUser().id;
+    const resolvedUserId = googleUserId ?? (await ensureLocalDevUser()).id;
     const { completeLocalAuthorization } = await import("./services/mcp_oauth.js");
     const { connectionId, redirectUri, clientState } = await completeLocalAuthorization(
       state,
@@ -3321,10 +3326,10 @@ app.get("/mcp/oauth/authorization-details", async (req, res) => {
     const { validateSessionToken } = await import("./services/mcp_auth.js");
     await validateSessionToken(token);
 
-    const db = getSqliteDb();
-    const stateData = db
+    const db = await getDb();
+    const stateData = (await db
       .prepare("SELECT redirect_uri FROM mcp_oauth_state WHERE state = ?")
-      .get(authorization_id) as { redirect_uri?: string } | undefined;
+      .get(authorization_id)) as { redirect_uri?: string } | undefined;
 
     if (!stateData?.redirect_uri) {
       return res.status(404).json({
@@ -3616,7 +3621,9 @@ async function resolveRoutePrincipal(
       isLocalRequest(req) &&
       !headerAuth.startsWith("Bearer ")
     ) {
-      const userId = _localSandboxActive ? ensureLocalSandboxUser().id : ensureLocalDevUser().id;
+      const userId = _localSandboxActive
+        ? (await ensureLocalSandboxUser()).id
+        : (await ensureLocalDevUser()).id;
       // Stamp the principal so a later `getAuthenticatedUserId` in the handler
       // resolves the same local user without re-tripping the missing-Bearer gate.
       stampUserPrincipal(req, userId);
@@ -3682,9 +3689,9 @@ export async function resolveGuestUserId(
     // shared nil-UUID LOCAL_DEV_USER_ID. Outside local_sandbox mode (e.g. pure
     // dev with explicit auth configured) continue to use the nil-UUID fallback.
     if (_localSandboxActive) {
-      return ensureLocalSandboxUser().id;
+      return (await ensureLocalSandboxUser()).id;
     }
-    return ensureLocalDevUser().id;
+    return (await ensureLocalDevUser()).id;
   }
 
   throw new Error(
@@ -3844,14 +3851,14 @@ app.use(async (req, res, next) => {
       return next();
     }
     if (_localSandboxActive) {
-      const sandboxUser = ensureLocalSandboxUser();
+      const sandboxUser = await ensureLocalSandboxUser();
       stampUserPrincipal(req, sandboxUser.id);
       logger.info(
         `[Auth] ${req.method} ${req.path} auth_method=local_sandbox user_id=${sandboxUser.id}`
       );
       return next();
     }
-    const devUser = ensureLocalDevUser();
+    const devUser = await ensureLocalDevUser();
     stampUserPrincipal(req, devUser.id);
     logger.info(
       `[Auth] ${req.method} ${req.path} auth_method=local_no_bearer user_id=${devUser.id}`
@@ -3862,7 +3869,7 @@ app.use(async (req, res, next) => {
   // Sandbox ephemeral session: resolve from cookie or Bearer token before
   // falling back to the shared public user. Expired/revoked sessions 401.
   if (isSandboxMode()) {
-    const sessionInfo = resolveSessionFromRequest(req);
+    const sessionInfo = await resolveSessionFromRequest(req);
     if (sessionInfo) {
       stampUserPrincipal(req, sessionInfo.userId);
       logger.info(
@@ -3889,14 +3896,14 @@ app.use(async (req, res, next) => {
       req as express.Request & { aauth?: { verified?: boolean; thumbprint?: string } }
     ).aauth;
     if (aauthCtx?.verified === true && typeof aauthCtx.thumbprint === "string") {
-      const aauthUser = ensureSandboxAauthUser(aauthCtx.thumbprint);
+      const aauthUser = await ensureSandboxAauthUser(aauthCtx.thumbprint);
       stampUserPrincipal(req, aauthUser.id);
       logger.info(
         `[Auth] ${req.method} ${req.path} auth_method=sandbox_aauth user_id=${aauthUser.id} thumbprint=${aauthCtx.thumbprint}`
       );
       return next();
     }
-    const sandboxUser = ensureSandboxPublicUser();
+    const sandboxUser = await ensureSandboxPublicUser();
     stampUserPrincipal(req, sandboxUser.id);
     logger.info(
       `[Auth] ${req.method} ${req.path} auth_method=sandbox_public user_id=${sandboxUser.id}`
@@ -3912,7 +3919,7 @@ app.use(async (req, res, next) => {
   if (headerAuth.startsWith("Bearer ") && mcpExpectedToken) {
     const token = headerAuth.slice(7).trim();
     if (safeCompareTokens(token, mcpExpectedToken)) {
-      const devUser = ensureLocalDevUser();
+      const devUser = await ensureLocalDevUser();
       stampUserPrincipal(req, devUser.id);
       logger.info(
         `[Auth] ${req.method} ${req.path} auth_method=bearer_mcp_token user_id=${devUser.id}`
@@ -3931,14 +3938,14 @@ app.use(async (req, res, next) => {
       }
       if (isLocalRequest(req)) {
         if (_localSandboxActive) {
-          const sandboxUser = ensureLocalSandboxUser();
+          const sandboxUser = await ensureLocalSandboxUser();
           stampUserPrincipal(req, sandboxUser.id);
           logger.info(
             `[Auth] ${req.method} ${req.path} auth_method=local_sandbox user_id=${sandboxUser.id}`
           );
           return next();
         }
-        const devUser = ensureLocalDevUser();
+        const devUser = await ensureLocalDevUser();
         stampUserPrincipal(req, devUser.id);
         logger.info(
           `[Auth] ${req.method} ${req.path} auth_method=local_no_bearer user_id=${devUser.id}`
@@ -3949,7 +3956,7 @@ app.use(async (req, res, next) => {
     if (headerAuth.startsWith("Bearer ") && process.env.NEOTOMA_BEARER_TOKEN) {
       const token = headerAuth.slice(7).trim();
       if (safeCompareTokens(token, process.env.NEOTOMA_BEARER_TOKEN)) {
-        const devUser = ensureLocalDevUser();
+        const devUser = await ensureLocalDevUser();
         stampUserPrincipal(req, devUser.id);
         logger.info(
           `[Auth] ${req.method} ${req.path} auth_method=bearer_env user_id=${devUser.id}`
@@ -4067,7 +4074,7 @@ app.use(async (req, res, next) => {
       // sandboxDestructiveGuard, and AAuth-only routes by aauthRequired.
       if (isSandboxMode()) {
         res.clearCookie(SESSION_COOKIE_NAME, { path: "/" });
-        const sandboxUser = ensureSandboxPublicUser();
+        const sandboxUser = await ensureSandboxPublicUser();
         stampUserPrincipal(req, sandboxUser.id);
         logger.info(
           `[Auth] ${req.method} ${req.path} auth_method=sandbox_public_stale_bearer user_id=${sandboxUser.id}`
@@ -5481,7 +5488,7 @@ app.get("/record_activity", async (req, res) => {
     const limit = parseInt(String(req.query.limit ?? "50"), 10) || 50;
     const offset = parseInt(String(req.query.offset ?? "0"), 10) || 0;
     const recordTypes = parseRecordActivityTypesQuery(req.query.record_types);
-    const result = listRecentRecordActivity(userId, {
+    const result = await listRecentRecordActivity(userId, {
       limit,
       offset,
       ...(recordTypes?.length ? { recordTypes } : {}),
@@ -5504,7 +5511,7 @@ app.get("/record_activity", async (req, res) => {
 app.get("/agents", async (req, res) => {
   try {
     const userId = await getAuthenticatedUserId(req, req.query.user_id as string | undefined);
-    const result = listAgents(userId);
+    const result = await listAgents(userId);
     return res.json(result);
   } catch (error) {
     return handleApiError(
@@ -5707,7 +5714,7 @@ app.get("/agents/:key", async (req, res) => {
   try {
     const userId = await getAuthenticatedUserId(req, req.query.user_id as string | undefined);
     const agentKey = decodeURIComponent(req.params.key);
-    const agent = getAgent(userId, agentKey);
+    const agent = await getAgent(userId, agentKey);
     if (!agent) {
       return sendError(res, 404, "RESOURCE_NOT_FOUND", `Agent not found: ${agentKey}`);
     }
@@ -5734,7 +5741,7 @@ app.get("/agents/:key/records", async (req, res) => {
     const agentKey = decodeURIComponent(req.params.key);
     const limit = parseInt(String(req.query.limit ?? "50"), 10) || 50;
     const offset = parseInt(String(req.query.offset ?? "0"), 10) || 0;
-    const result = listAgentRecords(userId, agentKey, limit, offset);
+    const result = await listAgentRecords(userId, agentKey, limit, offset);
     return res.json(result);
   } catch (error) {
     return handleApiError(
@@ -5753,7 +5760,7 @@ app.get("/recent_conversations/:conversation_id", async (req, res) => {
   try {
     const userId = await getAuthenticatedUserId(req, req.query.user_id as string | undefined);
     const conversationId = String(req.params.conversation_id ?? "").trim();
-    const item = getRecentConversationById(userId, conversationId);
+    const item = await getRecentConversationById(userId, conversationId);
     if (!item) {
       return sendError(res, 404, "RESOURCE_NOT_FOUND", "Conversation not found");
     }
@@ -5786,7 +5793,7 @@ app.get("/recent_conversations", async (req, res) => {
     // UI and bookmarks may send agent_key=all; never treat that as a real deriveAgentKey value.
     const agent_key =
       agentKeyRaw.length > 0 && agentKeyRaw.toLowerCase() !== "all" ? agentKeyRaw : null;
-    const result = listRecentConversations(userId, limit, offset, {
+    const result = await listRecentConversations(userId, limit, offset, {
       activity_after,
       activity_before,
       agent_key,
@@ -5868,7 +5875,7 @@ app.get("/turns", async (req, res) => {
       typeof req.query.activity_before === "string"
         ? req.query.activity_before.trim() || null
         : null;
-    const result = listConversationTurns(userId, limit, offset, {
+    const result = await listConversationTurns(userId, limit, offset, {
       harness,
       status,
       activity_after,
@@ -5892,7 +5899,7 @@ app.get("/turns/:turn_key", async (req, res) => {
   try {
     const userId = await getAuthenticatedUserId(req, req.query.user_id as string | undefined);
     const turnKey = decodeURIComponent(req.params.turn_key);
-    const result = getConversationTurn(userId, turnKey);
+    const result = await getConversationTurn(userId, turnKey);
     if (!result) {
       return res.status(404).json({ error: "Turn not found", code: "NOT_FOUND" });
     }
@@ -5923,7 +5930,7 @@ app.get("/admin/compliance/scorecard", async (req, res) => {
       req.query.include_synthetic === "1" ||
       String(req.query.include_synthetic).toLowerCase() === "true";
 
-    const result = buildComplianceScorecard(userId, {
+    const result = await buildComplianceScorecard(userId, {
       since,
       until,
       group_by,
@@ -10028,7 +10035,7 @@ const handleIssuesSubmitHttp: express.RequestHandler = async (req, res) => {
     );
     const userId =
       principal.kind === "guest" && !principal.accessToken
-        ? ensureLocalDevUser().id
+        ? (await ensureLocalDevUser()).id
         : principal.kind === "guest" || guestSubmitPayload
           ? ((await resolveGuestUserId(req, principal)) ??
             (await getAuthenticatedUserId(req, parsed.data.user_id)))
@@ -11313,7 +11320,7 @@ app.get("/events/stream", async (req, res) => {
 
     if (lastEventId !== undefined && !ringHasId(lastEventId)) {
       const cursorSeq = Number(lastEventId);
-      if (Number.isFinite(cursorSeq) && hasDurableCursor(userId, cursorSeq)) {
+      if (Number.isFinite(cursorSeq) && (await hasDurableCursor(userId, cursorSeq))) {
         // Recoverable from durable storage: replay from the log, paging until
         // drained, then continue from the ring tail for anything newer.
         // Push the subscription's column-backed predicates into SQL so a narrow
@@ -11326,7 +11333,7 @@ app.get("/events/stream", async (req, res) => {
         };
         let after = cursorSeq;
         for (;;) {
-          const batch = getEventsAfterSeq(userId, after, 1000, durableFilter);
+          const batch = await getEventsAfterSeq(userId, after, 1000, durableFilter);
           if (batch.length === 0) break;
           for (const d of batch) {
             if (subscriptionMatchesEvent(sub, d.event)) writeEvent(String(d.seq), d.event);
@@ -11988,7 +11995,7 @@ export async function startHTTPServer() {
       // user rather than the shared nil-UUID LOCAL_DEV_USER_ID fallback.
       _localSandboxActive = true;
       try {
-        const sandboxUser = ensureLocalSandboxUser();
+        const sandboxUser = await ensureLocalSandboxUser();
         logger.info(`[sandbox_mode] local_sandbox principal provisioned: ${sandboxUser.id}`);
       } catch (err) {
         // DB may not be initialised yet on very first boot; the principal will

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -2841,7 +2841,7 @@ app.get("/mcp/oauth/google/callback", async (req, res) => {
     // with it) — generate an unguessable throwaway so createLocalAuthUser's
     // shared code path is satisfied without weakening any other account.
     const throwawayPassword = randomBytes(32).toString("hex");
-    const perEmailUser = createLocalAuthUser(email, throwawayPassword);
+    const perEmailUser = await createLocalAuthUser(email, throwawayPassword);
 
     // Shared-graph opt-in: when NEOTOMA_SHARED_GRAPH_USER_ID is set, an
     // approved teammate (the email already passed the allowlist inside

--- a/src/cli/commands/db_migrate_env_split.ts
+++ b/src/cli/commands/db_migrate_env_split.ts
@@ -53,9 +53,10 @@ export interface MigrateEnvSplitResult extends EnvSplitReport {
   renamed: boolean;
 }
 
-import { createRequire } from "node:module";
-
-const _nodeRequire = createRequire(import.meta.url);
+// Offline, read-only inspection of explicit SQLite files (no running server,
+// never on the server event loop) — the repo-layer synchronous driver is the
+// right tool here and keeps native-module selection in one place.
+import Database from "../../repositories/sqlite/sqlite_driver.js";
 
 type SimpleDb = {
   prepare: (sql: string) => { get: (...p: unknown[]) => unknown };
@@ -63,13 +64,7 @@ type SimpleDb = {
 };
 
 function openDb(dbPath: string): SimpleDb {
-  try {
-    const native = _nodeRequire("node:sqlite") as { DatabaseSync: new (path: string) => SimpleDb };
-    return new native.DatabaseSync(dbPath);
-  } catch {
-    const bsq = _nodeRequire("better-sqlite3") as new (path: string) => SimpleDb;
-    return new bsq(dbPath);
-  }
+  return new Database(dbPath);
 }
 
 /** Count user-contributed rows in a SQLite file without starting the full API. */

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -20,7 +20,7 @@ import {
   type Stats,
 } from "node:fs";
 import * as readline from "node:readline";
-import Database, { type SqliteDatabase } from "../repositories/sqlite/sqlite_driver.js";
+import { AsyncSqliteDatabase } from "../repositories/sqlite/sqlite_driver.js";
 
 import { config as appConfig } from "../config.js";
 import { getMcpAuthToken } from "../crypto/mcp_auth_token.js";
@@ -2887,9 +2887,9 @@ async function backupFilesWithTimestamp(filePaths: string[], ts: string): Promis
   return backups;
 }
 
-function checkpointWal(db: SqliteDatabase): void {
+async function checkpointWal(db: AsyncSqliteDatabase): Promise<void> {
   try {
-    db.pragma("wal_checkpoint(FULL)");
+    await db.pragma("wal_checkpoint(FULL)");
   } catch {
     // Ignore checkpoint failures for non-WAL or read-only databases.
   }
@@ -2902,15 +2902,15 @@ function stableValueSignature(value: unknown): string {
   return `${typeof value}:${String(value)}`;
 }
 
-function mergeSqliteDatabase(
+async function mergeSqliteDatabase(
   sourceDbPath: string,
   targetDbPath: string,
   options?: DbMergeOptions
-): DbMergeStats {
+): Promise<DbMergeStats> {
   const mode: DbMergeMode = options?.mode ?? "keep-target";
   const dryRun = options?.dryRun === true;
-  let sourceDb: SqliteDatabase | null = null;
-  let targetDb: SqliteDatabase | null = null;
+  let sourceDb: AsyncSqliteDatabase | null = null;
+  let targetDb: AsyncSqliteDatabase | null = null;
   let attached = false;
   const stats: DbMergeStats = {
     source_db: sourceDbPath,
@@ -2925,23 +2925,23 @@ function mergeSqliteDatabase(
     conflict_samples: [],
   };
   try {
-    sourceDb = new Database(sourceDbPath);
-    targetDb = new Database(targetDbPath);
-    checkpointWal(sourceDb);
-    checkpointWal(targetDb);
-    targetDb.prepare("ATTACH DATABASE ? AS src").run(sourceDbPath);
+    sourceDb = new AsyncSqliteDatabase(sourceDbPath);
+    targetDb = new AsyncSqliteDatabase(targetDbPath);
+    await checkpointWal(sourceDb);
+    await checkpointWal(targetDb);
+    await targetDb.prepare("ATTACH DATABASE ? AS src").run(sourceDbPath);
     attached = true;
 
-    const targetTables = targetDb
+    const targetTables = (await targetDb
       .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'")
-      .all() as Array<{ name: string }>;
+      .all()) as Array<{ name: string }>;
     const sourceTableSet = new Set(
       (
-        targetDb
+        (await targetDb
           .prepare(
             "SELECT name FROM src.sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'"
           )
-          .all() as Array<{ name: string }>
+          .all()) as Array<{ name: string }>
       ).map((row) => row.name)
     );
 
@@ -2963,16 +2963,18 @@ function mergeSqliteDatabase(
       const tableName = table.name;
       if (!sourceTableSet.has(tableName)) continue;
 
-      const targetCols = targetDb
+      const targetCols = (await targetDb
         .prepare(`PRAGMA table_info(${quoteSqlIdent(tableName)})`)
-        .all() as Array<{
+        .all()) as Array<{
         name: string;
         pk?: number;
       }>;
       const targetColNames = targetCols.map((row) => row.name);
       const sourceCols = new Set(
         (
-          targetDb.prepare(`PRAGMA src.table_info(${quoteSqlIdent(tableName)})`).all() as Array<{
+          (await targetDb
+            .prepare(`PRAGMA src.table_info(${quoteSqlIdent(tableName)})`)
+            .all()) as Array<{
             name: string;
           }>
         ).map((row) => row.name)
@@ -2982,9 +2984,9 @@ function mergeSqliteDatabase(
 
       const quotedCols = sharedCols.map((name) => quoteSqlIdent(name)).join(", ");
       const quotedTable = quoteSqlIdent(tableName);
-      const sourceCountRow = targetDb
+      const sourceCountRow = (await targetDb
         .prepare(`SELECT COUNT(*) as count FROM src.${quotedTable}`)
-        .get() as { count?: number };
+        .get()) as { count?: number };
       const sourceCount = Number(sourceCountRow?.count ?? 0);
 
       let conflictCount = 0;
@@ -3006,11 +3008,11 @@ function mergeSqliteDatabase(
           const diffCond = nonPkSharedCols
             .map((col) => `NOT (t.${quoteSqlIdent(col)} IS s.${quoteSqlIdent(col)})`)
             .join(" OR ");
-          const conflictCountRow = targetDb
+          const conflictCountRow = (await targetDb
             .prepare(
               `SELECT COUNT(*) as count FROM src.${quotedTable} s JOIN ${quotedTable} t ON ${joinCond} WHERE ${diffCond}`
             )
-            .get() as { count?: number };
+            .get()) as { count?: number };
           conflictCount = Number(conflictCountRow?.count ?? 0);
           if (conflictCount > 0) {
             const selectPk = pkCols
@@ -3022,11 +3024,11 @@ function mergeSqliteDatabase(
                   `s.${quoteSqlIdent(col)} AS s_${col.replace(/"/g, "_")}, t.${quoteSqlIdent(col)} AS t_${col.replace(/"/g, "_")}`
               )
               .join(", ");
-            const sampleRows = targetDb
+            const sampleRows = (await targetDb
               .prepare(
                 `SELECT ${selectPk}, ${selectVals} FROM src.${quotedTable} s JOIN ${quotedTable} t ON ${joinCond} WHERE ${diffCond} LIMIT 25`
               )
-              .all() as Array<Record<string, unknown>>;
+              .all()) as Array<Record<string, unknown>>;
             for (const row of sampleRows) {
               const differingColumns = nonPkSharedCols.filter((col) => {
                 const sKey = `s_${col.replace(/"/g, "_")}`;
@@ -3068,9 +3070,9 @@ function mergeSqliteDatabase(
 
     if (!dryRun) {
       const insertPrefix = mode === "keep-source" ? "INSERT OR REPLACE" : "INSERT OR IGNORE";
-      const writeTx = targetDb.transaction((mergePlans: TablePlan[]) => {
-        for (const plan of mergePlans) {
-          const insertResult = targetDb!
+      await targetDb.transaction(async (tx) => {
+        for (const plan of plans) {
+          const insertResult = await tx
             .prepare(
               `${insertPrefix} INTO ${plan.quotedTable} (${plan.quotedCols}) SELECT ${plan.quotedCols} FROM src.${plan.quotedTable}`
             )
@@ -3084,18 +3086,17 @@ function mergeSqliteDatabase(
           }
         }
       });
-      writeTx(plans);
     }
   } finally {
     if (targetDb) {
       try {
-        if (attached) targetDb.prepare("DETACH DATABASE src").run();
+        if (attached) await targetDb.prepare("DETACH DATABASE src").run();
       } catch {
         // ignore detach failures
       }
-      targetDb.close();
+      await targetDb.close();
     }
-    if (sourceDb) sourceDb.close();
+    if (sourceDb) await sourceDb.close();
   }
   return stats;
 }
@@ -3123,18 +3124,21 @@ async function recomputeMergedDbSnapshots(targetDbPath: string): Promise<DbSnaps
     entity_snapshot_recompute_errors: 0,
     relationship_snapshot_recompute_errors: 0,
   };
-  const db = new Database(targetDbPath);
+  const db = new AsyncSqliteDatabase(targetDbPath);
   try {
-    const tableExists = (tableName: string): boolean => {
-      const row = db
+    const tableExists = async (tableName: string): Promise<boolean> => {
+      const row = (await db
         .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name = ?")
-        .get(tableName) as { name?: string } | undefined;
+        .get(tableName)) as { name?: string } | undefined;
       return row?.name === tableName;
     };
-    if (!tableExists("entity_snapshots") || !tableExists("relationship_snapshots")) {
+    if (
+      !(await tableExists("entity_snapshots")) ||
+      !(await tableExists("relationship_snapshots"))
+    ) {
       return stats;
     }
-    if (!tableExists("observations") || !tableExists("relationship_observations")) {
+    if (!(await tableExists("observations")) || !(await tableExists("relationship_observations"))) {
       return stats;
     }
 
@@ -3144,34 +3148,37 @@ async function recomputeMergedDbSnapshots(targetDbPath: string): Promise<DbSnaps
     const relationshipReducer = new RelationshipReducer();
 
     const entityIds = (
-      db
+      (await db
         .prepare("SELECT DISTINCT entity_id FROM observations WHERE entity_id IS NOT NULL")
-        .all() as Array<{
+        .all()) as Array<{
         entity_id: string;
       }>
     ).map((row) => row.entity_id);
     const relationshipKeys = (
-      db
+      (await db
         .prepare(
           "SELECT DISTINCT relationship_key FROM relationship_observations WHERE relationship_key IS NOT NULL"
         )
-        .all() as Array<{ relationship_key: string }>
+        .all()) as Array<{ relationship_key: string }>
     ).map((row) => row.relationship_key);
 
-    db.prepare("DELETE FROM entity_snapshots").run();
-    db.prepare("DELETE FROM relationship_snapshots").run();
+    await db.prepare("DELETE FROM entity_snapshots").run();
+    await db.prepare("DELETE FROM relationship_snapshots").run();
 
     for (const entityId of entityIds) {
-      const observations = db
-        .prepare("SELECT * FROM observations WHERE entity_id = ? ORDER BY observed_at DESC, id ASC")
-        .all(entityId)
-        .map((row) => {
-          const observation = row as Record<string, unknown>;
-          if ("fields" in observation) {
-            observation.fields = parseJsonLike(observation.fields);
-          }
-          return observation;
-        });
+      const observations = (
+        await db
+          .prepare(
+            "SELECT * FROM observations WHERE entity_id = ? ORDER BY observed_at DESC, id ASC"
+          )
+          .all(entityId)
+      ).map((row) => {
+        const observation = row as Record<string, unknown>;
+        if ("fields" in observation) {
+          observation.fields = parseJsonLike(observation.fields);
+        }
+        return observation;
+      });
       if (observations.length === 0) continue;
       try {
         const snapshot = (await observationReducer.computeSnapshot(
@@ -3185,9 +3192,11 @@ async function recomputeMergedDbSnapshots(targetDbPath: string): Promise<DbSnaps
         const cols = Object.keys(payload);
         const placeholders = cols.map(() => "?").join(", ");
         const vals = cols.map((k) => payload[k]);
-        db.prepare(
-          `INSERT OR REPLACE INTO entity_snapshots (${cols.map((c) => quoteSqlIdent(c)).join(", ")}) VALUES (${placeholders})`
-        ).run(vals);
+        await db
+          .prepare(
+            `INSERT OR REPLACE INTO entity_snapshots (${cols.map((c) => quoteSqlIdent(c)).join(", ")}) VALUES (${placeholders})`
+          )
+          .run(vals);
         stats.entity_snapshots_recomputed += 1;
       } catch {
         stats.entity_snapshot_recompute_errors += 1;
@@ -3195,18 +3204,19 @@ async function recomputeMergedDbSnapshots(targetDbPath: string): Promise<DbSnaps
     }
 
     for (const relationshipKey of relationshipKeys) {
-      const relationshipObservations = db
-        .prepare(
-          "SELECT * FROM relationship_observations WHERE relationship_key = ? ORDER BY observed_at DESC, id ASC"
-        )
-        .all(relationshipKey)
-        .map((row) => {
-          const observation = row as Record<string, unknown>;
-          if ("metadata" in observation) {
-            observation.metadata = parseJsonLike(observation.metadata);
-          }
-          return observation;
-        });
+      const relationshipObservations = (
+        await db
+          .prepare(
+            "SELECT * FROM relationship_observations WHERE relationship_key = ? ORDER BY observed_at DESC, id ASC"
+          )
+          .all(relationshipKey)
+      ).map((row) => {
+        const observation = row as Record<string, unknown>;
+        if ("metadata" in observation) {
+          observation.metadata = parseJsonLike(observation.metadata);
+        }
+        return observation;
+      });
       if (relationshipObservations.length === 0) continue;
       try {
         const snapshot = (await relationshipReducer.computeSnapshot(
@@ -3220,16 +3230,18 @@ async function recomputeMergedDbSnapshots(targetDbPath: string): Promise<DbSnaps
         const cols = Object.keys(payload);
         const placeholders = cols.map(() => "?").join(", ");
         const vals = cols.map((k) => payload[k]);
-        db.prepare(
-          `INSERT OR REPLACE INTO relationship_snapshots (${cols.map((c) => quoteSqlIdent(c)).join(", ")}) VALUES (${placeholders})`
-        ).run(vals);
+        await db
+          .prepare(
+            `INSERT OR REPLACE INTO relationship_snapshots (${cols.map((c) => quoteSqlIdent(c)).join(", ")}) VALUES (${placeholders})`
+          )
+          .run(vals);
         stats.relationship_snapshots_recomputed += 1;
       } catch {
         stats.relationship_snapshot_recompute_errors += 1;
       }
     }
   } finally {
-    db.close();
+    await db.close();
   }
   return stats;
 }
@@ -3802,19 +3814,21 @@ async function startSessionWatch(
     }
   }
   type DbInstance = {
-    close: () => void;
-    prepare: (sql: string) => { all: (...args: unknown[]) => unknown[] };
-    pragma: (s: string) => void;
+    close: () => Promise<void>;
+    prepare: (sql: string) => { all: (...args: unknown[]) => Promise<unknown[]> };
+    pragma: (s: string) => Promise<unknown[]>;
   };
   const sqlite3Mod = await import("../repositories/sqlite/sqlite_driver.js");
-  const Database = (sqlite3Mod as unknown as { default: new (path: string) => DbInstance }).default;
+  const Database = (
+    sqlite3Mod as unknown as { AsyncSqliteDatabase: new (path: string) => DbInstance }
+  ).AsyncSqliteDatabase;
   const dbs: { path: string; label: string; db: DbInstance; cursors: Record<string, string> }[] =
     [];
   const nowIso = new Date().toISOString();
   try {
     await fs.access(dbPath);
     const db = new Database(dbPath);
-    db.pragma("busy_timeout = 2000");
+    await db.pragma("busy_timeout = 2000");
     const cursors: Record<string, string> = {};
     for (const { table } of WATCH_TABLE_DEFS) cursors[table] = nowIso;
     dbs.push({ path: dbPath, label: preferredEnv, db, cursors });
@@ -3823,11 +3837,11 @@ async function startSessionWatch(
   }
   if (dbs.length === 0) return () => {};
 
-  function fetchEntityNames(
+  async function fetchEntityNames(
     db: DbInstance,
     entityIds: Set<string>,
     forUserId: string
-  ): Map<string, string> {
+  ): Promise<Map<string, string>> {
     const map = new Map<string, string>();
     if (entityIds.size === 0 || !forUserId) return map;
     try {
@@ -3837,7 +3851,7 @@ async function startSessionWatch(
       const stmt = db.prepare(
         `SELECT id, canonical_name, entity_type FROM entities WHERE id IN (${placeholders}) AND user_id = ?`
       );
-      const rows = stmt.all(...entityIds, forUserId) as {
+      const rows = (await stmt.all(...entityIds, forUserId)) as {
         id: string;
         canonical_name: string;
         entity_type?: string;
@@ -3850,11 +3864,11 @@ async function startSessionWatch(
   }
 
   /** Entity id -> entity_type for Type column and entity_merges. */
-  function fetchEntityTypes(
+  async function fetchEntityTypes(
     db: DbInstance,
     entityIds: Set<string>,
     forUserId: string
-  ): Map<string, string> {
+  ): Promise<Map<string, string>> {
     const map = new Map<string, string>();
     if (entityIds.size === 0 || !forUserId) return map;
     try {
@@ -3864,7 +3878,10 @@ async function startSessionWatch(
       const stmt = db.prepare(
         `SELECT id, entity_type FROM entities WHERE id IN (${placeholders}) AND user_id = ?`
       );
-      const rows = stmt.all(...entityIds, forUserId) as { id: string; entity_type: string }[];
+      const rows = (await stmt.all(...entityIds, forUserId)) as {
+        id: string;
+        entity_type: string;
+      }[];
       for (const r of rows) if (r.entity_type) map.set(r.id, r.entity_type);
     } catch {
       // ignore
@@ -3929,7 +3946,7 @@ async function startSessionWatch(
   const ENTITY_SNAPSHOT_EMIT_WINDOW_MS = 2000;
   const lastEmittedEntitySnapshot: Record<string, number> = {};
 
-  function pollOne(db: DbInstance, cursors: Record<string, string>): void {
+  async function pollOne(db: DbInstance, cursors: Record<string, string>): Promise<void> {
     for (const { table, idCol, tsCol, userFilter } of WATCH_TABLE_DEFS) {
       try {
         const cursor = cursors[table] ?? "1970-01-01T00:00:00Z";
@@ -3940,10 +3957,10 @@ async function startSessionWatch(
         const stmt = db.prepare(
           `SELECT * FROM ${table} WHERE ${tsCol} IS NOT NULL AND ${tsCol} > ? AND ${userClause} ORDER BY ${tsCol} ASC LIMIT 100`
         );
-        const rows = stmt.all(cursor, userId) as Record<string, unknown>[];
+        const rows = (await stmt.all(cursor, userId)) as Record<string, unknown>[];
         const entityIds = collectEntityIds(table, rows);
-        const entityNames = fetchEntityNames(db, entityIds, userId);
-        const entityTypes = fetchEntityTypes(db, entityIds, userId);
+        const entityNames = await fetchEntityNames(db, entityIds, userId);
+        const entityTypes = await fetchEntityTypes(db, entityIds, userId);
         for (const row of rows) {
           const ts = String(row[tsCol] ?? "");
           if (ts && (!cursors[table] || ts > cursors[table])) cursors[table] = ts;
@@ -3980,11 +3997,13 @@ async function startSessionWatch(
 
   const intervalMs = 400;
   const id = setInterval(() => {
-    for (const { db, cursors } of dbs) pollOne(db, cursors);
+    void (async () => {
+      for (const { db, cursors } of dbs) await pollOne(db, cursors);
+    })();
   }, intervalMs);
   return () => {
     clearInterval(id);
-    for (const { db } of dbs) db.close();
+    for (const { db } of dbs) void db.close();
   };
 }
 
@@ -5666,8 +5685,7 @@ NEOTOMA_MCP_TOKEN_ENCRYPTION_KEY=${mcpTokenEncryptionKey}
         }
         const dbFiles = ["neotoma.db", "neotoma.prod.db"] as const;
         if (!opts.skipDb) {
-          const { ensureSqliteDbInitialized } =
-            await import("../repositories/sqlite/sqlite_client.js");
+          const { ensureDbInitialized } = await import("../repositories/db/connection.js");
           const recoverSqliteSidecars = async (dbPath: string): Promise<void> => {
             const suffix = `.stale-${Date.now()}`;
             const sidecars = [`${dbPath}-wal`, `${dbPath}-shm`];
@@ -5686,14 +5704,14 @@ NEOTOMA_MCP_TOKEN_ENCRYPTION_KEY=${mcpTokenEncryptionKey}
           };
           const ensureSqliteDbInitializedWithRetry = async (dbPath: string): Promise<void> => {
             try {
-              ensureSqliteDbInitialized(dbPath);
+              await ensureDbInitialized(dbPath);
             } catch (error) {
               const message = error instanceof Error ? error.message : String(error);
               if (!/disk i\/o error/i.test(message)) {
                 throw error;
               }
               await recoverSqliteSidecars(dbPath);
-              ensureSqliteDbInitialized(dbPath);
+              await ensureDbInitialized(dbPath);
             }
           };
           for (const dbFile of dbFiles) {
@@ -8793,9 +8811,9 @@ program
 
       // Open read-write so we can attach to WAL/shm; we only run SELECT. Opening readonly
       // while the API has the DB in WAL mode often causes "disk I/O error" (readers need shm access).
-      const { default: Database } = await import("../repositories/sqlite/sqlite_driver.js");
-      const db = new Database(resolvedPath);
-      db.pragma("busy_timeout = 2000");
+      const { AsyncSqliteDatabase } = await import("../repositories/sqlite/sqlite_driver.js");
+      const db = new AsyncSqliteDatabase(resolvedPath);
+      await db.pragma("busy_timeout = 2000");
 
       type TableDef = {
         table: string;
@@ -8829,7 +8847,10 @@ program
         relationship_snapshots: "🔗",
       };
 
-      function fetchEntityNames(entityIds: Set<string>, forUserId: string): Map<string, string> {
+      async function fetchEntityNames(
+        entityIds: Set<string>,
+        forUserId: string
+      ): Promise<Map<string, string>> {
         const map = new Map<string, string>();
         if (entityIds.size === 0) return map;
         try {
@@ -8839,7 +8860,7 @@ program
           const stmt = db.prepare(
             `SELECT id, canonical_name FROM entities WHERE id IN (${placeholders}) AND user_id = ?`
           );
-          const rows = stmt.all(...entityIds, forUserId) as {
+          const rows = (await stmt.all(...entityIds, forUserId)) as {
             id: string;
             canonical_name: string;
           }[];
@@ -8964,7 +8985,7 @@ program
         return ids;
       }
 
-      function poll(): void {
+      async function poll(): Promise<void> {
         for (const { table, idCol, tsCol, userFilter } of tableDefs) {
           try {
             const cursor = cursors[table] ?? "1970-01-01T00:00:00Z";
@@ -8975,8 +8996,8 @@ program
             const stmt = db.prepare(
               `SELECT * FROM ${table} WHERE ${tsCol} IS NOT NULL AND ${tsCol} > ? AND ${userClause} ORDER BY ${tsCol} ASC LIMIT 100`
             );
-            const rows = stmt.all(cursor, userId) as Record<string, unknown>[];
-            const entityNames = fetchEntityNames(collectEntityIds(table, rows), userId);
+            const rows = (await stmt.all(cursor, userId)) as Record<string, unknown>[];
+            const entityNames = await fetchEntityNames(collectEntityIds(table, rows), userId);
 
             for (const row of rows) {
               const ts = String(row[tsCol] ?? "");
@@ -9018,11 +9039,13 @@ program
         }
       }
 
-      poll();
-      const interval = setInterval(poll, intervalMs);
+      await poll();
+      const interval = setInterval(() => {
+        void poll();
+      }, intervalMs);
       const onExit = () => {
         clearInterval(interval);
-        db.close();
+        void db.close();
         process.exit(0);
       };
       process.on("SIGINT", onExit);
@@ -10467,7 +10490,7 @@ storageCommand
             const sourceDbPath = path.join(currentDataDir, baseName);
             const targetDbPath = path.join(targetDataDir, baseName);
             if (!(await pathExists(sourceDbPath)) || !(await pathExists(targetDbPath))) continue;
-            const stats = mergeSqliteDatabase(sourceDbPath, targetDbPath);
+            const stats = await mergeSqliteDatabase(sourceDbPath, targetDbPath);
             mergeStats.push(stats);
           }
         }
@@ -10571,7 +10594,7 @@ storageCommand
         throw new Error("Invalid --mode value. Expected one of: safe, keep-target, keep-source.");
       }
 
-      const mergeStats = mergeSqliteDatabase(sourcePath, targetPath, {
+      const mergeStats = await mergeSqliteDatabase(sourcePath, targetPath, {
         mode,
         dryRun: opts.dryRun === true,
       });
@@ -15103,7 +15126,7 @@ program
           const { storeRawContent } = await import("../services/raw_storage.js");
           const { ensureLocalDevUser } = await import("../services/local_auth.js");
 
-          const userRow = ensureLocalDevUser();
+          const userRow = await ensureLocalDevUser();
           const userId = userRow.id;
 
           const idempotencyKey =
@@ -16629,43 +16652,45 @@ async function getLocalIntroStats(
     return null;
   }
   type DbInstance = {
-    close: () => void;
-    prepare: (sql: string) => { get: (...args: unknown[]) => { "count(*)": number } | undefined };
-    pragma: (s: string) => void;
+    close: () => Promise<void>;
+    prepare: (sql: string) => {
+      get: (...args: unknown[]) => Promise<{ "count(*)": number } | undefined>;
+    };
+    pragma: (s: string) => Promise<unknown[]>;
   };
   try {
-    const { default: Database } = await import("../repositories/sqlite/sqlite_driver.js");
-    const db = new Database(dbPath) as unknown as DbInstance;
-    db.pragma("busy_timeout = 2000");
-    const getCount = (sql: string, ...args: unknown[]): number => {
-      const row = db.prepare(sql).get(...args) as { "count(*)": number } | undefined;
+    const { AsyncSqliteDatabase } = await import("../repositories/sqlite/sqlite_driver.js");
+    const db = new AsyncSqliteDatabase(dbPath) as unknown as DbInstance;
+    await db.pragma("busy_timeout = 2000");
+    const getCount = async (sql: string, ...args: unknown[]): Promise<number> => {
+      const row = (await db.prepare(sql).get(...args)) as { "count(*)": number } | undefined;
       return row != null && typeof row["count(*)"] === "number" ? row["count(*)"] : 0;
     };
-    const entities = getCount(
+    const entities = await getCount(
       "SELECT count(*) FROM entities WHERE user_id = ? AND merged_to_entity_id IS NULL",
       userId
     );
-    const relationships = getCount(
+    const relationships = await getCount(
       "SELECT count(*) FROM relationship_snapshots WHERE user_id = ?",
       userId
     );
-    const sources = getCount("SELECT count(*) FROM sources WHERE user_id = ?", userId);
-    const events = getCount(
+    const sources = await getCount("SELECT count(*) FROM sources WHERE user_id = ?", userId);
+    const events = await getCount(
       "SELECT count(*) FROM timeline_events WHERE source_id IN (SELECT id FROM sources WHERE user_id = ?)",
       userId
     );
     let observations = 0;
     let interpretations = 0;
     try {
-      observations = getCount("SELECT count(*) FROM observations WHERE user_id = ?", userId);
-      interpretations = getCount(
+      observations = await getCount("SELECT count(*) FROM observations WHERE user_id = ?", userId);
+      interpretations = await getCount(
         "SELECT count(*) FROM interpretations WHERE source_id IN (SELECT id FROM sources WHERE user_id = ?)",
         userId
       );
     } catch {
       // observations or interpretations table may not exist in older DBs
     }
-    db.close();
+    await db.close();
     return {
       total_entities: entities,
       total_relationships: relationships,
@@ -16699,29 +16724,29 @@ async function getEntityFromLocalDb(
   }
   type Row = Record<string, unknown>;
   type DbInstance = {
-    close: () => void;
-    pragma: (sql: string) => void;
+    close: () => Promise<void>;
+    pragma: (sql: string) => Promise<unknown[]>;
     prepare: (sql: string) => {
-      get: (...args: unknown[]) => Row | undefined;
-      all: (...args: unknown[]) => Row[];
+      get: (...args: unknown[]) => Promise<Row | undefined>;
+      all: (...args: unknown[]) => Promise<Row[]>;
     };
   };
-  const { default: Database } = await import("../repositories/sqlite/sqlite_driver.js");
-  const db = new Database(dbPath) as unknown as DbInstance;
-  db.pragma("busy_timeout = 2000");
+  const { AsyncSqliteDatabase } = await import("../repositories/sqlite/sqlite_driver.js");
+  const db = new AsyncSqliteDatabase(dbPath) as unknown as DbInstance;
+  await db.pragma("busy_timeout = 2000");
   try {
-    const entity = db
+    const entity = (await db
       .prepare(
         "SELECT id, entity_type, canonical_name, merged_to_entity_id FROM entities WHERE id = ? AND user_id = ?"
       )
-      .get(entityId, userId) as Row | undefined;
+      .get(entityId, userId)) as Row | undefined;
     if (!entity) return null;
     const resolvedId = (entity.merged_to_entity_id as string) || entityId;
     let snapshot: Record<string, unknown> | null = null;
     try {
-      const snap = db
+      const snap = (await db
         .prepare("SELECT snapshot FROM entity_snapshots WHERE entity_id = ? AND user_id = ?")
-        .get(resolvedId, userId) as { snapshot?: unknown } | undefined;
+        .get(resolvedId, userId)) as { snapshot?: unknown } | undefined;
       if (snap?.snapshot && typeof snap.snapshot === "object" && !Array.isArray(snap.snapshot)) {
         snapshot = snap.snapshot as Record<string, unknown>;
       }
@@ -16735,7 +16760,7 @@ async function getEntityFromLocalDb(
       ...(snapshot ? { snapshot } : {}),
     };
   } finally {
-    db.close();
+    await db.close();
   }
 }
 
@@ -16759,20 +16784,20 @@ async function getSourceFromLocalDb(
   }
   type Row = Record<string, unknown>;
   type DbInstance = {
-    close: () => void;
-    pragma: (sql: string) => void;
-    prepare: (sql: string) => { get: (...args: unknown[]) => Row | undefined };
+    close: () => Promise<void>;
+    pragma: (sql: string) => Promise<unknown[]>;
+    prepare: (sql: string) => { get: (...args: unknown[]) => Promise<Row | undefined> };
   };
-  const { default: Database } = await import("../repositories/sqlite/sqlite_driver.js");
-  const db = new Database(dbPath) as unknown as DbInstance;
-  db.pragma("busy_timeout = 2000");
+  const { AsyncSqliteDatabase } = await import("../repositories/sqlite/sqlite_driver.js");
+  const db = new AsyncSqliteDatabase(dbPath) as unknown as DbInstance;
+  await db.pragma("busy_timeout = 2000");
   try {
-    const source = db
+    const source = (await db
       .prepare("SELECT * FROM sources WHERE id = ? AND user_id = ?")
-      .get(sourceId, userId) as Row | undefined;
+      .get(sourceId, userId)) as Row | undefined;
     return source ?? null;
   } finally {
-    db.close();
+    await db.close();
   }
 }
 
@@ -16796,27 +16821,27 @@ async function getRelationshipFromLocalDb(
   }
   type Row = Record<string, unknown>;
   type DbInstance = {
-    close: () => void;
-    pragma: (sql: string) => void;
-    prepare: (sql: string) => { get: (...args: unknown[]) => Row | undefined };
+    close: () => Promise<void>;
+    pragma: (sql: string) => Promise<unknown[]>;
+    prepare: (sql: string) => { get: (...args: unknown[]) => Promise<Row | undefined> };
   };
-  const { default: Database } = await import("../repositories/sqlite/sqlite_driver.js");
-  const db = new Database(dbPath) as unknown as DbInstance;
-  db.pragma("busy_timeout = 2000");
+  const { AsyncSqliteDatabase } = await import("../repositories/sqlite/sqlite_driver.js");
+  const db = new AsyncSqliteDatabase(dbPath) as unknown as DbInstance;
+  await db.pragma("busy_timeout = 2000");
   try {
-    const snapshot = db
+    const snapshot = (await db
       .prepare("SELECT * FROM relationship_snapshots WHERE relationship_key = ? AND user_id = ?")
-      .get(relationshipKey, userId) as Row | undefined;
+      .get(relationshipKey, userId)) as Row | undefined;
     if (snapshot) return snapshot;
 
-    const lastObservation = db
+    const lastObservation = (await db
       .prepare(
         "SELECT relationship_key, relationship_type, source_entity_id, target_entity_id, observed_at, created_at, source_id, interpretation_id, user_id FROM relationship_observations WHERE relationship_key = ? AND user_id = ? ORDER BY created_at DESC LIMIT 1"
       )
-      .get(relationshipKey, userId) as Row | undefined;
+      .get(relationshipKey, userId)) as Row | undefined;
     return lastObservation ?? null;
   } finally {
-    db.close();
+    await db.close();
   }
 }
 
@@ -16845,13 +16870,13 @@ async function getLastNWatchEntries(
   }
   type Row = Record<string, unknown>;
   type DbInstance = {
-    close: () => void;
-    prepare: (sql: string) => { all: (...args: unknown[]) => Row[] };
-    pragma: (s: string) => void;
+    close: () => Promise<void>;
+    prepare: (sql: string) => { all: (...args: unknown[]) => Promise<Row[]> };
+    pragma: (s: string) => Promise<unknown[]>;
   };
-  const { default: Database } = await import("../repositories/sqlite/sqlite_driver.js");
-  const db = new Database(dbPath) as unknown as DbInstance;
-  db.pragma("busy_timeout = 2000");
+  const { AsyncSqliteDatabase } = await import("../repositories/sqlite/sqlite_driver.js");
+  const db = new AsyncSqliteDatabase(dbPath) as unknown as DbInstance;
+  await db.pragma("busy_timeout = 2000");
   const merged: { table: string; ts: string; id: string; row: Row }[] = [];
   try {
     for (const { table, idCol, tsCol, userFilter } of WATCH_ENTRY_TABLE_DEFS) {
@@ -16862,7 +16887,7 @@ async function getLastNWatchEntries(
             : "user_id = ?";
         const perTable = Math.max(5, Math.ceil(limit / WATCH_ENTRY_TABLE_DEFS.length) + 2);
         const sql = `SELECT * FROM ${table} WHERE ${tsCol} IS NOT NULL AND ${userClause} ORDER BY ${tsCol} DESC LIMIT ${perTable}`;
-        const rows = db.prepare(sql).all(userId) as Row[];
+        const rows = (await db.prepare(sql).all(userId)) as Row[];
         for (const row of rows) {
           const ts = String(row[tsCol] ?? "");
           const id = String(row[idCol] ?? "");
@@ -16896,20 +16921,24 @@ async function getLastNWatchEntries(
       const ph = Array.from(entityIds)
         .map(() => "?")
         .join(",");
-      const entityRows = db
+      const entityRows = (await db
         .prepare(
           `SELECT id, entity_type, canonical_name FROM entities WHERE id IN (${ph}) AND user_id = ?`
         )
-        .all(...entityIds, userId) as { id: string; entity_type: string; canonical_name: string }[];
+        .all(...entityIds, userId)) as {
+        id: string;
+        entity_type: string;
+        canonical_name: string;
+      }[];
       for (const r of entityRows) {
         entityMeta.set(r.id, { entity_type: r.entity_type, canonical_name: r.canonical_name });
       }
       try {
-        const snapshotRows = db
+        const snapshotRows = (await db
           .prepare(
             `SELECT entity_id, snapshot FROM entity_snapshots WHERE entity_id IN (${ph}) AND user_id = ?`
           )
-          .all(...entityIds, userId) as { entity_id: string; snapshot: unknown }[];
+          .all(...entityIds, userId)) as { entity_id: string; snapshot: unknown }[];
         for (const r of snapshotRows) {
           if (r.snapshot && typeof r.snapshot === "object" && !Array.isArray(r.snapshot)) {
             entitySnapshot.set(r.entity_id, r.snapshot as Record<string, unknown>);
@@ -16981,7 +17010,7 @@ async function getLastNWatchEntries(
       return out;
     });
   } finally {
-    db.close();
+    await db.close();
   }
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -153,10 +153,36 @@ function discoverTunnelUrl(httpPort: number, allowAutoDiscovery: boolean): strin
   return `http://localhost:${httpPort}`;
 }
 
+/**
+ * DB backend selection (concurrent-backend plan). `sqlite` (default) keeps the
+ * zero-config synchronous better-sqlite3/node:sqlite path. `libsql` opts into
+ * the concurrent backend — statements run off the Node event loop, so slow
+ * queries cannot freeze the whole server. For local `file:` URLs that is
+ * delivered by worker threads hosting the synchronous libSQL driver (a writer
+ * plus a read-only reader pool under WAL — every local Node binding is
+ * synchronous on the calling thread, so "async" local libSQL alone would not
+ * fix blocking); remote URLs (sqld/Turso) use the genuinely-async
+ * @libsql/client. The trigger for opting in is genuine multi-writer/hosted
+ * contention (agent-heavy or shared instances), not data size. Same file
+ * format and SQL dialect; a `file:` URL derived from sqlitePath is used
+ * unless NEOTOMA_DB_URL points at a remote instance.
+ */
+const dbBackend = (process.env.NEOTOMA_DB_BACKEND || "sqlite").toLowerCase();
+if (dbBackend !== "sqlite" && dbBackend !== "libsql") {
+  throw new Error(
+    `Invalid NEOTOMA_DB_BACKEND "${process.env.NEOTOMA_DB_BACKEND}": expected "sqlite" or "libsql"`
+  );
+}
+
 export const config = {
   projectRoot,
   storageBackend,
   dataDir,
+  dbBackend: dbBackend as "sqlite" | "libsql",
+  /** Connection URL for non-file backends (e.g. libsql://…, http(s)://… for sqld/Turso). */
+  dbUrl: process.env.NEOTOMA_DB_URL || "",
+  /** Auth token for remote libSQL (sqld/Turso) connections. */
+  dbAuthToken: process.env.NEOTOMA_DB_AUTH_TOKEN || "",
   sqlitePath:
     process.env.NEOTOMA_SQLITE_PATH ||
     join(dataDir, env === "production" ? "neotoma.prod.db" : "neotoma.db"),

--- a/src/openclaw_entry.ts
+++ b/src/openclaw_entry.ts
@@ -147,7 +147,7 @@ async function withServerUser<T>(
 ): Promise<T> {
   const server = await ensureServer(cfg);
   const { ensureLocalDevUser } = await import("./services/local_auth.js");
-  const localUser = ensureLocalDevUser();
+  const localUser = await ensureLocalDevUser();
   return fn(server, localUser.id);
 }
 
@@ -396,7 +396,7 @@ const neotomaPlugin = {
         async execute(_id: string, params: Record<string, unknown>) {
           const server = await ensureServer(pluginConfig);
           const { ensureLocalDevUser } = await import("./services/local_auth.js");
-          const localUser = ensureLocalDevUser();
+          const localUser = await ensureLocalDevUser();
           return server.executeToolForCli(tool.name, params, localUser.id);
         },
       });

--- a/src/repositories/db/connection.ts
+++ b/src/repositories/db/connection.ts
@@ -1,0 +1,119 @@
+/**
+ * Backend-agnostic DB connection lifecycle (concurrent-backend plan).
+ *
+ * Selects the driver from NEOTOMA_DB_BACKEND (`sqlite` default — synchronous
+ * better-sqlite3/node:sqlite wrapped in the async contract; `libsql` —
+ * statements off the event loop via worker-hosted driver for local files or
+ * @libsql/client for remote sqld/Turso), opens the connection, applies
+ * connection PRAGMAs, ensures the schema, and caches the handle.
+ */
+
+import { mkdirSync } from "fs";
+import path from "path";
+import { config } from "../../config.js";
+import {
+  applyConnectionPragmas,
+  ensureSchema,
+  SQLITE_BUSY_TIMEOUT_MS,
+} from "../sqlite/sqlite_client.js";
+import { AsyncSqliteDatabase } from "../sqlite/sqlite_driver.js";
+import type { DbDatabase } from "./driver.js";
+
+let cachedDb: DbDatabase | null = null;
+let opening: Promise<DbDatabase> | null = null;
+
+function libsqlUrl(): string {
+  return config.dbUrl || `file:${config.sqlitePath}`;
+}
+
+function ensureParentDirForFileUrl(url: string): void {
+  if (!url.startsWith("file:")) return;
+  const filePath = url.slice("file:".length).replace(/^\/\//, "/");
+  mkdirSync(path.dirname(filePath), { recursive: true });
+}
+
+async function openDb(): Promise<DbDatabase> {
+  if (config.dbBackend === "libsql") {
+    const { openLibsqlDatabase } = await import("../libsql/libsql_driver.js");
+    const url = libsqlUrl();
+    ensureParentDirForFileUrl(url);
+    const db = openLibsqlDatabase(url, {
+      authToken: config.dbAuthToken || undefined,
+      busyTimeoutMs: SQLITE_BUSY_TIMEOUT_MS,
+    });
+    // Connection PRAGMAs are per-connection concepts; remote sqld manages its
+    // own journal mode and lock handling, so only apply them to local files.
+    if (url.startsWith("file:")) {
+      await applyConnectionPragmas(db);
+    }
+    await ensureSchema(db);
+    return db;
+  }
+
+  const dbPath = config.sqlitePath;
+  mkdirSync(path.dirname(dbPath), { recursive: true });
+  const db = new AsyncSqliteDatabase(dbPath);
+  await applyConnectionPragmas(db);
+  await ensureSchema(db);
+  return db;
+}
+
+/**
+ * Get the cached DB handle, opening (and schema-initializing) it on first use.
+ * Concurrent first calls share one open — no double-initialization race.
+ */
+export function getDb(): Promise<DbDatabase> {
+  if (cachedDb) return Promise.resolve(cachedDb);
+  if (!opening) {
+    opening = openDb()
+      .then((db) => {
+        cachedDb = db;
+        return db;
+      })
+      .catch((error) => {
+        opening = null;
+        throw error;
+      });
+  }
+  return opening;
+}
+
+/**
+ * Clear the cached connection. The next getDb() opens a new one (creating the
+ * DB file if missing). Call after I/O errors (disk I/O error, DB file deleted
+ * while the server was running).
+ */
+export function clearDbCache(): void {
+  if (cachedDb) {
+    const stale = cachedDb;
+    cachedDb = null;
+    opening = null;
+    stale.close().catch(() => {
+      // Ignore close errors (e.g. file already deleted).
+    });
+  } else {
+    opening = null;
+  }
+}
+
+/**
+ * Ensure a local database file exists with Neotoma schema initialized, using
+ * the configured backend. Used by init to eagerly provision both dev and prod
+ * databases.
+ */
+export async function ensureDbInitialized(dbPath: string): Promise<void> {
+  mkdirSync(path.dirname(dbPath), { recursive: true });
+  let db: DbDatabase;
+  if (config.dbBackend === "libsql") {
+    const { openLibsqlDatabase } = await import("../libsql/libsql_driver.js");
+    db = openLibsqlDatabase(`file:${dbPath}`, { busyTimeoutMs: SQLITE_BUSY_TIMEOUT_MS });
+  } else {
+    db = new AsyncSqliteDatabase(dbPath);
+  }
+  try {
+    await applyConnectionPragmas(db);
+    await ensureSchema(db);
+  } finally {
+    await db.close();
+  }
+}

--- a/src/repositories/db/connection.ts
+++ b/src/repositories/db/connection.ts
@@ -26,6 +26,45 @@ function libsqlUrl(): string {
   return config.dbUrl || `file:${config.sqlitePath}`;
 }
 
+/**
+ * NEOTOMA_DB_URL is only honored by the libsql backend. On the default `sqlite`
+ * backend it is otherwise ignored with no signal, so an operator who sets
+ * `NEOTOMA_DB_URL=libsql://...` but forgets `NEOTOMA_DB_BACKEND=libsql` silently
+ * gets the local sqlite file instead of the remote instance they intended (the
+ * silent-misconfiguration gap flagged by the ux review on PR #1944).
+ *
+ * Returns a directive for the sqlite backend to act on:
+ *  - `throw` for a remote URL — unambiguously incompatible with this backend, so
+ *    fail loud at startup rather than open the wrong database.
+ *  - `warn` for a divergent local `file:` URL — ignored but harmless, so surface
+ *    it without hard-failing (a stale env value pointing at the same file, or a
+ *    bare path equal to sqlitePath, is silent — nothing to flag).
+ *  - `null` when there is nothing to flag.
+ */
+export function sqliteUrlMisconfig(
+  dbUrl: string | undefined,
+  sqlitePath: string
+): { level: "throw" | "warn"; message: string } | null {
+  if (!dbUrl) return null;
+  const sameFile = dbUrl === `file:${sqlitePath}` || dbUrl === sqlitePath;
+  if (sameFile) return null;
+  if (/^(libsql|https?|wss?):\/\//i.test(dbUrl)) {
+    return {
+      level: "throw",
+      message:
+        `NEOTOMA_DB_URL is set to "${dbUrl}" but NEOTOMA_DB_BACKEND is "sqlite", ` +
+        `which ignores it and opens the local file ${sqlitePath} instead. ` +
+        `Set NEOTOMA_DB_BACKEND=libsql to use a remote sqld/Turso URL, or unset NEOTOMA_DB_URL.`,
+    };
+  }
+  return {
+    level: "warn",
+    message:
+      `[neotoma] NEOTOMA_DB_URL="${dbUrl}" is ignored on the sqlite backend; ` +
+      `opening ${sqlitePath}. Set NEOTOMA_DB_BACKEND=libsql to honor NEOTOMA_DB_URL.`,
+  };
+}
+
 function ensureParentDirForFileUrl(url: string): void {
   if (!url.startsWith("file:")) return;
   const filePath = url.slice("file:".length).replace(/^\/\//, "/");
@@ -49,6 +88,12 @@ async function openDb(): Promise<DbDatabase> {
     await ensureSchema(db);
     return db;
   }
+
+  // Guard the silent-misconfiguration footgun (ux review, PR #1944): see
+  // sqliteUrlMisconfig() below.
+  const misconfig = sqliteUrlMisconfig(config.dbUrl, config.sqlitePath);
+  if (misconfig?.level === "throw") throw new Error(misconfig.message);
+  if (misconfig?.level === "warn") console.warn(misconfig.message);
 
   const dbPath = config.sqlitePath;
   mkdirSync(path.dirname(dbPath), { recursive: true });

--- a/src/repositories/db/driver.ts
+++ b/src/repositories/db/driver.ts
@@ -1,0 +1,90 @@
+/**
+ * Async DB driver contract (concurrent-backend plan).
+ *
+ * Every backend (better-sqlite3 / node:sqlite, libSQL, future Postgres)
+ * implements this interface, so call sites are written once against an async
+ * contract. The synchronous SQLite implementation resolves immediately; the
+ * libSQL implementation runs statements off the Node event loop, which is the
+ * fix for the single-threaded blocking that froze hosted instances (a slow
+ * query no longer stalls health checks or concurrent MCP requests).
+ *
+ * Transaction semantics
+ * ---------------------
+ * `transaction(fn)` opens BEGIN..COMMIT around `fn` and rolls back on throw.
+ * Transactions are serialized: while one is open, other transactions AND
+ * statements issued outside it queue until it settles, so an async callback
+ * cannot have unrelated writes interleaved into its transaction (the isolation
+ * the old synchronous better-sqlite3 `db.transaction()` gave for free).
+ * Statements issued on the database handle from *inside* the callback's async
+ * context are routed into the open transaction via AsyncLocalStorage rather
+ * than deadlocking on the queue.
+ */
+
+export interface DbRunResult {
+  /** Number of rows changed by the statement. */
+  changes: number;
+  /** Rowid of the last inserted row, when the backend reports it. */
+  lastInsertRowid?: number | bigint;
+}
+
+export interface DbStatement {
+  run(...params: unknown[]): Promise<DbRunResult>;
+  get(...params: unknown[]): Promise<unknown>;
+  all(...params: unknown[]): Promise<unknown[]>;
+}
+
+/** The statement surface shared by a database handle and an open transaction. */
+export interface DbConnection {
+  prepare(sql: string): DbStatement;
+  exec(sql: string): Promise<void>;
+}
+
+export interface DbDatabase extends DbConnection {
+  pragma(command: string): Promise<unknown[]>;
+  /** Run `fn` atomically; commit on resolve, rollback on throw. */
+  transaction<T>(fn: (tx: DbConnection) => Promise<T>): Promise<T>;
+  close(): Promise<void>;
+}
+
+/**
+ * Normalize positional bind params. Callers historically pass either
+ * `.run(a, b, c)` or `.run(valuesArray)`; both must bind identically.
+ */
+export function normalizeParams(params: unknown[]): unknown[] {
+  if (params.length === 1 && Array.isArray(params[0])) {
+    return params[0] as unknown[];
+  }
+  return params;
+}
+
+/**
+ * Serializes transactions against each other and lets non-transaction work
+ * wait for the currently open transaction. Backends compose this with an
+ * AsyncLocalStorage check so statements inside the transaction's own async
+ * context bypass the gate instead of deadlocking.
+ */
+export class TransactionGate {
+  private tail: Promise<void> = Promise.resolve();
+
+  /** Resolves once every transaction enqueued so far has settled. */
+  whenIdle(): Promise<void> {
+    return this.tail;
+  }
+
+  /** Enqueue `fn` after all prior transactions; holds the gate until settled. */
+  runExclusive<T>(fn: () => Promise<T>): Promise<T> {
+    const prev = this.tail;
+    let release!: () => void;
+    this.tail = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    return (async () => {
+      await prev;
+      try {
+        return await fn();
+      } finally {
+        release();
+      }
+    })();
+  }
+}

--- a/src/repositories/db/driver.ts
+++ b/src/repositories/db/driver.ts
@@ -62,6 +62,19 @@ export function normalizeParams(params: unknown[]): unknown[] {
  * wait for the currently open transaction. Backends compose this with an
  * AsyncLocalStorage check so statements inside the transaction's own async
  * context bypass the gate instead of deadlocking.
+ *
+ * DESIGN NOTE — process-global, NOT per-tenant (arch review, PR #1944): the
+ * single tail-promise queue serializes ALL transactions in this process
+ * against each other, regardless of tenant/user. One caller's slow transaction
+ * queues every other caller's transaction behind it. This is the SAME
+ * global-serial constraint the prior synchronous better-sqlite3 driver had
+ * (single-threaded engine, one writer) — carried forward, just made explicit
+ * and now shared across the worker + reader pools. Do NOT "optimize" this into
+ * per-tenant sharding without preserving the atomicity guarantee entity_merge.ts
+ * relies on: its AsyncLocalStorage-routed statements join the caller's OPEN
+ * transaction, keyed on gate identity (the open BEGIN), not on tenant. A
+ * per-tenant gate would let a second tenant's statement interleave into the
+ * first tenant's transaction window and break that guarantee.
  */
 export class TransactionGate {
   private tail: Promise<void> = Promise.resolve();

--- a/src/repositories/db/driver.ts
+++ b/src/repositories/db/driver.ts
@@ -47,6 +47,22 @@ export interface DbDatabase extends DbConnection {
 }
 
 /**
+ * Thrown when `transaction()` is called from inside another transaction's
+ * callback. Transactions are gate-serialized, so a nested call would await a
+ * queue tail that only resolves after the outer (waiting) transaction finishes
+ * — a self-deadlock. Every backend fails fast with this message instead of
+ * hanging. Statements issued on the db handle inside a transaction callback
+ * join the open transaction and are fine; only a nested `transaction()` is
+ * unsupported.
+ */
+export const NESTED_TRANSACTION_ERROR =
+  "Nested transaction() is not supported: a transaction() call was issued from " +
+  "inside another transaction's callback. Transactions are serialized, so this " +
+  "would deadlock. Issue statements directly on the db handle inside the " +
+  "callback (they join the open transaction), or restructure so the inner work " +
+  "runs outside the outer transaction.";
+
+/**
  * Normalize positional bind params. Callers historically pass either
  * `.run(a, b, c)` or `.run(valuesArray)`; both must bind identically.
  */

--- a/src/repositories/libsql/libsql_driver.ts
+++ b/src/repositories/libsql/libsql_driver.ts
@@ -1,0 +1,199 @@
+/**
+ * libSQL backend for the async DB driver contract (concurrent-backend plan).
+ *
+ * Uses @libsql/client, whose native binding executes statements off the Node
+ * event loop — a slow query no longer freezes health checks, the web UI, or
+ * concurrent MCP requests (the bottega8 failure mode). Supports:
+ *   - `file:` URLs — embedded local database, same file format and SQL dialect
+ *     as the SQLite backend, preserving the zero-config local-first default.
+ *   - `http(s):`/`ws(s):`/`libsql:` URLs — remote sqld / Turso, for hosted
+ *     deployments (NEOTOMA_DB_AUTH_TOKEN supplies credentials when required).
+ *
+ * The file-protocol client runs transactions on the same underlying
+ * connection as ordinary statements, so the TransactionGate serializes
+ * transactions against outside statements for isolation; statements issued
+ * from inside the transaction's async context are routed into the open
+ * transaction via AsyncLocalStorage (see driver.ts).
+ */
+
+import { AsyncLocalStorage } from "node:async_hooks";
+import { createClient, type Client, type InValue, type Transaction } from "@libsql/client";
+import {
+  normalizeParams,
+  TransactionGate,
+  type DbConnection,
+  type DbDatabase,
+  type DbRunResult,
+  type DbStatement,
+} from "../db/driver.js";
+import { WorkerFileDatabase } from "../worker/worker_file_database.js";
+
+/** Convert a file: URL (file:/path, file:///path) to a filesystem path. */
+export function fileUrlToPath(url: string): string {
+  return url.slice("file:".length).replace(/^\/\//, "/");
+}
+
+/**
+ * Open the libsql backend for a connection URL.
+ *
+ * - `file:` URLs: EVERY Node binding for local libSQL/SQLite files executes
+ *   synchronously on the calling thread (verified empirically — including
+ *   @libsql/client's file protocol and `libsql/promise`, whose promises
+ *   resolve only after blocking the event loop for the whole statement). To
+ *   actually deliver statements-off-the-event-loop locally, file URLs are
+ *   served by WorkerFileDatabase: the synchronous driver hosted in worker
+ *   threads (single writer + read-only reader pool under WAL) behind the
+ *   same DbDatabase contract.
+ * - Remote URLs (http/https/ws/wss/libsql): @libsql/client is genuinely
+ *   async — network I/O — so the direct client is used.
+ */
+export function openLibsqlDatabase(
+  url: string,
+  options: { authToken?: string; busyTimeoutMs?: number } = {}
+): DbDatabase {
+  if (url.startsWith("file:")) {
+    return new WorkerFileDatabase(fileUrlToPath(url), {
+      busyTimeoutMs: options.busyTimeoutMs,
+    });
+  }
+  return new LibsqlDatabase(url, { authToken: options.authToken });
+}
+
+/** SQLite accepts numbers, strings, bigints, buffers, and null; map the rest. */
+function toInValue(value: unknown): InValue {
+  if (value === undefined || value === null) return null;
+  if (typeof value === "boolean") return value ? 1 : 0;
+  return value as InValue;
+}
+
+/**
+ * libSQL rows are array-likes with numeric and named accessors; normalize to
+ * plain objects keyed by column name so callers can spread and JSON-serialize
+ * them exactly like better-sqlite3 rows.
+ */
+function rowToObject(
+  row: Record<string | number, unknown>,
+  columns: string[]
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (let i = 0; i < columns.length; i += 1) {
+    out[columns[i]] = row[i];
+  }
+  return out;
+}
+
+/** The statement-execution surface shared by the client and an open transaction. */
+type Executor = Pick<Client, "execute">;
+
+class LibsqlStatement implements DbStatement {
+  constructor(
+    private readonly db: LibsqlDatabase,
+    private readonly sql: string
+  ) {}
+
+  private async execute(params: unknown[]): Promise<{
+    rows: Record<string, unknown>[];
+    rowsAffected: number;
+    lastInsertRowid: bigint | undefined;
+  }> {
+    const executor = await this.db.executorForStatement();
+    const args = normalizeParams(params).map(toInValue);
+    const result = await executor.execute({ sql: this.sql, args });
+    return {
+      rows: result.rows.map((row) =>
+        rowToObject(row as unknown as Record<string | number, unknown>, result.columns)
+      ),
+      rowsAffected: result.rowsAffected,
+      lastInsertRowid: result.lastInsertRowid,
+    };
+  }
+
+  async run(...params: unknown[]): Promise<DbRunResult> {
+    const result = await this.execute(params);
+    return { changes: result.rowsAffected, lastInsertRowid: result.lastInsertRowid };
+  }
+
+  async get(...params: unknown[]): Promise<unknown> {
+    const result = await this.execute(params);
+    return result.rows[0];
+  }
+
+  async all(...params: unknown[]): Promise<unknown[]> {
+    const result = await this.execute(params);
+    return result.rows;
+  }
+}
+
+export class LibsqlDatabase implements DbDatabase {
+  private readonly client: Client;
+  private readonly gate = new TransactionGate();
+  private readonly txContext = new AsyncLocalStorage<Transaction>();
+
+  constructor(url: string, options: { authToken?: string; syncUrl?: string } = {}) {
+    this.client = createClient({
+      url,
+      // Neotoma stores integers well inside Number.MAX_SAFE_INTEGER; "number"
+      // matches better-sqlite3's default return type for INTEGER columns.
+      intMode: "number",
+      ...(options.authToken ? { authToken: options.authToken } : {}),
+      ...(options.syncUrl ? { syncUrl: options.syncUrl } : {}),
+    });
+  }
+
+  /**
+   * @internal Statements wait for any open transaction unless they execute
+   * inside its async context, in which case they join the open transaction.
+   */
+  async executorForStatement(): Promise<Executor> {
+    const activeTx = this.txContext.getStore();
+    if (activeTx) return activeTx;
+    await this.gate.whenIdle();
+    return this.client;
+  }
+
+  prepare(sql: string): DbStatement {
+    return new LibsqlStatement(this, sql);
+  }
+
+  async exec(sql: string): Promise<void> {
+    const activeTx = this.txContext.getStore();
+    if (activeTx) {
+      await activeTx.executeMultiple(sql);
+      return;
+    }
+    await this.gate.whenIdle();
+    await this.client.executeMultiple(sql);
+  }
+
+  async pragma(command: string): Promise<unknown[]> {
+    await this.gate.whenIdle();
+    const result = await this.client.execute(`PRAGMA ${command}`);
+    return result.rows.map((row) =>
+      rowToObject(row as unknown as Record<string | number, unknown>, result.columns)
+    );
+  }
+
+  transaction<T>(fn: (tx: DbConnection) => Promise<T>): Promise<T> {
+    return this.gate.runExclusive(async () => {
+      const tx = await this.client.transaction("write");
+      try {
+        const result = await this.txContext.run(tx, () => fn(this));
+        await tx.commit();
+        return result;
+      } catch (error) {
+        try {
+          await tx.rollback();
+        } catch {
+          // Ignore rollback errors during unwind.
+        }
+        throw error;
+      } finally {
+        tx.close();
+      }
+    });
+  }
+
+  async close(): Promise<void> {
+    this.client.close();
+  }
+}

--- a/src/repositories/libsql/libsql_driver.ts
+++ b/src/repositories/libsql/libsql_driver.ts
@@ -19,6 +19,7 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import { createClient, type Client, type InValue, type Transaction } from "@libsql/client";
 import {
+  NESTED_TRANSACTION_ERROR,
   normalizeParams,
   TransactionGate,
   type DbConnection,
@@ -174,6 +175,9 @@ export class LibsqlDatabase implements DbDatabase {
   }
 
   transaction<T>(fn: (tx: DbConnection) => Promise<T>): Promise<T> {
+    // Fail loud on nested transaction() — see NESTED_TRANSACTION_ERROR; a
+    // gate-serialized nested call self-deadlocks (qa review, PR #1944).
+    if (this.txContext.getStore()) throw new Error(NESTED_TRANSACTION_ERROR);
     return this.gate.runExclusive(async () => {
       const tx = await this.client.transaction("write");
       try {

--- a/src/repositories/sqlite/local_db_adapter.ts
+++ b/src/repositories/sqlite/local_db_adapter.ts
@@ -2,7 +2,8 @@ import crypto from "crypto";
 import { mkdirSync, readFileSync } from "fs";
 import fs from "fs/promises";
 import path from "path";
-import { clearSqliteCache, getSqliteDb } from "./sqlite_client.js";
+import { clearDbCache, getDb } from "../db/connection.js";
+import type { DbDatabase } from "../db/driver.js";
 import { config } from "../../config.js";
 import { encryptColumn, decryptColumn, isEncryptedColumn } from "../../crypto/column_encryption.js";
 import { deriveKeys, deriveKeysFromMnemonic, hexToKey } from "../../crypto/key_derivation.js";
@@ -455,14 +456,14 @@ function deriveCanonicalNameFromObject(value: unknown): string | null {
 }
 
 async function ensureEntityRowForObservation(
-  db: ReturnType<typeof getSqliteDb>,
+  db: DbDatabase,
   obs: Record<string, unknown>
 ): Promise<void> {
   const entityId = typeof obs["entity_id"] === "string" ? (obs["entity_id"] as string) : null;
   const entityType = typeof obs["entity_type"] === "string" ? (obs["entity_type"] as string) : null;
   if (!entityId || !entityType) return;
 
-  const existing = db.prepare("SELECT id FROM entities WHERE id = ?").get(entityId) as
+  const existing = (await db.prepare("SELECT id FROM entities WHERE id = ?").get(entityId)) as
     | { id: string }
     | undefined;
   if (existing) return;
@@ -476,13 +477,15 @@ async function ensureEntityRowForObservation(
   const userId =
     typeof obs["user_id"] === "string" || obs["user_id"] === null ? obs["user_id"] : null;
 
-  db.prepare(
-    "INSERT INTO entities (id, entity_type, canonical_name, created_at, updated_at, user_id) VALUES (?, ?, ?, ?, ?, ?)"
-  ).run(entityId, entityType, canonicalName, now, now, userId);
+  await db
+    .prepare(
+      "INSERT INTO entities (id, entity_type, canonical_name, created_at, updated_at, user_id) VALUES (?, ?, ?, ?, ?, ?)"
+    )
+    .run(entityId, entityType, canonicalName, now, now, userId);
 }
 
 async function ensureEntityRowForSnapshot(
-  db: ReturnType<typeof getSqliteDb>,
+  db: DbDatabase,
   snapshotRow: Record<string, unknown>
 ): Promise<void> {
   const entityId =
@@ -491,7 +494,7 @@ async function ensureEntityRowForSnapshot(
     typeof snapshotRow["entity_type"] === "string" ? (snapshotRow["entity_type"] as string) : null;
   if (!entityId || !entityType) return;
 
-  const existing = db.prepare("SELECT id FROM entities WHERE id = ?").get(entityId) as
+  const existing = (await db.prepare("SELECT id FROM entities WHERE id = ?").get(entityId)) as
     | { id: string }
     | undefined;
   if (existing) return;
@@ -506,31 +509,29 @@ async function ensureEntityRowForSnapshot(
       ? snapshotRow["user_id"]
       : null;
 
-  db.prepare(
-    "INSERT INTO entities (id, entity_type, canonical_name, created_at, updated_at, user_id) VALUES (?, ?, ?, ?, ?, ?)"
-  ).run(entityId, entityType, canonicalName, now, now, userId);
+  await db
+    .prepare(
+      "INSERT INTO entities (id, entity_type, canonical_name, created_at, updated_at, user_id) VALUES (?, ?, ?, ?, ?, ?)"
+    )
+    .run(entityId, entityType, canonicalName, now, now, userId);
 }
 
-async function recomputeEntitySnapshot(
-  db: ReturnType<typeof getSqliteDb>,
-  entityId: string
-): Promise<void> {
+async function recomputeEntitySnapshot(db: DbDatabase, entityId: string): Promise<void> {
   const { ObservationReducer } = await import("../../reducers/observation_reducer.js");
   const reducer = new ObservationReducer();
 
-  const rows = db.prepare("SELECT * FROM observations WHERE entity_id = ?").all(entityId) as Record<
-    string,
-    unknown
-  >[];
+  const rows = (await db
+    .prepare("SELECT * FROM observations WHERE entity_id = ?")
+    .all(entityId)) as Record<string, unknown>[];
   const observations = rows.map((r) => fromDbRow("observations", r)) as any[];
   if (observations.length === 0) {
-    db.prepare("DELETE FROM entity_snapshots WHERE entity_id = ?").run(entityId);
+    await db.prepare("DELETE FROM entity_snapshots WHERE entity_id = ?").run(entityId);
     return;
   }
 
   const snapshot = await reducer.computeSnapshot(entityId, observations);
   if (!snapshot) {
-    db.prepare("DELETE FROM entity_snapshots WHERE entity_id = ?").run(entityId);
+    await db.prepare("DELETE FROM entity_snapshots WHERE entity_id = ?").run(entityId);
     return;
   }
 
@@ -543,26 +544,28 @@ async function recomputeEntitySnapshot(
   const columns = Object.keys(payload);
   const values = columns.map((column) => toDbValue("entity_snapshots", column, payload[column]));
   const placeholders = columns.map(() => "?").join(", ");
-  db.prepare(
-    `INSERT OR REPLACE INTO entity_snapshots (${columns.join(", ")}) VALUES (${placeholders})`
-  ).run(values);
+  await db
+    .prepare(
+      `INSERT OR REPLACE INTO entity_snapshots (${columns.join(", ")}) VALUES (${placeholders})`
+    )
+    .run(values);
 }
 
 async function recomputeRelationshipSnapshot(
-  db: ReturnType<typeof getSqliteDb>,
+  db: DbDatabase,
   relationshipKey: string
 ): Promise<void> {
   const { RelationshipReducer } = await import("../../reducers/relationship_reducer.js");
   const reducer = new RelationshipReducer();
 
-  const rows = db
+  const rows = (await db
     .prepare("SELECT * FROM relationship_observations WHERE relationship_key = ?")
-    .all(relationshipKey) as Record<string, unknown>[];
+    .all(relationshipKey)) as Record<string, unknown>[];
   const observations = rows.map((r) => fromDbRow("relationship_observations", r)) as any[];
   if (observations.length === 0) {
-    db.prepare("DELETE FROM relationship_snapshots WHERE relationship_key = ?").run(
-      relationshipKey
-    );
+    await db
+      .prepare("DELETE FROM relationship_snapshots WHERE relationship_key = ?")
+      .run(relationshipKey);
     return;
   }
 
@@ -573,9 +576,11 @@ async function recomputeRelationshipSnapshot(
     toDbValue("relationship_snapshots", column, payload[column])
   );
   const placeholders = columns.map(() => "?").join(", ");
-  db.prepare(
-    `INSERT OR REPLACE INTO relationship_snapshots (${columns.join(", ")}) VALUES (${placeholders})`
-  ).run(values);
+  await db
+    .prepare(
+      `INSERT OR REPLACE INTO relationship_snapshots (${columns.join(", ")}) VALUES (${placeholders})`
+    )
+    .run(values);
 }
 
 class LocalQueryBuilder {
@@ -849,13 +854,13 @@ class LocalQueryBuilder {
     let lastLockError: { code?: string; errno?: number; message?: string } | null = null;
     for (let lockRetry = 0; lockRetry < SQLITE_LOCK_MAX_RETRIES; lockRetry += 1) {
       for (let attempt = 0; attempt < 2; attempt += 1) {
-        const db = getSqliteDb();
+        const db = await getDb();
         try {
           if (this.operation === "select") {
             const countRow = this.countExact
-              ? (db
+              ? ((await db
                   .prepare(`SELECT COUNT(*) as count FROM ${this.table} ${whereSql}`)
-                  .get(values) as { count: number } | undefined)
+                  .get(values)) as { count: number } | undefined)
               : undefined;
             const count = countRow?.count;
 
@@ -874,10 +879,9 @@ class LocalQueryBuilder {
 
             const sql =
               `SELECT ${this.selectColumns || "*"} FROM ${this.table} ${whereSql} ${orderSql} ${limitSql} ${offsetSql}`.trim();
-            const rows = db
-              .prepare(sql)
-              .all(values)
-              .map((row: any) => fromDbRow(this.table, row));
+            const rows = (await db.prepare(sql).all(values)).map((row: any) =>
+              fromDbRow(this.table, row)
+            );
 
             if (this.expectSingle) {
               const row = rows[0] || null;
@@ -980,9 +984,11 @@ class LocalQueryBuilder {
                 toDbValue(this.table, column, payload[column])
               );
               const placeholders = columns.map(() => "?").join(", ");
-              db.prepare(
-                `INSERT INTO ${this.table} (${columns.join(", ")}) VALUES (${placeholders})`
-              ).run(values);
+              await db
+                .prepare(
+                  `INSERT INTO ${this.table} (${columns.join(", ")}) VALUES (${placeholders})`
+                )
+                .run(values);
               inserted.push(payload);
 
               // Local backend parity: inserts can materialize related state (entities + snapshots).
@@ -1017,16 +1023,16 @@ class LocalQueryBuilder {
             );
             const updateSql = columns.map((column) => `${column} = ?`).join(", ");
 
-            db.prepare(`UPDATE ${this.table} SET ${updateSql} ${whereSql}`).run([
-              ...updateValues,
-              ...values,
-            ]);
+            await db
+              .prepare(`UPDATE ${this.table} SET ${updateSql} ${whereSql}`)
+              .run([...updateValues, ...values]);
 
             if (this.selectColumns) {
-              const rows = db
-                .prepare(`SELECT ${this.selectColumns} FROM ${this.table} ${whereSql}`)
-                .all(values)
-                .map((row: any) => fromDbRow(this.table, row));
+              const rows = (
+                await db
+                  .prepare(`SELECT ${this.selectColumns} FROM ${this.table} ${whereSql}`)
+                  .all(values)
+              ).map((row: any) => fromDbRow(this.table, row));
               if (this.expectSingle) {
                 const row = rows[0] || null;
                 if (!row && !this.allowNullSingle) {
@@ -1069,9 +1075,11 @@ class LocalQueryBuilder {
                 toDbValue(this.table, column, payload[column])
               );
               const placeholders = columns.map(() => "?").join(", ");
-              db.prepare(
-                `INSERT OR REPLACE INTO ${this.table} (${columns.join(", ")}) VALUES (${placeholders})`
-              ).run(values);
+              await db
+                .prepare(
+                  `INSERT OR REPLACE INTO ${this.table} (${columns.join(", ")}) VALUES (${placeholders})`
+                )
+                .run(values);
               inserted.push(payload);
 
               if (this.table === "entity_snapshots") {
@@ -1085,14 +1093,14 @@ class LocalQueryBuilder {
           }
 
           if (this.operation === "delete") {
-            db.prepare(`DELETE FROM ${this.table} ${whereSql}`).run(values);
+            await db.prepare(`DELETE FROM ${this.table} ${whereSql}`).run(values);
             return { data: null, error: null };
           }
 
           return { data: null, error: { message: "Unsupported operation" } };
         } catch (error: any) {
           if (attempt === 0 && isRecoverableSqliteConnectionError(error)) {
-            clearSqliteCache();
+            clearDbCache();
             continue;
           }
           if (isSqliteLockError(error)) {
@@ -1242,8 +1250,8 @@ class LocalAuthAdmin {
   async getUserById(
     userId: string
   ): Promise<QueryResult<{ user: { id: string; email?: string | null } | null }>> {
-    const db = getSqliteDb();
-    const user = db.prepare("SELECT id, email FROM auth_users WHERE id = ?").get(userId) as
+    const db = await getDb();
+    const user = (await db.prepare("SELECT id, email FROM auth_users WHERE id = ?").get(userId)) as
       | { id: string; email?: string | null }
       | undefined;
     if (!user) {
@@ -1257,20 +1265,18 @@ class LocalAuthAdmin {
     email?: string;
     email_confirm?: boolean;
   }): Promise<QueryResult<{ user: { id: string; email?: string | null } }>> {
-    const db = getSqliteDb();
+    const db = await getDb();
     const id = payload.id || crypto.randomUUID();
     const email = payload.email || null;
-    db.prepare("INSERT INTO auth_users (id, email, created_at) VALUES (?, ?, ?)").run(
-      id,
-      email,
-      new Date().toISOString()
-    );
+    await db
+      .prepare("INSERT INTO auth_users (id, email, created_at) VALUES (?, ?, ?)")
+      .run(id, email, new Date().toISOString());
     return { data: { user: { id, email } }, error: null };
   }
 
   async listUsers(): Promise<QueryResult<{ users: Array<{ id: string; email?: string | null }> }>> {
-    const db = getSqliteDb();
-    const users = db.prepare("SELECT id, email FROM auth_users").all();
+    const db = await getDb();
+    const users = await db.prepare("SELECT id, email FROM auth_users").all();
     return { data: { users: users as any }, error: null };
   }
 
@@ -1279,10 +1285,10 @@ class LocalAuthAdmin {
     email: string;
     options?: { redirectTo?: string };
   }): Promise<QueryResult<{ properties: { action_link: string } }>> {
-    const db = getSqliteDb();
-    const user = db
+    const db = await getDb();
+    const user = (await db
       .prepare("SELECT id, email FROM auth_users WHERE email = ?")
-      .get(payload.email) as { id: string; email?: string } | undefined;
+      .get(payload.email)) as { id: string; email?: string } | undefined;
     if (!user) {
       return { data: null, error: { message: "User not found", code: "PGRST116" } };
     }
@@ -1292,9 +1298,11 @@ class LocalAuthAdmin {
     const expiresAt = new Date(Date.now() + 60 * 60 * 1000).toISOString();
     const sessionId = crypto.randomUUID();
 
-    db.prepare(
-      "INSERT INTO auth_sessions (id, user_id, access_token, refresh_token, expires_at, created_at) VALUES (?, ?, ?, ?, ?, ?)"
-    ).run(sessionId, user.id, accessToken, refreshToken, expiresAt, new Date().toISOString());
+    await db
+      .prepare(
+        "INSERT INTO auth_sessions (id, user_id, access_token, refresh_token, expires_at, created_at) VALUES (?, ?, ?, ?, ?, ?)"
+      )
+      .run(sessionId, user.id, accessToken, refreshToken, expiresAt, new Date().toISOString());
 
     const redirectTo = payload.options?.redirectTo || "http://localhost:5173";
     const actionLink = `${redirectTo}#access_token=${accessToken}&refresh_token=${refreshToken}`;
@@ -1317,19 +1325,19 @@ class LocalAuthClient {
   async getUser(
     token: string
   ): Promise<QueryResult<{ user: { id: string; email?: string | null } }>> {
-    const db = getSqliteDb();
-    const session = db
+    const db = await getDb();
+    const session = (await db
       .prepare("SELECT user_id, access_token, expires_at FROM auth_sessions WHERE access_token = ?")
-      .get(token) as { user_id: string; expires_at: string | null } | undefined;
+      .get(token)) as { user_id: string; expires_at: string | null } | undefined;
     if (!session) {
       return { data: null, error: { message: "Invalid token", code: "AUTH_INVALID" } };
     }
     if (session.expires_at && new Date(session.expires_at).getTime() < Date.now()) {
       return { data: null, error: { message: "Token expired", code: "AUTH_EXPIRED" } };
     }
-    const user = db
+    const user = (await db
       .prepare("SELECT id, email FROM auth_users WHERE id = ?")
-      .get(session.user_id) as { id: string; email?: string | null } | undefined;
+      .get(session.user_id)) as { id: string; email?: string | null } | undefined;
     if (!user) {
       return { data: null, error: { message: "User not found", code: "PGRST116" } };
     }

--- a/src/repositories/sqlite/sqlite_client.ts
+++ b/src/repositories/sqlite/sqlite_client.ts
@@ -1,7 +1,4 @@
-import { mkdirSync } from "fs";
-import path from "path";
-import { config } from "../../config.js";
-import Database, { type SqliteDatabase } from "./sqlite_driver.js";
+import type { DbConnection, DbDatabase } from "../db/driver.js";
 
 /**
  * Milliseconds a SQLite connection waits for a contended lock before failing
@@ -22,13 +19,11 @@ export const SQLITE_BUSY_TIMEOUT_MS = Math.max(
  * concurrent readers alongside a single writer, foreign-key enforcement, and a
  * busy_timeout so lock contention waits rather than throwing immediately.
  */
-function applyConnectionPragmas(db: SqliteDatabase): void {
-  db.pragma("journal_mode = WAL");
-  db.pragma("foreign_keys = ON");
-  db.pragma(`busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS}`);
+export async function applyConnectionPragmas(db: DbDatabase): Promise<void> {
+  await db.pragma("journal_mode = WAL");
+  await db.pragma("foreign_keys = ON");
+  await db.pragma(`busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS}`);
 }
-
-let cachedDb: SqliteDatabase | null = null;
 
 const SCHEMA_STATEMENTS = [
   `CREATE TABLE IF NOT EXISTS sources (
@@ -361,95 +356,111 @@ const DEPRECATED_TABLES = [
 ];
 
 /** Add a column to a table if it does not exist (for existing SQLite DBs). */
-function addColumnIfMissing(db: SqliteDatabase, table: string, column: string, type: string): void {
-  const rows = db.prepare(`PRAGMA table_info(${table})`).all() as { name: string }[];
+async function addColumnIfMissing(
+  db: DbConnection,
+  table: string,
+  column: string,
+  type: string
+): Promise<void> {
+  const rows = (await db.prepare(`PRAGMA table_info(${table})`).all()) as { name: string }[];
   if (rows.some((r) => r.name === column)) return;
-  db.prepare(`ALTER TABLE ${table} ADD COLUMN ${column} ${type}`).run();
+  await db.prepare(`ALTER TABLE ${table} ADD COLUMN ${column} ${type}`).run();
 }
 
-function ensureSchema(db: SqliteDatabase): void {
-  const transaction = db.transaction(() => {
-    db.pragma("foreign_keys = OFF");
+export async function ensureSchema(database: DbDatabase): Promise<void> {
+  await database.transaction(async (db) => {
+    await db.exec("PRAGMA foreign_keys = OFF");
     for (const table of DEPRECATED_TABLES) {
-      db.prepare(`DROP TABLE IF EXISTS ${table}`).run();
+      await db.prepare(`DROP TABLE IF EXISTS ${table}`).run();
     }
-    db.pragma("foreign_keys = ON");
+    await db.exec("PRAGMA foreign_keys = ON");
 
     for (const statement of SCHEMA_STATEMENTS) {
-      db.prepare(statement).run();
+      await db.prepare(statement).run();
     }
 
     // Add columns if missing (existing DBs created before these columns existed)
-    addColumnIfMissing(db, "sources", "source_type", "TEXT");
-    addColumnIfMissing(db, "sources", "original_filename", "TEXT");
-    addColumnIfMissing(db, "sources", "mime_type", "TEXT");
-    addColumnIfMissing(db, "sources", "storage_url", "TEXT");
-    addColumnIfMissing(db, "sources", "file_size", "INTEGER");
-    addColumnIfMissing(db, "sources", "idempotency_key", "TEXT");
-    addColumnIfMissing(db, "observations", "idempotency_key", "TEXT");
-    addColumnIfMissing(db, "interpretations", "user_id", "TEXT");
-    addColumnIfMissing(db, "interpretations", "created_at", "TEXT");
-    addColumnIfMissing(db, "interpretations", "error_message", "TEXT");
-    addColumnIfMissing(db, "interpretations", "unknown_fields_count", "INTEGER");
-    addColumnIfMissing(db, "observations", "canonical_hash", "TEXT");
-    addColumnIfMissing(db, "observations", "identity_basis", "TEXT");
-    addColumnIfMissing(db, "observations", "identity_rule", "TEXT");
+    await addColumnIfMissing(db, "sources", "source_type", "TEXT");
+    await addColumnIfMissing(db, "sources", "original_filename", "TEXT");
+    await addColumnIfMissing(db, "sources", "mime_type", "TEXT");
+    await addColumnIfMissing(db, "sources", "storage_url", "TEXT");
+    await addColumnIfMissing(db, "sources", "file_size", "INTEGER");
+    await addColumnIfMissing(db, "sources", "idempotency_key", "TEXT");
+    await addColumnIfMissing(db, "observations", "idempotency_key", "TEXT");
+    await addColumnIfMissing(db, "interpretations", "user_id", "TEXT");
+    await addColumnIfMissing(db, "interpretations", "created_at", "TEXT");
+    await addColumnIfMissing(db, "interpretations", "error_message", "TEXT");
+    await addColumnIfMissing(db, "interpretations", "unknown_fields_count", "INTEGER");
+    await addColumnIfMissing(db, "observations", "canonical_hash", "TEXT");
+    await addColumnIfMissing(db, "observations", "identity_basis", "TEXT");
+    await addColumnIfMissing(db, "observations", "identity_rule", "TEXT");
     // Agent attribution (Phase 1 AAuth integration). `provenance` is a JSON
     // blob containing AAuth fields, fallback clientInfo, and trust tier; see
     // src/crypto/agent_identity.ts AttributionProvenance shape. Adding via
     // the soft-migration helper keeps existing databases backward-compatible.
-    addColumnIfMissing(db, "observations", "provenance", "TEXT");
+    await addColumnIfMissing(db, "observations", "provenance", "TEXT");
     // Write-kind classification (sensor / llm_summary / workflow_state /
     // human / import), orthogonal to numeric `source_priority` and to the
     // `provenance` attribution blob. Soft migration keeps pre-existing
     // rows at NULL so historical data round-trips intact.
-    addColumnIfMissing(db, "observations", "observation_source", "TEXT");
+    await addColumnIfMissing(db, "observations", "observation_source", "TEXT");
     // Cross-instance sync (Phase 5): originating peer id stamped on
     // observations created from peer webhook replay; drives subscription
     // loop prevention on the event bus.
-    addColumnIfMissing(db, "observations", "source_peer_id", "TEXT");
+    await addColumnIfMissing(db, "observations", "source_peer_id", "TEXT");
     // Sighting deduplication (#1604): canonical_key groups N reports of the
     // same event into one logical signal; sighting_source_id is the origin
     // record (e.g. a webhook event id) that produced this observation. Together
     // they form a stable compound key for upsert idempotency. Indexed to
     // support fast collapse_by grouping on retrieve_entities.
-    addColumnIfMissing(db, "observations", "canonical_key", "TEXT");
-    addColumnIfMissing(db, "observations", "sighting_source_id", "TEXT");
-    db.prepare(
-      "CREATE INDEX IF NOT EXISTS idx_observations_canonical_key ON observations(canonical_key, user_id)"
-    ).run();
-    db.prepare(
-      "CREATE INDEX IF NOT EXISTS idx_observations_sighting_key ON observations(sighting_source_id, canonical_key, user_id)"
-    ).run();
+    await addColumnIfMissing(db, "observations", "canonical_key", "TEXT");
+    await addColumnIfMissing(db, "observations", "sighting_source_id", "TEXT");
+    await db
+      .prepare(
+        "CREATE INDEX IF NOT EXISTS idx_observations_canonical_key ON observations(canonical_key, user_id)"
+      )
+      .run();
+    await db
+      .prepare(
+        "CREATE INDEX IF NOT EXISTS idx_observations_sighting_key ON observations(sighting_source_id, canonical_key, user_id)"
+      )
+      .run();
     // Deleted-entity resolution (#1943): getDeletedEntityIds queries observations
     // by entity_id ordered by (source_priority DESC, observed_at DESC) to find the
     // highest-priority observation per entity. Without this index every call was
     // an unindexed scan of the whole observations table, and the old chunked-scan
     // pagination called it once per chunk — compounding into the reported
     // event-loop freeze at deep offsets. Matches the query's own ordering.
-    db.prepare(
-      "CREATE INDEX IF NOT EXISTS idx_observations_entity_id ON observations(entity_id, source_priority, observed_at)"
-    ).run();
-    addColumnIfMissing(db, "timeline_events", "provenance", "TEXT");
-    addColumnIfMissing(db, "interpretations", "provenance", "TEXT");
-    addColumnIfMissing(db, "relationship_observations", "provenance", "TEXT");
-    addColumnIfMissing(db, "timeline_events", "entity_id", "TEXT");
-    addColumnIfMissing(db, "entity_snapshots", "canonical_name", "TEXT");
-    addColumnIfMissing(db, "entities", "first_seen_at", "TEXT");
-    addColumnIfMissing(db, "entities", "last_seen_at", "TEXT");
-    addColumnIfMissing(db, "timeline_events", "event_date", "TEXT");
-    addColumnIfMissing(db, "raw_fragments", "entity_id", "TEXT");
-    addColumnIfMissing(db, "auto_enhancement_queue", "fragment_key", "TEXT");
-    addColumnIfMissing(db, "auto_enhancement_queue", "frequency_count", "INTEGER");
-    addColumnIfMissing(db, "auto_enhancement_queue", "confidence_score", "REAL");
-    addColumnIfMissing(db, "auto_enhancement_queue", "priority", "INTEGER");
-    addColumnIfMissing(db, "auto_enhancement_queue", "retry_count", "INTEGER");
-    addColumnIfMissing(db, "auto_enhancement_queue", "processed_at", "TEXT");
-    addColumnIfMissing(db, "auto_enhancement_queue", "last_retry_at", "TEXT");
-    addColumnIfMissing(db, "auto_enhancement_queue", "error_message", "TEXT");
-    addColumnIfMissing(db, "auto_enhancement_queue", "job_type", "TEXT DEFAULT 'auto_enhance'");
+    await db
+      .prepare(
+        "CREATE INDEX IF NOT EXISTS idx_observations_entity_id ON observations(entity_id, source_priority, observed_at)"
+      )
+      .run();
+    await addColumnIfMissing(db, "timeline_events", "provenance", "TEXT");
+    await addColumnIfMissing(db, "interpretations", "provenance", "TEXT");
+    await addColumnIfMissing(db, "relationship_observations", "provenance", "TEXT");
+    await addColumnIfMissing(db, "timeline_events", "entity_id", "TEXT");
+    await addColumnIfMissing(db, "entity_snapshots", "canonical_name", "TEXT");
+    await addColumnIfMissing(db, "entities", "first_seen_at", "TEXT");
+    await addColumnIfMissing(db, "entities", "last_seen_at", "TEXT");
+    await addColumnIfMissing(db, "timeline_events", "event_date", "TEXT");
+    await addColumnIfMissing(db, "raw_fragments", "entity_id", "TEXT");
+    await addColumnIfMissing(db, "auto_enhancement_queue", "fragment_key", "TEXT");
+    await addColumnIfMissing(db, "auto_enhancement_queue", "frequency_count", "INTEGER");
+    await addColumnIfMissing(db, "auto_enhancement_queue", "confidence_score", "REAL");
+    await addColumnIfMissing(db, "auto_enhancement_queue", "priority", "INTEGER");
+    await addColumnIfMissing(db, "auto_enhancement_queue", "retry_count", "INTEGER");
+    await addColumnIfMissing(db, "auto_enhancement_queue", "processed_at", "TEXT");
+    await addColumnIfMissing(db, "auto_enhancement_queue", "last_retry_at", "TEXT");
+    await addColumnIfMissing(db, "auto_enhancement_queue", "error_message", "TEXT");
+    await addColumnIfMissing(
+      db,
+      "auto_enhancement_queue",
+      "job_type",
+      "TEXT DEFAULT 'auto_enhance'"
+    );
 
-    addColumnIfMissing(db, "local_auth_users", "is_ephemeral", "INTEGER NOT NULL DEFAULT 0");
+    await addColumnIfMissing(db, "local_auth_users", "is_ephemeral", "INTEGER NOT NULL DEFAULT 0");
 
     // Materialized relationship liveness (#1570). Derived from the
     // highest-priority `relationship_observations` row's `metadata._deleted`
@@ -461,19 +472,20 @@ function ensureSchema(db: SqliteDatabase): void {
     // backfill below recomputes them; the value is re-stamped on every
     // snapshot recompute (computeRelationshipSnapshot), so observations remain
     // the source of truth and the column self-heals.
-    addColumnIfMissing(db, "relationship_snapshots", "is_live", "INTEGER NOT NULL DEFAULT 1");
+    await addColumnIfMissing(db, "relationship_snapshots", "is_live", "INTEGER NOT NULL DEFAULT 1");
 
     // By-reference source storage (#1775): path-only ingestion mode where bytes
     // remain on disk. Additive columns; existing rows default storage_mode='inline'
     // so all pre-existing sources behave identically without migration work.
-    addColumnIfMissing(db, "sources", "storage_mode", "TEXT NOT NULL DEFAULT 'inline'");
-    addColumnIfMissing(db, "sources", "reference_path", "TEXT");
-    addColumnIfMissing(db, "sources", "host_id", "TEXT");
-    addColumnIfMissing(db, "sources", "size_bytes", "INTEGER");
-    addColumnIfMissing(db, "sources", "mtime", "TEXT");
+    await addColumnIfMissing(db, "sources", "storage_mode", "TEXT NOT NULL DEFAULT 'inline'");
+    await addColumnIfMissing(db, "sources", "reference_path", "TEXT");
+    await addColumnIfMissing(db, "sources", "host_id", "TEXT");
+    await addColumnIfMissing(db, "sources", "size_bytes", "INTEGER");
+    await addColumnIfMissing(db, "sources", "mtime", "TEXT");
 
-    db.prepare(
-      `CREATE TABLE IF NOT EXISTS sandbox_sessions (
+    await db
+      .prepare(
+        `CREATE TABLE IF NOT EXISTS sandbox_sessions (
       user_id TEXT PRIMARY KEY REFERENCES local_auth_users(id) ON DELETE CASCADE,
       bearer_token_hash TEXT NOT NULL,
       one_time_code_hash TEXT,
@@ -482,13 +494,18 @@ function ensureSchema(db: SqliteDatabase): void {
       expires_at TEXT NOT NULL,
       revoked_at TEXT
     )`
-    ).run();
-    db.prepare(
-      "CREATE INDEX IF NOT EXISTS idx_sandbox_sessions_expires ON sandbox_sessions(expires_at)"
-    ).run();
-    db.prepare(
-      "CREATE INDEX IF NOT EXISTS idx_sandbox_sessions_revoked ON sandbox_sessions(revoked_at)"
-    ).run();
+      )
+      .run();
+    await db
+      .prepare(
+        "CREATE INDEX IF NOT EXISTS idx_sandbox_sessions_expires ON sandbox_sessions(expires_at)"
+      )
+      .run();
+    await db
+      .prepare(
+        "CREATE INDEX IF NOT EXISTS idx_sandbox_sessions_revoked ON sandbox_sessions(revoked_at)"
+      )
+      .run();
 
     // Graph-traversal indexes (#1467): every hop of retrieve_related_entities /
     // retrieve_graph_neighborhood filters relationship_snapshots by
@@ -497,36 +514,50 @@ function ensureSchema(db: SqliteDatabase): void {
     // traversal cost grows with total table size. Composite indexes turn each
     // hop into an indexed lookup, flattening traversal latency vs graph size
     // (measured: 3-hop over 50k relationships dropped from ~777ms to ~6ms).
-    db.prepare(
-      "CREATE INDEX IF NOT EXISTS idx_rel_snapshots_source_user ON relationship_snapshots(source_entity_id, user_id)"
-    ).run();
-    db.prepare(
-      "CREATE INDEX IF NOT EXISTS idx_rel_snapshots_target_user ON relationship_snapshots(target_entity_id, user_id)"
-    ).run();
+    await db
+      .prepare(
+        "CREATE INDEX IF NOT EXISTS idx_rel_snapshots_source_user ON relationship_snapshots(source_entity_id, user_id)"
+      )
+      .run();
+    await db
+      .prepare(
+        "CREATE INDEX IF NOT EXISTS idx_rel_snapshots_target_user ON relationship_snapshots(target_entity_id, user_id)"
+      )
+      .run();
     // Liveness-aware composites (#1570): the default list_relationships read
     // filters by (source|target entity, user_id, is_live) before paginating at
     // the DB. Including is_live in the index keeps that access path covered so
     // the live-edge filter never falls back to a table scan.
-    db.prepare(
-      "CREATE INDEX IF NOT EXISTS idx_rel_snapshots_source_user_live ON relationship_snapshots(source_entity_id, user_id, is_live)"
-    ).run();
-    db.prepare(
-      "CREATE INDEX IF NOT EXISTS idx_rel_snapshots_target_user_live ON relationship_snapshots(target_entity_id, user_id, is_live)"
-    ).run();
+    await db
+      .prepare(
+        "CREATE INDEX IF NOT EXISTS idx_rel_snapshots_source_user_live ON relationship_snapshots(source_entity_id, user_id, is_live)"
+      )
+      .run();
+    await db
+      .prepare(
+        "CREATE INDEX IF NOT EXISTS idx_rel_snapshots_target_user_live ON relationship_snapshots(target_entity_id, user_id, is_live)"
+      )
+      .run();
 
     // Durable substrate-event log (#1464 Tier 2): resume queries read by
     // (user_id, seq); pruning reads by created_at.
-    db.prepare(
-      "CREATE INDEX IF NOT EXISTS idx_substrate_events_user_seq ON substrate_events(user_id, seq)"
-    ).run();
-    db.prepare(
-      "CREATE INDEX IF NOT EXISTS idx_substrate_events_created ON substrate_events(created_at)"
-    ).run();
+    await db
+      .prepare(
+        "CREATE INDEX IF NOT EXISTS idx_substrate_events_user_seq ON substrate_events(user_id, seq)"
+      )
+      .run();
+    await db
+      .prepare(
+        "CREATE INDEX IF NOT EXISTS idx_substrate_events_created ON substrate_events(created_at)"
+      )
+      .run();
 
     // Parity with Postgres: unique constraint on (content_hash, user_id) for deduplication
-    db.prepare(
-      "CREATE UNIQUE INDEX IF NOT EXISTS idx_sources_content_hash_user ON sources(content_hash, user_id) WHERE content_hash IS NOT NULL AND user_id IS NOT NULL"
-    ).run();
+    await db
+      .prepare(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_sources_content_hash_user ON sources(content_hash, user_id) WHERE content_hash IS NOT NULL AND user_id IS NOT NULL"
+      )
+      .run();
 
     // One-time backfill of relationship_snapshots.is_live (#1570). New rows are
     // stamped at write time by computeRelationshipSnapshot, but pre-existing
@@ -537,9 +568,8 @@ function ensureSchema(db: SqliteDatabase): void {
     // materialized is_live disagrees with the observation-derived value, so it
     // is a no-op once converged. Guarded so it only runs when there is at least
     // one deletion observation to reconcile (the common case has none).
-    backfillRelationshipLiveness(db);
+    await backfillRelationshipLiveness(db);
   });
-  transaction();
 }
 
 /**
@@ -550,10 +580,10 @@ function ensureSchema(db: SqliteDatabase): void {
  * inside `ensureSchema`'s transaction; idempotent and cheap when no deletion
  * observations exist.
  */
-function backfillRelationshipLiveness(db: SqliteDatabase): void {
+async function backfillRelationshipLiveness(db: DbConnection): Promise<void> {
   // Fast exit: if no deletion observations exist, every snapshot is live and
   // the column default (1) is already correct — nothing to reconcile.
-  const deletionProbe = db
+  const deletionProbe = await db
     .prepare(
       `SELECT 1 FROM relationship_observations
        WHERE json_extract(metadata, '$._deleted') = 1
@@ -566,7 +596,7 @@ function backfillRelationshipLiveness(db: SqliteDatabase): void {
   // Derive the dead set: relationship_keys whose highest-priority (source_priority
   // DESC, then observed_at DESC) observation is a deletion. SQLite window-function
   // ranking selects one winning observation per key, matching the app-side rule.
-  const deadRows = db
+  const deadRows = (await db
     .prepare(
       `WITH ranked AS (
          SELECT relationship_key,
@@ -582,7 +612,7 @@ function backfillRelationshipLiveness(db: SqliteDatabase): void {
          AND (json_extract(metadata, '$._deleted') = 1
               OR json_extract(metadata, '$._deleted') = 'true')`
     )
-    .all() as { relationship_key: string }[];
+    .all()) as { relationship_key: string }[];
 
   const deadKeys = new Set(deadRows.map((r) => r.relationship_key));
 
@@ -596,63 +626,20 @@ function backfillRelationshipLiveness(db: SqliteDatabase): void {
     "UPDATE relationship_snapshots SET is_live = 1 WHERE relationship_key = ? AND is_live <> 1"
   );
 
-  const allKeys = db.prepare("SELECT relationship_key FROM relationship_snapshots").all() as {
+  const allKeys = (await db
+    .prepare("SELECT relationship_key FROM relationship_snapshots")
+    .all()) as {
     relationship_key: string;
   }[];
   for (const { relationship_key } of allKeys) {
     if (deadKeys.has(relationship_key)) {
-      setDead.run(relationship_key);
+      await setDead.run(relationship_key);
     } else {
-      setLive.run(relationship_key);
+      await setLive.run(relationship_key);
     }
   }
 }
 
-/**
- * Clear the cached SQLite connection. Next getSqliteDb() will open a new
- * connection (and create the DB file if missing). Call this after I/O errors
- * (e.g. disk I/O error, DB file deleted while server was running).
- */
-export function clearSqliteCache(): void {
-  if (cachedDb) {
-    try {
-      cachedDb.close();
-    } catch {
-      // Ignore close errors (e.g. file already deleted)
-    }
-    cachedDb = null;
-  }
-}
-
-export function getSqliteDb(): SqliteDatabase {
-  if (cachedDb) {
-    return cachedDb;
-  }
-
-  const dbPath = config.sqlitePath;
-  const dir = path.dirname(dbPath);
-  mkdirSync(dir, { recursive: true });
-
-  const db = new Database(dbPath);
-  applyConnectionPragmas(db);
-
-  ensureSchema(db);
-  cachedDb = db;
-  return db;
-}
-
-/**
- * Ensure a SQLite database file exists with Neotoma schema initialized.
- * Used by init to eagerly provision both dev and prod databases.
- */
-export function ensureSqliteDbInitialized(dbPath: string): void {
-  const dir = path.dirname(dbPath);
-  mkdirSync(dir, { recursive: true });
-  const db = new Database(dbPath);
-  try {
-    applyConnectionPragmas(db);
-    ensureSchema(db);
-  } finally {
-    db.close();
-  }
-}
+// Connection lifecycle (open/cache/clear/init) lives in
+// src/repositories/db/connection.ts, which selects the backend
+// (NEOTOMA_DB_BACKEND) and runs applyConnectionPragmas + ensureSchema on open.

--- a/src/repositories/sqlite/sqlite_driver.ts
+++ b/src/repositories/sqlite/sqlite_driver.ts
@@ -1,4 +1,13 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import { createRequire } from "node:module";
+import {
+  normalizeParams,
+  TransactionGate,
+  type DbConnection,
+  type DbDatabase,
+  type DbRunResult,
+  type DbStatement,
+} from "../db/driver.js";
 
 const nodeRequire = createRequire(import.meta.url);
 let DatabaseCtor: new (path: string) => any;
@@ -29,13 +38,6 @@ try {
 }
 
 type UnknownRecord = Record<string, unknown>;
-
-function normalizeParams(params: unknown[]): unknown[] {
-  if (params.length === 1 && Array.isArray(params[0])) {
-    return params[0] as unknown[];
-  }
-  return params;
-}
 
 class SqliteStatementImpl {
   constructor(private readonly statement: any) {}
@@ -100,6 +102,134 @@ class SqliteDatabaseImpl {
   }
 
   close(): void {
+    this.db.close();
+  }
+}
+
+/**
+ * Async adapter over the synchronous SQLite implementation, satisfying the
+ * shared DbDatabase contract. Statements resolve immediately (the underlying
+ * driver is sync), but the call-site contract is identical to concurrent
+ * backends like libSQL, so backends can be swapped via configuration.
+ */
+/**
+ * SQLite only binds numbers, strings, bigints, buffers, and null. Match the
+ * libSQL driver's normalization so both backends accept the same inputs.
+ */
+function toSqliteBindValue(value: unknown): unknown {
+  if (value === undefined || value === null) return null;
+  if (typeof value === "boolean") return value ? 1 : 0;
+  return value;
+}
+
+class AsyncSqliteStatement implements DbStatement {
+  constructor(
+    private readonly db: AsyncSqliteDatabase,
+    private readonly sql: string
+  ) {}
+
+  private async exec<T>(op: (stmt: SqliteStatementImpl) => T): Promise<T> {
+    await this.db.readyForStatement();
+    return op(this.db.rawDb().prepare(this.sql));
+  }
+
+  run(...params: unknown[]): Promise<DbRunResult> {
+    const bound = normalizeParams(params).map(toSqliteBindValue);
+    return this.exec((stmt) => {
+      const result = stmt.run(...bound) as {
+        changes?: number | bigint;
+        lastInsertRowid?: number | bigint;
+      };
+      return {
+        changes: Number(result?.changes ?? 0),
+        lastInsertRowid: result?.lastInsertRowid,
+      };
+    });
+  }
+
+  get(...params: unknown[]): Promise<unknown> {
+    const bound = normalizeParams(params).map(toSqliteBindValue);
+    return this.exec((stmt) => stmt.get(...bound));
+  }
+
+  all(...params: unknown[]): Promise<unknown[]> {
+    const bound = normalizeParams(params).map(toSqliteBindValue);
+    return this.exec((stmt) => stmt.all(...bound));
+  }
+}
+
+export class AsyncSqliteDatabase implements DbDatabase {
+  private readonly db: SqliteDatabaseImpl;
+  private readonly gate = new TransactionGate();
+  private readonly txContext = new AsyncLocalStorage<boolean>();
+
+  constructor(path: string) {
+    this.db = new SqliteDatabaseImpl(path);
+  }
+
+  /** @internal Exposes the sync database to statement wrappers. */
+  rawDb(): SqliteDatabaseImpl {
+    return this.db;
+  }
+
+  /**
+   * @internal Statements wait for any open transaction unless they run inside
+   * its async context (then they join it — the single connection is already
+   * inside BEGIN, matching the old synchronous semantics).
+   */
+  async readyForStatement(): Promise<void> {
+    if (this.txContext.getStore()) return;
+    await this.gate.whenIdle();
+  }
+
+  prepare(sql: string): DbStatement {
+    return new AsyncSqliteStatement(this, sql);
+  }
+
+  async exec(sql: string): Promise<void> {
+    await this.readyForStatement();
+    this.db.exec(sql);
+  }
+
+  async pragma(command: string): Promise<unknown[]> {
+    await this.readyForStatement();
+    return this.db.pragma(command);
+  }
+
+  transaction<T>(fn: (tx: DbConnection) => Promise<T>): Promise<T> {
+    // Manual BEGIN/COMMIT: the native sync transaction() helper commits when
+    // its callback *returns*, which for an async fn would be before any awaited
+    // work ran. The gate serializes transactions and holds unrelated statements
+    // out of the open transaction window.
+    //
+    // IMMEDIATE (not deferred): a deferred transaction acquires the write lock
+    // at its first write, and if another connection wrote since our read
+    // snapshot, SQLite fails that upgrade with "database is locked"
+    // IMMEDIATELY — busy_timeout never applies to upgrades because retrying
+    // against a stale snapshot cannot succeed. Acquiring the write lock at
+    // BEGIN makes contention wait up to busy_timeout instead, which matters
+    // now that the async callback keeps transactions open across microtask
+    // hops (observed as cross-process lock failures in ensureSchema).
+    return this.gate.runExclusive(() =>
+      this.txContext.run(true, async () => {
+        this.db.exec("BEGIN IMMEDIATE");
+        try {
+          const result = await fn(this);
+          this.db.exec("COMMIT");
+          return result;
+        } catch (error) {
+          try {
+            this.db.exec("ROLLBACK");
+          } catch {
+            // Ignore rollback errors during unwind.
+          }
+          throw error;
+        }
+      })
+    );
+  }
+
+  async close(): Promise<void> {
     this.db.close();
   }
 }

--- a/src/repositories/sqlite/sqlite_driver.ts
+++ b/src/repositories/sqlite/sqlite_driver.ts
@@ -1,6 +1,7 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import { createRequire } from "node:module";
 import {
+  NESTED_TRANSACTION_ERROR,
   normalizeParams,
   TransactionGate,
   type DbConnection,
@@ -197,6 +198,17 @@ export class AsyncSqliteDatabase implements DbDatabase {
   }
 
   transaction<T>(fn: (tx: DbConnection) => Promise<T>): Promise<T> {
+    // Fail loud, not silent, on nested transaction() (qa review, PR #1944).
+    // The gate serializes transactions against each other, so a transaction()
+    // issued from inside another transaction()'s callback would await a tail
+    // that only resolves once the OUTER transaction finishes — which is itself
+    // waiting on this inner call: a self-deadlock that hangs forever. No current
+    // call site nests, but this throws a clear, actionable error if one ever
+    // does (matching this driver's other fail-loud config guards) instead of
+    // wedging the process. Statements on the db handle inside a transaction
+    // callback join the open transaction (see run/get/all); only a nested
+    // transaction() is unsupported.
+    if (this.txContext.getStore()) throw new Error(NESTED_TRANSACTION_ERROR);
     // Manual BEGIN/COMMIT: the native sync transaction() helper commits when
     // its callback *returns*, which for an async fn would be before any awaited
     // work ran. The gate serializes transactions and holds unrelated statements

--- a/src/repositories/worker/worker_file_database.ts
+++ b/src/repositories/worker/worker_file_database.ts
@@ -1,0 +1,382 @@
+/**
+ * Worker-hosted file database (concurrent-backend plan).
+ *
+ * Why this exists: every Node binding for LOCAL SQLite/libSQL files executes
+ * statements synchronously on the calling thread — better-sqlite3, node:sqlite,
+ * and both APIs of the `libsql` package (its promise API and @libsql/client's
+ * `file:` protocol return pre-resolved promises after blocking). Verified
+ * empirically 2026-07-16: a 1s self-join blocked the event loop for the full
+ * second under every local variant. Only remote sqld URLs are genuinely async.
+ *
+ * So for local files, "statements off the event loop" is delivered by hosting
+ * the synchronous driver in worker threads behind the same async DbDatabase
+ * contract:
+ *
+ *   - One WRITER worker owns all mutating statements, exec/pragma, and
+ *     transactions (SQLite has a single writer anyway).
+ *   - A small pool of READER workers opens the file read-only; under WAL,
+ *     readers run concurrently with the writer, so a slow read no longer
+ *     delays other reads — the bottega8 symptom (one deep-offset query
+ *     freezing every concurrent request) is fixed at the root.
+ *   - A read routed to a reader that turns out to write (e.g. INSERT …
+ *     RETURNING via .get()) fails with SQLITE_READONLY and is retried on the
+ *     writer — no SQL parsing heuristics.
+ *
+ * Transaction semantics match the other backends: the TransactionGate
+ * serializes transactions and keeps unrelated statements out of the open
+ * transaction window, and AsyncLocalStorage routes statements issued on the
+ * database handle from inside the callback into the transaction (they all
+ * land on the writer worker, whose statements execute in message order).
+ */
+
+import { AsyncLocalStorage } from "node:async_hooks";
+import { createRequire } from "node:module";
+import { Worker } from "node:worker_threads";
+import {
+  normalizeParams,
+  TransactionGate,
+  type DbConnection,
+  type DbDatabase,
+  type DbRunResult,
+  type DbStatement,
+} from "../db/driver.js";
+
+const nodeRequire = createRequire(import.meta.url);
+
+/**
+ * Resolve the synchronous driver module the worker will load. Preference:
+ * `libsql` (libSQL's better-sqlite3-compatible binding — reads/writes the
+ * same files and understands libSQL extensions), then `better-sqlite3`.
+ * `node:sqlite` (Node 22+) is the final fallback, flagged rather than
+ * path-resolved.
+ */
+function resolveWorkerDriver(): { driverPath: string | null; useNodeSqlite: boolean } {
+  for (const name of ["libsql", "better-sqlite3"]) {
+    try {
+      return { driverPath: nodeRequire.resolve(name), useNodeSqlite: false };
+    } catch {
+      // try next
+    }
+  }
+  return { driverPath: null, useNodeSqlite: true };
+}
+
+/**
+ * CommonJS source executed with `eval: true` — avoids build/dist asset
+ * plumbing for a separate worker file. Kept dependency-free apart from the
+ * driver module whose absolute path the parent resolves and passes in.
+ */
+const WORKER_SOURCE = `
+const { parentPort, workerData } = require("node:worker_threads");
+
+let DatabaseCtor;
+if (workerData.useNodeSqlite) {
+  DatabaseCtor = require("node:sqlite").DatabaseSync;
+} else {
+  DatabaseCtor = require(workerData.driverPath);
+}
+
+const openOptions = workerData.readonly ? { readonly: true } : {};
+const db = new DatabaseCtor(workerData.dbPath, openOptions);
+
+function pragma(command) {
+  if (typeof db.pragma === "function") {
+    return db.pragma(command);
+  }
+  db.exec("PRAGMA " + command);
+  return [];
+}
+
+pragma("busy_timeout = " + workerData.busyTimeoutMs);
+pragma("foreign_keys = ON");
+if (!workerData.readonly) {
+  pragma("journal_mode = WAL");
+}
+
+// The libsql driver stamps a non-column "_metadata" object onto each row;
+// strip it so rows match better-sqlite3's plain shape (spread/JSON parity).
+const stripMetadata = workerData.stripRowMetadata
+  ? (row) => {
+      if (row && typeof row === "object" && "_metadata" in row) delete row._metadata;
+      return row;
+    }
+  : (row) => row;
+
+parentPort.on("message", (msg) => {
+  try {
+    let result;
+    if (msg.op === "run") {
+      const r = db.prepare(msg.sql).run(...msg.params);
+      result = { changes: Number(r.changes ?? 0), lastInsertRowid: r.lastInsertRowid };
+    } else if (msg.op === "get") {
+      result = stripMetadata(db.prepare(msg.sql).get(...msg.params));
+    } else if (msg.op === "all") {
+      result = db.prepare(msg.sql).all(...msg.params).map(stripMetadata);
+    } else if (msg.op === "exec") {
+      db.exec(msg.sql);
+      result = undefined;
+    } else if (msg.op === "pragma") {
+      result = pragma(msg.sql);
+    } else {
+      throw new Error("unknown op: " + msg.op);
+    }
+    parentPort.postMessage({ id: msg.id, ok: true, result });
+  } catch (error) {
+    parentPort.postMessage({
+      id: msg.id,
+      ok: false,
+      error: {
+        message: (error && error.message) || String(error),
+        code: error && error.code,
+        errno: error && error.errno,
+      },
+    });
+  }
+});
+`;
+
+type WorkerReply = {
+  id: number;
+  ok: boolean;
+  result?: unknown;
+  error?: { message: string; code?: string; errno?: number };
+};
+
+class WorkerConnection {
+  private worker: Worker;
+  private nextId = 1;
+  private pending = new Map<
+    number,
+    { resolve: (v: unknown) => void; reject: (e: Error) => void }
+  >();
+
+  constructor(options: {
+    dbPath: string;
+    readonly: boolean;
+    busyTimeoutMs: number;
+    driverPath: string | null;
+    useNodeSqlite: boolean;
+    stripRowMetadata: boolean;
+  }) {
+    this.worker = new Worker(WORKER_SOURCE, { eval: true, workerData: options });
+    this.worker.on("message", (reply: WorkerReply) => {
+      const entry = this.pending.get(reply.id);
+      if (!entry) return;
+      this.pending.delete(reply.id);
+      if (this.pending.size === 0) this.worker.unref();
+      if (reply.ok) {
+        entry.resolve(reply.result);
+      } else {
+        const error = new Error(reply.error?.message ?? "worker db error") as Error & {
+          code?: string;
+          errno?: number;
+        };
+        if (reply.error?.code !== undefined) error.code = reply.error.code;
+        if (reply.error?.errno !== undefined) error.errno = reply.error.errno;
+        entry.reject(error);
+      }
+    });
+    this.worker.on("error", (error) => {
+      for (const entry of this.pending.values()) entry.reject(error as Error);
+      this.pending.clear();
+    });
+    // Never keep the process alive just for an idle DB worker.
+    this.worker.unref();
+  }
+
+  request(
+    op: "run" | "get" | "all" | "exec" | "pragma",
+    sql: string,
+    params: unknown[] = []
+  ): Promise<unknown> {
+    const id = this.nextId++;
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      // Hold the process open while a request is in flight.
+      this.worker.ref();
+      this.worker.postMessage({ id, op, sql, params });
+    });
+  }
+
+  async terminate(): Promise<void> {
+    await this.worker.terminate();
+  }
+}
+
+function isReadonlyRejection(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const e = error as { code?: string; message?: string };
+  const code = (e.code || "").toUpperCase();
+  const message = (e.message || "").toLowerCase();
+  return code.startsWith("SQLITE_READONLY") || message.includes("readonly database");
+}
+
+/** SQLite binds numbers, strings, bigints, buffers, and null; map the rest. */
+function toBindValue(value: unknown): unknown {
+  if (value === undefined || value === null) return null;
+  if (typeof value === "boolean") return value ? 1 : 0;
+  return value;
+}
+
+class WorkerStatement implements DbStatement {
+  constructor(
+    private readonly db: WorkerFileDatabase,
+    private readonly sql: string
+  ) {}
+
+  async run(...params: unknown[]): Promise<DbRunResult> {
+    const bound = normalizeParams(params).map(toBindValue);
+    const result = (await this.db.routeWrite("run", this.sql, bound)) as {
+      changes: number;
+      lastInsertRowid?: number | bigint;
+    };
+    return result;
+  }
+
+  get(...params: unknown[]): Promise<unknown> {
+    const bound = normalizeParams(params).map(toBindValue);
+    return this.db.routeRead("get", this.sql, bound);
+  }
+
+  all(...params: unknown[]): Promise<unknown[]> {
+    const bound = normalizeParams(params).map(toBindValue);
+    return this.db.routeRead("all", this.sql, bound) as Promise<unknown[]>;
+  }
+}
+
+export class WorkerFileDatabase implements DbDatabase {
+  private readonly dbPath: string;
+  private readonly busyTimeoutMs: number;
+  private readonly readerCount: number;
+  private readonly driver = resolveWorkerDriver();
+  private writer: WorkerConnection | null = null;
+  private readers: WorkerConnection[] = [];
+  private nextReader = 0;
+  private readonly gate = new TransactionGate();
+  private readonly txContext = new AsyncLocalStorage<boolean>();
+
+  constructor(dbPath: string, options: { busyTimeoutMs?: number; readerWorkers?: number } = {}) {
+    this.dbPath = dbPath;
+    this.busyTimeoutMs = options.busyTimeoutMs ?? 5000;
+    const fromEnv = Number.parseInt(process.env.NEOTOMA_DB_READER_WORKERS || "", 10);
+    this.readerCount = Math.max(
+      0,
+      options.readerWorkers ?? (Number.isFinite(fromEnv) ? fromEnv : 2)
+    );
+    // The writer opens eagerly so the DB file exists before any read-only
+    // reader connects (read-only opens fail on a missing file).
+    this.writerConnection();
+  }
+
+  private stripRowMetadata(): boolean {
+    return this.driver.driverPath !== null && /[\\/]libsql[\\/]/.test(this.driver.driverPath);
+  }
+
+  private writerConnection(): WorkerConnection {
+    if (!this.writer) {
+      this.writer = new WorkerConnection({
+        dbPath: this.dbPath,
+        readonly: false,
+        busyTimeoutMs: this.busyTimeoutMs,
+        driverPath: this.driver.driverPath,
+        useNodeSqlite: this.driver.useNodeSqlite,
+        stripRowMetadata: this.stripRowMetadata(),
+      });
+    }
+    return this.writer;
+  }
+
+  private readerConnection(): WorkerConnection {
+    if (this.readerCount === 0) return this.writerConnection();
+    if (this.readers.length < this.readerCount) {
+      this.readers.push(
+        new WorkerConnection({
+          dbPath: this.dbPath,
+          readonly: true,
+          busyTimeoutMs: this.busyTimeoutMs,
+          driverPath: this.driver.driverPath,
+          useNodeSqlite: this.driver.useNodeSqlite,
+          stripRowMetadata: this.stripRowMetadata(),
+        })
+      );
+      return this.readers[this.readers.length - 1];
+    }
+    this.nextReader = (this.nextReader + 1) % this.readers.length;
+    return this.readers[this.nextReader];
+  }
+
+  /** @internal Mutating ops and everything inside a transaction → writer. */
+  async routeWrite(
+    op: "run" | "exec" | "pragma",
+    sql: string,
+    params: unknown[] = []
+  ): Promise<unknown> {
+    if (!this.txContext.getStore()) await this.gate.whenIdle();
+    return this.writerConnection().request(op, sql, params);
+  }
+
+  /**
+   * @internal Reads route to the reader pool; a read that turns out to write
+   * (INSERT/UPDATE … RETURNING via get/all) is rejected read-only by SQLite
+   * and retried on the writer. Inside a transaction, reads must see the
+   * transaction's uncommitted state, so they go to the writer directly.
+   */
+  async routeRead(op: "get" | "all", sql: string, params: unknown[]): Promise<unknown> {
+    if (this.txContext.getStore()) {
+      return this.writerConnection().request(op, sql, params);
+    }
+    await this.gate.whenIdle();
+    try {
+      return await this.readerConnection().request(op, sql, params);
+    } catch (error) {
+      if (isReadonlyRejection(error)) {
+        return this.writerConnection().request(op, sql, params);
+      }
+      throw error;
+    }
+  }
+
+  prepare(sql: string): DbStatement {
+    return new WorkerStatement(this, sql);
+  }
+
+  async exec(sql: string): Promise<void> {
+    await this.routeWrite("exec", sql);
+  }
+
+  async pragma(command: string): Promise<unknown[]> {
+    return (await this.routeWrite("pragma", command)) as unknown[];
+  }
+
+  transaction<T>(fn: (tx: DbConnection) => Promise<T>): Promise<T> {
+    return this.gate.runExclusive(() =>
+      this.txContext.run(true, async () => {
+        // IMMEDIATE for the same reason as the sqlite backend: acquire the
+        // write lock where busy_timeout applies instead of failing on a
+        // mid-transaction lock upgrade.
+        await this.writerConnection().request("exec", "BEGIN IMMEDIATE");
+        try {
+          const result = await fn(this);
+          await this.writerConnection().request("exec", "COMMIT");
+          return result;
+        } catch (error) {
+          try {
+            await this.writerConnection().request("exec", "ROLLBACK");
+          } catch {
+            // Ignore rollback errors during unwind.
+          }
+          throw error;
+        }
+      })
+    );
+  }
+
+  async close(): Promise<void> {
+    const connections = [this.writer, ...this.readers].filter(
+      (c): c is WorkerConnection => c !== null
+    );
+    this.writer = null;
+    this.readers = [];
+    await Promise.all(connections.map((c) => c.terminate()));
+  }
+}

--- a/src/repositories/worker/worker_file_database.ts
+++ b/src/repositories/worker/worker_file_database.ts
@@ -105,7 +105,11 @@ const stripMetadata = workerData.stripRowMetadata
 parentPort.on("message", (msg) => {
   try {
     let result;
-    if (msg.op === "run") {
+    if (msg.sql === "__crash__") {
+      // Test-only hook: simulate a hard worker crash so supervised-restart is
+      // exercisable. Never issued by production code paths.
+      process.exit(1);
+    } else if (msg.op === "run") {
       const r = db.prepare(msg.sql).run(...msg.params);
       result = { changes: Number(r.changes ?? 0), lastInsertRowid: r.lastInsertRowid };
     } else if (msg.op === "get") {
@@ -142,28 +146,53 @@ type WorkerReply = {
   error?: { message: string; code?: string; errno?: number };
 };
 
+/**
+ * Thrown when a worker dies (crash or unexpected `exit`) with requests still in
+ * flight. The requests that were mid-execution reject with this — the caller
+ * can't know whether a mutating statement committed, so it is surfaced rather
+ * than silently retried. The connection self-heals: the next request spawns a
+ * fresh worker.
+ */
+export class WorkerDbCrashError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "WorkerDbCrashError";
+  }
+}
+
 class WorkerConnection {
-  private worker: Worker;
+  private worker: Worker | null = null;
   private nextId = 1;
   private pending = new Map<
     number,
     { resolve: (v: unknown) => void; reject: (e: Error) => void }
   >();
+  private closed = false;
 
-  constructor(options: {
-    dbPath: string;
-    readonly: boolean;
-    busyTimeoutMs: number;
-    driverPath: string | null;
-    useNodeSqlite: boolean;
-    stripRowMetadata: boolean;
-  }) {
-    this.worker = new Worker(WORKER_SOURCE, { eval: true, workerData: options });
-    this.worker.on("message", (reply: WorkerReply) => {
+  constructor(
+    private readonly options: {
+      dbPath: string;
+      readonly: boolean;
+      busyTimeoutMs: number;
+      driverPath: string | null;
+      useNodeSqlite: boolean;
+      stripRowMetadata: boolean;
+    }
+  ) {}
+
+  /**
+   * Spawn (or respawn) the worker and wire its lifecycle. Lazy: a crashed
+   * worker is only recreated when the next request arrives, so a permanently
+   * failing DB doesn't spin in a respawn loop while idle.
+   */
+  private ensureWorker(): Worker {
+    if (this.worker) return this.worker;
+    const worker = new Worker(WORKER_SOURCE, { eval: true, workerData: this.options });
+    worker.on("message", (reply: WorkerReply) => {
       const entry = this.pending.get(reply.id);
       if (!entry) return;
       this.pending.delete(reply.id);
-      if (this.pending.size === 0) this.worker.unref();
+      if (this.pending.size === 0) worker.unref();
       if (reply.ok) {
         entry.resolve(reply.result);
       } else {
@@ -176,12 +205,30 @@ class WorkerConnection {
         entry.reject(error);
       }
     });
-    this.worker.on("error", (error) => {
-      for (const entry of this.pending.values()) entry.reject(error as Error);
-      this.pending.clear();
+    worker.on("error", (error) => {
+      this.failInFlight(error instanceof Error ? error : new Error(String(error)));
     });
-    // Never keep the process alive just for an idle DB worker.
-    this.worker.unref();
+    // A crashed or self-exited worker fires `exit` with a non-zero code. Without
+    // this handler, `postMessage` after a crash would enqueue a request that
+    // never settles — a permanent hang. Reject everything in flight and drop the
+    // handle so the next request respawns.
+    worker.on("exit", (code) => {
+      if (this.worker !== worker) return; // already replaced (normal terminate)
+      if (code !== 0 && !this.closed) {
+        this.failInFlight(new WorkerDbCrashError(`DB worker exited unexpectedly (code ${code})`));
+      }
+      this.worker = null;
+    });
+    worker.unref();
+    this.worker = worker;
+    return worker;
+  }
+
+  /** Reject all in-flight requests and drop the dead worker handle. */
+  private failInFlight(error: Error): void {
+    for (const entry of this.pending.values()) entry.reject(error);
+    this.pending.clear();
+    this.worker = null;
   }
 
   request(
@@ -189,17 +236,24 @@ class WorkerConnection {
     sql: string,
     params: unknown[] = []
   ): Promise<unknown> {
+    if (this.closed) {
+      return Promise.reject(new WorkerDbCrashError("DB connection is closed"));
+    }
+    const worker = this.ensureWorker();
     const id = this.nextId++;
     return new Promise((resolve, reject) => {
       this.pending.set(id, { resolve, reject });
       // Hold the process open while a request is in flight.
-      this.worker.ref();
-      this.worker.postMessage({ id, op, sql, params });
+      worker.ref();
+      worker.postMessage({ id, op, sql, params });
     });
   }
 
   async terminate(): Promise<void> {
-    await this.worker.terminate();
+    this.closed = true;
+    const worker = this.worker;
+    this.worker = null;
+    if (worker) await worker.terminate();
   }
 }
 
@@ -252,6 +306,7 @@ export class WorkerFileDatabase implements DbDatabase {
   private writer: WorkerConnection | null = null;
   private readers: WorkerConnection[] = [];
   private nextReader = 0;
+  private closed = false;
   private readonly gate = new TransactionGate();
   private readonly txContext = new AsyncLocalStorage<boolean>();
 
@@ -273,6 +328,9 @@ export class WorkerFileDatabase implements DbDatabase {
   }
 
   private writerConnection(): WorkerConnection {
+    if (this.closed) {
+      throw new WorkerDbCrashError("DB connection is closed");
+    }
     if (!this.writer) {
       this.writer = new WorkerConnection({
         dbPath: this.dbPath,
@@ -287,6 +345,9 @@ export class WorkerFileDatabase implements DbDatabase {
   }
 
   private readerConnection(): WorkerConnection {
+    if (this.closed) {
+      throw new WorkerDbCrashError("DB connection is closed");
+    }
     if (this.readerCount === 0) return this.writerConnection();
     if (this.readers.length < this.readerCount) {
       this.readers.push(
@@ -336,6 +397,16 @@ export class WorkerFileDatabase implements DbDatabase {
     }
   }
 
+  /**
+   * @internal Test-only: force the writer or a reader worker to crash, to
+   * exercise the supervised-restart path. Returns the promise that rejects with
+   * the crash error. Never called by production code.
+   */
+  __crashWorkerForTest(which: "writer" | "reader"): Promise<unknown> {
+    const conn = which === "writer" ? this.writerConnection() : this.readerConnection();
+    return conn.request("run", "__crash__", []);
+  }
+
   prepare(sql: string): DbStatement {
     return new WorkerStatement(this, sql);
   }
@@ -372,6 +443,7 @@ export class WorkerFileDatabase implements DbDatabase {
   }
 
   async close(): Promise<void> {
+    this.closed = true;
     const connections = [this.writer, ...this.readers].filter(
       (c): c is WorkerConnection => c !== null
     );

--- a/src/repositories/worker/worker_file_database.ts
+++ b/src/repositories/worker/worker_file_database.ts
@@ -33,6 +33,7 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import { createRequire } from "node:module";
 import { Worker } from "node:worker_threads";
 import {
+  NESTED_TRANSACTION_ERROR,
   normalizeParams,
   TransactionGate,
   type DbConnection,
@@ -420,6 +421,9 @@ export class WorkerFileDatabase implements DbDatabase {
   }
 
   transaction<T>(fn: (tx: DbConnection) => Promise<T>): Promise<T> {
+    // Fail loud on nested transaction() — see NESTED_TRANSACTION_ERROR; a
+    // gate-serialized nested call self-deadlocks (qa review, PR #1944).
+    if (this.txContext.getStore()) throw new Error(NESTED_TRANSACTION_ERROR);
     return this.gate.runExclusive(() =>
       this.txContext.run(true, async () => {
         // IMMEDIATE for the same reason as the sqlite backend: acquire the

--- a/src/server.ts
+++ b/src/server.ts
@@ -432,7 +432,7 @@ export class NeotomaServer {
 
         // Dev-local (HTTPS or secure): no-auth default with full dev user. Allowed when no creds over secure transport.
         if (connectionId === "dev-local") {
-          const devUser = ensureLocalDevUser();
+          const devUser = await ensureLocalDevUser();
           this.authenticatedUserId = devUser.id;
           this.requestAuth.set(requestId, {
             userId: this.authenticatedUserId,
@@ -476,7 +476,7 @@ export class NeotomaServer {
             logger.info(
               "[MCP Server] Stdio with encryption off: falling back to dev-local (no auth required)."
             );
-            const devUser = ensureLocalDevUser();
+            const devUser = await ensureLocalDevUser();
             this.authenticatedUserId = devUser.id;
             this.requestAuth.set(requestId, {
               userId: this.authenticatedUserId,
@@ -1042,7 +1042,7 @@ export class NeotomaServer {
     const parsed = schema.parse(args ?? {});
     const userId = this.getAuthenticatedUserId(undefined);
     const { listRecentRecordActivity } = await import("./services/recent_record_activity.js");
-    const result = listRecentRecordActivity(userId, parsed.limit, parsed.offset);
+    const result = await listRecentRecordActivity(userId, parsed.limit, parsed.offset);
     return this.buildTextResponse(result);
   }
 
@@ -1816,7 +1816,7 @@ export class NeotomaServer {
         if (connectionId) {
           try {
             if (connectionId === "dev-local") {
-              userId = ensureLocalDevUser().id;
+              userId = (await ensureLocalDevUser()).id;
             } else {
               const { getAccessTokenForConnection } = await import("./services/mcp_oauth.js");
               const { userId: resolvedUserId } = await getAccessTokenForConnection(connectionId);
@@ -2202,7 +2202,7 @@ export class NeotomaServer {
         if (connectionId) {
           try {
             if (connectionId === "dev-local") {
-              userId = ensureLocalDevUser().id;
+              userId = (await ensureLocalDevUser()).id;
             } else {
               const { getAccessTokenForConnection } = await import("./services/mcp_oauth.js");
               const { userId: resolvedUserId } = await getAccessTokenForConnection(connectionId);

--- a/src/services/__tests__/local_auth.test.ts
+++ b/src/services/__tests__/local_auth.test.ts
@@ -16,10 +16,14 @@ describe("local_auth", () => {
     const tempDir = path.join(process.cwd(), "tmp", `neotoma-local-auth-${Date.now()}`);
     const localAuth = await loadLocalAuthModule(tempDir);
 
-    const user = localAuth.createLocalAuthUser("test@example.com", "password123");
+    const user = await localAuth.createLocalAuthUser("test@example.com", "password123");
     expect(user.email).toBe("test@example.com");
 
-    const authenticated = localAuth.authenticateLocalUser("test@example.com", "password123", false);
+    const authenticated = await localAuth.authenticateLocalUser(
+      "test@example.com",
+      "password123",
+      false
+    );
     expect(authenticated.id).toBe(user.id);
     rmSync(tempDir, { recursive: true, force: true });
   });
@@ -28,10 +32,10 @@ describe("local_auth", () => {
     const tempDir = path.join(process.cwd(), "tmp", `neotoma-local-auth-${Date.now()}-invalid`);
     const localAuth = await loadLocalAuthModule(tempDir);
 
-    localAuth.createLocalAuthUser("test@example.com", "password123");
-    expect(() =>
+    await localAuth.createLocalAuthUser("test@example.com", "password123");
+    await expect(
       localAuth.authenticateLocalUser("test@example.com", "wrong-password", false)
-    ).toThrow("Invalid local credentials.");
+    ).rejects.toThrow("Invalid local credentials.");
     rmSync(tempDir, { recursive: true, force: true });
   });
 
@@ -40,8 +44,8 @@ describe("local_auth", () => {
     const localAuth = await loadLocalAuthModule(tempDir);
 
     // Create first user (bootstrap path creates user when count is 0; sqlite is process-global so we create explicitly)
-    localAuth.createLocalAuthUser("first@example.com", "bootstrap");
-    const user = localAuth.authenticateLocalUser("first@example.com", "bootstrap", true);
+    await localAuth.createLocalAuthUser("first@example.com", "bootstrap");
+    const user = await localAuth.authenticateLocalUser("first@example.com", "bootstrap", true);
     expect(user.email).toBe("first@example.com");
     rmSync(tempDir, { recursive: true, force: true });
   });

--- a/src/services/__tests__/local_entity_embedding.test.ts
+++ b/src/services/__tests__/local_entity_embedding.test.ts
@@ -7,7 +7,8 @@ import {
   searchLocalEntityEmbeddings,
   ensureSqliteVecLoaded,
 } from "../local_entity_embedding.js";
-import { getSqliteDb } from "../../repositories/sqlite/sqlite_client.js";
+import { getDb } from "../../repositories/db/connection.js";
+import { AsyncSqliteDatabase } from "../../repositories/sqlite/sqlite_driver.js";
 
 const EMBEDDING_DIM = 1536;
 
@@ -19,17 +20,17 @@ function makeEmbedding(seed = 0): number[] {
 }
 
 describe("local_entity_embedding", () => {
-  beforeEach(() => {
-    const db = getSqliteDb();
+  beforeEach(async () => {
+    const db = await getDb();
     try {
-      db.exec("DELETE FROM entity_embedding_rows");
+      await db.exec("DELETE FROM entity_embedding_rows");
     } catch {
       // Table may not exist
     }
   });
 
   describe("storeLocalEntityEmbedding", () => {
-    it("returns without throwing when sqlite-vec loads", () => {
+    it("returns without throwing when sqlite-vec loads", async () => {
       const row = {
         entity_id: "ent_test_store_1",
         embedding: makeEmbedding(1),
@@ -37,33 +38,33 @@ describe("local_entity_embedding", () => {
         entity_type: "contact",
         merged: false,
       };
-      expect(() => storeLocalEntityEmbedding(row)).not.toThrow();
+      await expect(storeLocalEntityEmbedding(row)).resolves.toBeUndefined();
     });
 
-    it("ignores rows with wrong embedding dimension", () => {
+    it("ignores rows with wrong embedding dimension", async () => {
       const row = {
         entity_id: "ent_bad_dim",
         embedding: [1, 2, 3],
         user_id: "user_test",
         entity_type: "contact",
       };
-      expect(() => storeLocalEntityEmbedding(row)).not.toThrow();
+      await expect(storeLocalEntityEmbedding(row)).resolves.toBeUndefined();
     });
 
-    it("ignores rows with null embedding", () => {
+    it("ignores rows with null embedding", async () => {
       const row = {
         entity_id: "ent_null",
         embedding: null,
         user_id: "user_test",
         entity_type: "contact",
       };
-      expect(() => storeLocalEntityEmbedding(row)).not.toThrow();
+      await expect(storeLocalEntityEmbedding(row)).resolves.toBeUndefined();
     });
   });
 
   describe("searchLocalEntityEmbeddings", () => {
-    it("returns empty array when no embeddings", () => {
-      const result = searchLocalEntityEmbeddings({
+    it("returns empty array when no embeddings", async () => {
+      const result = await searchLocalEntityEmbeddings({
         queryEmbedding: makeEmbedding(0),
         userId: "user_test",
         includeMerged: false,
@@ -74,8 +75,8 @@ describe("local_entity_embedding", () => {
       expect(result.total).toBe(0);
     });
 
-    it("returns stored entity after store when sqlite-vec works", () => {
-      storeLocalEntityEmbedding({
+    it("returns stored entity after store when sqlite-vec works", async () => {
+      await storeLocalEntityEmbedding({
         entity_id: "ent_search_1",
         embedding: makeEmbedding(5),
         user_id: "user_test",
@@ -83,7 +84,7 @@ describe("local_entity_embedding", () => {
         merged: false,
       });
 
-      const result = searchLocalEntityEmbeddings({
+      const result = await searchLocalEntityEmbeddings({
         queryEmbedding: makeEmbedding(5),
         userId: "user_test",
         includeMerged: false,
@@ -100,9 +101,12 @@ describe("local_entity_embedding", () => {
   });
 
   describe("ensureSqliteVecLoaded", () => {
-    it("returns boolean and does not throw", () => {
-      const db = getSqliteDb();
-      const loaded = ensureSqliteVecLoaded(db);
+    it("returns boolean and does not throw", async () => {
+      const db = await getDb();
+      // sqlite-vec needs the raw synchronous handle; backends without one
+      // (e.g. libSQL) degrade the same way as a failed extension load.
+      if (!(db instanceof AsyncSqliteDatabase)) return;
+      const loaded = ensureSqliteVecLoaded(db.rawDb());
       expect(typeof loaded).toBe("boolean");
     });
   });

--- a/src/services/__tests__/mcp_oauth.test.ts
+++ b/src/services/__tests__/mcp_oauth.test.ts
@@ -55,11 +55,11 @@ async function loadLocalMcpAuthModule(tempDir: string) {
   return await import(cacheBustUrl);
 }
 
-async function loadSqliteClient(tempDir: string) {
+async function loadDbConnection(tempDir: string) {
   process.env.NEOTOMA_DATA_DIR = tempDir;
   process.env.NEOTOMA_RAW_STORAGE_DIR = path.join(tempDir, "sources");
 
-  const moduleUrl = new URL("../../repositories/sqlite/sqlite_client.js", import.meta.url).href;
+  const moduleUrl = new URL("../../repositories/db/connection.js", import.meta.url).href;
   const cacheBustUrl = `${moduleUrl}?cacheBust=${Date.now()}`;
   return await import(cacheBustUrl);
 }
@@ -231,8 +231,8 @@ describe("MCP OAuth Service", () => {
       const tempDir = path.join(process.cwd(), "tmp", `neotoma-oauth-${Date.now()}`);
       const oauth = await loadLocalOAuthModule(tempDir);
       const localAuth = await loadLocalAuthModule(tempDir);
-      localAuth.createLocalAuthUser("local@example.com", "password123");
-      const user = localAuth.getLocalAuthUserByEmail("local@example.com");
+      await localAuth.createLocalAuthUser("local@example.com", "password123");
+      const user = await localAuth.getLocalAuthUserByEmail("local@example.com");
       if (!user) {
         throw new Error("Local auth user not found in test");
       }
@@ -263,9 +263,9 @@ describe("MCP OAuth Service", () => {
       const tempDir = path.join(process.cwd(), "tmp", `neotoma-oauth-renew-${Date.now()}`);
       const oauth = await loadLocalOAuthModule(tempDir);
       const localAuth = await loadLocalAuthModule(tempDir);
-      const { getSqliteDb } = await loadSqliteClient(tempDir);
-      localAuth.createLocalAuthUser("renew@example.com", "password123");
-      const user = localAuth.getLocalAuthUserByEmail("renew@example.com");
+      const { getDb } = await loadDbConnection(tempDir);
+      await localAuth.createLocalAuthUser("renew@example.com", "password123");
+      const user = await localAuth.getLocalAuthUserByEmail("renew@example.com");
       if (!user) {
         throw new Error("Local auth user not found in test");
       }
@@ -280,7 +280,7 @@ describe("MCP OAuth Service", () => {
       await oauth.completeLocalAuthorization(request.state, user.id);
       const firstToken = await oauth.getTokenResponseForConnection(connectionId);
 
-      getSqliteDb()
+      await (await getDb())
         .prepare(
           "UPDATE mcp_oauth_connections SET access_token_expires_at = ? WHERE connection_id = ?"
         )
@@ -303,9 +303,9 @@ describe("MCP OAuth Service", () => {
       const oauth = await loadLocalOAuthModule(tempDir);
       const localAuth = await loadLocalAuthModule(tempDir);
       const mcpAuth = await loadLocalMcpAuthModule(tempDir);
-      const { getSqliteDb } = await loadSqliteClient(tempDir);
-      localAuth.createLocalAuthUser("expired@example.com", "password123");
-      const user = localAuth.getLocalAuthUserByEmail("expired@example.com");
+      const { getDb } = await loadDbConnection(tempDir);
+      await localAuth.createLocalAuthUser("expired@example.com", "password123");
+      const user = await localAuth.getLocalAuthUserByEmail("expired@example.com");
       if (!user) {
         throw new Error("Local auth user not found in test");
       }
@@ -319,7 +319,7 @@ describe("MCP OAuth Service", () => {
       });
       await oauth.completeLocalAuthorization(request.state, user.id);
       const tokenResponse = await oauth.getTokenResponseForConnection(connectionId);
-      getSqliteDb()
+      await (await getDb())
         .prepare(
           "UPDATE mcp_oauth_connections SET access_token_expires_at = ? WHERE connection_id = ?"
         )
@@ -339,8 +339,8 @@ describe("MCP OAuth Service", () => {
       const tempDir = path.join(process.cwd(), "tmp", `neotoma-oauth-refresh-${Date.now()}`);
       const oauth = await loadLocalOAuthModule(tempDir);
       const localAuth = await loadLocalAuthModule(tempDir);
-      localAuth.createLocalAuthUser("refresh@example.com", "password123");
-      const user = localAuth.getLocalAuthUserByEmail("refresh@example.com");
+      await localAuth.createLocalAuthUser("refresh@example.com", "password123");
+      const user = await localAuth.getLocalAuthUserByEmail("refresh@example.com");
       if (!user) {
         throw new Error("Local auth user not found in test");
       }
@@ -372,8 +372,8 @@ describe("MCP OAuth Service", () => {
       const tempDir = path.join(process.cwd(), "tmp", `neotoma-oauth-concurrent-${Date.now()}`);
       const oauth = await loadLocalOAuthModule(tempDir);
       const localAuth = await loadLocalAuthModule(tempDir);
-      localAuth.createLocalAuthUser("concurrent@example.com", "password123");
-      const user = localAuth.getLocalAuthUserByEmail("concurrent@example.com");
+      await localAuth.createLocalAuthUser("concurrent@example.com", "password123");
+      const user = await localAuth.getLocalAuthUserByEmail("concurrent@example.com");
       if (!user) throw new Error("Local auth user not found in test");
 
       const connectionId = "cursor-local-concurrent";
@@ -409,9 +409,9 @@ describe("MCP OAuth Service", () => {
       const tempDir = path.join(process.cwd(), "tmp", `neotoma-oauth-revoked-${Date.now()}`);
       const oauth = await loadLocalOAuthModule(tempDir);
       const localAuth = await loadLocalAuthModule(tempDir);
-      const { getSqliteDb } = await loadSqliteClient(tempDir);
-      localAuth.createLocalAuthUser("revoked@example.com", "password123");
-      const user = localAuth.getLocalAuthUserByEmail("revoked@example.com");
+      const { getDb } = await loadDbConnection(tempDir);
+      await localAuth.createLocalAuthUser("revoked@example.com", "password123");
+      const user = await localAuth.getLocalAuthUserByEmail("revoked@example.com");
       if (!user) throw new Error("Local auth user not found in test");
 
       const connectionId = "cursor-local-revoked";
@@ -425,7 +425,7 @@ describe("MCP OAuth Service", () => {
       const firstToken = await oauth.getTokenResponseForConnection(connectionId);
       if (!firstToken.refresh_token) throw new Error("Expected refresh token");
 
-      getSqliteDb()
+      await (await getDb())
         .prepare("UPDATE mcp_oauth_connections SET revoked_at = ? WHERE connection_id = ?")
         .run(new Date().toISOString(), connectionId);
 
@@ -440,9 +440,9 @@ describe("MCP OAuth Service", () => {
       const tempDir = path.join(process.cwd(), "tmp", `neotoma-oauth-tunnel-${Date.now()}`);
       const oauth = await loadLocalOAuthModule(tempDir);
       const localAuth = await loadLocalAuthModule(tempDir);
-      const { getSqliteDb } = await loadSqliteClient(tempDir);
-      localAuth.createLocalAuthUser("tunnel@example.com", "password123");
-      const user = localAuth.getLocalAuthUserByEmail("tunnel@example.com");
+      const { getDb } = await loadDbConnection(tempDir);
+      await localAuth.createLocalAuthUser("tunnel@example.com", "password123");
+      const user = await localAuth.getLocalAuthUserByEmail("tunnel@example.com");
       if (!user) throw new Error("Local auth user not found in test");
 
       const connectionId = "cursor-local-tunnel-restart";
@@ -455,7 +455,7 @@ describe("MCP OAuth Service", () => {
       await oauth.completeLocalAuthorization(request.state, user.id);
       const firstToken = await oauth.getTokenResponseForConnection(connectionId);
 
-      getSqliteDb()
+      await (await getDb())
         .prepare(
           "UPDATE mcp_oauth_connections SET access_token_expires_at = ? WHERE connection_id = ?"
         )

--- a/src/services/agents_directory.ts
+++ b/src/services/agents_directory.ts
@@ -10,7 +10,7 @@
  * the view is always live.
  */
 
-import { getSqliteDb } from "../repositories/sqlite/sqlite_client.js";
+import { getDb } from "../repositories/db/connection.js";
 import { deriveAgentKey } from "./agent_key.js";
 import {
   listRecentRecordActivity,
@@ -225,10 +225,10 @@ function minIso(a: string | null, b: string | null): string | null {
   return a <= b ? a : b;
 }
 
-function fetchAgentRows(userId: string): AgentRow[] {
-  const db = getSqliteDb();
+async function fetchAgentRows(userId: string): Promise<AgentRow[]> {
+  const db = await getDb();
   const stmt = db.prepare(AGENT_ROWS_SQL);
-  return stmt.all(userId, userId, userId, userId, userId) as AgentRow[];
+  return (await stmt.all(userId, userId, userId, userId, userId)) as AgentRow[];
 }
 
 function aggregate(rows: AgentRow[]): Map<string, AgentDirectoryEntry> {
@@ -320,8 +320,8 @@ function aggregate(rows: AgentRow[]): Map<string, AgentDirectoryEntry> {
 }
 
 /** List every agent that has written something for this user. */
-export function listAgents(userId: string): ListAgentsResult {
-  const rows = fetchAgentRows(userId);
+export async function listAgents(userId: string): Promise<ListAgentsResult> {
+  const rows = await fetchAgentRows(userId);
   const byKey = aggregate(rows);
   const agents = [...byKey.values()].sort((a, b) => {
     const lb = b.last_seen_at ?? "";
@@ -332,8 +332,11 @@ export function listAgents(userId: string): ListAgentsResult {
 }
 
 /** Fetch a single agent by key; `null` when the key is unknown. */
-export function getAgent(userId: string, agentKey: string): AgentDirectoryEntry | null {
-  const rows = fetchAgentRows(userId).filter(
+export async function getAgent(
+  userId: string,
+  agentKey: string
+): Promise<AgentDirectoryEntry | null> {
+  const rows = (await fetchAgentRows(userId)).filter(
     (r) =>
       deriveAgentKey({
         agent_thumbprint: r.agent_thumbprint,
@@ -357,6 +360,6 @@ export function listAgentRecords(
   agentKey: string,
   limit: number,
   offset: number
-): { items: RecordActivityItem[]; has_more: boolean; limit: number; offset: number } {
+): Promise<{ items: RecordActivityItem[]; has_more: boolean; limit: number; offset: number }> {
   return listRecentRecordActivity(userId, { limit, offset, agentKey });
 }

--- a/src/services/compliance/scorecard.ts
+++ b/src/services/compliance/scorecard.ts
@@ -3,7 +3,7 @@
  * the Inspector scorecard JSON. Single source for GET /admin/compliance/scorecard.
  */
 
-import { getSqliteDb } from "../../repositories/sqlite/sqlite_client.js";
+import { getDb } from "../../repositories/db/connection.js";
 
 const TS_EPOCH = "1970-01-01T00:00:00.000Z";
 
@@ -225,10 +225,10 @@ function topMissed(m: Map<string, number>, n: number): Array<{ step: string; cou
   return arr.slice(0, Math.max(0, n));
 }
 
-export function buildComplianceScorecard(
+export async function buildComplianceScorecard(
   userId: string,
   params: ComplianceScorecardParams = {}
-): ComplianceScorecard {
+): Promise<ComplianceScorecard> {
   const refMs = params.ref_ms ?? Date.now();
   const { sinceIso, untilIso, sinceLabel, untilLabel } = resolveScorecardWindow(
     params.since,
@@ -243,8 +243,8 @@ export function buildComplianceScorecard(
   const topN = Math.min(50, Math.max(1, params.top_missed_steps ?? 5));
   const includeSynthetic = params.include_synthetic === true;
 
-  const db = getSqliteDb();
-  const rows = db.prepare(TURNS_IN_WINDOW_SQL).all(userId, sinceIso, untilIso) as TurnRow[];
+  const db = await getDb();
+  const rows = (await db.prepare(TURNS_IN_WINDOW_SQL).all(userId, sinceIso, untilIso)) as TurnRow[];
 
   const cells = new Map<string, MutableCell>();
 

--- a/src/services/conversation_turn.ts
+++ b/src/services/conversation_turn.ts
@@ -1,4 +1,4 @@
-import { getSqliteDb } from "../repositories/sqlite/sqlite_client.js";
+import { getDb } from "../repositories/db/connection.js";
 
 const TS_EPOCH = "1970-01-01T00:00:00.000Z";
 
@@ -281,13 +281,13 @@ ORDER BY
 LIMIT ? OFFSET ?
 `;
 
-export function listConversationTurns(
+export async function listConversationTurns(
   userId: string,
   limit: number,
   offset: number,
   filters?: ConversationTurnsFilters | null
-): { items: ConversationTurnSummary[]; has_more: boolean; limit: number; offset: number } {
-  const db = getSqliteDb();
+): Promise<{ items: ConversationTurnSummary[]; has_more: boolean; limit: number; offset: number }> {
+  const db = await getDb();
   const safeLimit = Math.min(Math.max(limit, 1), 100);
   const safeOffset = Math.max(offset, 0);
   const fetchLimit = safeLimit + 1;
@@ -297,7 +297,7 @@ export function listConversationTurns(
   const activityAfter = filters?.activity_after?.trim() || null;
   const activityBefore = filters?.activity_before?.trim() || null;
 
-  const rows = db
+  const rows = (await db
     .prepare(LIST_SQL)
     .all(
       userId,
@@ -312,7 +312,7 @@ export function listConversationTurns(
       activityBefore,
       fetchLimit,
       safeOffset
-    ) as TurnRow[];
+    )) as TurnRow[];
 
   const hasMore = rows.length > safeLimit;
   const page = hasMore ? rows.slice(0, safeLimit) : rows;
@@ -347,12 +347,12 @@ WHERE e.user_id = ?
 LIMIT 1
 `;
 
-export function getConversationTurn(
+export async function getConversationTurn(
   userId: string,
   turnKey: string
-): ConversationTurnDetail | null {
-  const db = getSqliteDb();
-  const row = db.prepare(DETAIL_SQL).get(userId, userId, turnKey) as TurnRow | undefined;
+): Promise<ConversationTurnDetail | null> {
+  const db = await getDb();
+  const row = (await db.prepare(DETAIL_SQL).get(userId, userId, turnKey)) as TurnRow | undefined;
   if (!row) return null;
   const summary = buildSummaryFromRow(row);
   const snap = safeJson<Record<string, unknown>>(row.snapshot_json) ?? {};
@@ -366,11 +366,11 @@ export function getConversationTurn(
 
   const related: ConversationTurnRelatedEntity[] = [];
   if (allIds.length > 0) {
-    const relatedRows = db
+    const relatedRows = (await db
       .prepare(
         `SELECT id, entity_type, canonical_name FROM entities WHERE user_id = ? AND id IN (${placeholders(allIds.length)})`
       )
-      .all(userId, ...allIds) as Array<{
+      .all(userId, ...allIds)) as Array<{
       id: string;
       entity_type: string | null;
       canonical_name: string | null;
@@ -406,20 +406,20 @@ export function getConversationTurn(
   return {
     ...summary,
     related_entities: related,
-    messages: listMessagesForTurn(userId, summary.turn_key, summary.hook_summary),
+    messages: await listMessagesForTurn(userId, summary.turn_key, summary.hook_summary),
   };
 }
 
-function listMessagesForTurn(
+async function listMessagesForTurn(
   userId: string,
   turnKey: string,
   hookSummary: ConversationTurnHookSummary
-): ConversationTurnMessage[] {
+): Promise<ConversationTurnMessage[]> {
   const cleanTurnKey = cleanString(turnKey);
   if (!cleanTurnKey) return [];
 
-  const db = getSqliteDb();
-  const messageRows = db
+  const db = await getDb();
+  const messageRows = (await db
     .prepare(
       `SELECT
         e.id AS message_id,
@@ -446,7 +446,7 @@ function listMessagesForTurn(
         ) ASC,
         e.id ASC`
     )
-    .all(userId, cleanTurnKey, `${cleanTurnKey}:assistant`) as MessageRow[];
+    .all(userId, cleanTurnKey, `${cleanTurnKey}:assistant`)) as MessageRow[];
 
   const messages = messageRows.map((row) => ({
     message_id: row.message_id,
@@ -462,7 +462,7 @@ function listMessagesForTurn(
 
   if (messages.length === 0) return messages;
 
-  const relatedRows = db
+  const relatedRows = (await db
     .prepare(
       `SELECT
         rs.source_entity_id AS message_id,
@@ -488,7 +488,7 @@ function listMessagesForTurn(
         AND rs.relationship_type != 'PART_OF'
       ORDER BY rs.last_observation_at DESC, rs.computed_at DESC, te.id`
     )
-    .all(userId, userId, ...messages.map((message) => message.message_id)) as RelatedEntityRow[];
+    .all(userId, userId, ...messages.map((message) => message.message_id))) as RelatedEntityRow[];
 
   const relatedByMessage = new Map<string, ConversationTurnMessageRelatedEntity[]>();
   for (const row of relatedRows) {
@@ -514,13 +514,13 @@ function listMessagesForTurn(
  * Build a lightweight hook summary for a set of turn_keys,
  * used to enrich recent_conversations messages.
  */
-export function listHookSummariesByTurnKeys(
+export async function listHookSummariesByTurnKeys(
   userId: string,
   turnKeys: string[]
-): Map<string, ConversationTurnHookSummary> {
+): Promise<Map<string, ConversationTurnHookSummary>> {
   if (turnKeys.length === 0) return new Map();
-  const db = getSqliteDb();
-  const rows = db
+  const db = await getDb();
+  const rows = (await db
     .prepare(
       `SELECT e.canonical_name, es.snapshot
        FROM entities e
@@ -529,7 +529,7 @@ export function listHookSummariesByTurnKeys(
          AND e.entity_type IN ('conversation_turn', 'turn_compliance', 'turn_activity')
          AND e.canonical_name IN (${placeholders(turnKeys.length)})`
     )
-    .all(userId, ...turnKeys) as Array<{ canonical_name: string; snapshot: string | null }>;
+    .all(userId, ...turnKeys)) as Array<{ canonical_name: string; snapshot: string | null }>;
 
   const result = new Map<string, ConversationTurnHookSummary>();
   for (const row of rows) {

--- a/src/services/entity_merge.ts
+++ b/src/services/entity_merge.ts
@@ -10,9 +10,11 @@
  * The full mutation sequence — observation rewrite, relationship repoint +
  * dedup/self-loop deletes, entity merged-mark, entity_merges audit insert,
  * entity_snapshots delete, and relationship_snapshots delete — is executed
- * inside a single synchronous better-sqlite3 `db.transaction()` call via
- * `getSqliteDb()`. This guarantees atomicity: a partial failure leaves the
- * source entity still alive and queryable rather than orphaning edges.
+ * inside a single async `db.transaction()` call on the shared driver. The
+ * driver serializes transactions and holds unrelated statements out of the
+ * open transaction window (see repositories/db/driver.ts), so the sequence
+ * commits or rolls back as a unit on every backend: a partial failure leaves
+ * the source entity still alive and queryable rather than orphaning edges.
  *
  * The pre-mutation validation reads (entity existence + merged status) run
  * *outside* the transaction so we can throw typed errors before entering
@@ -22,7 +24,7 @@
  */
 
 import crypto from "crypto";
-import { getSqliteDb } from "../repositories/sqlite/sqlite_client.js";
+import { getDb } from "../repositories/db/connection.js";
 import { db } from "../db.js";
 import { emitEntityLifecycle, emitEntitySnapshotChange } from "../events/substrate_store_emit.js";
 
@@ -73,20 +75,20 @@ export async function mergeEntities(params: MergeEntitiesParams): Promise<MergeR
 
   // --- Atomic mutation sequence ---
 
-  const sqliteDb = getSqliteDb();
+  const sqliteDb = await getDb();
   const merged_at = new Date().toISOString();
 
-  const result = sqliteDb.transaction(
-    (): { observations_moved: number; relationships_repointed: number } => {
+  const result = await sqliteDb.transaction(
+    async (tx): Promise<{ observations_moved: number; relationships_repointed: number }> => {
       // 1. Rewrite observation entity_id (observations table)
-      const obsResult = sqliteDb
+      const obsResult = await tx
         .prepare(
           `UPDATE observations
            SET entity_id = ?
            WHERE entity_id = ? AND user_id = ?`
         )
         .run(toEntityId, fromEntityId, userId);
-      const observations_moved = (obsResult.changes as number) ?? 0;
+      const observations_moved = obsResult.changes ?? 0;
 
       // 2. Fetch relationship_observations rows that reference fromEntityId
       type RelRow = {
@@ -97,7 +99,7 @@ export async function mergeEntities(params: MergeEntitiesParams): Promise<MergeR
         target_entity_id: string;
         canonical_hash: string | null;
       };
-      const fromRows = sqliteDb
+      const fromRows = (await tx
         .prepare(
           `SELECT id, relationship_key, relationship_type,
                   source_entity_id, target_entity_id, canonical_hash
@@ -105,7 +107,7 @@ export async function mergeEntities(params: MergeEntitiesParams): Promise<MergeR
            WHERE user_id = ?
              AND (source_entity_id = ? OR target_entity_id = ?)`
         )
-        .all(userId, fromEntityId, fromEntityId) as RelRow[];
+        .all(userId, fromEntityId, fromEntityId)) as RelRow[];
 
       // 3. Build dedup set from rows already owned by the survivor.
       // Collapse by relationship_key (type:source:target) — the unique edge
@@ -113,14 +115,14 @@ export async function mergeEntities(params: MergeEntitiesParams): Promise<MergeR
       // so that duplicate edges differing only in observation metadata still
       // collapse to a single edge on the survivor after a merge.
       type SurvivorRow = { relationship_key: string };
-      const survivorRows = sqliteDb
+      const survivorRows = (await tx
         .prepare(
           `SELECT relationship_key
            FROM relationship_observations
            WHERE user_id = ?
              AND (source_entity_id = ? OR target_entity_id = ?)`
         )
-        .all(userId, toEntityId, toEntityId) as SurvivorRow[];
+        .all(userId, toEntityId, toEntityId)) as SurvivorRow[];
 
       const survivorKeys = new Set<string>(survivorRows.map((r) => r.relationship_key));
 
@@ -160,7 +162,7 @@ export async function mergeEntities(params: MergeEntitiesParams): Promise<MergeR
       // 4. Delete self-loops and duplicates
       if (idsToDelete.length > 0) {
         const placeholders = idsToDelete.map(() => "?").join(",");
-        sqliteDb
+        await tx
           .prepare(
             `DELETE FROM relationship_observations
              WHERE id IN (${placeholders}) AND user_id = ?`
@@ -169,7 +171,7 @@ export async function mergeEntities(params: MergeEntitiesParams): Promise<MergeR
       }
 
       // 5. Repoint surviving relationship_observations rows
-      const updateRelStmt = sqliteDb.prepare(
+      const updateRelStmt = tx.prepare(
         `UPDATE relationship_observations
          SET source_entity_id = ?,
              target_entity_id = ?,
@@ -177,11 +179,17 @@ export async function mergeEntities(params: MergeEntitiesParams): Promise<MergeR
          WHERE id = ? AND user_id = ?`
       );
       for (const { id, newRelationshipKey, newSourceEntityId, newTargetEntityId } of repointed) {
-        updateRelStmt.run(newSourceEntityId, newTargetEntityId, newRelationshipKey, id, userId);
+        await updateRelStmt.run(
+          newSourceEntityId,
+          newTargetEntityId,
+          newRelationshipKey,
+          id,
+          userId
+        );
       }
 
       // 6. Clean up stale relationship_snapshots for fromEntityId
-      sqliteDb
+      await tx
         .prepare(
           `DELETE FROM relationship_snapshots
            WHERE user_id = ?
@@ -191,7 +199,7 @@ export async function mergeEntities(params: MergeEntitiesParams): Promise<MergeR
 
       // 7. Mark source entity as merged (LAST mutation — ensures entity stays
       //    alive/queryable on any earlier failure so edges are never orphaned)
-      sqliteDb
+      await tx
         .prepare(
           `UPDATE entities
            SET merged_to_entity_id = ?,
@@ -201,7 +209,7 @@ export async function mergeEntities(params: MergeEntitiesParams): Promise<MergeR
         .run(toEntityId, merged_at, fromEntityId, userId);
 
       // 8. Audit record
-      sqliteDb
+      await tx
         .prepare(
           `INSERT INTO entity_merges
              (id, user_id, from_entity_id, to_entity_id, reason, merged_by, observations_rewritten, created_at)
@@ -219,7 +227,7 @@ export async function mergeEntities(params: MergeEntitiesParams): Promise<MergeR
         );
 
       // 9. Delete entity_snapshots for the merged-away entity
-      sqliteDb
+      await tx
         .prepare(
           `DELETE FROM entity_snapshots
            WHERE entity_id = ? AND user_id = ?`
@@ -228,7 +236,7 @@ export async function mergeEntities(params: MergeEntitiesParams): Promise<MergeR
 
       return { observations_moved, relationships_repointed: repointed.length };
     }
-  )();
+  );
 
   // --- Post-mutation side effects (events — outside transaction intentionally) ---
 

--- a/src/services/entity_semantic_search.ts
+++ b/src/services/entity_semantic_search.ts
@@ -50,7 +50,7 @@ export async function semanticSearchEntities(
     return { entityIds: [], total: 0 };
   }
 
-  const { entityIds, total } = searchLocalEntityEmbeddings({
+  const { entityIds, total } = await searchLocalEntityEmbeddings({
     queryEmbedding,
     userId,
     entityType: entityType ?? null,

--- a/src/services/entity_snapshot_embedding.ts
+++ b/src/services/entity_snapshot_embedding.ts
@@ -78,7 +78,7 @@ export async function upsertEntitySnapshotWithEmbedding(
     .from("entity_snapshots")
     .upsert(payload as Record<string, unknown>, { onConflict: "entity_id" });
   if (config.storageBackend === "local" && row.embedding) {
-    storeLocalEntityEmbedding({
+    await storeLocalEntityEmbedding({
       entity_id: row.entity_id,
       embedding: row.embedding,
       user_id: row.user_id,

--- a/src/services/local_auth.ts
+++ b/src/services/local_auth.ts
@@ -1,6 +1,6 @@
 import { createHash, randomBytes, scryptSync, timingSafeEqual } from "node:crypto";
 import { config } from "../config.js";
-import { getSqliteDb } from "../repositories/sqlite/sqlite_client.js";
+import { getDb } from "../repositories/db/connection.js";
 import {
   getOrCreateInstallFingerprint,
   sandboxPrincipalIdFromFingerprint,
@@ -54,10 +54,10 @@ function hashEmailToUserId(email: string): string {
   return hashStringToUserId(email);
 }
 
-export function getLocalAuthUserByEmail(email: string): LocalAuthUser | null {
-  const db = getSqliteDb();
+export async function getLocalAuthUserByEmail(email: string): Promise<LocalAuthUser | null> {
+  const db = await getDb();
   const normalized = normalizeEmail(email);
-  const row = db
+  const row = await db
     .prepare(
       "SELECT id, email, created_at, updated_at, last_login_at FROM local_auth_users WHERE email = ?"
     )
@@ -65,9 +65,9 @@ export function getLocalAuthUserByEmail(email: string): LocalAuthUser | null {
   return row ? (row as LocalAuthUser) : null;
 }
 
-export function getLocalAuthUserById(userId: string): LocalAuthUser | null {
-  const db = getSqliteDb();
-  const row = db
+export async function getLocalAuthUserById(userId: string): Promise<LocalAuthUser | null> {
+  const db = await getDb();
+  const row = await db
     .prepare(
       "SELECT id, email, created_at, updated_at, last_login_at FROM local_auth_users WHERE id = ?"
     )
@@ -75,18 +75,18 @@ export function getLocalAuthUserById(userId: string): LocalAuthUser | null {
   return row ? (row as LocalAuthUser) : null;
 }
 
-export function countLocalAuthUsers(): number {
-  const db = getSqliteDb();
-  const row = db.prepare("SELECT COUNT(*) as count FROM local_auth_users").get() as
+export async function countLocalAuthUsers(): Promise<number> {
+  const db = await getDb();
+  const row = (await db.prepare("SELECT COUNT(*) as count FROM local_auth_users").get()) as
     | { count: number }
     | undefined;
   return row?.count ? Number(row.count) : 0;
 }
 
-export function createLocalAuthUser(email: string, password: string): LocalAuthUser {
-  const db = getSqliteDb();
+export async function createLocalAuthUser(email: string, password: string): Promise<LocalAuthUser> {
+  const db = await getDb();
   const normalized = normalizeEmail(email);
-  const existing = getLocalAuthUserByEmail(normalized);
+  const existing = await getLocalAuthUserByEmail(normalized);
   if (existing) {
     return existing;
   }
@@ -95,9 +95,11 @@ export function createLocalAuthUser(email: string, password: string): LocalAuthU
   const userId = hashEmailToUserId(normalized);
   const { salt, hash } = hashPassword(password);
 
-  db.prepare(
-    "INSERT INTO local_auth_users (id, email, password_hash, password_salt, created_at, updated_at, last_login_at) VALUES (?, ?, ?, ?, ?, ?, ?)"
-  ).run(userId, normalized, hash, salt, now, now, null);
+  await db
+    .prepare(
+      "INSERT INTO local_auth_users (id, email, password_hash, password_salt, created_at, updated_at, last_login_at) VALUES (?, ?, ?, ?, ?, ?, ?)"
+    )
+    .run(userId, normalized, hash, salt, now, now, null);
 
   return {
     id: userId,
@@ -108,24 +110,24 @@ export function createLocalAuthUser(email: string, password: string): LocalAuthU
   };
 }
 
-export function authenticateLocalUser(
+export async function authenticateLocalUser(
   email: string,
   password: string,
   allowBootstrap: boolean
-): LocalAuthUser {
-  const db = getSqliteDb();
+): Promise<LocalAuthUser> {
+  const db = await getDb();
   const normalized = normalizeEmail(email);
 
-  const existing = db
+  const existing = (await db
     .prepare(
       "SELECT id, email, password_hash, password_salt, created_at, updated_at, last_login_at FROM local_auth_users WHERE email = ?"
     )
-    .get(normalized) as
+    .get(normalized)) as
     | (LocalAuthUser & { password_hash: string; password_salt: string })
     | undefined;
 
   if (!existing) {
-    const existingCount = countLocalAuthUsers();
+    const existingCount = await countLocalAuthUsers();
     if (!allowBootstrap || existingCount > 0) {
       throw new Error("Local user not found. Create a local user first.");
     }
@@ -137,11 +139,9 @@ export function authenticateLocalUser(
   }
 
   const now = new Date().toISOString();
-  db.prepare("UPDATE local_auth_users SET last_login_at = ?, updated_at = ? WHERE id = ?").run(
-    now,
-    now,
-    existing.id
-  );
+  await db
+    .prepare("UPDATE local_auth_users SET last_login_at = ?, updated_at = ? WHERE id = ?")
+    .run(now, now, existing.id);
 
   return {
     id: existing.id,
@@ -152,18 +152,20 @@ export function authenticateLocalUser(
   };
 }
 
-export function ensureLocalDevUser(): LocalAuthUser {
-  const db = getSqliteDb();
-  const existing = getLocalAuthUserById(LOCAL_DEV_USER_ID);
+export async function ensureLocalDevUser(): Promise<LocalAuthUser> {
+  const db = await getDb();
+  const existing = await getLocalAuthUserById(LOCAL_DEV_USER_ID);
   if (existing) {
     return existing;
   }
   const now = new Date().toISOString();
   const email = "local-dev@neotoma.local";
   const { salt, hash } = hashPassword("dev-only");
-  db.prepare(
-    "INSERT INTO local_auth_users (id, email, password_hash, password_salt, created_at, updated_at, last_login_at) VALUES (?, ?, ?, ?, ?, ?, ?)"
-  ).run(LOCAL_DEV_USER_ID, email, hash, salt, now, now, null);
+  await db
+    .prepare(
+      "INSERT INTO local_auth_users (id, email, password_hash, password_salt, created_at, updated_at, last_login_at) VALUES (?, ?, ?, ?, ?, ?, ?)"
+    )
+    .run(LOCAL_DEV_USER_ID, email, hash, salt, now, now, null);
   return {
     id: LOCAL_DEV_USER_ID,
     email,
@@ -188,20 +190,22 @@ export function ensureLocalDevUser(): LocalAuthUser {
  *
  * Idempotent. Safe to call on every boot.
  */
-export function ensureLocalSandboxUser(): LocalAuthUser {
-  const db = getSqliteDb();
+export async function ensureLocalSandboxUser(): Promise<LocalAuthUser> {
+  const db = await getDb();
   const fingerprint = getOrCreateInstallFingerprint(config.dataDir);
   const userId = sandboxPrincipalIdFromFingerprint(fingerprint);
-  const existing = getLocalAuthUserById(userId);
+  const existing = await getLocalAuthUserById(userId);
   if (existing) {
     return existing;
   }
   const now = new Date().toISOString();
   const email = `local-sandbox-${fingerprint.slice(0, 8)}@neotoma.local`;
   const { salt, hash } = hashPassword(`local-sandbox-no-password:${fingerprint}`);
-  db.prepare(
-    "INSERT INTO local_auth_users (id, email, password_hash, password_salt, created_at, updated_at, last_login_at) VALUES (?, ?, ?, ?, ?, ?, ?)"
-  ).run(userId, email, hash, salt, now, now, null);
+  await db
+    .prepare(
+      "INSERT INTO local_auth_users (id, email, password_hash, password_salt, created_at, updated_at, last_login_at) VALUES (?, ?, ?, ?, ?, ?, ?)"
+    )
+    .run(userId, email, hash, salt, now, now, null);
   return {
     id: userId,
     email,
@@ -216,18 +220,20 @@ export function ensureLocalSandboxUser(): LocalAuthUser {
  * bypass for unauthenticated writes on `sandbox.neotoma.io`. Idempotent; safe
  * to call on every request.
  */
-export function ensureSandboxPublicUser(): LocalAuthUser {
-  const db = getSqliteDb();
-  const existing = getLocalAuthUserById(SANDBOX_PUBLIC_USER_ID);
+export async function ensureSandboxPublicUser(): Promise<LocalAuthUser> {
+  const db = await getDb();
+  const existing = await getLocalAuthUserById(SANDBOX_PUBLIC_USER_ID);
   if (existing) {
     return existing;
   }
   const now = new Date().toISOString();
   const email = "sandbox-public@neotoma.local";
   const { salt, hash } = hashPassword("sandbox-public-no-password");
-  db.prepare(
-    "INSERT INTO local_auth_users (id, email, password_hash, password_salt, created_at, updated_at, last_login_at) VALUES (?, ?, ?, ?, ?, ?, ?)"
-  ).run(SANDBOX_PUBLIC_USER_ID, email, hash, salt, now, now, null);
+  await db
+    .prepare(
+      "INSERT INTO local_auth_users (id, email, password_hash, password_salt, created_at, updated_at, last_login_at) VALUES (?, ?, ?, ?, ?, ?, ?)"
+    )
+    .run(SANDBOX_PUBLIC_USER_ID, email, hash, salt, now, now, null);
   return {
     id: SANDBOX_PUBLIC_USER_ID,
     email,
@@ -249,13 +255,13 @@ export function ensureSandboxPublicUser(): LocalAuthUser {
  * `@sandbox.neotoma.local` email is not exposed to `authenticateLocalUser`
  * via any external surface. Idempotent; safe to call on every request.
  */
-export function ensureSandboxAauthUser(thumbprint: string): LocalAuthUser {
+export async function ensureSandboxAauthUser(thumbprint: string): Promise<LocalAuthUser> {
   if (!thumbprint || typeof thumbprint !== "string") {
     throw new Error("ensureSandboxAauthUser requires a non-empty thumbprint");
   }
-  const db = getSqliteDb();
+  const db = await getDb();
   const userId = hashStringToUserId(`aauth:${thumbprint}`);
-  const existing = getLocalAuthUserById(userId);
+  const existing = await getLocalAuthUserById(userId);
   if (existing) {
     return existing;
   }
@@ -266,9 +272,11 @@ export function ensureSandboxAauthUser(thumbprint: string): LocalAuthUser {
   const email = `aauth-${short}@sandbox.neotoma.local`;
   const now = new Date().toISOString();
   const { salt, hash } = hashPassword(`sandbox-aauth-no-password:${thumbprint}`);
-  db.prepare(
-    "INSERT INTO local_auth_users (id, email, password_hash, password_salt, created_at, updated_at, last_login_at) VALUES (?, ?, ?, ?, ?, ?, ?)"
-  ).run(userId, email, hash, salt, now, now, null);
+  await db
+    .prepare(
+      "INSERT INTO local_auth_users (id, email, password_hash, password_salt, created_at, updated_at, last_login_at) VALUES (?, ?, ?, ?, ?, ?, ?)"
+    )
+    .run(userId, email, hash, salt, now, now, null);
   return {
     id: userId,
     email,

--- a/src/services/local_entity_embedding.ts
+++ b/src/services/local_entity_embedding.ts
@@ -2,10 +2,11 @@
 // Used when storageBackend === "local" and OPENAI_API_KEY is set
 
 import { createRequire } from "node:module";
-import type { SqliteDatabase } from "../repositories/sqlite/sqlite_driver.js";
+import { AsyncSqliteDatabase, type SqliteDatabase } from "../repositories/sqlite/sqlite_driver.js";
+import type { DbDatabase } from "../repositories/db/driver.js";
 import { config } from "../config.js";
 import { logger } from "../utils/logger.js";
-import { getSqliteDb } from "../repositories/sqlite/sqlite_client.js";
+import { getDb } from "../repositories/db/connection.js";
 
 const createRequireFromMeta = createRequire(import.meta.url);
 const EMBEDDING_DIM = 1536;
@@ -33,6 +34,15 @@ export function ensureSqliteVecLoaded(db: SqliteDatabase): boolean {
 }
 
 /**
+ * Extract the raw synchronous SQLite handle needed by sqlite-vec's `load()`.
+ * Returns null for backends without one (e.g. libSQL), where sqlite-vec is
+ * unavailable — same degradation as a failed extension load.
+ */
+function rawSqliteHandle(db: DbDatabase): SqliteDatabase | null {
+  return db instanceof AsyncSqliteDatabase ? db.rawDb() : null;
+}
+
+/**
  * Ensure vec0 virtual table exists. Call after ensureSqliteVecLoaded.
  * entity_embedding_rows is created by sqlite_client schema.
  */
@@ -48,13 +58,13 @@ function ensureVecSchema(db: SqliteDatabase): void {
  * Store or update entity embedding in local vec0 table.
  * Call when entity_snapshots upsert succeeds and row has embedding.
  */
-export function storeLocalEntityEmbedding(row: {
+export async function storeLocalEntityEmbedding(row: {
   entity_id: string;
   embedding?: number[] | null;
   user_id: string;
   entity_type: string;
   merged?: boolean;
-}): void {
+}): Promise<void> {
   if (!row.embedding || row.embedding.length !== EMBEDDING_DIM) {
     return;
   }
@@ -62,43 +72,45 @@ export function storeLocalEntityEmbedding(row: {
     return;
   }
 
-  const db = getSqliteDb();
-  if (!ensureSqliteVecLoaded(db)) {
+  const db = await getDb();
+  const rawDb = rawSqliteHandle(db);
+  if (!rawDb || !ensureSqliteVecLoaded(rawDb)) {
     return;
   }
-  ensureVecSchema(db);
+  ensureVecSchema(rawDb);
 
   const merged = row.merged ? 1 : 0;
 
   // Upsert: delete existing row for entity_id if any, then insert
-  const existing = db
+  const existing = (await db
     .prepare("SELECT rowid FROM entity_embedding_rows WHERE entity_id = ?")
-    .get(row.entity_id) as { rowid: number } | undefined;
+    .get(row.entity_id)) as { rowid: number } | undefined;
 
   if (existing) {
-    db.prepare("DELETE FROM entity_embeddings_vec WHERE rowid = ?").run(existing.rowid);
-    db.prepare("DELETE FROM entity_embedding_rows WHERE rowid = ?").run(existing.rowid);
+    await db.prepare("DELETE FROM entity_embeddings_vec WHERE rowid = ?").run(existing.rowid);
+    await db.prepare("DELETE FROM entity_embedding_rows WHERE rowid = ?").run(existing.rowid);
   }
 
   const embeddingBlob = new Float32Array(row.embedding);
-  db.prepare("INSERT INTO entity_embeddings_vec(rowid, embedding) VALUES (?, ?)").run(
-    null,
-    embeddingBlob
-  );
+  await db
+    .prepare("INSERT INTO entity_embeddings_vec(rowid, embedding) VALUES (?, ?)")
+    .run(null, embeddingBlob);
 
-  const rowid = db.prepare("SELECT last_insert_rowid() as id").get() as {
+  const rowid = (await db.prepare("SELECT last_insert_rowid() as id").get()) as {
     id: number;
   };
-  db.prepare(
-    "INSERT INTO entity_embedding_rows(rowid, entity_id, user_id, entity_type, merged) VALUES (?, ?, ?, ?, ?)"
-  ).run(rowid.id, row.entity_id, row.user_id, row.entity_type, merged);
+  await db
+    .prepare(
+      "INSERT INTO entity_embedding_rows(rowid, entity_id, user_id, entity_type, merged) VALUES (?, ?, ?, ?, ?)"
+    )
+    .run(rowid.id, row.entity_id, row.user_id, row.entity_type, merged);
 }
 
 /**
  * Semantic search over local entity embeddings.
  * Returns entity IDs ordered by similarity.
  */
-export function searchLocalEntityEmbeddings(options: {
+export async function searchLocalEntityEmbeddings(options: {
   queryEmbedding: number[];
   userId: string;
   entityType?: string | null;
@@ -116,7 +128,7 @@ export function searchLocalEntityEmbeddings(options: {
   distanceThreshold?: number;
   limit: number;
   offset: number;
-}): { entityIds: string[]; total: number } {
+}): Promise<{ entityIds: string[]; total: number }> {
   const {
     queryEmbedding,
     userId,
@@ -153,24 +165,29 @@ export function searchLocalEntityEmbeddings(options: {
     return { entityIds: [], total: 0 };
   }
 
-  const db = getSqliteDb();
-  if (!ensureSqliteVecLoaded(db)) {
+  const db = await getDb();
+  const rawDb = rawSqliteHandle(db);
+  if (!rawDb || !ensureSqliteVecLoaded(rawDb)) {
     logger.warn("[searchLocalEntityEmbeddings] sqlite-vec not loaded");
     return { entityIds: [], total: 0 };
   }
-  ensureVecSchema(db);
+  ensureVecSchema(rawDb);
 
   // Debug: row counts for userId
   const totalRows = (
-    db.prepare("SELECT COUNT(*) as c FROM entity_embedding_rows").get() as { c: number }
+    (await db.prepare("SELECT COUNT(*) as c FROM entity_embedding_rows").get()) as { c: number }
   ).c;
   const userRows = (
-    db.prepare("SELECT COUNT(*) as c FROM entity_embedding_rows WHERE user_id = ?").get(userId) as {
+    (await db
+      .prepare("SELECT COUNT(*) as c FROM entity_embedding_rows WHERE user_id = ?")
+      .get(userId)) as {
       c: number;
     }
   ).c;
   const distinctUsers = (
-    db.prepare("SELECT DISTINCT user_id FROM entity_embedding_rows").all() as { user_id: string }[]
+    (await db.prepare("SELECT DISTINCT user_id FROM entity_embedding_rows").all()) as {
+      user_id: string;
+    }[]
   ).map((r) => r.user_id);
   if (userRows === 0) {
     logger.warn(
@@ -192,7 +209,7 @@ export function searchLocalEntityEmbeddings(options: {
         ? "r.entity_type = ?"
         : `r.entity_type IN (${typeFilter.map(() => "?").join(", ")})`;
 
-  const rows = db
+  const rows = (await db
     .prepare(
       `
     SELECT r.entity_id, v.distance
@@ -211,7 +228,7 @@ export function searchLocalEntityEmbeddings(options: {
       userId,
       ...typeFilter,
       includeMerged ? 1 : 0 /* includeMerged=1: all rows; =0: only non-merged (r.merged=0) */
-    ) as Array<{ entity_id: string; distance: number }>;
+    )) as Array<{ entity_id: string; distance: number }>;
 
   const filtered =
     distanceThreshold !== undefined ? rows.filter((r) => r.distance < distanceThreshold) : rows;

--- a/src/services/mcp_auth.ts
+++ b/src/services/mcp_auth.ts
@@ -5,7 +5,7 @@
  */
 
 import { logger } from "../utils/logger.js";
-import { getSqliteDb } from "../repositories/sqlite/sqlite_client.js";
+import { getDb } from "../repositories/db/connection.js";
 import { getLocalAuthUserById } from "./local_auth.js";
 
 export interface ValidatedUser {
@@ -44,12 +44,12 @@ function decodeJWTUnverified(token: string): {
  * @throws Error if token is invalid or expired
  */
 export async function validateSessionToken(token: string): Promise<ValidatedUser> {
-  const db = getSqliteDb();
-  const connection = db
+  const db = await getDb();
+  const connection = (await db
     .prepare(
       "SELECT user_id, access_token_expires_at FROM mcp_oauth_connections WHERE access_token = ? AND revoked_at IS NULL"
     )
-    .get(token) as { user_id?: string; access_token_expires_at?: string } | undefined;
+    .get(token)) as { user_id?: string; access_token_expires_at?: string } | undefined;
 
   if (!connection?.user_id) {
     const decoded = decodeJWTUnverified(token);
@@ -70,7 +70,7 @@ export async function validateSessionToken(token: string): Promise<ValidatedUser
     throw new Error("Local session token expired");
   }
 
-  const user = getLocalAuthUserById(connection.user_id);
+  const user = await getLocalAuthUserById(connection.user_id);
   return {
     userId: connection.user_id,
     email: user?.email,

--- a/src/services/mcp_oauth.ts
+++ b/src/services/mcp_oauth.ts
@@ -9,7 +9,7 @@ import { getServiceRoleClient, db } from "../db.js";
 import { logger } from "../utils/logger.js";
 import { config } from "../config.js";
 import { OAuthError, createOAuthError } from "./mcp_oauth_errors.js";
-import { clearSqliteCache, getSqliteDb } from "../repositories/sqlite/sqlite_client.js";
+import { clearDbCache, getDb } from "../repositories/db/connection.js";
 import type { LocalDbClient } from "../repositories/sqlite/local_db_adapter.js";
 
 // Cached service role client instance
@@ -113,9 +113,9 @@ function generateLocalToken(prefix: string): string {
   return `${prefix}_${randomBytes(16).toString("hex")}`;
 }
 
-function getLocalOAuthState(state: string): LocalOAuthStateRow | null {
-  const db = getSqliteDb();
-  const row = db
+async function getLocalOAuthState(state: string): Promise<LocalOAuthStateRow | null> {
+  const db = await getDb();
+  const row = await db
     .prepare(
       "SELECT id, state, code_verifier, code_challenge, connection_id, redirect_uri, client_state, created_at, expires_at, final_redirect_uri FROM mcp_oauth_state WHERE state = ?"
     )
@@ -123,9 +123,11 @@ function getLocalOAuthState(state: string): LocalOAuthStateRow | null {
   return row ? (row as LocalOAuthStateRow) : null;
 }
 
-function getLocalOAuthStateForConnection(connectionId: string): LocalOAuthStateRow | null {
-  const db = getSqliteDb();
-  const row = db
+async function getLocalOAuthStateForConnection(
+  connectionId: string
+): Promise<LocalOAuthStateRow | null> {
+  const db = await getDb();
+  const row = await db
     .prepare(
       "SELECT id, state, code_verifier, code_challenge, connection_id, redirect_uri, client_state, created_at, expires_at, final_redirect_uri FROM mcp_oauth_state WHERE connection_id = ?"
     )
@@ -133,25 +135,25 @@ function getLocalOAuthStateForConnection(connectionId: string): LocalOAuthStateR
   return row ? (row as LocalOAuthStateRow) : null;
 }
 
-function deleteLocalOAuthState(state: string): void {
-  const db = getSqliteDb();
-  db.prepare("DELETE FROM mcp_oauth_state WHERE state = ?").run(state);
+async function deleteLocalOAuthState(state: string): Promise<void> {
+  const db = await getDb();
+  await db.prepare("DELETE FROM mcp_oauth_state WHERE state = ?").run(state);
 }
 
-function cleanupExpiredLocalStates(): void {
+async function cleanupExpiredLocalStates(): Promise<void> {
   try {
-    const db = getSqliteDb();
-    db.prepare("DELETE FROM mcp_oauth_state WHERE expires_at < ?").run(nowIso());
+    const db = await getDb();
+    await db.prepare("DELETE FROM mcp_oauth_state WHERE expires_at < ?").run(nowIso());
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     logger.warn(
       `[MCP OAuth] Local state cleanup failed (sqlitePath=${config.sqlitePath}): ${msg}. Clearing DB cache so next use will recreate the file if missing.`
     );
-    clearSqliteCache();
+    clearDbCache();
   }
 }
 
-function insertLocalOAuthState(payload: {
+async function insertLocalOAuthState(payload: {
   state: string;
   codeVerifier: string;
   codeChallenge: string | null;
@@ -160,28 +162,30 @@ function insertLocalOAuthState(payload: {
   clientState?: string | null;
   finalRedirectUri?: string | null;
   expiresAt: string;
-}): void {
-  const db = getSqliteDb();
+}): Promise<void> {
+  const db = await getDb();
   const id = randomUUID();
-  db.prepare(
-    "INSERT INTO mcp_oauth_state (id, state, code_verifier, code_challenge, connection_id, redirect_uri, client_state, created_at, expires_at, final_redirect_uri) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
-  ).run(
-    id,
-    payload.state,
-    payload.codeVerifier,
-    payload.codeChallenge,
-    payload.connectionId,
-    payload.redirectUri,
-    payload.clientState ?? null,
-    nowIso(),
-    payload.expiresAt,
-    payload.finalRedirectUri ?? null
-  );
+  await db
+    .prepare(
+      "INSERT INTO mcp_oauth_state (id, state, code_verifier, code_challenge, connection_id, redirect_uri, client_state, created_at, expires_at, final_redirect_uri) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+    )
+    .run(
+      id,
+      payload.state,
+      payload.codeVerifier,
+      payload.codeChallenge,
+      payload.connectionId,
+      payload.redirectUri,
+      payload.clientState ?? null,
+      nowIso(),
+      payload.expiresAt,
+      payload.finalRedirectUri ?? null
+    );
 }
 
-function getLocalConnectionById(connectionId: string): LocalConnectionRow | null {
-  const db = getSqliteDb();
-  const row = db
+async function getLocalConnectionById(connectionId: string): Promise<LocalConnectionRow | null> {
+  const db = await getDb();
+  const row = await db
     .prepare(
       "SELECT id, user_id, connection_id, refresh_token, access_token, access_token_expires_at, client_name, last_used_at, created_at, revoked_at FROM mcp_oauth_connections WHERE connection_id = ? AND revoked_at IS NULL"
     )
@@ -189,9 +193,11 @@ function getLocalConnectionById(connectionId: string): LocalConnectionRow | null
   return row ? (row as LocalConnectionRow) : null;
 }
 
-function getLocalConnectionByAccessToken(accessToken: string): LocalConnectionRow | null {
-  const db = getSqliteDb();
-  const row = db
+async function getLocalConnectionByAccessToken(
+  accessToken: string
+): Promise<LocalConnectionRow | null> {
+  const db = await getDb();
+  const row = await db
     .prepare(
       "SELECT id, user_id, connection_id, refresh_token, access_token, access_token_expires_at, client_name, last_used_at, created_at, revoked_at FROM mcp_oauth_connections WHERE access_token = ? AND revoked_at IS NULL"
     )
@@ -199,9 +205,11 @@ function getLocalConnectionByAccessToken(accessToken: string): LocalConnectionRo
   return row ? (row as LocalConnectionRow) : null;
 }
 
-function getLocalConnectionByRefreshToken(refreshToken: string): LocalConnectionRow | null {
-  const db = getSqliteDb();
-  const row = db
+async function getLocalConnectionByRefreshToken(
+  refreshToken: string
+): Promise<LocalConnectionRow | null> {
+  const db = await getDb();
+  const row = await db
     .prepare(
       "SELECT id, user_id, connection_id, refresh_token, access_token, access_token_expires_at, client_name, last_used_at, created_at, revoked_at FROM mcp_oauth_connections WHERE refresh_token = ? AND revoked_at IS NULL"
     )
@@ -209,59 +217,64 @@ function getLocalConnectionByRefreshToken(refreshToken: string): LocalConnection
   return row ? (row as LocalConnectionRow) : null;
 }
 
-function upsertLocalConnection(payload: {
+async function upsertLocalConnection(payload: {
   userId: string;
   connectionId: string;
   refreshToken: string;
   accessToken: string;
   accessTokenExpiresAt: string;
   clientName?: string | null;
-}): void {
-  const db = getSqliteDb();
-  const existing = getLocalConnectionById(payload.connectionId);
+}): Promise<void> {
+  const db = await getDb();
+  const existing = await getLocalConnectionById(payload.connectionId);
   if (existing) {
-    db.prepare(
-      "UPDATE mcp_oauth_connections SET user_id = ?, refresh_token = ?, access_token = ?, access_token_expires_at = ?, client_name = ?, last_used_at = ?, revoked_at = NULL WHERE connection_id = ?"
-    ).run(
+    await db
+      .prepare(
+        "UPDATE mcp_oauth_connections SET user_id = ?, refresh_token = ?, access_token = ?, access_token_expires_at = ?, client_name = ?, last_used_at = ?, revoked_at = NULL WHERE connection_id = ?"
+      )
+      .run(
+        payload.userId,
+        payload.refreshToken,
+        payload.accessToken,
+        payload.accessTokenExpiresAt,
+        payload.clientName ?? null,
+        nowIso(),
+        payload.connectionId
+      );
+    return;
+  }
+  await db
+    .prepare(
+      "INSERT INTO mcp_oauth_connections (id, user_id, connection_id, refresh_token, access_token, access_token_expires_at, client_name, last_used_at, created_at, revoked_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+    )
+    .run(
+      randomUUID(),
       payload.userId,
+      payload.connectionId,
       payload.refreshToken,
       payload.accessToken,
       payload.accessTokenExpiresAt,
       payload.clientName ?? null,
       nowIso(),
-      payload.connectionId
+      nowIso(),
+      null
     );
-    return;
-  }
-  db.prepare(
-    "INSERT INTO mcp_oauth_connections (id, user_id, connection_id, refresh_token, access_token, access_token_expires_at, client_name, last_used_at, created_at, revoked_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
-  ).run(
-    randomUUID(),
-    payload.userId,
-    payload.connectionId,
-    payload.refreshToken,
-    payload.accessToken,
-    payload.accessTokenExpiresAt,
-    payload.clientName ?? null,
-    nowIso(),
-    nowIso(),
-    null
-  );
 }
 
-function updateLocalConnectionLastUsed(connectionId: string): void {
-  const db = getSqliteDb();
-  db.prepare("UPDATE mcp_oauth_connections SET last_used_at = ? WHERE connection_id = ?").run(
-    nowIso(),
-    connectionId
-  );
+async function updateLocalConnectionLastUsed(connectionId: string): Promise<void> {
+  const db = await getDb();
+  await db
+    .prepare("UPDATE mcp_oauth_connections SET last_used_at = ? WHERE connection_id = ?")
+    .run(nowIso(), connectionId);
 }
 
-function revokeLocalConnection(connectionId: string, userId: string): void {
-  const db = getSqliteDb();
-  db.prepare(
-    "UPDATE mcp_oauth_connections SET revoked_at = ? WHERE connection_id = ? AND user_id = ?"
-  ).run(nowIso(), connectionId, userId);
+async function revokeLocalConnection(connectionId: string, userId: string): Promise<void> {
+  const db = await getDb();
+  await db
+    .prepare(
+      "UPDATE mcp_oauth_connections SET revoked_at = ? WHERE connection_id = ? AND user_id = ?"
+    )
+    .run(nowIso(), connectionId, userId);
 }
 
 /**
@@ -505,14 +518,16 @@ async function registerOAuthClient(redirectUri: string): Promise<string> {
     try {
       if (isLocalBackend) {
         const localClientId = "local_mcp_oauth_client";
-        const db = getSqliteDb();
-        const existing = db
+        const db = await getDb();
+        const existing = await db
           .prepare("SELECT id, client_id FROM mcp_oauth_client_state WHERE client_id = ?")
           .get(localClientId);
         if (!existing) {
-          db.prepare(
-            "INSERT INTO mcp_oauth_client_state (id, client_id, redirect_uri, created_at) VALUES (?, ?, ?, ?)"
-          ).run(randomUUID(), localClientId, redirectUri, nowIso());
+          await db
+            .prepare(
+              "INSERT INTO mcp_oauth_client_state (id, client_id, redirect_uri, created_at) VALUES (?, ?, ?, ?)"
+            )
+            .run(randomUUID(), localClientId, redirectUri, nowIso());
         }
         cachedClientId = localClientId;
         cachedRedirectUri = redirectUri;
@@ -775,7 +790,7 @@ export async function createAuthUrl(
 async function cleanupExpiredStates(): Promise<void> {
   try {
     if (isLocalBackend) {
-      cleanupExpiredLocalStates();
+      await cleanupExpiredLocalStates();
       return;
     }
 
@@ -926,7 +941,7 @@ export async function initiateOAuthFlow(
   const finalRedirectUri = redirectUri ?? `${frontendBase}/oauth`;
 
   if (isLocalBackend) {
-    insertLocalOAuthState({
+    await insertLocalOAuthState({
       state,
       codeVerifier,
       codeChallenge,
@@ -1027,7 +1042,7 @@ export async function createLocalAuthorizationRequest(params: {
   const expiresAt = new Date(Date.now() + STATE_TTL_MS);
   const codeVerifier = params.codeVerifier ?? generatePKCE().codeVerifier;
 
-  insertLocalOAuthState({
+  await insertLocalOAuthState({
     state,
     codeVerifier,
     codeChallenge: params.codeChallenge,
@@ -1057,14 +1072,14 @@ export async function completeLocalAuthorization(
   }
 
   validateState(state);
-  const stateData = getLocalOAuthState(state);
+  const stateData = await getLocalOAuthState(state);
   if (!stateData) {
     throw createOAuthError.stateInvalid(
       "This authorization link has expired or was already used. If you have not used it before, more than one server instance may be running and state was stored on a different instance. Use a single instance or enable sticky sessions for /mcp/oauth so the same instance handles the full flow. Otherwise, click Connect again in Cursor to start a new authorization."
     );
   }
 
-  deleteLocalOAuthState(state);
+  await deleteLocalOAuthState(state);
 
   if (new Date(stateData.expires_at) < new Date()) {
     throw createOAuthError.stateExpired(state);
@@ -1079,7 +1094,7 @@ export async function completeLocalAuthorization(
   const encryptedRefreshToken = encryptRefreshTokenForStorage(tokens.refreshToken);
   const expiresAt = new Date(Date.now() + tokens.expiresIn * 1000);
 
-  upsertLocalConnection({
+  await upsertLocalConnection({
     userId,
     connectionId: stateData.connection_id,
     refreshToken: encryptedRefreshToken,
@@ -1392,7 +1407,7 @@ export async function getAccessTokenForConnection(
   validateConnectionId(connectionId);
 
   if (isLocalBackend) {
-    const connection = getLocalConnectionById(connectionId);
+    const connection = await getLocalConnectionById(connectionId);
     if (!connection) {
       logger.error(
         `[MCP OAuth] Connection not found: ${connectionId} (storage: ${config.storageBackend}). Re-run neotoma auth login to create a connection for this backend.`
@@ -1405,7 +1420,7 @@ export async function getAccessTokenForConnection(
       connection.access_token_expires_at &&
       new Date(connection.access_token_expires_at).getTime() - Date.now() > TOKEN_REFRESH_BUFFER_MS
     ) {
-      updateLocalConnectionLastUsed(connectionId);
+      await updateLocalConnectionLastUsed(connectionId);
       return {
         accessToken: connection.access_token,
         userId: connection.user_id,
@@ -1421,7 +1436,7 @@ export async function getAccessTokenForConnection(
 
     const accessToken = generateLocalToken("local_access");
     const expiresAt = new Date(Date.now() + 3600 * 1000);
-    upsertLocalConnection({
+    await upsertLocalConnection({
       userId: connection.user_id,
       connectionId,
       refreshToken: connection.refresh_token,
@@ -1513,7 +1528,7 @@ export async function refreshAccessToken(refreshToken: string): Promise<OAuthTok
   }
 
   if (isLocalBackend) {
-    const connection = getLocalConnectionByRefreshToken(refreshToken);
+    const connection = await getLocalConnectionByRefreshToken(refreshToken);
     if (!connection) {
       throw createOAuthError.connectionNotFound("Connection not found for refresh token");
     }
@@ -1529,7 +1544,7 @@ export async function refreshAccessToken(refreshToken: string): Promise<OAuthTok
 
     const accessToken = generateLocalToken("local_access");
     const expiresAt = new Date(Date.now() + 3600 * 1000);
-    upsertLocalConnection({
+    await upsertLocalConnection({
       userId: connection.user_id,
       connectionId: connection.connection_id,
       refreshToken: connection.refresh_token,
@@ -1625,7 +1640,7 @@ export async function getTokenResponseForConnection(
 
   const { accessToken } = await getAccessTokenForConnection(connectionId);
   if (isLocalBackend) {
-    const connection = getLocalConnectionById(connectionId);
+    const connection = await getLocalConnectionById(connectionId);
     const expiresAt = connection?.access_token_expires_at
       ? new Date(connection.access_token_expires_at).getTime()
       : Date.now() + 3600 * 1000;
@@ -1691,7 +1706,7 @@ export async function validateTokenAndGetConnectionId(
   accessToken: string
 ): Promise<{ connectionId: string; userId: string }> {
   if (isLocalBackend) {
-    const connection = getLocalConnectionByAccessToken(accessToken);
+    const connection = await getLocalConnectionByAccessToken(accessToken);
     if (!connection) {
       throw createOAuthError.connectionNotFound("Connection not found for access token");
     }
@@ -1749,11 +1764,11 @@ export async function getConnectionStatus(
   validateConnectionId(connectionId);
 
   if (isLocalBackend) {
-    const connection = getLocalConnectionById(connectionId);
+    const connection = await getLocalConnectionById(connectionId);
     if (connection) {
       return connection.revoked_at ? "expired" : "active";
     }
-    const state = getLocalOAuthStateForConnection(connectionId);
+    const state = await getLocalOAuthStateForConnection(connectionId);
     if (state) {
       return new Date(state.expires_at) > new Date() ? "pending" : "expired";
     }
@@ -1811,8 +1826,8 @@ export async function listConnections(userId: string): Promise<
   }>
 > {
   if (isLocalBackend) {
-    const db = getSqliteDb();
-    const rows = db
+    const db = await getDb();
+    const rows = await db
       .prepare(
         "SELECT connection_id, client_name, created_at, last_used_at FROM mcp_oauth_connections WHERE user_id = ? AND revoked_at IS NULL ORDER BY created_at DESC"
       )
@@ -1870,7 +1885,7 @@ export async function revokeConnection(connectionId: string, userId: string): Pr
   validateConnectionId(connectionId);
 
   if (isLocalBackend) {
-    revokeLocalConnection(connectionId, userId);
+    await revokeLocalConnection(connectionId, userId);
     logger.info(`[MCP OAuth] Connection revoked: ${connectionId}`);
     auditLog("connection_revoked", {
       connectionId,

--- a/src/services/recent_conversations.ts
+++ b/src/services/recent_conversations.ts
@@ -1,4 +1,4 @@
-import { getSqliteDb } from "../repositories/sqlite/sqlite_client.js";
+import { getDb } from "../repositories/db/connection.js";
 import {
   listHookSummariesByTurnKeys,
   type ConversationTurnHookSummary,
@@ -346,18 +346,18 @@ ORDER BY rs.last_observation_at DESC, rs.computed_at DESC, te.id
 `;
 }
 
-function assembleConversationItems(
+async function assembleConversationItems(
   userId: string,
   conversationRows: ConversationRow[]
-): RecentConversationItem[] {
-  const db = getSqliteDb();
+): Promise<RecentConversationItem[]> {
+  const db = await getDb();
   const conversationIds = conversationRows.map((row) => row.conversation_id);
   const messagesByConversation = new Map<string, RecentConversationMessage[]>();
   let messageIds: string[] = [];
   if (conversationIds.length > 0) {
-    const messageRows = db
+    const messageRows = (await db
       .prepare(buildMessagesSql(conversationIds.length))
-      .all(userId, userId, ...conversationIds) as MessageRow[];
+      .all(userId, userId, ...conversationIds)) as MessageRow[];
 
     const normalizedMessages = messageRows.map((row) => ({
       conversation_id: row.conversation_id,
@@ -394,9 +394,9 @@ function assembleConversationItems(
 
   const relatedByMessage = new Map<string, RecentConversationRelatedEntity[]>();
   if (messageIds.length > 0) {
-    const relatedRows = db
+    const relatedRows = (await db
       .prepare(buildRelatedEntitiesSql(messageIds.length))
-      .all(userId, userId, ...messageIds) as RelatedEntityRow[];
+      .all(userId, userId, ...messageIds)) as RelatedEntityRow[];
 
     for (const row of relatedRows) {
       const list = relatedByMessage.get(row.message_id) ?? [];
@@ -422,7 +422,7 @@ function assembleConversationItems(
   }
   const hookSummaries =
     allTurnKeys.size > 0
-      ? listHookSummariesByTurnKeys(userId, [...allTurnKeys])
+      ? await listHookSummariesByTurnKeys(userId, [...allTurnKeys])
       : new Map<string, ConversationTurnHookSummary>();
 
   return conversationRows.map((row) => {
@@ -451,13 +451,18 @@ function assembleConversationItems(
   });
 }
 
-export function listRecentConversations(
+export async function listRecentConversations(
   userId: string,
   limit: number,
   offset: number,
   filters?: RecentConversationsFilters | null
-): { items: RecentConversationItem[]; has_more: boolean; limit: number; offset: number } {
-  const db = getSqliteDb();
+): Promise<{
+  items: RecentConversationItem[];
+  has_more: boolean;
+  limit: number;
+  offset: number;
+}> {
+  const db = await getDb();
   const safeLimit = Math.min(Math.max(limit, 1), 100);
   const safeOffset = Math.max(offset, 0);
   const fetchLimit = safeLimit + 1;
@@ -466,7 +471,7 @@ export function listRecentConversations(
   const activityBefore = filters?.activity_before?.trim() ? filters.activity_before.trim() : null;
   const agentKey = filters?.agent_key?.trim() ? filters.agent_key.trim() : null;
 
-  const conversationRows = db
+  const conversationRows = (await db
     .prepare(CONVERSATIONS_SQL)
     .all(
       userId,
@@ -482,11 +487,11 @@ export function listRecentConversations(
       agentKey,
       fetchLimit,
       safeOffset
-    ) as ConversationRow[];
+    )) as ConversationRow[];
 
   const hasMore = conversationRows.length > safeLimit;
   const conversationsPage = hasMore ? conversationRows.slice(0, safeLimit) : conversationRows;
-  const items = assembleConversationItems(userId, conversationsPage);
+  const items = await assembleConversationItems(userId, conversationsPage);
 
   return {
     items,
@@ -500,17 +505,17 @@ export function listRecentConversations(
  * Full recent-conversation payload for a single `conversation` entity id.
  * Returns null when the id is missing, merged away, wrong type, or not owned by the user.
  */
-export function getRecentConversationById(
+export async function getRecentConversationById(
   userId: string,
   conversationId: string
-): RecentConversationItem | null {
-  const db = getSqliteDb();
+): Promise<RecentConversationItem | null> {
+  const db = await getDb();
   const id = conversationId.trim();
   if (!id) return null;
-  const row = db.prepare(CONVERSATION_BY_ID_SQL).get(userId, userId, userId, userId, id) as
+  const row = (await db.prepare(CONVERSATION_BY_ID_SQL).get(userId, userId, userId, userId, id)) as
     | ConversationRow
     | undefined;
   if (!row) return null;
-  const items = assembleConversationItems(userId, [row]);
+  const items = await assembleConversationItems(userId, [row]);
   return items[0] ?? null;
 }

--- a/src/services/recent_record_activity.ts
+++ b/src/services/recent_record_activity.ts
@@ -1,4 +1,4 @@
-import { getSqliteDb } from "../repositories/sqlite/sqlite_client.js";
+import { getDb } from "../repositories/db/connection.js";
 import { deriveAgentKeyFromProvenance } from "./agent_key.js";
 
 /** Fallback so max() never compares empty strings (ISO strings sort lexicographically). */
@@ -468,16 +468,16 @@ export interface ListRecentRecordActivityOptions {
   agentKey?: string;
 }
 
-export function listRecentRecordActivity(
+export async function listRecentRecordActivity(
   userId: string,
   limitOrOptions: number | ListRecentRecordActivityOptions,
   offset?: number
-): { items: RecordActivityItem[]; has_more: boolean; limit: number; offset: number } {
+): Promise<{ items: RecordActivityItem[]; has_more: boolean; limit: number; offset: number }> {
   const options: ListRecentRecordActivityOptions =
     typeof limitOrOptions === "number"
       ? { limit: limitOrOptions, offset: offset ?? 0 }
       : limitOrOptions;
-  const db = getSqliteDb();
+  const db = await getDb();
   const safeLimit = Math.min(Math.max(options.limit, 1), 200);
   const safeOffset = Math.max(options.offset, 0);
   const fetchLimit = safeLimit + 1;
@@ -492,7 +492,7 @@ export function listRecentRecordActivity(
     const binds: Array<string | number> = [userId, userId, userId, userId, userId, userId];
     if (recordTypes?.length) binds.push(...recordTypes);
     binds.push(windowSize, 0);
-    const rows = stmt.all(...binds) as SqlRow[];
+    const rows = (await stmt.all(...binds)) as SqlRow[];
     const matching: SqlRow[] = [];
     for (const row of rows) {
       const prov = parseProvenance(row.provenance_json);
@@ -515,7 +515,7 @@ export function listRecentRecordActivity(
   const binds: Array<string | number> = [userId, userId, userId, userId, userId, userId];
   if (recordTypes?.length) binds.push(...recordTypes);
   binds.push(fetchLimit, safeOffset);
-  const rows = stmt.all(...binds) as SqlRow[];
+  const rows = (await stmt.all(...binds)) as SqlRow[];
   const hasMore = rows.length > safeLimit;
   const slice = hasMore ? rows.slice(0, safeLimit) : rows;
   return {

--- a/src/services/sandbox/sessions.ts
+++ b/src/services/sandbox/sessions.ts
@@ -11,7 +11,7 @@
 
 import crypto from "node:crypto";
 import type { Request } from "express";
-import { getSqliteDb } from "../../repositories/sqlite/sqlite_client.js";
+import { getDb } from "../../repositories/db/connection.js";
 
 export const SESSION_COOKIE_NAME = "neotoma_sandbox_session";
 const DEFAULT_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
@@ -49,8 +49,8 @@ export interface SessionInfo {
   expiresAt: string;
 }
 
-export function createSandboxSession(packId: string = "generic"): SandboxSession {
-  const db = getSqliteDb();
+export async function createSandboxSession(packId: string = "generic"): Promise<SandboxSession> {
+  const db = await getDb();
   const userId = generateUserId();
   const bearerToken = generateToken();
   const oneTimeCode = generateCode();
@@ -63,15 +63,19 @@ export function createSandboxSession(packId: string = "generic"): SandboxSession
   const salt = crypto.randomBytes(16).toString("hex");
   const passwordHash = sha256(crypto.randomBytes(32).toString("hex") + salt);
 
-  db.prepare(
-    `INSERT INTO local_auth_users (id, email, password_hash, password_salt, created_at, updated_at, is_ephemeral)
+  await db
+    .prepare(
+      `INSERT INTO local_auth_users (id, email, password_hash, password_salt, created_at, updated_at, is_ephemeral)
      VALUES (?, ?, ?, ?, ?, ?, 1)`
-  ).run(userId, email, passwordHash, salt, createdAt, createdAt);
+    )
+    .run(userId, email, passwordHash, salt, createdAt, createdAt);
 
-  db.prepare(
-    `INSERT INTO sandbox_sessions (user_id, bearer_token_hash, one_time_code_hash, pack_id, created_at, expires_at)
+  await db
+    .prepare(
+      `INSERT INTO sandbox_sessions (user_id, bearer_token_hash, one_time_code_hash, pack_id, created_at, expires_at)
      VALUES (?, ?, ?, ?, ?, ?)`
-  ).run(userId, sha256(bearerToken), sha256(oneTimeCode), packId, createdAt, expiresAtStr);
+    )
+    .run(userId, sha256(bearerToken), sha256(oneTimeCode), packId, createdAt, expiresAtStr);
 
   return {
     userId,
@@ -90,36 +94,35 @@ export interface RedeemResult {
   expiresAt: string;
 }
 
-export function redeemOneTimeCode(code: string): RedeemResult | null {
-  const db = getSqliteDb();
+export async function redeemOneTimeCode(code: string): Promise<RedeemResult | null> {
+  const db = await getDb();
   const codeHash = sha256(code);
   const now = new Date().toISOString();
 
-  const row = db
+  const row = (await db
     .prepare(
       `SELECT user_id, bearer_token_hash, pack_id, expires_at
      FROM sandbox_sessions
      WHERE one_time_code_hash = ? AND revoked_at IS NULL AND expires_at > ?`
     )
-    .get(codeHash, now) as
+    .get(codeHash, now)) as
     | { user_id: string; bearer_token_hash: string; pack_id: string; expires_at: string }
     | undefined;
 
   if (!row) return null;
 
   // Clear the one-time code after redemption
-  db.prepare(`UPDATE sandbox_sessions SET one_time_code_hash = NULL WHERE user_id = ?`).run(
-    row.user_id
-  );
+  await db
+    .prepare(`UPDATE sandbox_sessions SET one_time_code_hash = NULL WHERE user_id = ?`)
+    .run(row.user_id);
 
   // We cannot reverse the bearer hash, so we regenerate a fresh bearer token
   // and update the stored hash (the code-based handoff is the only time this
   // happens, so the original bearer from createSandboxSession is invalidated).
   const freshBearer = generateToken();
-  db.prepare(`UPDATE sandbox_sessions SET bearer_token_hash = ? WHERE user_id = ?`).run(
-    sha256(freshBearer),
-    row.user_id
-  );
+  await db
+    .prepare(`UPDATE sandbox_sessions SET bearer_token_hash = ? WHERE user_id = ?`)
+    .run(sha256(freshBearer), row.user_id);
 
   return {
     bearerToken: freshBearer,
@@ -129,7 +132,7 @@ export function redeemOneTimeCode(code: string): RedeemResult | null {
   };
 }
 
-export function resolveSessionFromRequest(req: Request): SessionInfo | null {
+export async function resolveSessionFromRequest(req: Request): Promise<SessionInfo | null> {
   // Try cookie first
   const cookieToken = req.cookies?.[SESSION_COOKIE_NAME];
   // Then Authorization header
@@ -139,17 +142,17 @@ export function resolveSessionFromRequest(req: Request): SessionInfo | null {
   const token = cookieToken || headerToken;
   if (!token) return null;
 
-  const db = getSqliteDb();
+  const db = await getDb();
   const tokenHash = sha256(token);
   const now = new Date().toISOString();
 
-  const row = db
+  const row = (await db
     .prepare(
       `SELECT user_id, pack_id, created_at, expires_at
      FROM sandbox_sessions
      WHERE bearer_token_hash = ? AND revoked_at IS NULL AND expires_at > ?`
     )
-    .get(tokenHash, now) as
+    .get(tokenHash, now)) as
     | { user_id: string; pack_id: string; created_at: string; expires_at: string }
     | undefined;
 
@@ -163,52 +166,54 @@ export function resolveSessionFromRequest(req: Request): SessionInfo | null {
   };
 }
 
-export function revokeSession(userId: string): void {
-  const db = getSqliteDb();
+export async function revokeSession(userId: string): Promise<void> {
+  const db = await getDb();
   const now = new Date().toISOString();
-  db.prepare(
-    `UPDATE sandbox_sessions SET revoked_at = ? WHERE user_id = ? AND revoked_at IS NULL`
-  ).run(now, userId);
+  await db
+    .prepare(`UPDATE sandbox_sessions SET revoked_at = ? WHERE user_id = ? AND revoked_at IS NULL`)
+    .run(now, userId);
 }
 
-export function purgeSessionUserData(userId: string): void {
-  const db = getSqliteDb();
-  const transaction = db.transaction(() => {
-    db.prepare("DELETE FROM sandbox_sessions WHERE user_id = ?").run(userId);
-    db.prepare("DELETE FROM observations WHERE user_id = ?").run(userId);
-    db.prepare("DELETE FROM entity_snapshots WHERE user_id = ?").run(userId);
-    db.prepare("DELETE FROM entities WHERE user_id = ?").run(userId);
-    db.prepare("DELETE FROM sources WHERE user_id = ?").run(userId);
-    db.prepare("DELETE FROM timeline_events WHERE user_id = ?").run(userId);
-    db.prepare("DELETE FROM local_auth_users WHERE id = ? AND is_ephemeral = 1").run(userId);
+export async function purgeSessionUserData(userId: string): Promise<void> {
+  const db = await getDb();
+  await db.transaction(async (tx) => {
+    await tx.prepare("DELETE FROM sandbox_sessions WHERE user_id = ?").run(userId);
+    await tx.prepare("DELETE FROM observations WHERE user_id = ?").run(userId);
+    await tx.prepare("DELETE FROM entity_snapshots WHERE user_id = ?").run(userId);
+    await tx.prepare("DELETE FROM entities WHERE user_id = ?").run(userId);
+    await tx.prepare("DELETE FROM sources WHERE user_id = ?").run(userId);
+    await tx.prepare("DELETE FROM timeline_events WHERE user_id = ?").run(userId);
+    await tx.prepare("DELETE FROM local_auth_users WHERE id = ? AND is_ephemeral = 1").run(userId);
   });
-  transaction();
 }
 
-export function sweepExpiredSessions(): number {
-  const db = getSqliteDb();
+export async function sweepExpiredSessions(): Promise<number> {
+  const db = await getDb();
   const _now = new Date().toISOString();
 
-  const expired = db
+  const expired = (await db
     .prepare(`SELECT user_id FROM sandbox_sessions WHERE expires_at <= ? OR revoked_at IS NOT NULL`)
-    .all() as { user_id: string }[];
+    .all()) as { user_id: string }[];
 
   let purged = 0;
   for (const row of expired) {
-    purgeSessionUserData(row.user_id);
+    await purgeSessionUserData(row.user_id);
     purged++;
   }
   return purged;
 }
 
-export function resetSandboxSession(userId: string, packId?: string): SandboxSession | null {
-  const db = getSqliteDb();
-  const existing = db
+export async function resetSandboxSession(
+  userId: string,
+  packId?: string
+): Promise<SandboxSession | null> {
+  const db = await getDb();
+  const existing = (await db
     .prepare(`SELECT pack_id FROM sandbox_sessions WHERE user_id = ? AND revoked_at IS NULL`)
-    .get(userId) as { pack_id: string } | undefined;
+    .get(userId)) as { pack_id: string } | undefined;
 
   if (!existing) return null;
 
-  purgeSessionUserData(userId);
+  await purgeSessionUserData(userId);
   return createSandboxSession(packId ?? existing.pack_id);
 }

--- a/src/services/subscriptions/event_log.ts
+++ b/src/services/subscriptions/event_log.ts
@@ -7,12 +7,13 @@
  * `substrate_events` table so resume can fall back to durable storage when the
  * cursor has left the ring.
  *
- * Writes are synchronous (in the same path as the ring push) so an event is
- * durable as soon as it is emitted. The log is pruned to a rolling retention
- * window (NEOTOMA_EVENT_RETENTION_DAYS, default 7).
+ * Writes happen in the same path as the ring push (awaited before the emit
+ * completes) so an event is durable as soon as it is emitted. The log is
+ * pruned to a rolling retention window (NEOTOMA_EVENT_RETENTION_DAYS,
+ * default 7).
  */
 
-import { getSqliteDb } from "../../repositories/sqlite/sqlite_client.js";
+import { getDb } from "../../repositories/db/connection.js";
 import { getDataKey } from "../../repositories/sqlite/local_db_adapter.js";
 import { encryptColumn, decryptColumn, isEncryptedColumn } from "../../crypto/column_encryption.js";
 import { logger } from "../../utils/logger.js";
@@ -71,18 +72,18 @@ export interface DurableEventFilter {
 }
 
 /**
- * Persist a substrate event to the durable log. Synchronous: returns the
- * assigned durable `seq` (monotonic, distinct from the in-memory ring id).
+ * Persist a substrate event to the durable log. Returns the assigned durable
+ * `seq` (monotonic, distinct from the in-memory ring id).
  * `nowIso` is injectable for deterministic tests; defaults to wall clock.
  */
-export function persistSubstrateEvent(
+export async function persistSubstrateEvent(
   event: SubstrateEvent,
   ringId: string | null,
   nowIso?: string
-): number {
-  const db = getSqliteDb();
+): Promise<number> {
+  const db = await getDb();
   const createdAt = nowIso ?? new Date().toISOString();
-  const info = db
+  const info = await db
     .prepare(
       `INSERT INTO substrate_events (ring_id, event_type, user_id, entity_id, payload, created_at)
        VALUES (?, ?, ?, ?, ?, ?)`
@@ -109,13 +110,13 @@ export function persistSubstrateEvent(
  * `entity_type`) MUST still be applied by the caller — and never widens the
  * result set.
  */
-export function getEventsAfterSeq(
+export async function getEventsAfterSeq(
   userId: string,
   afterSeq: number,
   limit = 1000,
   filter?: DurableEventFilter
-): DurableEvent[] {
-  const db = getSqliteDb();
+): Promise<DurableEvent[]> {
+  const db = await getDb();
   const clauses: string[] = ["user_id = ?", "seq > ?"];
   const params: Array<string | number> = [userId, afterSeq];
 
@@ -132,14 +133,14 @@ export function getEventsAfterSeq(
   }
 
   params.push(limit);
-  const rows = db
+  const rows = (await db
     .prepare(
       `SELECT seq, payload FROM substrate_events
        WHERE ${clauses.join(" AND ")}
        ORDER BY seq ASC
        LIMIT ?`
     )
-    .all(...params) as Array<{ seq: number; payload: string }>;
+    .all(...params)) as Array<{ seq: number; payload: string }>;
   const out: DurableEvent[] = [];
   for (const row of rows) {
     try {
@@ -171,13 +172,13 @@ export function getEventsAfterSeq(
  *
  * Returns false for a user with no durable events (nothing to recover from).
  */
-export function hasDurableCursor(userId: string, seq: number): boolean {
-  const db = getSqliteDb();
-  const row = db
+export async function hasDurableCursor(userId: string, seq: number): Promise<boolean> {
+  const db = await getDb();
+  const row = (await db
     .prepare(
       `SELECT MIN(seq) AS min_seq, MAX(seq) AS max_seq FROM substrate_events WHERE user_id = ?`
     )
-    .get(userId) as { min_seq: number | null; max_seq: number | null } | undefined;
+    .get(userId)) as { min_seq: number | null; max_seq: number | null } | undefined;
   if (!row || row.min_seq === null || row.max_seq === null) return false;
   // `seq` is the last delivered cursor; replay covers (seq, max]. The cursor is
   // recoverable when at least one retained event is strictly newer than it
@@ -189,10 +190,13 @@ export function hasDurableCursor(userId: string, seq: number): boolean {
  * Delete events older than the retention window. Returns the number of rows
  * pruned. `nowMs` is injectable for deterministic tests.
  */
-export function pruneEventLog(retentionDays = EVENT_RETENTION_DAYS, nowMs?: number): number {
-  const db = getSqliteDb();
+export async function pruneEventLog(
+  retentionDays = EVENT_RETENTION_DAYS,
+  nowMs?: number
+): Promise<number> {
+  const db = await getDb();
   const cutoffMs = (nowMs ?? Date.now()) - retentionDays * 24 * 60 * 60 * 1000;
   const cutoffIso = new Date(cutoffMs).toISOString();
-  const info = db.prepare(`DELETE FROM substrate_events WHERE created_at < ?`).run(cutoffIso);
+  const info = await db.prepare(`DELETE FROM substrate_events WHERE created_at < ?`).run(cutoffIso);
   return Number(info.changes ?? 0);
 }

--- a/src/services/subscriptions/install_subscription_bridge.ts
+++ b/src/services/subscriptions/install_subscription_bridge.ts
@@ -19,14 +19,15 @@ export function installSubscriptionBridge(): void {
   // Durable event-log retention (#1464 Tier 2): prune on startup and on a slow
   // interval. Best-effort — a prune failure must never affect delivery.
   const runPrune = (): void => {
-    try {
-      const removed = pruneEventLog();
-      if (removed > 0) logger.info("[subscriptions] pruned durable event log", { removed });
-    } catch (err) {
-      logger.warn("[subscriptions] event-log prune failed", {
-        message: err instanceof Error ? err.message : String(err),
+    void pruneEventLog()
+      .then((removed) => {
+        if (removed > 0) logger.info("[subscriptions] pruned durable event log", { removed });
+      })
+      .catch((err: unknown) => {
+        logger.warn("[subscriptions] event-log prune failed", {
+          message: err instanceof Error ? err.message : String(err),
+        });
       });
-    }
   };
   runPrune();
   const timer = setInterval(runPrune, EVENT_LOG_PRUNE_INTERVAL_MS);

--- a/src/services/subscriptions/subscription_bridge.ts
+++ b/src/services/subscriptions/subscription_bridge.ts
@@ -17,7 +17,7 @@ export async function handleSubstrateEventForSubscriptions(event: SubstrateEvent
     // must never break delivery, so fall back to the ring's own id.
     let durableSeq: number | null = null;
     try {
-      durableSeq = persistSubstrateEvent(event, null);
+      durableSeq = await persistSubstrateEvent(event, null);
     } catch (err) {
       logger.warn("[subscriptions] durable event persist failed", {
         message: err instanceof Error ? err.message : String(err),

--- a/tests/integration/aauth_sandbox_attribution_partition.test.ts
+++ b/tests/integration/aauth_sandbox_attribution_partition.test.ts
@@ -100,15 +100,19 @@ function makeSandboxBypassApp(): express.Application {
       }
     ).aauth;
     if (aauthCtx?.verified === true && typeof aauthCtx.thumbprint === "string") {
-      const aauthUser = ensureSandboxAauthUser(aauthCtx.thumbprint);
-      (req as express.Request & { authenticatedUserId?: string }).authenticatedUserId =
-        aauthUser.id;
-      return next();
+      void ensureSandboxAauthUser(aauthCtx.thumbprint).then((aauthUser) => {
+        (req as express.Request & { authenticatedUserId?: string }).authenticatedUserId =
+          aauthUser.id;
+        next();
+      }, next);
+      return;
     }
-    const sandboxUser = ensureSandboxPublicUser();
-    (req as express.Request & { authenticatedUserId?: string }).authenticatedUserId =
-      sandboxUser.id;
-    return next();
+    void ensureSandboxPublicUser().then((sandboxUser) => {
+      (req as express.Request & { authenticatedUserId?: string }).authenticatedUserId =
+        sandboxUser.id;
+      next();
+    }, next);
+    return;
   });
   app.get("/probe", (req, res) => {
     const userId = (req as express.Request & { authenticatedUserId?: string })
@@ -244,9 +248,9 @@ describe("sandbox attribution partitioning (Option α)", () => {
 });
 
 describe("ensureSandboxAauthUser (deterministic provisioning)", () => {
-  it("produces a stable UUID-shaped id for the same thumbprint", () => {
-    const a = ensureSandboxAauthUser("tp-stable-1");
-    const b = ensureSandboxAauthUser("tp-stable-1");
+  it("produces a stable UUID-shaped id for the same thumbprint", async () => {
+    const a = await ensureSandboxAauthUser("tp-stable-1");
+    const b = await ensureSandboxAauthUser("tp-stable-1");
     expect(a.id).toBe(b.id);
     expect(a.id).toMatch(
       /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
@@ -255,14 +259,14 @@ describe("ensureSandboxAauthUser (deterministic provisioning)", () => {
     expect(a.email.endsWith("@sandbox.neotoma.local")).toBe(true);
   });
 
-  it("produces distinct ids for distinct thumbprints", () => {
-    const a = ensureSandboxAauthUser("tp-distinct-A");
-    const b = ensureSandboxAauthUser("tp-distinct-B");
+  it("produces distinct ids for distinct thumbprints", async () => {
+    const a = await ensureSandboxAauthUser("tp-distinct-A");
+    const b = await ensureSandboxAauthUser("tp-distinct-B");
     expect(a.id).not.toBe(b.id);
   });
 
-  it("rejects empty / non-string thumbprints", () => {
-    expect(() => ensureSandboxAauthUser("")).toThrow();
-    expect(() => ensureSandboxAauthUser(undefined as unknown as string)).toThrow();
+  it("rejects empty / non-string thumbprints", async () => {
+    await expect(ensureSandboxAauthUser("")).rejects.toThrow();
+    await expect(ensureSandboxAauthUser(undefined as unknown as string)).rejects.toThrow();
   });
 });

--- a/tests/integration/aauth_sandbox_write_admission.test.ts
+++ b/tests/integration/aauth_sandbox_write_admission.test.ts
@@ -110,13 +110,13 @@ function makeSandboxWriteApp(): express.Application {
     });
   };
 
-  app.post("/sandbox/aauth-only/store", aauthRequired, (req, res) => {
+  app.post("/sandbox/aauth-only/store", aauthRequired, async (req, res) => {
     const aauthCtx = (
       req as express.Request & {
         aauth?: { verified?: boolean; thumbprint?: string };
       }
     ).aauth;
-    const user = ensureSandboxAauthUser(aauthCtx!.thumbprint!);
+    const user = await ensureSandboxAauthUser(aauthCtx!.thumbprint!);
     res.status(200).json({
       ok: true,
       user_id: user.id,
@@ -230,7 +230,7 @@ describe("γ-write: POST /sandbox/aauth-only/store (sandbox-only AAuth admission
     expect(body.user_id).not.toBe(SANDBOX_PUBLIC_USER_ID);
     expect(body.entity_id.length).toBeGreaterThan(0);
 
-    const expected = ensureSandboxAauthUser("tp-gamma-write-1");
+    const expected = await ensureSandboxAauthUser("tp-gamma-write-1");
     expect(body.user_id).toBe(expected.id);
   });
 });

--- a/tests/integration/agent_memory_turn_lifecycle.test.ts
+++ b/tests/integration/agent_memory_turn_lifecycle.test.ts
@@ -23,7 +23,7 @@ describe("@neotoma/agent turn lifecycle (LocalTransport)", () => {
   let userId: string;
 
   beforeAll(async () => {
-    const localUser = ensureLocalDevUser();
+    const localUser = await ensureLocalDevUser();
     userId = localUser.id;
     const operations = createOperations({ userId });
     transport = new LocalTransport({ userId, operations });

--- a/tests/integration/conversation_turn_accrual.test.ts
+++ b/tests/integration/conversation_turn_accrual.test.ts
@@ -9,7 +9,7 @@ import { randomUUID } from "node:crypto";
 import { AddressInfo } from "node:net";
 import express from "express";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { getSqliteDb } from "../../src/repositories/sqlite/sqlite_client.js";
+import { getDb } from "../../src/repositories/db/connection.js";
 import {
   listConversationTurns,
   getConversationTurn,
@@ -58,8 +58,8 @@ function turnKey(seed: TurnSeed): string {
   return `${seed.session_id}:${seed.turn_id}`;
 }
 
-function seedTurn(seed: TurnSeed) {
-  const db = getSqliteDb();
+async function seedTurn(seed: TurnSeed) {
+  const db = await getDb();
   const id = entityIdFor(seed);
   const tk = turnKey(seed);
   const snapshot: Record<string, unknown> = {
@@ -86,37 +86,41 @@ function seedTurn(seed: TurnSeed) {
   };
 
   const now = new Date().toISOString();
-  db.prepare(
-    `INSERT OR REPLACE INTO entities (id, entity_type, canonical_name, aliases, created_at, updated_at, user_id, first_seen_at, last_seen_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-  ).run(
-    id,
-    seed.entity_type,
-    tk,
-    JSON.stringify([]),
-    seed.started_at ?? now,
-    seed.ended_at ?? seed.started_at ?? now,
-    TEST_USER_ID,
-    seed.started_at ?? now,
-    seed.ended_at ?? seed.started_at ?? now,
-  );
+  await db
+    .prepare(
+      `INSERT OR REPLACE INTO entities (id, entity_type, canonical_name, aliases, created_at, updated_at, user_id, first_seen_at, last_seen_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      id,
+      seed.entity_type,
+      tk,
+      JSON.stringify([]),
+      seed.started_at ?? now,
+      seed.ended_at ?? seed.started_at ?? now,
+      TEST_USER_ID,
+      seed.started_at ?? now,
+      seed.ended_at ?? seed.started_at ?? now,
+    );
 
-  db.prepare(
-    `INSERT OR REPLACE INTO entity_snapshots (entity_id, entity_type, schema_version, canonical_name, snapshot, computed_at, observation_count, last_observation_at, user_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-  ).run(
-    id,
-    seed.entity_type,
-    "1.0.0",
-    tk,
-    JSON.stringify(snapshot),
-    seed.ended_at ?? seed.started_at ?? now,
-    1,
-    seed.ended_at ?? seed.started_at ?? now,
-    TEST_USER_ID,
-  );
+  await db
+    .prepare(
+      `INSERT OR REPLACE INTO entity_snapshots (entity_id, entity_type, schema_version, canonical_name, snapshot, computed_at, observation_count, last_observation_at, user_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      id,
+      seed.entity_type,
+      "1.0.0",
+      tk,
+      JSON.stringify(snapshot),
+      seed.ended_at ?? seed.started_at ?? now,
+      1,
+      seed.ended_at ?? seed.started_at ?? now,
+      TEST_USER_ID,
+    );
 }
 
-function seedMessage(seed: MessageSeed) {
-  const db = getSqliteDb();
+async function seedMessage(seed: MessageSeed) {
+  const db = await getDb();
   const snapshot = {
     role: seed.role,
     sender_kind: seed.sender_kind,
@@ -124,75 +128,85 @@ function seedMessage(seed: MessageSeed) {
     turn_key: seed.turn_key,
   };
 
-  db.prepare(
-    `INSERT OR REPLACE INTO entities (id, entity_type, canonical_name, aliases, created_at, updated_at, user_id, first_seen_at, last_seen_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-  ).run(
-    seed.id,
-    "conversation_message",
-    `conversation_message:${seed.turn_key}`,
-    JSON.stringify([]),
-    seed.observed_at,
-    seed.observed_at,
-    TEST_USER_ID,
-    seed.observed_at,
-    seed.observed_at,
-  );
+  await db
+    .prepare(
+      `INSERT OR REPLACE INTO entities (id, entity_type, canonical_name, aliases, created_at, updated_at, user_id, first_seen_at, last_seen_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      seed.id,
+      "conversation_message",
+      `conversation_message:${seed.turn_key}`,
+      JSON.stringify([]),
+      seed.observed_at,
+      seed.observed_at,
+      TEST_USER_ID,
+      seed.observed_at,
+      seed.observed_at,
+    );
 
-  db.prepare(
-    `INSERT OR REPLACE INTO entity_snapshots (entity_id, entity_type, schema_version, canonical_name, snapshot, computed_at, observation_count, last_observation_at, user_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-  ).run(
-    seed.id,
-    "conversation_message",
-    "1.2",
-    `conversation_message:${seed.turn_key}`,
-    JSON.stringify(snapshot),
-    seed.observed_at,
-    1,
-    seed.observed_at,
-    TEST_USER_ID,
-  );
+  await db
+    .prepare(
+      `INSERT OR REPLACE INTO entity_snapshots (entity_id, entity_type, schema_version, canonical_name, snapshot, computed_at, observation_count, last_observation_at, user_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      seed.id,
+      "conversation_message",
+      "1.2",
+      `conversation_message:${seed.turn_key}`,
+      JSON.stringify(snapshot),
+      seed.observed_at,
+      1,
+      seed.observed_at,
+      TEST_USER_ID,
+    );
 }
 
-function seedRelatedEntity(id: string, title: string) {
-  const db = getSqliteDb();
+async function seedRelatedEntity(id: string, title: string) {
+  const db = await getDb();
   const now = "2026-04-28T10:00:30Z";
-  db.prepare(
-    `INSERT OR REPLACE INTO entities (id, entity_type, canonical_name, aliases, created_at, updated_at, user_id, first_seen_at, last_seen_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-  ).run(id, "task", title, JSON.stringify([]), now, now, TEST_USER_ID, now, now);
-  db.prepare(
-    `INSERT OR REPLACE INTO entity_snapshots (entity_id, entity_type, schema_version, canonical_name, snapshot, computed_at, observation_count, last_observation_at, user_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-  ).run(
-    id,
-    "task",
-    "1.0.0",
-    title,
-    JSON.stringify({ title }),
-    now,
-    1,
-    now,
-    TEST_USER_ID,
-  );
+  await db
+    .prepare(
+      `INSERT OR REPLACE INTO entities (id, entity_type, canonical_name, aliases, created_at, updated_at, user_id, first_seen_at, last_seen_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(id, "task", title, JSON.stringify([]), now, now, TEST_USER_ID, now, now);
+  await db
+    .prepare(
+      `INSERT OR REPLACE INTO entity_snapshots (entity_id, entity_type, schema_version, canonical_name, snapshot, computed_at, observation_count, last_observation_at, user_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      id,
+      "task",
+      "1.0.0",
+      title,
+      JSON.stringify({ title }),
+      now,
+      1,
+      now,
+      TEST_USER_ID,
+    );
 }
 
-function seedRelationship(sourceId: string, targetId: string, relationshipType: string) {
-  const db = getSqliteDb();
+async function seedRelationship(sourceId: string, targetId: string, relationshipType: string) {
+  const db = await getDb();
   const now = "2026-04-28T10:00:31Z";
   const key = `${relationshipType}:${sourceId}:${targetId}`;
-  db.prepare(
-    `INSERT OR REPLACE INTO relationship_snapshots (relationship_key, relationship_type, source_entity_id, target_entity_id, schema_version, snapshot, computed_at, observation_count, last_observation_at, provenance, user_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-  ).run(
-    key,
-    relationshipType,
-    sourceId,
-    targetId,
-    "1.0",
-    JSON.stringify({}),
-    now,
-    1,
-    now,
-    JSON.stringify({}),
-    TEST_USER_ID,
-  );
+  await db
+    .prepare(
+      `INSERT OR REPLACE INTO relationship_snapshots (relationship_key, relationship_type, source_entity_id, target_entity_id, schema_version, snapshot, computed_at, observation_count, last_observation_at, provenance, user_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      key,
+      relationshipType,
+      sourceId,
+      targetId,
+      "1.0",
+      JSON.stringify({}),
+      now,
+      1,
+      now,
+      JSON.stringify({}),
+      TEST_USER_ID,
+    );
 }
 
 const seeds: TurnSeed[] = [
@@ -246,9 +260,9 @@ const seeds: TurnSeed[] = [
   },
 ];
 
-beforeAll(() => {
-  for (const seed of seeds) seedTurn(seed);
-  seedMessage({
+beforeAll(async () => {
+  for (const seed of seeds) await seedTurn(seed);
+  await seedMessage({
     id: "ent_msg_turn_1_user",
     role: "user",
     sender_kind: "user",
@@ -256,7 +270,7 @@ beforeAll(() => {
     turn_key: "sess-1:turn-1",
     observed_at: "2026-04-28T10:00:05Z",
   });
-  seedMessage({
+  await seedMessage({
     id: "ent_msg_turn_1_assistant",
     role: "assistant",
     sender_kind: "assistant",
@@ -264,25 +278,25 @@ beforeAll(() => {
     turn_key: "sess-1:turn-1:assistant",
     observed_at: "2026-04-28T10:00:45Z",
   });
-  seedRelatedEntity("ent_turn_1_task", "Check Neotoma compliance flow");
-  seedRelationship("ent_msg_turn_1_user", "ent_turn_1_task", "REFERS_TO");
+  await seedRelatedEntity("ent_turn_1_task", "Check Neotoma compliance flow");
+  await seedRelationship("ent_msg_turn_1_user", "ent_turn_1_task", "REFERS_TO");
 });
 
-afterAll(() => {
-  const db = getSqliteDb();
+afterAll(async () => {
+  const db = await getDb();
   const ids = seeds.map((s) => entityIdFor(s));
   for (const key of ["REFERS_TO:ent_msg_turn_1_user:ent_turn_1_task"]) {
-    db.prepare("DELETE FROM relationship_snapshots WHERE relationship_key = ?").run(key);
+    await db.prepare("DELETE FROM relationship_snapshots WHERE relationship_key = ?").run(key);
   }
   for (const id of [...ids, "ent_msg_turn_1_user", "ent_msg_turn_1_assistant", "ent_turn_1_task"]) {
-    db.prepare("DELETE FROM entity_snapshots WHERE entity_id = ?").run(id);
-    db.prepare("DELETE FROM entities WHERE id = ?").run(id);
+    await db.prepare("DELETE FROM entity_snapshots WHERE entity_id = ?").run(id);
+    await db.prepare("DELETE FROM entities WHERE id = ?").run(id);
   }
 });
 
 describe("listConversationTurns", () => {
-  it("returns seeded turns ordered by activity_at descending", () => {
-    const { items, has_more } = listConversationTurns(TEST_USER_ID, 10, 0);
+  it("returns seeded turns ordered by activity_at descending", async () => {
+    const { items, has_more } = await listConversationTurns(TEST_USER_ID, 10, 0);
     expect(items.length).toBeGreaterThanOrEqual(4);
     expect(has_more).toBe(false);
     const turnKeys = items.map((i) => i.turn_key);
@@ -292,21 +306,21 @@ describe("listConversationTurns", () => {
     expect(turnKeys).toContain("sess-2:turn-1");
   });
 
-  it("filters by harness", () => {
-    const { items } = listConversationTurns(TEST_USER_ID, 10, 0, { harness: "opencode" });
+  it("filters by harness", async () => {
+    const { items } = await listConversationTurns(TEST_USER_ID, 10, 0, { harness: "opencode" });
     expect(items.length).toBeGreaterThanOrEqual(1);
     for (const item of items) {
       expect(item.harness).toBe("opencode");
     }
   });
 
-  it("respects limit and offset", () => {
-    const { items } = listConversationTurns(TEST_USER_ID, 2, 0);
+  it("respects limit and offset", async () => {
+    const { items } = await listConversationTurns(TEST_USER_ID, 2, 0);
     expect(items.length).toBeLessThanOrEqual(2);
   });
 
-  it("includes hook_summary counters", () => {
-    const { items } = listConversationTurns(TEST_USER_ID, 10, 0);
+  it("includes hook_summary counters", async () => {
+    const { items } = await listConversationTurns(TEST_USER_ID, 10, 0);
     const turn1 = items.find((i) => i.turn_key === "sess-1:turn-1");
     expect(turn1).toBeDefined();
     expect(turn1!.hook_summary.hook_event_count).toBe(3);
@@ -317,8 +331,8 @@ describe("listConversationTurns", () => {
 });
 
 describe("getConversationTurn", () => {
-  it("returns detail for an existing turn_key", () => {
-    const detail = getConversationTurn(TEST_USER_ID, "sess-1:turn-1");
+  it("returns detail for an existing turn_key", async () => {
+    const detail = await getConversationTurn(TEST_USER_ID, "sess-1:turn-1");
     expect(detail).not.toBeNull();
     expect(detail!.turn_key).toBe("sess-1:turn-1");
     expect(detail!.harness).toBe("cursor");
@@ -331,8 +345,8 @@ describe("getConversationTurn", () => {
     expect(detail!.related_entities).toBeDefined();
   });
 
-  it("returns user and assistant messages for the turn key", () => {
-    const detail = getConversationTurn(TEST_USER_ID, "sess-1:turn-1");
+  it("returns user and assistant messages for the turn key", async () => {
+    const detail = await getConversationTurn(TEST_USER_ID, "sess-1:turn-1");
     expect(detail).not.toBeNull();
     expect(detail!.messages).toHaveLength(2);
     expect(detail!.messages.map((m) => m.sender_kind)).toEqual(["user", "assistant"]);
@@ -341,13 +355,13 @@ describe("getConversationTurn", () => {
     expect(detail!.messages[0]!.related_entities[0]?.title).toBe("Check Neotoma compliance flow");
   });
 
-  it("returns null for a non-existent turn_key", () => {
-    const detail = getConversationTurn(TEST_USER_ID, "nope:nope");
+  it("returns null for a non-existent turn_key", async () => {
+    const detail = await getConversationTurn(TEST_USER_ID, "nope:nope");
     expect(detail).toBeNull();
   });
 
-  it("finds legacy turn_compliance entities", () => {
-    const detail = getConversationTurn(TEST_USER_ID, "sess-legacy:turn-legacy");
+  it("finds legacy turn_compliance entities", async () => {
+    const detail = await getConversationTurn(TEST_USER_ID, "sess-legacy:turn-legacy");
     expect(detail).not.toBeNull();
     expect(detail!.harness).toBe("opencode");
     expect(detail!.status).toBe("backfilled_by_hook");
@@ -355,8 +369,8 @@ describe("getConversationTurn", () => {
 });
 
 describe("listHookSummariesByTurnKeys", () => {
-  it("returns summaries keyed by turn_key", () => {
-    const summaries = listHookSummariesByTurnKeys(TEST_USER_ID, [
+  it("returns summaries keyed by turn_key", async () => {
+    const summaries = await listHookSummariesByTurnKeys(TEST_USER_ID, [
       "sess-1:turn-1",
       "sess-1:turn-2",
       "nonexistent:key",

--- a/tests/integration/mcp_oauth_token_endpoint.test.ts
+++ b/tests/integration/mcp_oauth_token_endpoint.test.ts
@@ -34,8 +34,8 @@ describe("MCP OAuth token endpoint", () => {
   it("accepts refresh_token grant for local OAuth sessions", async () => {
     currentTempDir = path.join(process.cwd(), "tmp", `neotoma-oauth-token-endpoint-${Date.now()}`);
     const { oauth, localAuth, app } = await loadLocalModules(currentTempDir);
-    localAuth.createLocalAuthUser("token-endpoint@example.com", "password123");
-    const user = localAuth.getLocalAuthUserByEmail("token-endpoint@example.com");
+    await localAuth.createLocalAuthUser("token-endpoint@example.com", "password123");
+    const user = await localAuth.getLocalAuthUserByEmail("token-endpoint@example.com");
     if (!user) {
       throw new Error("Local auth user not found in test");
     }

--- a/tests/integration/merge_repoint_relationship_edges.test.ts
+++ b/tests/integration/merge_repoint_relationship_edges.test.ts
@@ -22,11 +22,13 @@
  * `npm run test:integration`.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { db } from "../../src/db.js";
 import { repointRelationshipObservations } from "../../src/services/observation_storage.js";
 import { createRelationshipObservations } from "../../src/services/interpretation.js";
 import { mergeEntities } from "../../src/services/entity_merge.js";
+import { getDb } from "../../src/repositories/db/connection.js";
+import type { DbConnection } from "../../src/repositories/db/driver.js";
 
 const TEST_USER = "test-merge-repoint-1507";
 
@@ -469,5 +471,101 @@ describe("mergeEntities() — round-trip integration (#1507 transaction wrap)", 
 
     expect(tombstone).toBeDefined();
     expect((tombstone as { merged_to_entity_id: string }).merged_to_entity_id).toBe(entityA);
+  });
+
+  // Async-transaction rollback (PR #1944, QA blocker). The merge sequence was
+  // rewritten from a synchronous better-sqlite3 db.transaction(fn)() to an async
+  // db.transaction(async (tx) => …). This asserts atomicity is preserved under
+  // the async contract: a failure late in the sequence (after the observation
+  // rewrite, relationship repoint, and snapshot deletes have run) rolls the
+  // WHOLE thing back — the source entity stays alive and its edges intact,
+  // rather than leaving a half-merged, orphaned-edge state.
+  it("(rollback) a mid-transaction failure leaves the source entity and edges untouched", async () => {
+    const entityA = "ent_e2e_rollback_A";
+    const entityB = "ent_e2e_rollback_B";
+    const entityC = "ent_e2e_rollback_C";
+
+    await seedEntity(entityA);
+    await seedEntity(entityB);
+    await seedEntity(entityC);
+
+    // B → C so the transaction does real repoint work before the injected fault.
+    await createRelationshipObservations(
+      [
+        {
+          relationship_type: "PART_OF",
+          source_entity_id: entityB,
+          target_entity_id: entityC,
+          metadata: { note: "rollback B→C" },
+        },
+      ],
+      "src_e2e_rollback",
+      null,
+      E2E_USER,
+      50
+    );
+
+    // Inject a fault at the entity_merges audit INSERT — step 8 of 9, so every
+    // prior mutation in the transaction has already executed when it throws.
+    const conn = await getDb();
+    const realPrepare = conn.prepare.bind(conn);
+    const spy = vi
+      .spyOn(conn, "prepare")
+      .mockImplementation((sql: string): ReturnType<DbConnection["prepare"]> => {
+        if (sql.includes("INSERT INTO entity_merges")) {
+          throw new Error("injected mid-merge fault");
+        }
+        return realPrepare(sql);
+      });
+
+    try {
+      await expect(
+        mergeEntities({
+          fromEntityId: entityB,
+          toEntityId: entityA,
+          userId: E2E_USER,
+          mergeReason: "rollback test",
+          mergedBy: "test",
+        })
+      ).rejects.toThrow("injected mid-merge fault");
+    } finally {
+      spy.mockRestore();
+    }
+
+    // Source entity B must still be ALIVE (not marked merged) — the merged-mark
+    // and audit rows are in the rolled-back transaction.
+    const { data: source } = await db
+      .from("entities")
+      .select("id, merged_to_entity_id")
+      .eq("id", entityB)
+      .eq("user_id", E2E_USER)
+      .single();
+    expect((source as { merged_to_entity_id: string | null }).merged_to_entity_id).toBeNull();
+
+    // No audit row landed.
+    const { data: audits } = await db
+      .from("entity_merges")
+      .select("id")
+      .eq("user_id", E2E_USER)
+      .eq("from_entity_id", entityB);
+    expect((audits ?? []).length).toBe(0);
+
+    // B's edge is intact and was NOT repointed onto A (observation rewrite +
+    // repoint both rolled back).
+    const { data: bEdges } = await db
+      .from("relationship_observations")
+      .select("relationship_key")
+      .eq("user_id", E2E_USER)
+      .or(`source_entity_id.eq.${entityB},target_entity_id.eq.${entityB}`);
+    expect((bEdges ?? []).map((r: { relationship_key: string }) => r.relationship_key)).toContain(
+      `PART_OF:${entityB}:${entityC}`
+    );
+
+    const { data: aEdges } = await db
+      .from("relationship_observations")
+      .select("id")
+      .eq("user_id", E2E_USER)
+      .or(`source_entity_id.eq.${entityA},target_entity_id.eq.${entityA}`);
+    expect((aEdges ?? []).length).toBe(0);
   });
 });

--- a/tests/scripts/validate_libsql_migration.test.ts
+++ b/tests/scripts/validate_libsql_migration.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Fixture test for scripts/validate_libsql_migration.ts (concurrent-backend plan).
+ *
+ * Exercises the migration-safety checker directly (not the CLI wrapper) against
+ * a sqlite/libsql pair with deliberately injected divergence, so a broken
+ * validator can't silently report "safe to migrate" on a bad database.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { AsyncSqliteDatabase } from "../../src/repositories/sqlite/sqlite_driver.js";
+import { openLibsqlDatabase } from "../../src/repositories/libsql/libsql_driver.js";
+import { validateMigration } from "../../scripts/validate_libsql_migration.js";
+
+const workDir = mkdtempSync(path.join(tmpdir(), "neotoma-libsql-migration-validate-"));
+const cleanups: Array<() => Promise<void>> = [];
+
+afterAll(async () => {
+  for (const cleanup of cleanups) await cleanup();
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+let dbCounter = 0;
+async function seedPair(
+  seedSqlite: (db: AsyncSqliteDatabase) => Promise<void>,
+  seedLibsql: (db: ReturnType<typeof openLibsqlDatabase>) => Promise<void>
+): Promise<{ sqlite: AsyncSqliteDatabase; libsql: ReturnType<typeof openLibsqlDatabase> }> {
+  dbCounter += 1;
+  const sqliteFile = path.join(workDir, `sqlite-${dbCounter}.db`);
+  const libsqlFile = path.join(workDir, `libsql-${dbCounter}.db`);
+
+  const sqlite = new AsyncSqliteDatabase(sqliteFile);
+  const libsql = openLibsqlDatabase(`file:${libsqlFile}`);
+  cleanups.push(() => sqlite.close());
+  cleanups.push(() => libsql.close());
+
+  await seedSqlite(sqlite);
+  await seedLibsql(libsql);
+
+  return { sqlite, libsql };
+}
+
+const CREATE_ENTITIES = "CREATE TABLE entities (entity_id TEXT PRIMARY KEY, entity_type TEXT)";
+const CREATE_SNAPSHOTS = `CREATE TABLE entity_snapshots (
+  entity_id TEXT, entity_type TEXT, snapshot TEXT, computed_at TEXT
+)`;
+
+describe("validateMigration", () => {
+  it("passes when sqlite and libsql views agree", async () => {
+    const { sqlite, libsql } = await seedPair(
+      async (db) => {
+        await db.exec(CREATE_ENTITIES);
+        await db.exec(CREATE_SNAPSHOTS);
+        await db.prepare("INSERT INTO entities VALUES (?, ?)").run("e1", "contact");
+        await db
+          .prepare("INSERT INTO entity_snapshots VALUES (?, ?, ?, ?)")
+          .run("e1", "contact", JSON.stringify({ name: "Alice" }), "2026-01-01T00:00:00Z");
+      },
+      async (db) => {
+        await db.exec(CREATE_ENTITIES);
+        await db.exec(CREATE_SNAPSHOTS);
+        await db.prepare("INSERT INTO entities VALUES (?, ?)").run("e1", "contact");
+        await db
+          .prepare("INSERT INTO entity_snapshots VALUES (?, ?, ?, ?)")
+          .run("e1", "contact", JSON.stringify({ name: "Alice" }), "2026-01-01T00:00:00Z");
+      }
+    );
+
+    const result = await validateMigration(sqlite, libsql);
+
+    expect(result.passed).toBe(true);
+    expect(result.failedTables).toEqual([]);
+    expect(result.messages.some((m) => m.includes("integrity_check: ok"))).toBe(true);
+  });
+
+  it("fails with the named table when row counts diverge (injected bad data)", async () => {
+    const { sqlite, libsql } = await seedPair(
+      async (db) => {
+        await db.exec(CREATE_ENTITIES);
+        await db.exec(CREATE_SNAPSHOTS);
+        await db.prepare("INSERT INTO entities VALUES (?, ?)").run("e1", "contact");
+        await db.prepare("INSERT INTO entities VALUES (?, ?)").run("e2", "contact");
+      },
+      async (db) => {
+        await db.exec(CREATE_ENTITIES);
+        await db.exec(CREATE_SNAPSHOTS);
+        // Injected bad data: libsql copy is missing a row the source has.
+        await db.prepare("INSERT INTO entities VALUES (?, ?)").run("e1", "contact");
+      }
+    );
+
+    const result = await validateMigration(sqlite, libsql);
+
+    expect(result.passed).toBe(false);
+    expect(result.failedTables).toEqual(["entities"]);
+    expect(result.messages.some((m) => m.includes("entities: sqlite=2 libsql=1"))).toBe(true);
+  });
+
+  it("fails when the snapshot spot check diverges between drivers", async () => {
+    const { sqlite, libsql } = await seedPair(
+      async (db) => {
+        await db.exec(CREATE_ENTITIES);
+        await db.exec(CREATE_SNAPSHOTS);
+        await db
+          .prepare("INSERT INTO entity_snapshots VALUES (?, ?, ?, ?)")
+          .run("e1", "contact", JSON.stringify({ name: "Alice" }), "2026-01-01T00:00:00Z");
+      },
+      async (db) => {
+        await db.exec(CREATE_ENTITIES);
+        await db.exec(CREATE_SNAPSHOTS);
+        // Injected bad data: same row count, but hydrated snapshot content differs.
+        await db
+          .prepare("INSERT INTO entity_snapshots VALUES (?, ?, ?, ?)")
+          .run("e1", "contact", JSON.stringify({ name: "CORRUPTED" }), "2026-01-01T00:00:00Z");
+      }
+    );
+
+    const result = await validateMigration(sqlite, libsql);
+
+    expect(result.passed).toBe(false);
+    expect(result.failedTables).toEqual([]);
+    expect(result.messages.some((m) => m.includes("snapshot spot check: rows differ"))).toBe(
+      true
+    );
+  });
+});

--- a/tests/subscriptions/durable_event_log.test.ts
+++ b/tests/subscriptions/durable_event_log.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { getSqliteDb } from "../../src/repositories/sqlite/sqlite_client.js";
+import { getDb } from "../../src/repositories/db/connection.js";
 import {
   persistSubstrateEvent,
   getEventsAfterSeq,
@@ -39,102 +39,102 @@ function ev(
 }
 
 describe("durable substrate-event log (#1464 Tier 2)", () => {
-  beforeEach(() => {
-    getSqliteDb().prepare("DELETE FROM substrate_events").run();
+  beforeEach(async () => {
+    await (await getDb()).prepare("DELETE FROM substrate_events").run();
   });
-  afterEach(() => {
-    getSqliteDb().prepare("DELETE FROM substrate_events").run();
+  afterEach(async () => {
+    await (await getDb()).prepare("DELETE FROM substrate_events").run();
   });
 
-  it("persist returns a monotonically increasing seq", () => {
-    const s1 = persistSubstrateEvent(ev("a"), null);
-    const s2 = persistSubstrateEvent(ev("b"), null);
+  it("persist returns a monotonically increasing seq", async () => {
+    const s1 = await persistSubstrateEvent(ev("a"), null);
+    const s2 = await persistSubstrateEvent(ev("b"), null);
     expect(s2).toBeGreaterThan(s1);
   });
 
-  it("recovers events after the cursor even when the ring is gone (restart sim)", () => {
-    const s1 = persistSubstrateEvent(ev("r1"), null);
-    persistSubstrateEvent(ev("r2"), null);
-    persistSubstrateEvent(ev("r3"), null);
+  it("recovers events after the cursor even when the ring is gone (restart sim)", async () => {
+    const s1 = await persistSubstrateEvent(ev("r1"), null);
+    await persistSubstrateEvent(ev("r2"), null);
+    await persistSubstrateEvent(ev("r3"), null);
 
     // Simulate a reconnect with a cursor that is no longer in any in-memory
     // ring: read straight from the durable log.
-    const recovered = getEventsAfterSeq(USER, s1);
+    const recovered = await getEventsAfterSeq(USER, s1);
     const ids = recovered.map((d) => d.event.entity_id);
     expect(ids).toEqual(["r2", "r3"]);
     // Returned seqs are strictly greater than the cursor.
     expect(recovered.every((d) => d.seq > s1)).toBe(true);
   });
 
-  it("hasDurableCursor is true within retention, false once pruned away", () => {
+  it("hasDurableCursor is true within retention, false once pruned away", async () => {
     const oldNow = Date.parse("2026-01-01T00:00:00.000Z");
-    const seqOld = persistSubstrateEvent(ev("old"), null, new Date(oldNow).toISOString());
+    const seqOld = await persistSubstrateEvent(ev("old"), null, new Date(oldNow).toISOString());
 
     // Cursor is present, so it is recoverable.
-    expect(hasDurableCursor(USER, seqOld)).toBe(true);
+    expect(await hasDurableCursor(USER, seqOld)).toBe(true);
 
     // Prune relative to a "now" 8 days after the old event with a 7-day window:
     // the old event falls outside retention and is removed.
     const eightDaysLater = oldNow + 8 * 24 * 60 * 60 * 1000;
-    const pruned = pruneEventLog(7, eightDaysLater);
+    const pruned = await pruneEventLog(7, eightDaysLater);
     expect(pruned).toBe(1);
 
     // With the row gone, the cursor is beyond retention → not recoverable.
-    expect(hasDurableCursor(USER, seqOld)).toBe(false);
+    expect(await hasDurableCursor(USER, seqOld)).toBe(false);
   });
 
-  it("pruning keeps events inside the window and drops only older ones", () => {
+  it("pruning keeps events inside the window and drops only older ones", async () => {
     const base = Date.parse("2026-01-01T00:00:00.000Z");
     // One old (10 days ago) and one recent (1 day ago) relative to `now`.
     const now = base + 10 * 24 * 60 * 60 * 1000;
-    persistSubstrateEvent(ev("stale"), null, new Date(base).toISOString());
-    const recentSeq = persistSubstrateEvent(
+    await persistSubstrateEvent(ev("stale"), null, new Date(base).toISOString());
+    const recentSeq = await persistSubstrateEvent(
       ev("fresh"),
       null,
       new Date(now - 24 * 60 * 60 * 1000).toISOString()
     );
 
-    const pruned = pruneEventLog(7, now);
+    const pruned = await pruneEventLog(7, now);
     expect(pruned).toBe(1); // only the stale one
 
-    const remaining = getEventsAfterSeq(USER, 0);
+    const remaining = await getEventsAfterSeq(USER, 0);
     expect(remaining.map((d) => d.event.entity_id)).toEqual(["fresh"]);
-    expect(hasDurableCursor(USER, recentSeq)).toBe(true);
+    expect(await hasDurableCursor(USER, recentSeq)).toBe(true);
   });
 
-  it("preserves NULL user_id / entity_id without crashing", () => {
+  it("preserves NULL user_id / entity_id without crashing", async () => {
     const e = ev("n");
     // @ts-expect-error intentional: exercise the NULL-coalescing path
     e.user_id = undefined;
-    const seq = persistSubstrateEvent(e, null);
+    const seq = await persistSubstrateEvent(e, null);
     expect(seq).toBeGreaterThan(0);
     // Stored with NULL user_id; a user-scoped read does not return it.
-    expect(getEventsAfterSeq(USER, 0).length).toBe(0);
+    expect((await getEventsAfterSeq(USER, 0)).length).toBe(0);
   });
 
   // --- Advisory 1: SQL-side narrowing (#1482 review) ---
 
-  it("narrows by event_type in SQL without widening the result set", () => {
-    persistSubstrateEvent(ev("created-1", { eventType: "entity.created" }), null);
-    persistSubstrateEvent(ev("updated-1", { eventType: "entity.updated" }), null);
-    persistSubstrateEvent(ev("created-2", { eventType: "entity.created" }), null);
+  it("narrows by event_type in SQL without widening the result set", async () => {
+    await persistSubstrateEvent(ev("created-1", { eventType: "entity.created" }), null);
+    await persistSubstrateEvent(ev("updated-1", { eventType: "entity.updated" }), null);
+    await persistSubstrateEvent(ev("created-2", { eventType: "entity.created" }), null);
 
-    const filtered = getEventsAfterSeq(USER, 0, 1000, {
+    const filtered = await getEventsAfterSeq(USER, 0, 1000, {
       eventTypes: ["entity.updated"],
     });
     expect(filtered.map((d) => d.event.entity_id)).toEqual(["updated-1"]);
 
     // No filter still returns everything (narrowing never widens or hides).
-    expect(getEventsAfterSeq(USER, 0).length).toBe(3);
+    expect((await getEventsAfterSeq(USER, 0)).length).toBe(3);
   });
 
-  it("narrows by entity_id in SQL and combines with event_type", () => {
-    persistSubstrateEvent(ev("a", { eventType: "entity.created" }), null);
-    persistSubstrateEvent(ev("b", { eventType: "entity.created" }), null);
-    persistSubstrateEvent(ev("b", { eventType: "entity.updated" }), null);
+  it("narrows by entity_id in SQL and combines with event_type", async () => {
+    await persistSubstrateEvent(ev("a", { eventType: "entity.created" }), null);
+    await persistSubstrateEvent(ev("b", { eventType: "entity.created" }), null);
+    await persistSubstrateEvent(ev("b", { eventType: "entity.updated" }), null);
 
-    expect(getEventsAfterSeq(USER, 0, 1000, { entityIds: ["b"] }).length).toBe(2);
-    const combined = getEventsAfterSeq(USER, 0, 1000, {
+    expect((await getEventsAfterSeq(USER, 0, 1000, { entityIds: ["b"] })).length).toBe(2);
+    const combined = await getEventsAfterSeq(USER, 0, 1000, {
       entityIds: ["b"],
       eventTypes: ["entity.updated"],
     });
@@ -142,37 +142,39 @@ describe("durable substrate-event log (#1464 Tier 2)", () => {
     expect(combined[0]!.event.event_type).toBe("entity.updated");
   });
 
-  it("treats an empty filter array as no restriction", () => {
-    persistSubstrateEvent(ev("x"), null);
-    persistSubstrateEvent(ev("y"), null);
-    expect(getEventsAfterSeq(USER, 0, 1000, { eventTypes: [], entityIds: [] }).length).toBe(2);
+  it("treats an empty filter array as no restriction", async () => {
+    await persistSubstrateEvent(ev("x"), null);
+    await persistSubstrateEvent(ev("y"), null);
+    expect(
+      (await getEventsAfterSeq(USER, 0, 1000, { eventTypes: [], entityIds: [] })).length
+    ).toBe(2);
   });
 
   // --- Advisory 2: cursor-ahead-of-head false positive (#1482 review) ---
 
-  it("hasDurableCursor is false when the cursor is ahead of the durable head", () => {
-    const seq = persistSubstrateEvent(ev("only"), null);
+  it("hasDurableCursor is false when the cursor is ahead of the durable head", async () => {
+    const seq = await persistSubstrateEvent(ev("only"), null);
     // Exactly at head: nothing strictly newer to replay, but it is the boundary —
     // recoverable (replay returns empty, then falls through to ring).
-    expect(hasDurableCursor(USER, seq)).toBe(true);
+    expect(await hasDurableCursor(USER, seq)).toBe(true);
     // Ahead of head (e.g. a ring-only id or future seq): NOT durably recoverable,
     // must fall through to the ring rather than silently deliver nothing.
-    expect(hasDurableCursor(USER, seq + 1)).toBe(false);
-    expect(hasDurableCursor(USER, seq + 50)).toBe(false);
+    expect(await hasDurableCursor(USER, seq + 1)).toBe(false);
+    expect(await hasDurableCursor(USER, seq + 50)).toBe(false);
   });
 
-  it("hasDurableCursor is false for a quiet user with no durable events", () => {
+  it("hasDurableCursor is false for a quiet user with no durable events", async () => {
     // No rows persisted for this user at all.
-    expect(hasDurableCursor("11111111-1111-1111-1111-111111111111", 0)).toBe(false);
-    expect(hasDurableCursor("11111111-1111-1111-1111-111111111111", 999)).toBe(false);
+    expect(await hasDurableCursor("11111111-1111-1111-1111-111111111111", 0)).toBe(false);
+    expect(await hasDurableCursor("11111111-1111-1111-1111-111111111111", 999)).toBe(false);
   });
 
-  it("hasDurableCursor still accepts a cursor one below the oldest retained seq", () => {
-    const seq = persistSubstrateEvent(ev("first"), null);
+  it("hasDurableCursor still accepts a cursor one below the oldest retained seq", async () => {
+    const seq = await persistSubstrateEvent(ev("first"), null);
     // Resuming from just before the oldest event replays it gap-free.
-    expect(hasDurableCursor(USER, seq - 1)).toBe(true);
+    expect(await hasDurableCursor(USER, seq - 1)).toBe(true);
     // Two below the oldest means an event was pruned between cursor and window.
-    expect(hasDurableCursor(USER, seq - 2)).toBe(false);
+    expect(await hasDurableCursor(USER, seq - 2)).toBe(false);
   });
 });
 
@@ -184,11 +186,11 @@ describe("durable substrate-event log: payload encryption at rest", () => {
     "test test test test test test test test test test test test " +
     "test test test test test test test test test test test junk";
 
-  beforeEach(() => {
-    getSqliteDb().prepare("DELETE FROM substrate_events").run();
+  beforeEach(async () => {
+    await (await getDb()).prepare("DELETE FROM substrate_events").run();
   });
-  afterEach(() => {
-    getSqliteDb().prepare("DELETE FROM substrate_events").run();
+  afterEach(async () => {
+    await (await getDb()).prepare("DELETE FROM substrate_events").run();
     config.encryption.enabled = false;
     config.encryption.mnemonic = "";
     clearCachedDataKey();
@@ -202,52 +204,52 @@ describe("durable substrate-event log: payload encryption at rest", () => {
     clearCachedDataKey();
   }
 
-  function rawPayload(seq: number): string {
-    const row = getSqliteDb()
+  async function rawPayload(seq: number): Promise<string> {
+    const row = (await (await getDb())
       .prepare("SELECT payload FROM substrate_events WHERE seq = ?")
-      .get(seq) as { payload: string } | undefined;
+      .get(seq)) as { payload: string } | undefined;
     return row?.payload ?? "";
   }
 
-  it("writes the payload as ciphertext on disk when encryption is enabled", () => {
+  it("writes the payload as ciphertext on disk when encryption is enabled", async () => {
     enableEncryption();
-    const seq = persistSubstrateEvent(ev("secret-entity"), null);
+    const seq = await persistSubstrateEvent(ev("secret-entity"), null);
 
-    const stored = rawPayload(seq);
+    const stored = await rawPayload(seq);
     // Stored value is the iv:authTag:ciphertext format, not the plaintext JSON.
     expect(isEncryptedColumn(stored)).toBe(true);
     expect(stored).not.toContain("secret-entity");
     expect(stored).not.toContain("entity.created");
   });
 
-  it("round-trips an encrypted payload back to the original event on read", () => {
+  it("round-trips an encrypted payload back to the original event on read", async () => {
     enableEncryption();
-    const seq = persistSubstrateEvent(ev("rt"), null);
+    const seq = await persistSubstrateEvent(ev("rt"), null);
 
-    const recovered = getEventsAfterSeq(USER, seq - 1);
+    const recovered = await getEventsAfterSeq(USER, seq - 1);
     expect(recovered).toHaveLength(1);
     expect(recovered[0]!.event.entity_id).toBe("rt");
     expect(recovered[0]!.event.event_type).toBe("entity.created");
   });
 
-  it("reads legacy plaintext rows written before encryption was enabled", () => {
+  it("reads legacy plaintext rows written before encryption was enabled", async () => {
     // Write a plaintext row (encryption disabled), then enable encryption.
-    const plainSeq = persistSubstrateEvent(ev("legacy"), null);
-    expect(isEncryptedColumn(rawPayload(plainSeq))).toBe(false);
+    const plainSeq = await persistSubstrateEvent(ev("legacy"), null);
+    expect(isEncryptedColumn(await rawPayload(plainSeq))).toBe(false);
 
     enableEncryption();
-    const encSeq = persistSubstrateEvent(ev("modern"), null);
-    expect(isEncryptedColumn(rawPayload(encSeq))).toBe(true);
+    const encSeq = await persistSubstrateEvent(ev("modern"), null);
+    expect(isEncryptedColumn(await rawPayload(encSeq))).toBe(true);
 
     // Both the legacy-plaintext and the newly-encrypted row read back correctly.
-    const recovered = getEventsAfterSeq(USER, plainSeq - 1);
+    const recovered = await getEventsAfterSeq(USER, plainSeq - 1);
     expect(recovered.map((d) => d.event.entity_id)).toEqual(["legacy", "modern"]);
   });
 
-  it("still writes plaintext when encryption is disabled (no key)", () => {
-    const seq = persistSubstrateEvent(ev("plain"), null);
-    expect(isEncryptedColumn(rawPayload(seq))).toBe(false);
-    const recovered = getEventsAfterSeq(USER, seq - 1);
+  it("still writes plaintext when encryption is disabled (no key)", async () => {
+    const seq = await persistSubstrateEvent(ev("plain"), null);
+    expect(isEncryptedColumn(await rawPayload(seq))).toBe(false);
+    const recovered = await getEventsAfterSeq(USER, seq - 1);
     expect(recovered[0]!.event.entity_id).toBe("plain");
   });
 });

--- a/tests/unit/compliance_scorecard.test.ts
+++ b/tests/unit/compliance_scorecard.test.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { getSqliteDb } from "../../src/repositories/sqlite/sqlite_client.js";
+import { getDb } from "../../src/repositories/db/connection.js";
 import {
   buildComplianceScorecard,
   resolveScorecardWindow,
@@ -8,7 +8,7 @@ import {
 
 const TEST_USER_ID = `compliance-sc-${randomUUID().slice(0, 8)}`;
 
-function seedTurn(input: {
+async function seedTurn(input: {
   session_id: string;
   turn_id: string;
   harness: string;
@@ -18,7 +18,7 @@ function seedTurn(input: {
   started_at: string;
   ended_at: string;
 }) {
-  const db = getSqliteDb();
+  const db = await getDb();
   const turnKey = `${input.session_id}:${input.turn_id}`;
   const id = `ent_comp_${input.session_id}_${input.turn_id}`;
   const snapshot = {
@@ -33,20 +33,22 @@ function seedTurn(input: {
     started_at: input.started_at,
     ended_at: input.ended_at,
   };
-  db.prepare(
-    `INSERT OR REPLACE INTO entities (id, entity_type, canonical_name, aliases, created_at, updated_at, user_id, first_seen_at, last_seen_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-  ).run(
-    id,
-    "conversation_turn",
-    turnKey,
-    JSON.stringify([]),
-    input.started_at,
-    input.ended_at,
-    TEST_USER_ID,
-    input.started_at,
-    input.ended_at,
-  );
-  db.prepare(
+  await db
+    .prepare(
+      `INSERT OR REPLACE INTO entities (id, entity_type, canonical_name, aliases, created_at, updated_at, user_id, first_seen_at, last_seen_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      id,
+      "conversation_turn",
+      turnKey,
+      JSON.stringify([]),
+      input.started_at,
+      input.ended_at,
+      TEST_USER_ID,
+      input.started_at,
+      input.ended_at,
+    );
+  await db.prepare(
     `INSERT OR REPLACE INTO entity_snapshots (entity_id, entity_type, schema_version, canonical_name, snapshot, computed_at, observation_count, last_observation_at, user_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     id,
@@ -64,8 +66,8 @@ function seedTurn(input: {
 describe("compliance scorecard", () => {
   const refMs = Date.parse("2026-04-28T15:00:00.000Z");
 
-  beforeAll(() => {
-    seedTurn({
+  beforeAll(async () => {
+    await seedTurn({
       session_id: "s1",
       turn_id: "t1",
       harness: "cursor",
@@ -74,7 +76,7 @@ describe("compliance scorecard", () => {
       started_at: "2026-04-27T10:00:00.000Z",
       ended_at: "2026-04-27T10:05:00.000Z",
     });
-    seedTurn({
+    await seedTurn({
       session_id: "s1",
       turn_id: "t2",
       harness: "cursor",
@@ -84,7 +86,7 @@ describe("compliance scorecard", () => {
       started_at: "2026-04-27T11:00:00.000Z",
       ended_at: "2026-04-27T11:05:00.000Z",
     });
-    seedTurn({
+    await seedTurn({
       session_id: "s2",
       turn_id: "t1",
       harness: "claude-code",
@@ -95,12 +97,12 @@ describe("compliance scorecard", () => {
     });
   });
 
-  afterAll(() => {
-    const db = getSqliteDb();
+  afterAll(async () => {
+    const db = await getDb();
     const ids = ["ent_comp_s1_t1", "ent_comp_s1_t2", "ent_comp_s2_t1"];
     for (const id of ids) {
-      db.prepare(`DELETE FROM entity_snapshots WHERE entity_id = ?`).run(id);
-      db.prepare(`DELETE FROM entities WHERE id = ?`).run(id);
+      await db.prepare(`DELETE FROM entity_snapshots WHERE entity_id = ?`).run(id);
+      await db.prepare(`DELETE FROM entities WHERE id = ?`).run(id);
     }
   });
 
@@ -111,8 +113,8 @@ describe("compliance scorecard", () => {
     expect(refMs - sinceT).toBe(7 * 86400000);
   });
 
-  it("aggregates model+harness cells and summary", () => {
-    const card = buildComplianceScorecard(TEST_USER_ID, {
+  it("aggregates model+harness cells and summary", async () => {
+    const card = await buildComplianceScorecard(TEST_USER_ID, {
       since: "7d",
       until: "2026-04-28T23:59:59.999Z",
       group_by: "model+harness",
@@ -132,8 +134,8 @@ describe("compliance scorecard", () => {
     expect(cursorA!.top_missed_steps[0]?.step).toBe("user_phase_store");
   });
 
-  it("respects min_turns filter", () => {
-    const card = buildComplianceScorecard(TEST_USER_ID, {
+  it("respects min_turns filter", async () => {
+    const card = await buildComplianceScorecard(TEST_USER_ID, {
       since: "7d",
       until: "2026-04-28T23:59:59.999Z",
       group_by: "model+harness",

--- a/tests/unit/config_db_backend.test.ts
+++ b/tests/unit/config_db_backend.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Unit tests for NEOTOMA_DB_BACKEND validation (concurrent-backend plan,
+ * PR #1944 QA follow-up).
+ *
+ * src/config.ts validates NEOTOMA_DB_BACKEND at module load time (a top-level
+ * throw, not inside an exported function), so these tests exercise it via
+ * fresh dynamic imports under different env values rather than calling a
+ * function directly.
+ */
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+async function importFreshConfig() {
+  vi.resetModules();
+  return import("../../src/config.ts");
+}
+
+async function makeProjectRoot(prefix: string): Promise<{ homeDir: string; projectRoot: string }> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  const homeDir = path.join(root, "home");
+  const projectRoot = path.join(root, "project");
+  await fs.mkdir(homeDir, { recursive: true });
+  await fs.mkdir(projectRoot, { recursive: true });
+  await fs.writeFile(
+    path.join(projectRoot, "package.json"),
+    JSON.stringify({ name: "neotoma", version: "0.0.0-test" }, null, 2)
+  );
+  return { homeDir, projectRoot };
+}
+
+async function stubBaseEnv(prefix: string) {
+  const { homeDir, projectRoot } = await makeProjectRoot(prefix);
+  vi.stubEnv("HOME", homeDir);
+  vi.stubEnv("USERPROFILE", homeDir);
+  vi.stubEnv("NEOTOMA_ENV", "development");
+  vi.stubEnv("NEOTOMA_PROJECT_ROOT", projectRoot);
+  vi.stubEnv("NEOTOMA_DATA_DIR", path.join(projectRoot, "data"));
+}
+
+describe("NEOTOMA_DB_BACKEND validation", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it("defaults to sqlite when unset", async () => {
+    await stubBaseEnv("neotoma-db-backend-default-");
+    vi.stubEnv("NEOTOMA_DB_BACKEND", "");
+
+    const { config } = await importFreshConfig();
+    expect(config.dbBackend).toBe("sqlite");
+  });
+
+  it.each(["sqlite", "SQLITE", "libsql", "LibSQL"])(
+    "accepts %s case-insensitively",
+    async (value) => {
+      await stubBaseEnv(`neotoma-db-backend-case-${value}-`);
+      vi.stubEnv("NEOTOMA_DB_BACKEND", value);
+
+      const { config } = await importFreshConfig();
+      expect(config.dbBackend).toBe(value.toLowerCase());
+    }
+  );
+
+  it("throws a clear error for an invalid backend value", async () => {
+    await stubBaseEnv("neotoma-db-backend-invalid-");
+    vi.stubEnv("NEOTOMA_DB_BACKEND", "postgres");
+
+    await expect(importFreshConfig()).rejects.toThrow(
+      /Invalid NEOTOMA_DB_BACKEND "postgres": expected "sqlite" or "libsql"/
+    );
+  });
+});

--- a/tests/unit/db_driver_contract.test.ts
+++ b/tests/unit/db_driver_contract.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Async DB driver contract tests (concurrent-backend plan).
+ *
+ * Runs the same behavioral suite against both backends — the synchronous
+ * SQLite driver wrapped in the async contract, and the libSQL driver — so a
+ * backend swap via NEOTOMA_DB_BACKEND cannot silently change semantics:
+ * run/get/all results, positional-vs-array binding, run() change counts,
+ * transaction commit/rollback atomicity, statement isolation while a
+ * transaction is open, and the AsyncLocalStorage join rule (statements issued
+ * on the db handle inside a transaction callback land inside the transaction).
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import type { DbDatabase } from "../../src/repositories/db/driver.js";
+import { AsyncSqliteDatabase } from "../../src/repositories/sqlite/sqlite_driver.js";
+import { openLibsqlDatabase } from "../../src/repositories/libsql/libsql_driver.js";
+
+const workDir = mkdtempSync(path.join(tmpdir(), "neotoma-driver-contract-"));
+const cleanups: Array<() => Promise<void>> = [];
+
+afterAll(async () => {
+  for (const cleanup of cleanups) await cleanup();
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+let dbCounter = 0;
+function makeDb(backend: "sqlite" | "libsql"): DbDatabase {
+  dbCounter += 1;
+  const file = path.join(workDir, `${backend}-${dbCounter}.db`);
+  const db: DbDatabase =
+    backend === "sqlite" ? new AsyncSqliteDatabase(file) : openLibsqlDatabase(`file:${file}`);
+  cleanups.push(() => db.close());
+  return db;
+}
+
+describe.each(["sqlite", "libsql"] as const)("db driver contract (%s)", (backend) => {
+  it("runs DDL/DML and reads rows back as plain objects", async () => {
+    const db = makeDb(backend);
+    await db.exec("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT, score REAL)");
+
+    const insert = await db
+      .prepare("INSERT INTO t (id, name, score) VALUES (?, ?, ?)")
+      .run(1, "alpha", 1.5);
+    expect(insert.changes).toBe(1);
+
+    // Array-style binding (adapter passes a values array as a single arg).
+    await db.prepare("INSERT INTO t (id, name, score) VALUES (?, ?, ?)").run([2, "beta", 2.5]);
+
+    const row = (await db.prepare("SELECT * FROM t WHERE id = ?").get(1)) as Record<
+      string,
+      unknown
+    >;
+    expect(row).toEqual({ id: 1, name: "alpha", score: 1.5 });
+    // Must be spreadable/JSON-serializable like a plain object.
+    expect({ ...row }).toEqual({ id: 1, name: "alpha", score: 1.5 });
+
+    const all = (await db.prepare("SELECT * FROM t ORDER BY id").all()) as Record<
+      string,
+      unknown
+    >[];
+    expect(all.map((r) => r.name)).toEqual(["alpha", "beta"]);
+
+    const missing = await db.prepare("SELECT * FROM t WHERE id = ?").get(999);
+    expect(missing).toBeUndefined();
+  });
+
+  it("binds null/undefined/boolean values safely", async () => {
+    const db = makeDb(backend);
+    await db.exec("CREATE TABLE b (id INTEGER PRIMARY KEY, flag INTEGER, note TEXT)");
+    await db.prepare("INSERT INTO b (id, flag, note) VALUES (?, ?, ?)").run(1, true, null);
+    const row = (await db.prepare("SELECT * FROM b WHERE id = 1").get()) as Record<
+      string,
+      unknown
+    >;
+    expect(row.flag).toBe(1);
+    expect(row.note).toBeNull();
+  });
+
+  it("reports UPDATE/DELETE change counts", async () => {
+    const db = makeDb(backend);
+    await db.exec("CREATE TABLE c (id INTEGER PRIMARY KEY, v TEXT)");
+    await db.prepare("INSERT INTO c (id, v) VALUES (1, 'x'), (2, 'x'), (3, 'y')").run();
+    const updated = await db.prepare("UPDATE c SET v = 'z' WHERE v = 'x'").run();
+    expect(updated.changes).toBe(2);
+    const deleted = await db.prepare("DELETE FROM c WHERE v = 'z'").run();
+    expect(deleted.changes).toBe(2);
+  });
+
+  it("commits a transaction and returns the callback result", async () => {
+    const db = makeDb(backend);
+    await db.exec("CREATE TABLE tx (id INTEGER PRIMARY KEY, v TEXT)");
+    const result = await db.transaction(async (tx) => {
+      await tx.prepare("INSERT INTO tx (id, v) VALUES (?, ?)").run(1, "committed");
+      const inserted = await tx.prepare("SELECT v FROM tx WHERE id = 1").get();
+      return inserted;
+    });
+    expect(result).toEqual({ v: "committed" });
+    const persisted = await db.prepare("SELECT COUNT(*) AS n FROM tx").get();
+    expect(persisted).toEqual({ n: 1 });
+  });
+
+  it("rolls back the whole transaction when the callback throws", async () => {
+    const db = makeDb(backend);
+    await db.exec("CREATE TABLE rb (id INTEGER PRIMARY KEY, v TEXT)");
+    await expect(
+      db.transaction(async (tx) => {
+        await tx.prepare("INSERT INTO rb (id, v) VALUES (1, 'a')").run();
+        await tx.prepare("INSERT INTO rb (id, v) VALUES (2, 'b')").run();
+        throw new Error("boom");
+      })
+    ).rejects.toThrow("boom");
+    const count = await db.prepare("SELECT COUNT(*) AS n FROM rb").get();
+    expect(count).toEqual({ n: 0 });
+  });
+
+  it("keeps statements issued outside an open transaction out of it", async () => {
+    const db = makeDb(backend);
+    await db.exec("CREATE TABLE iso (id INTEGER PRIMARY KEY, v TEXT)");
+
+    let outsideDone = false;
+    let insideDone = false;
+    const txPromise = db.transaction(async (tx) => {
+      await tx.prepare("INSERT INTO iso (id, v) VALUES (1, 'in-tx')").run();
+      // Yield so a queued outside write would have the chance to interleave
+      // if the gate were broken.
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      insideDone = true;
+      throw new Error("rollback-please");
+    });
+    // Issued while the transaction is open, from OUTSIDE its async context:
+    // must queue until the transaction settles, then apply independently.
+    const outsidePromise = db
+      .prepare("INSERT INTO iso (id, v) VALUES (2, 'outside')")
+      .run()
+      .then(() => {
+        outsideDone = true;
+        expect(insideDone).toBe(true); // gate held it until the tx settled
+      });
+
+    await expect(txPromise).rejects.toThrow("rollback-please");
+    await outsidePromise;
+    expect(outsideDone).toBe(true);
+
+    const rows = (await db.prepare("SELECT id, v FROM iso ORDER BY id").all()) as Array<{
+      id: number;
+      v: string;
+    }>;
+    // The tx insert rolled back; the outside insert survived independently.
+    expect(rows).toEqual([{ id: 2, v: "outside" }]);
+  });
+
+  it("routes db-handle statements inside a transaction callback into the transaction", async () => {
+    const db = makeDb(backend);
+    await db.exec("CREATE TABLE als (id INTEGER PRIMARY KEY, v TEXT)");
+    await expect(
+      db.transaction(async () => {
+        // Uses the db handle, not the tx handle — must join the open
+        // transaction (old synchronous semantics), not deadlock or escape it.
+        await db.prepare("INSERT INTO als (id, v) VALUES (1, 'joined')").run();
+        throw new Error("undo");
+      })
+    ).rejects.toThrow("undo");
+    const count = await db.prepare("SELECT COUNT(*) AS n FROM als").get();
+    expect(count).toEqual({ n: 0 }); // joined the tx, so it rolled back too
+  });
+
+  it("serializes back-to-back transactions", async () => {
+    const db = makeDb(backend);
+    await db.exec("CREATE TABLE seq (id INTEGER PRIMARY KEY AUTOINCREMENT, tag TEXT)");
+    await Promise.all(
+      ["a", "b", "c"].map((tag) =>
+        db.transaction(async (tx) => {
+          await tx.prepare("INSERT INTO seq (tag) VALUES (?)").run(tag);
+          await new Promise((resolve) => setTimeout(resolve, 5));
+          await tx.prepare("INSERT INTO seq (tag) VALUES (?)").run(tag);
+        })
+      )
+    );
+    const rows = (await db.prepare("SELECT tag FROM seq ORDER BY id").all()) as Array<{
+      tag: string;
+    }>;
+    // Each transaction's two inserts must be adjacent (no interleaving).
+    for (let i = 0; i < rows.length; i += 2) {
+      expect(rows[i].tag).toBe(rows[i + 1].tag);
+    }
+  });
+
+  it("supports pragma()", async () => {
+    const db = makeDb(backend);
+    const rows = await db.pragma("journal_mode = WAL");
+    expect(Array.isArray(rows)).toBe(true);
+  });
+});

--- a/tests/unit/db_driver_contract.test.ts
+++ b/tests/unit/db_driver_contract.test.ts
@@ -15,6 +15,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterAll, describe, expect, it } from "vitest";
 import type { DbDatabase } from "../../src/repositories/db/driver.js";
+import { NESTED_TRANSACTION_ERROR } from "../../src/repositories/db/driver.js";
 import { AsyncSqliteDatabase } from "../../src/repositories/sqlite/sqlite_driver.js";
 import { openLibsqlDatabase } from "../../src/repositories/libsql/libsql_driver.js";
 
@@ -192,5 +193,28 @@ describe.each(["sqlite", "libsql"] as const)("db driver contract (%s)", (backend
     const db = makeDb(backend);
     const rows = await db.pragma("journal_mode = WAL");
     expect(Array.isArray(rows)).toBe(true);
+  });
+
+  it("throws a clear error on a nested transaction() instead of deadlocking", async () => {
+    const db = makeDb(backend);
+    await db.exec("CREATE TABLE nested (id INTEGER PRIMARY KEY)");
+    // A transaction() issued from inside another transaction's callback would
+    // await the gate tail that only resolves once the outer (waiting)
+    // transaction finishes — a self-deadlock. It must fail fast instead of
+    // hanging. Promise.race with a timer guards the test against a regression
+    // that reintroduces the hang.
+    const attempt = db.transaction(async () => {
+      await db.transaction(async () => {
+        /* unreachable — the outer guard must reject first */
+      });
+    });
+    const timed = Promise.race([
+      attempt.then(
+        () => "resolved",
+        (e: Error) => e.message
+      ),
+      new Promise<string>((resolve) => setTimeout(() => resolve("DEADLOCK-TIMEOUT"), 3000)),
+    ]);
+    expect(await timed).toContain(NESTED_TRANSACTION_ERROR);
   });
 });

--- a/tests/unit/db_idempotency_concurrency.test.ts
+++ b/tests/unit/db_idempotency_concurrency.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Idempotency-under-concurrency (concurrent-backend plan, PR #1944 arch §3).
+ *
+ * The store path dedups content-addressed observations with a check-then-write:
+ * `SELECT ... WHERE id = ?`, and if absent, `INSERT`. Waxwing's arch review
+ * flagged that moving off the fully-synchronous better-sqlite3 driver removes
+ * the incidental mutex the blocking driver provided — two concurrent identical
+ * stores can now both pass the existence check before either inserts (a TOCTOU
+ * the old single-threaded driver structurally prevented).
+ *
+ * The real idempotency guarantee is therefore NOT the check — it is the PRIMARY
+ * KEY / UNIQUE constraint on `observations.id` (a deterministic content hash).
+ * This test asserts that guarantee holds under genuine concurrency on BOTH
+ * backends (AsyncSqlite and the worker-hosted libsql local file): N concurrent
+ * inserts of the same-id row settle with exactly one success and the rest
+ * rejected by the constraint, leaving exactly one row. It also asserts the
+ * check-then-write dedup returns the existing row on a sequential re-store.
+ *
+ * Testing at the driver layer (not the config-selected adapter singleton)
+ * lets both backends run in one process and targets the exact invariant:
+ * the constraint survived the async conversion and holds off the main thread.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import type { DbDatabase } from "../../src/repositories/db/driver.js";
+import { AsyncSqliteDatabase } from "../../src/repositories/sqlite/sqlite_driver.js";
+import { openLibsqlDatabase } from "../../src/repositories/libsql/libsql_driver.js";
+
+const workDir = mkdtempSync(path.join(tmpdir(), "neotoma-idem-"));
+const cleanups: Array<() => Promise<void>> = [];
+
+afterAll(async () => {
+  for (const c of cleanups) await c();
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+let counter = 0;
+function makeDb(backend: "sqlite" | "libsql"): DbDatabase {
+  counter += 1;
+  const file = path.join(workDir, `${backend}-${counter}.db`);
+  const db: DbDatabase =
+    backend === "sqlite" ? new AsyncSqliteDatabase(file) : openLibsqlDatabase(`file:${file}`);
+  cleanups.push(() => db.close());
+  return db;
+}
+
+/** Minimal observations table with the id uniqueness the store path relies on. */
+async function createObservationsTable(db: DbDatabase): Promise<void> {
+  await db.exec(`
+    CREATE TABLE observations (
+      id TEXT PRIMARY KEY,
+      entity_id TEXT NOT NULL,
+      user_id TEXT,
+      fields TEXT
+    )
+  `);
+}
+
+function isUniqueViolation(error: unknown): boolean {
+  const msg = String((error as { message?: string })?.message ?? error).toLowerCase();
+  const code = String((error as { code?: string })?.code ?? "").toUpperCase();
+  return (
+    msg.includes("unique") ||
+    msg.includes("primary key") ||
+    msg.includes("constraint") ||
+    code.startsWith("SQLITE_CONSTRAINT")
+  );
+}
+
+describe.each(["sqlite", "libsql"] as const)(
+  "idempotency under concurrency (%s backend)",
+  (backend) => {
+    it("N concurrent inserts of the same observation id yield exactly one row", async () => {
+      const db = makeDb(backend);
+      await createObservationsTable(db);
+
+      const OBS_ID = "obs_content_hash_fixed_1";
+      const insertOnce = () =>
+        db
+          .prepare("INSERT INTO observations (id, entity_id, user_id, fields) VALUES (?, ?, ?, ?)")
+          .run(OBS_ID, "ent_target", "u1", JSON.stringify({ title: "same content" }));
+
+      // Fire concurrent duplicate inserts with no cross-check. On a
+      // fully-synchronous driver only one could ever be mid-flight; here they
+      // race, so the id constraint is the only thing preventing a double write.
+      const results = await Promise.allSettled(Array.from({ length: 8 }, insertOnce));
+
+      const ok = results.filter((r) => r.status === "fulfilled");
+      const rejected = results.filter((r): r is PromiseRejectedResult => r.status === "rejected");
+      expect(ok.length).toBe(1);
+      expect(rejected.length).toBe(7);
+      // Every failure must be the uniqueness constraint, not some other error.
+      for (const r of rejected) expect(isUniqueViolation(r.reason)).toBe(true);
+
+      const count = (await db
+        .prepare("SELECT COUNT(*) AS n FROM observations WHERE id = ?")
+        .get(OBS_ID)) as { n: number };
+      expect(count.n).toBe(1);
+    }, 30_000);
+
+    it("check-then-write dedup: a sequential re-store of the same id is a no-op", async () => {
+      const db = makeDb(backend);
+      await createObservationsTable(db);
+      const OBS_ID = "obs_seq_dedup_1";
+
+      const storeIfAbsent = async (): Promise<"inserted" | "existing"> => {
+        const existing = await db.prepare("SELECT id FROM observations WHERE id = ?").get(OBS_ID);
+        if (existing) return "existing";
+        await db
+          .prepare("INSERT INTO observations (id, entity_id, user_id) VALUES (?, ?, ?)")
+          .run(OBS_ID, "ent_target", "u1");
+        return "inserted";
+      };
+
+      expect(await storeIfAbsent()).toBe("inserted");
+      expect(await storeIfAbsent()).toBe("existing");
+      const count = (await db.prepare("SELECT COUNT(*) AS n FROM observations").get()) as {
+        n: number;
+      };
+      expect(count.n).toBe(1);
+    });
+  }
+);

--- a/tests/unit/db_libsql_nonblocking.test.ts
+++ b/tests/unit/db_libsql_nonblocking.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Regression test for the bottega8 event-loop freeze (concurrent-backend plan).
+ *
+ * With the synchronous SQLite driver, ANY slow query blocks the entire Node
+ * event loop — health checks, the web UI, and concurrent MCP requests all
+ * stall for the query's duration (observed live on a hosted instance: a
+ * deep-offset include_snapshots contact query froze the server for 4.8–7.5s).
+ *
+ * The libSQL backend executes statements off the event loop. This test
+ * asserts that symptom is fixed: while a multi-second query runs, a
+ * concurrent trivial query (standing in for GET /health) completes promptly
+ * and the event loop keeps ticking.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { openLibsqlDatabase } from "../../src/repositories/libsql/libsql_driver.js";
+
+const workDir = mkdtempSync(path.join(tmpdir(), "neotoma-nonblocking-"));
+
+afterAll(() => {
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+describe("libsql backend does not block the event loop", () => {
+  it("answers a concurrent health-check query while a slow query runs", async () => {
+    const db = openLibsqlDatabase(`file:${path.join(workDir, "slow.db")}`);
+    try {
+      await db.exec("CREATE TABLE load (id INTEGER PRIMARY KEY, v TEXT)");
+      await db.exec(`
+        WITH RECURSIVE cnt(x) AS (SELECT 1 UNION ALL SELECT x + 1 FROM cnt WHERE x < 6000)
+        INSERT INTO load (v) SELECT hex(randomblob(96)) FROM cnt
+      `);
+
+      let slowDone = false;
+      const slowStart = Date.now();
+      const slowQuery = (
+        db.prepare("SELECT COUNT(*) AS n FROM load a, load b WHERE a.v < b.v").get() as Promise<{
+          n: number;
+        }>
+      ).then((row) => {
+        slowDone = true;
+        return row;
+      });
+
+      // Give the slow query a moment to actually start executing.
+      await new Promise((resolve) => setTimeout(resolve, 25));
+
+      const healthStart = Date.now();
+      const health = await db.prepare("SELECT 1 AS ok").get();
+      const healthMs = Date.now() - healthStart;
+      const healthFinishedFirst = !slowDone;
+
+      const slow = await slowQuery;
+      const slowMs = Date.now() - slowStart;
+
+      expect(slow.n).toBeGreaterThan(0);
+      // The blocking signature (what the sync driver produces): the event
+      // loop cannot resolve the health check until the slow query finishes,
+      // so healthMs ~= slowMs and the slow query always completes first.
+      // Assertions are relative to the measured slow-query duration, never
+      // absolute wall-clock, so CPU saturation from parallel test workers
+      // cannot produce false failures.
+      expect(healthMs).toBeLessThan(Math.max(200, slowMs / 2));
+      if (slowMs > 300) {
+        expect(healthFinishedFirst).toBe(true);
+      }
+    } finally {
+      await db.close();
+    }
+  }, 60_000);
+});

--- a/tests/unit/db_libsql_remote_class.test.ts
+++ b/tests/unit/db_libsql_remote_class.test.ts
@@ -1,0 +1,150 @@
+/**
+ * LibsqlDatabase (remote sqld/Turso client path) contract tests
+ * (concurrent-backend plan, PR #1944 qa follow-up).
+ *
+ * The driver-contract suite exercises the libsql backend through
+ * openLibsqlDatabase("file:..."), which routes to WorkerFileDatabase — NOT the
+ * LibsqlDatabase class that serves remote sqld/Turso URLs. LibsqlDatabase is a
+ * distinct implementation with its own transaction wiring against
+ * @libsql/client's Transaction object (client.transaction("write"),
+ * tx.commit()/tx.rollback()/tx.close()), its own AsyncLocalStorage join, and its
+ * own pragma/statement classes. That is the path the config docs steer
+ * hosted/multi-tenant instances toward, and it previously had zero coverage.
+ *
+ * We construct LibsqlDatabase directly against a local temp-file @libsql/client
+ * (a `file:` URL — the same code path openLibsqlDatabase deliberately reserves
+ * for the worker, but here we bypass the factory to hit the class itself). This
+ * exercises the real Client, transaction("write"), commit/rollback, the
+ * AsyncLocalStorage join, and the row/pragma classes — everything the remote
+ * path runs except the network transport, which is @libsql/client's concern and
+ * not this driver's. It does NOT claim to verify network behavior against a live
+ * Turso endpoint; the transaction/statement/isolation SEMANTICS of the class are
+ * what this covers, which is the untested surface qa flagged.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { LibsqlDatabase } from "../../src/repositories/libsql/libsql_driver.js";
+import { NESTED_TRANSACTION_ERROR } from "../../src/repositories/db/driver.js";
+
+const workDir = mkdtempSync(path.join(tmpdir(), "neotoma-libsql-remote-"));
+const cleanups: Array<() => Promise<void>> = [];
+
+afterAll(async () => {
+  for (const cleanup of cleanups) await cleanup();
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+let counter = 0;
+function makeDb(): LibsqlDatabase {
+  counter += 1;
+  // A file: URL drives LibsqlDatabase's @libsql/client directly (state shared
+  // across the client's connections — libsql :memory: gives each connection a
+  // fresh DB, which would break multi-statement tests). This is the same class
+  // and transaction API the remote sqld/Turso URL path uses.
+  const db = new LibsqlDatabase(`file:${path.join(workDir, `r-${counter}.db`)}`);
+  cleanups.push(() => db.close());
+  return db;
+}
+
+describe("LibsqlDatabase (remote-client class path)", () => {
+  it("runs DDL/DML and reads rows back as plain objects", async () => {
+    const db = makeDb();
+    await db.exec("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT, score REAL)");
+    const insert = await db.prepare("INSERT INTO t (id, name, score) VALUES (?, ?, ?)").run(1, "alpha", 1.5);
+    expect(insert.changes).toBe(1);
+    await db.prepare("INSERT INTO t (id, name, score) VALUES (?, ?, ?)").run([2, "beta", 2.5]);
+
+    const row = (await db.prepare("SELECT * FROM t WHERE id = ?").get(1)) as Record<string, unknown>;
+    expect(row).toEqual({ id: 1, name: "alpha", score: 1.5 });
+    expect({ ...row }).toEqual({ id: 1, name: "alpha", score: 1.5 });
+
+    const all = (await db.prepare("SELECT * FROM t ORDER BY id").all()) as Record<string, unknown>[];
+    expect(all.map((r) => r.name)).toEqual(["alpha", "beta"]);
+    expect(await db.prepare("SELECT * FROM t WHERE id = ?").get(999)).toBeUndefined();
+  });
+
+  it("reports UPDATE/DELETE change counts and binds null/boolean", async () => {
+    const db = makeDb();
+    await db.exec("CREATE TABLE c (id INTEGER PRIMARY KEY, flag INTEGER, note TEXT)");
+    await db.prepare("INSERT INTO c (id, flag, note) VALUES (?, ?, ?)").run(1, true, null);
+    const row = (await db.prepare("SELECT * FROM c WHERE id = 1").get()) as Record<string, unknown>;
+    expect(row.flag).toBe(1);
+    expect(row.note).toBeNull();
+
+    await db.prepare("INSERT INTO c (id, flag, note) VALUES (2, 1, 'x'), (3, 1, 'x')").run();
+    const updated = await db.prepare("UPDATE c SET note = 'z' WHERE note = 'x'").run();
+    expect(updated.changes).toBe(2);
+  });
+
+  it("commits a transaction and returns the callback result", async () => {
+    const db = makeDb();
+    await db.exec("CREATE TABLE tx (id INTEGER PRIMARY KEY, v TEXT)");
+    const result = await db.transaction(async (t) => {
+      await t.prepare("INSERT INTO tx (id, v) VALUES (?, ?)").run(1, "committed");
+      return t.prepare("SELECT v FROM tx WHERE id = 1").get();
+    });
+    expect(result).toEqual({ v: "committed" });
+    expect(await db.prepare("SELECT COUNT(*) AS n FROM tx").get()).toEqual({ n: 1 });
+  });
+
+  it("rolls back the whole transaction when the callback throws", async () => {
+    const db = makeDb();
+    await db.exec("CREATE TABLE rb (id INTEGER PRIMARY KEY, v TEXT)");
+    await expect(
+      db.transaction(async (t) => {
+        await t.prepare("INSERT INTO rb (id, v) VALUES (1, 'a')").run();
+        await t.prepare("INSERT INTO rb (id, v) VALUES (2, 'b')").run();
+        throw new Error("boom");
+      })
+    ).rejects.toThrow("boom");
+    expect(await db.prepare("SELECT COUNT(*) AS n FROM rb").get()).toEqual({ n: 0 });
+  });
+
+  it("routes db-handle statements inside a transaction callback into the transaction", async () => {
+    const db = makeDb();
+    await db.exec("CREATE TABLE als (id INTEGER PRIMARY KEY, v TEXT)");
+    await expect(
+      db.transaction(async () => {
+        // Uses the db handle, not the tx arg — must join the open transaction
+        // via AsyncLocalStorage, then roll back with it.
+        await db.prepare("INSERT INTO als (id, v) VALUES (1, 'joined')").run();
+        throw new Error("undo");
+      })
+    ).rejects.toThrow("undo");
+    expect(await db.prepare("SELECT COUNT(*) AS n FROM als").get()).toEqual({ n: 0 });
+  });
+
+  it("serializes back-to-back transactions (gate holds order)", async () => {
+    const db = makeDb();
+    await db.exec("CREATE TABLE seq (id INTEGER PRIMARY KEY AUTOINCREMENT, tag TEXT)");
+    await Promise.all(
+      ["a", "b", "c"].map((tag) =>
+        db.transaction(async (t) => {
+          await t.prepare("INSERT INTO seq (tag) VALUES (?)").run(tag);
+        })
+      )
+    );
+    const rows = (await db.prepare("SELECT tag FROM seq ORDER BY id").all()) as Array<{ tag: string }>;
+    expect(rows.map((r) => r.tag).sort()).toEqual(["a", "b", "c"]);
+  });
+
+  it("supports pragma()", async () => {
+    const db = makeDb();
+    const rows = await db.pragma("integrity_check");
+    expect(String(Object.values(rows[0] ?? {})[0] ?? "")).toBe("ok");
+  });
+
+  it("throws a clear error on a nested transaction() instead of deadlocking", async () => {
+    const db = makeDb();
+    await db.exec("CREATE TABLE n (id INTEGER PRIMARY KEY)");
+    await expect(
+      db.transaction(async () => {
+        // A transaction() issued from inside another must fail fast, not hang.
+        await db.transaction(async () => {});
+      })
+    ).rejects.toThrow(NESTED_TRANSACTION_ERROR);
+  });
+});

--- a/tests/unit/db_url_misconfig_guard.test.ts
+++ b/tests/unit/db_url_misconfig_guard.test.ts
@@ -1,0 +1,57 @@
+/**
+ * NEOTOMA_DB_URL / NEOTOMA_DB_BACKEND misconfiguration guard (concurrent-backend
+ * plan, PR #1944 ux follow-up).
+ *
+ * NEOTOMA_DB_URL is only honored by the libsql backend. On the default `sqlite`
+ * backend it is silently ignored, so an operator who sets a remote URL but
+ * forgets NEOTOMA_DB_BACKEND=libsql gets the local sqlite file with no signal.
+ * sqliteUrlMisconfig() is the guard the sqlite branch of openDb() consults:
+ * throw for a remote URL, warn for a divergent local file: URL, stay silent
+ * when the URL is absent or points at the same file that would open anyway.
+ */
+
+import { describe, expect, it } from "vitest";
+import { sqliteUrlMisconfig } from "../../src/repositories/db/connection.js";
+
+const SQLITE_PATH = "/data/neotoma.db";
+
+describe("sqliteUrlMisconfig (NEOTOMA_DB_URL ignored on sqlite backend)", () => {
+  it("returns null when no URL is set (the zero-config default)", () => {
+    expect(sqliteUrlMisconfig(undefined, SQLITE_PATH)).toBeNull();
+    expect(sqliteUrlMisconfig("", SQLITE_PATH)).toBeNull();
+  });
+
+  it("returns null when the URL points at the same file that would open anyway", () => {
+    expect(sqliteUrlMisconfig(`file:${SQLITE_PATH}`, SQLITE_PATH)).toBeNull();
+    expect(sqliteUrlMisconfig(SQLITE_PATH, SQLITE_PATH)).toBeNull();
+  });
+
+  it.each([
+    "libsql://db.turso.io",
+    "https://sqld.example.com",
+    "http://localhost:8080",
+    "wss://sqld.example.com",
+    "LIBSQL://UPPERCASE.turso.io",
+  ])("throws (fail-loud) for a remote URL %s", (url) => {
+    const result = sqliteUrlMisconfig(url, SQLITE_PATH);
+    expect(result?.level).toBe("throw");
+    // Message names the offending value, the file that would open instead, and
+    // the fix — the actionable-hint standard the ux lens checks for.
+    expect(result?.message).toContain(url);
+    expect(result?.message).toContain(SQLITE_PATH);
+    expect(result?.message).toMatch(/NEOTOMA_DB_BACKEND=libsql/);
+  });
+
+  it("warns (not throws) for a divergent local file: URL", () => {
+    const result = sqliteUrlMisconfig("file:/somewhere/else.db", SQLITE_PATH);
+    expect(result?.level).toBe("warn");
+    expect(result?.message).toContain("/somewhere/else.db");
+    expect(result?.message).toContain(SQLITE_PATH);
+  });
+
+  it("warns for a bare divergent path (not a file: URL, not remote)", () => {
+    const result = sqliteUrlMisconfig("/other/path.db", SQLITE_PATH);
+    expect(result?.level).toBe("warn");
+    expect(result?.message).toContain("/other/path.db");
+  });
+});

--- a/tests/unit/db_worker_file_database.test.ts
+++ b/tests/unit/db_worker_file_database.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Worker-hosted local-file backend tests (concurrent-backend plan, PR #1944
+ * arch/QA follow-ups).
+ *
+ * WorkerFileDatabase is what actually serves local `file:` URLs on the libsql
+ * backend — the exact configuration of the hosted-instance freeze this whole
+ * change fixes. The generic driver-contract suite exercises it through
+ * openLibsqlDatabase(), but two properties are specific to the worker topology
+ * and were called out as blocking gaps in review:
+ *
+ *   1. Non-blocking on a LOCAL FILE: a slow query on the worker-hosted local
+ *      file must not stall concurrent queries (the literal repro).
+ *   2. Supervised restart: a crashed writer/reader worker must reject its
+ *      in-flight requests with a clear error and then self-heal on the next
+ *      request — not wedge the connection or leak a never-settling promise.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import {
+  WorkerFileDatabase,
+  WorkerDbCrashError,
+} from "../../src/repositories/worker/worker_file_database.js";
+
+const workDir = mkdtempSync(path.join(tmpdir(), "neotoma-worker-db-"));
+
+afterAll(() => {
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+let counter = 0;
+function makeDb(readerWorkers = 2): WorkerFileDatabase {
+  counter += 1;
+  return new WorkerFileDatabase(path.join(workDir, `w-${counter}.db`), { readerWorkers });
+}
+
+describe("WorkerFileDatabase (local-file libsql backend)", () => {
+  it("does not block a concurrent query while a slow query runs on the local file", async () => {
+    const db = makeDb();
+    try {
+      await db.exec("CREATE TABLE load (id INTEGER PRIMARY KEY, v TEXT)");
+      await db.exec(`
+        WITH RECURSIVE cnt(x) AS (SELECT 1 UNION ALL SELECT x + 1 FROM cnt WHERE x < 6000)
+        INSERT INTO load (v) SELECT hex(randomblob(96)) FROM cnt
+      `);
+
+      let slowDone = false;
+      const slowStart = Date.now();
+      const slow = (
+        db.prepare("SELECT COUNT(*) AS n FROM load a, load b WHERE a.v < b.v").get() as Promise<{
+          n: number;
+        }>
+      ).then((r) => {
+        slowDone = true;
+        return r;
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 25));
+
+      const healthStart = Date.now();
+      const health = await db.prepare("SELECT 1 AS ok").get();
+      const healthMs = Date.now() - healthStart;
+      const healthFinishedFirst = !slowDone;
+
+      const result = await slow;
+      const slowMs = Date.now() - slowStart;
+
+      expect(result.n).toBeGreaterThan(0);
+      expect(health).toEqual({ ok: 1 });
+      // Health check must not have waited for the slow query. Relative bound so
+      // parallel-worker CPU saturation can't flake it.
+      expect(healthMs).toBeLessThan(Math.max(200, slowMs / 2));
+      if (slowMs > 300) {
+        // On the old sync driver the slow query would always finish first
+        // (blocking); here the trivial read returns while the join is still running.
+        expect(healthFinishedFirst).toBe(true);
+      }
+    } finally {
+      await db.close();
+    }
+  }, 60_000);
+
+  it("rejects in-flight requests with WorkerDbCrashError when the writer worker crashes, then self-heals", async () => {
+    const db = makeDb(0); // reader pool off → all ops on the writer
+    try {
+      await db.exec("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)");
+      await db.prepare("INSERT INTO t (id, v) VALUES (1, 'before')").run();
+
+      // Crash mid-flight: the returned promise must reject (not hang forever).
+      await expect(
+        (
+          db as unknown as { __crashWorkerForTest(w: "writer" | "reader"): Promise<unknown> }
+        ).__crashWorkerForTest("writer")
+      ).rejects.toBeInstanceOf(WorkerDbCrashError);
+
+      // Self-heal: the next request spawns a fresh worker and sees committed data.
+      const row = await db.prepare("SELECT v FROM t WHERE id = 1").get();
+      expect(row).toEqual({ v: "before" });
+
+      // And writes work again on the respawned worker.
+      await db.prepare("INSERT INTO t (id, v) VALUES (2, 'after-respawn')").run();
+      const count = await db.prepare("SELECT COUNT(*) AS n FROM t").get();
+      expect(count).toEqual({ n: 2 });
+    } finally {
+      await db.close();
+    }
+  }, 30_000);
+
+  it("recovers when a reader worker crashes (reads reroute to a fresh reader)", async () => {
+    const db = makeDb(2);
+    try {
+      await db.exec("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)");
+      await db.prepare("INSERT INTO t (id, v) VALUES (1, 'x')").run();
+
+      await expect(
+        (
+          db as unknown as { __crashWorkerForTest(w: "writer" | "reader"): Promise<unknown> }
+        ).__crashWorkerForTest("reader")
+      ).rejects.toBeInstanceOf(WorkerDbCrashError);
+
+      // Subsequent reads still succeed (fresh reader spun up, or routed elsewhere).
+      const rows = (await db.prepare("SELECT v FROM t ORDER BY id").all()) as Array<{ v: string }>;
+      expect(rows).toEqual([{ v: "x" }]);
+    } finally {
+      await db.close();
+    }
+  }, 30_000);
+
+  it("rejects requests issued after close()", async () => {
+    const db = makeDb(0);
+    await db.exec("CREATE TABLE t (id INTEGER PRIMARY KEY)");
+    await db.close();
+    await expect(db.prepare("SELECT 1 AS ok").get()).rejects.toBeInstanceOf(WorkerDbCrashError);
+  });
+});

--- a/tests/unit/db_worker_file_database.test.ts
+++ b/tests/unit/db_worker_file_database.test.ts
@@ -134,4 +134,24 @@ describe("WorkerFileDatabase (local-file libsql backend)", () => {
     await db.close();
     await expect(db.prepare("SELECT 1 AS ok").get()).rejects.toBeInstanceOf(WorkerDbCrashError);
   });
+
+  it("transparently retries on the writer when a read-only reader rejects a read that writes", async () => {
+    const db = makeDb(2); // reader pool on, so routeRead tries a reader first
+    try {
+      await db.exec("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)");
+
+      // .get() issuing an INSERT ... RETURNING is a read-shaped call that
+      // mutates — SQLite rejects it on a read-only reader connection, which
+      // is exactly the isReadonlyRejection/retry path in routeRead().
+      const row = await db.prepare("INSERT INTO t (id, v) VALUES (1, 'x') RETURNING id, v").get();
+
+      expect(row).toEqual({ id: 1, v: "x" });
+
+      // Confirm it actually landed (retried on the writer, not silently dropped).
+      const persisted = await db.prepare("SELECT COUNT(*) AS n FROM t").get();
+      expect(persisted).toEqual({ n: 1 });
+    } finally {
+      await db.close();
+    }
+  }, 30_000);
 });

--- a/tests/unit/google_oidc_identity_resolution.test.ts
+++ b/tests/unit/google_oidc_identity_resolution.test.ts
@@ -95,7 +95,10 @@ describe("Google identity resolution (auth-layer only)", () => {
 
     // This is the exact call the callback route makes: resolve the
     // verified email to a user_id via the EXISTING per-email primitive.
-    const user = localAuth.createLocalAuthUser(verified.email, "unused-throwaway-password");
+    const user = await localAuth.createLocalAuthUser(
+      verified.email,
+      "unused-throwaway-password"
+    );
 
     expect(user.id).not.toBe(localAuth.LOCAL_DEV_USER_ID);
     expect(user.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
@@ -104,7 +107,7 @@ describe("Google identity resolution (auth-layer only)", () => {
     // SAME user_id (same person signing in again gets the same identity).
     const tokenAgain = await signIdToken("person@example.com");
     const verifiedAgain = await googleOidc.verifyGoogleIdToken(tokenAgain);
-    const userAgain = localAuth.createLocalAuthUser(
+    const userAgain = await localAuth.createLocalAuthUser(
       verifiedAgain.email,
       "different-unused-password"
     );
@@ -137,8 +140,8 @@ describe("Google identity resolution (auth-layer only)", () => {
     // Confirm no local_auth user was created for the rejected email, and
     // that the shared dev user (what the OLD hardwired path always used)
     // remains untouched/distinct.
-    expect(localAuth.getLocalAuthUserByEmail("stranger@example.com")).toBeNull();
-    const devUser = localAuth.ensureLocalDevUser();
+    expect(await localAuth.getLocalAuthUserByEmail("stranger@example.com")).toBeNull();
+    const devUser = await localAuth.ensureLocalDevUser();
     expect(devUser.id).toBe(localAuth.LOCAL_DEV_USER_ID);
 
     rmSync(tempDir, { recursive: true, force: true });

--- a/tests/unit/relationship_traversal_indexes.test.ts
+++ b/tests/unit/relationship_traversal_indexes.test.ts
@@ -10,40 +10,40 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { getSqliteDb } from "../../src/repositories/sqlite/sqlite_client.js";
+import { getDb } from "../../src/repositories/db/connection.js";
 
 describe("relationship_snapshots traversal indexes (#1467)", () => {
-  it("creates the source and target composite indexes", () => {
-    const db = getSqliteDb();
-    const rows = db
+  it("creates the source and target composite indexes", async () => {
+    const db = await getDb();
+    const rows = (await db
       .prepare(
         "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'relationship_snapshots'"
       )
-      .all() as Array<{ name: string }>;
+      .all()) as Array<{ name: string }>;
     const names = rows.map((r) => r.name);
     expect(names).toContain("idx_rel_snapshots_source_user");
     expect(names).toContain("idx_rel_snapshots_target_user");
   });
 
-  it("uses the source index for an outbound-hop query (not a full scan)", () => {
-    const db = getSqliteDb();
-    const plan = db
+  it("uses the source index for an outbound-hop query (not a full scan)", async () => {
+    const db = await getDb();
+    const plan = (await db
       .prepare(
         "EXPLAIN QUERY PLAN SELECT * FROM relationship_snapshots WHERE source_entity_id = ? AND user_id = ?"
       )
-      .all("ent_x", "user_y") as Array<{ detail: string }>;
+      .all("ent_x", "user_y")) as Array<{ detail: string }>;
     const detail = plan.map((p) => p.detail).join(" ");
     expect(detail).toMatch(/USING INDEX idx_rel_snapshots_source_user/);
     expect(detail).not.toMatch(/SCAN relationship_snapshots\b(?!.*USING INDEX)/);
   });
 
-  it("uses the target index for an inbound-hop query (not a full scan)", () => {
-    const db = getSqliteDb();
-    const plan = db
+  it("uses the target index for an inbound-hop query (not a full scan)", async () => {
+    const db = await getDb();
+    const plan = (await db
       .prepare(
         "EXPLAIN QUERY PLAN SELECT * FROM relationship_snapshots WHERE target_entity_id = ? AND user_id = ?"
       )
-      .all("ent_x", "user_y") as Array<{ detail: string }>;
+      .all("ent_x", "user_y")) as Array<{ detail: string }>;
     const detail = plan.map((p) => p.detail).join(" ");
     expect(detail).toMatch(/USING INDEX idx_rel_snapshots_target_user/);
   });

--- a/tests/unit/sqlite_connection_pragmas.test.ts
+++ b/tests/unit/sqlite_connection_pragmas.test.ts
@@ -15,16 +15,14 @@
  */
 
 import { describe, expect, it } from "vitest";
-import {
-  getSqliteDb,
-  SQLITE_BUSY_TIMEOUT_MS,
-} from "../../src/repositories/sqlite/sqlite_client.js";
+import { getDb } from "../../src/repositories/db/connection.js";
+import { SQLITE_BUSY_TIMEOUT_MS } from "../../src/repositories/sqlite/sqlite_client.js";
 
 /** Read a single-value PRAGMA back through the driver wrapper, or null if the
  *  active driver does not expose pragma readback (returns no rows). */
-function readPragma(command: string): number | string | null {
-  const db = getSqliteDb();
-  const rows = db.pragma(command) as Array<Record<string, unknown>>;
+async function readPragma(command: string): Promise<number | string | null> {
+  const db = await getDb();
+  const rows = (await db.pragma(command)) as Array<Record<string, unknown>>;
   if (!Array.isArray(rows) || rows.length === 0) return null;
   const first = rows[0];
   const values = Object.values(first);
@@ -32,21 +30,21 @@ function readPragma(command: string): number | string | null {
 }
 
 describe("SQLite connection PRAGMAs", () => {
-  it("applies WAL journal mode on open", () => {
-    const mode = readPragma("journal_mode");
+  it("applies WAL journal mode on open", async () => {
+    const mode = await readPragma("journal_mode");
     if (mode === null) return; // driver without pragma readback
     expect(String(mode).toLowerCase()).toBe("wal");
   });
 
-  it("applies a non-zero busy_timeout on open (not the better-sqlite3 default of 0)", () => {
-    const timeout = readPragma("busy_timeout");
+  it("applies a non-zero busy_timeout on open (not the better-sqlite3 default of 0)", async () => {
+    const timeout = await readPragma("busy_timeout");
     if (timeout === null) return; // driver without pragma readback
     expect(Number(timeout)).toBeGreaterThan(0);
     expect(Number(timeout)).toBe(SQLITE_BUSY_TIMEOUT_MS);
   });
 
-  it("enforces foreign keys on open", () => {
-    const fk = readPragma("foreign_keys");
+  it("enforces foreign keys on open", async () => {
+    const fk = await readPragma("foreign_keys");
     if (fk === null) return; // driver without pragma readback
     expect(Number(fk)).toBe(1);
   });

--- a/tests/unit/timeline_query.test.ts
+++ b/tests/unit/timeline_query.test.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { getSqliteDb } from "../../src/repositories/sqlite/sqlite_client.js";
+import { getDb } from "../../src/repositories/db/connection.js";
 import {
   getTimelineEventForUser,
   listTimelineEventsForUser,
@@ -15,8 +15,8 @@ const TARGET_EVENT_ID = `timeline-query-event-${TEST_RUN_ID}`;
 const OTHER_EVENT_ID = `timeline-query-other-event-${TEST_RUN_ID}`;
 const NOW = "2026-06-17T08:00:00.000Z";
 
-function insertSource(id: string, userId: string) {
-  getSqliteDb()
+async function insertSource(id: string, userId: string) {
+  await (await getDb())
     .prepare(
       `INSERT OR REPLACE INTO sources
         (id, user_id, content_hash, mime_type, storage_url, file_size, original_filename, source_type, created_at)
@@ -35,8 +35,8 @@ function insertSource(id: string, userId: string) {
     );
 }
 
-function insertEntity(id: string, userId: string, canonicalName: string) {
-  getSqliteDb()
+async function insertEntity(id: string, userId: string, canonicalName: string) {
+  await (await getDb())
     .prepare(
       `INSERT OR REPLACE INTO entities
         (id, entity_type, canonical_name, aliases, created_at, updated_at, user_id)
@@ -45,14 +45,14 @@ function insertEntity(id: string, userId: string, canonicalName: string) {
     .run(id, "task", canonicalName, JSON.stringify([]), NOW, NOW, userId);
 }
 
-function insertTimelineEvent(input: {
+async function insertTimelineEvent(input: {
   id: string;
   userId: string;
   sourceId: string;
   entityId: string;
   timestamp: string;
 }) {
-  getSqliteDb()
+  await (await getDb())
     .prepare(
       `INSERT OR REPLACE INTO timeline_events
         (id, event_type, event_timestamp, source_id, source_field, entity_id, created_at, user_id)
@@ -71,23 +71,23 @@ function insertTimelineEvent(input: {
 }
 
 describe("timeline_query", () => {
-  beforeAll(() => {
-    insertEntity(TARGET_ENTITY_ID, TEST_USER_ID, "Target Task");
-    insertEntity(OTHER_ENTITY_ID, OTHER_USER_ID, "Other Task");
+  beforeAll(async () => {
+    await insertEntity(TARGET_ENTITY_ID, TEST_USER_ID, "Target Task");
+    await insertEntity(OTHER_ENTITY_ID, OTHER_USER_ID, "Other Task");
 
     for (let i = 0; i < 1100; i += 1) {
-      insertSource(`timeline-query-source-${TEST_RUN_ID}-${i}`, TEST_USER_ID);
+      await insertSource(`timeline-query-source-${TEST_RUN_ID}-${i}`, TEST_USER_ID);
     }
-    insertSource(`timeline-query-other-source-${TEST_RUN_ID}`, OTHER_USER_ID);
+    await insertSource(`timeline-query-other-source-${TEST_RUN_ID}`, OTHER_USER_ID);
 
-    insertTimelineEvent({
+    await insertTimelineEvent({
       id: TARGET_EVENT_ID,
       userId: TEST_USER_ID,
       sourceId: `timeline-query-source-${TEST_RUN_ID}-0`,
       entityId: TARGET_ENTITY_ID,
       timestamp: "2026-06-18T00:00:00.000Z",
     });
-    insertTimelineEvent({
+    await insertTimelineEvent({
       id: OTHER_EVENT_ID,
       userId: OTHER_USER_ID,
       sourceId: `timeline-query-other-source-${TEST_RUN_ID}`,
@@ -96,11 +96,17 @@ describe("timeline_query", () => {
     });
   });
 
-  afterAll(() => {
-    const db = getSqliteDb();
-    db.prepare("DELETE FROM timeline_events WHERE user_id IN (?, ?)").run(TEST_USER_ID, OTHER_USER_ID);
-    db.prepare("DELETE FROM sources WHERE user_id IN (?, ?)").run(TEST_USER_ID, OTHER_USER_ID);
-    db.prepare("DELETE FROM entities WHERE user_id IN (?, ?)").run(TEST_USER_ID, OTHER_USER_ID);
+  afterAll(async () => {
+    const db = await getDb();
+    await db
+      .prepare("DELETE FROM timeline_events WHERE user_id IN (?, ?)")
+      .run(TEST_USER_ID, OTHER_USER_ID);
+    await db
+      .prepare("DELETE FROM sources WHERE user_id IN (?, ?)")
+      .run(TEST_USER_ID, OTHER_USER_ID);
+    await db
+      .prepare("DELETE FROM entities WHERE user_id IN (?, ?)")
+      .run(TEST_USER_ID, OTHER_USER_ID);
   });
 
   it("lists entity timeline events without building a large source_id IN filter", async () => {

--- a/tests/unit/usage_stats.test.ts
+++ b/tests/unit/usage_stats.test.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
-import { getSqliteDb } from "../../src/repositories/sqlite/sqlite_client.js";
+import { getDb } from "../../src/repositories/db/connection.js";
 import { getUsageStats } from "../../src/services/dashboard_stats.js";
 
 const TEST_USER_ID = `usage-stats-${randomUUID().slice(0, 8)}`;
@@ -8,14 +8,14 @@ const OTHER_USER_ID = `usage-stats-other-${randomUUID().slice(0, 8)}`;
 const NOW = "2026-06-16T08:00:00.000Z";
 const TEN_DAYS_AGO = "2026-06-06T08:00:00.000Z";
 
-function insertEntity(input: {
+async function insertEntity(input: {
   id: string;
   entityType: string;
   createdAt: string;
   userId: string;
   mergedToEntityId?: string | null;
 }) {
-  getSqliteDb()
+  await (await getDb())
     .prepare(
       `INSERT OR REPLACE INTO entities
         (id, entity_type, canonical_name, aliases, created_at, updated_at, user_id, first_seen_at, last_seen_at, merged_to_entity_id)
@@ -35,14 +35,14 @@ function insertEntity(input: {
     );
 }
 
-function insertObservation(input: {
+async function insertObservation(input: {
   id: string;
   entityId: string;
   entityType: string;
   observationSource: string | null;
   userId: string;
 }) {
-  getSqliteDb()
+  await (await getDb())
     .prepare(
       `INSERT OR REPLACE INTO observations
         (id, entity_id, entity_type, schema_version, observed_at, observation_source, fields, created_at, user_id)
@@ -61,8 +61,8 @@ function insertObservation(input: {
     );
 }
 
-function insertSchema(input: { id: string; entityType: string; userId?: string | null }) {
-  getSqliteDb()
+async function insertSchema(input: { id: string; entityType: string; userId?: string | null }) {
+  await (await getDb())
     .prepare(
       `INSERT OR REPLACE INTO schema_registry
         (id, entity_type, schema_version, schema_definition, reducer_config, active, created_at, user_id, scope, metadata)
@@ -88,42 +88,46 @@ describe("getUsageStats", () => {
     vi.setSystemTime(new Date(NOW));
   });
 
-  afterAll(() => {
-    const db = getSqliteDb();
-    db.prepare("DELETE FROM observations WHERE user_id IN (?, ?)").run(TEST_USER_ID, OTHER_USER_ID);
-    db.prepare("DELETE FROM entities WHERE user_id IN (?, ?)").run(TEST_USER_ID, OTHER_USER_ID);
-    db.prepare("DELETE FROM schema_registry WHERE id LIKE ?").run("usage-stats-%");
+  afterAll(async () => {
+    const db = await getDb();
+    await db
+      .prepare("DELETE FROM observations WHERE user_id IN (?, ?)")
+      .run(TEST_USER_ID, OTHER_USER_ID);
+    await db
+      .prepare("DELETE FROM entities WHERE user_id IN (?, ?)")
+      .run(TEST_USER_ID, OTHER_USER_ID);
+    await db.prepare("DELETE FROM schema_registry WHERE id LIKE ?").run("usage-stats-%");
     vi.useRealTimers();
   });
 
   it("returns user-scoped aggregate usage statistics", async () => {
-    insertEntity({ id: "usage-stats-task-1", entityType: "usage_stats_alpha", createdAt: NOW, userId: TEST_USER_ID });
-    insertEntity({ id: "usage-stats-task-2", entityType: "usage_stats_alpha", createdAt: TEN_DAYS_AGO, userId: TEST_USER_ID });
-    insertEntity({ id: "usage-stats-note-1", entityType: "usage_stats_beta", createdAt: NOW, userId: TEST_USER_ID });
-    insertEntity({
+    await insertEntity({ id: "usage-stats-task-1", entityType: "usage_stats_alpha", createdAt: NOW, userId: TEST_USER_ID });
+    await insertEntity({ id: "usage-stats-task-2", entityType: "usage_stats_alpha", createdAt: TEN_DAYS_AGO, userId: TEST_USER_ID });
+    await insertEntity({ id: "usage-stats-note-1", entityType: "usage_stats_beta", createdAt: NOW, userId: TEST_USER_ID });
+    await insertEntity({
       id: "usage-stats-merged-note",
       entityType: "usage_stats_beta",
       createdAt: NOW,
       userId: TEST_USER_ID,
       mergedToEntityId: "usage-stats-note-1",
     });
-    insertEntity({ id: "usage-stats-other-user-task", entityType: "usage_stats_alpha", createdAt: NOW, userId: OTHER_USER_ID });
+    await insertEntity({ id: "usage-stats-other-user-task", entityType: "usage_stats_alpha", createdAt: NOW, userId: OTHER_USER_ID });
 
-    insertObservation({
+    await insertObservation({
       id: "usage-stats-observation-1",
       entityId: "usage-stats-task-1",
       entityType: "usage_stats_alpha",
       observationSource: "llm_summary",
       userId: TEST_USER_ID,
     });
-    insertObservation({
+    await insertObservation({
       id: "usage-stats-observation-2",
       entityId: "usage-stats-task-2",
       entityType: "usage_stats_alpha",
       observationSource: null,
       userId: TEST_USER_ID,
     });
-    insertObservation({
+    await insertObservation({
       id: "usage-stats-observation-other-user",
       entityId: "usage-stats-other-user-task",
       entityType: "usage_stats_alpha",
@@ -131,7 +135,7 @@ describe("getUsageStats", () => {
       userId: OTHER_USER_ID,
     });
 
-    insertSchema({ id: "usage-stats-schema-task", entityType: "usage_stats_alpha" });
+    await insertSchema({ id: "usage-stats-schema-task", entityType: "usage_stats_alpha" });
 
     const stats = await getUsageStats(TEST_USER_ID);
 


### PR DESCRIPTION
Closes #1945

## Problem

Neotoma runs synchronous better-sqlite3 on a single Node event loop: any slow DB statement freezes the ENTIRE server — health checks, the web UI, and concurrent MCP requests. Observed live on a hosted instance (2026-07-16): a deep-offset `include_snapshots` contact query blocked the server 4.8–7.5s per page.

## What this does

**1. Async driver contract** (`src/repositories/db/driver.ts`) — every DB call site now goes through `DbDatabase`/`DbStatement` with promised `run/get/all/exec/pragma` and `transaction(fn)`. ~200 call sites across services, CLI, server, and tests converted; type-silent Promise leaks (truthiness checks on promises, `res.json` of a promise) swept manually beyond what tsc catches.

**2. Two backends** via `NEOTOMA_DB_BACKEND`:
- `sqlite` (default) — the existing sync driver wrapped in the async contract; zero-config behavior unchanged.
- `libsql` — statements run **off the event loop**:
  - **Local `file:` URLs → worker-hosted driver** (`src/repositories/worker/worker_file_database.ts`): one writer worker + a read-only reader pool (`NEOTOMA_DB_READER_WORKERS`, default 2) running concurrently under WAL. Reads that turn out to write are retried on the writer after `SQLITE_READONLY`.
  - **Remote sqld/Turso URLs → @libsql/client** (genuinely async network I/O), with `NEOTOMA_DB_AUTH_TOKEN`.

**Why workers, not just @libsql/client:** verified empirically that *every* Node binding for local SQLite/libSQL files executes synchronously on the calling thread — including `@libsql/client`'s `file:` protocol and `libsql/promise`, whose promises resolve only after blocking the loop for the entire statement. An "async local libSQL" backend alone would not have fixed anything; the new regression test caught this before it shipped.

**3. Transaction semantics preserved.** Transactions serialize against each other and against outside statements (`TransactionGate`); `AsyncLocalStorage` routes statements issued on the db handle inside a transaction callback INTO that transaction — matching the old synchronous semantics `entity_merge`'s atomicity relies on. `BEGIN IMMEDIATE` replaces deferred `BEGIN` (async callbacks hold transactions open across microtask hops; a deferred lock upgrade fails immediately with "database is locked" since `busy_timeout` doesn't apply to upgrades — this surfaced as real cross-process failures in `ensureSchema` before the fix).

**4. Migration** — libSQL adopts existing SQLite files in place (same format). `scripts/validate_libsql_migration.ts` proves adoption safety per database: integrity check + per-table row-count parity + snapshot hydration spot check on a copy.

**5. Tests**
- `tests/unit/db_driver_contract.test.ts`: the same behavioral suite against both backends — binding forms, change counts, commit/rollback atomicity, isolation gate, ALS join rule, transaction serialization.
- `tests/unit/db_libsql_nonblocking.test.ts`: the regression for the observed symptom — a concurrent health-check query completes while a multi-second query runs (assertions relative to measured query duration, so parallel-worker CPU saturation can't flake it).
- Full-stack smoke on both backends (insert → snapshot recompute → JSON roundtrip) verified.

## Verification

- `tsc --noEmit` clean; lint 0 errors; new files warning-free.
- Full vitest suite: **zero branch-only failures** vs an origin/main baseline run in the same environment (remaining failures are pre-existing environmental ones — unbuilt cursor-hooks/CLI dist, inspector assets — that fail identically on main).

## Rollout

After merge: deploy the hosted instance with `NEOTOMA_DB_BACKEND=libsql` and verify the deep-offset query no longer freezes the server. The separable keyset-pagination quick win for `entity_queries.ts` remains its own follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)