### PR TITLE
fix: retract stale auto-linked works_at edges when organization changes

### DIFF
--- a/docs/foundation/entity_resolution.md
+++ b/docs/foundation/entity_resolution.md
@@ -1,10 +1,12 @@
 # Entity Resolution Doctrine
+
 ## 15.1 Entity ID Generation (Deterministic)
+
 ```typescript
 function generateEntityId(
   entityType: string,
   canonicalName: string,
-  tenantSalt?: string, // optional — see tenant-scoping below
+  tenantSalt?: string // optional — see tenant-scoping below
 ): string {
   const normalized = normalizeEntityValue(entityType, canonicalName);
   const basis = tenantSalt
@@ -17,30 +19,32 @@ function normalizeEntityValue(entityType: string, raw: string): string {
   let normalized = raw.trim().toLowerCase();
   if (entityType === "company") {
     // Remove common suffixes deterministically
-    normalized = normalized.replace(
-      /\s+(inc|llc|ltd|corp|corporation)\.?$/i,
-      ""
-    );
+    normalized = normalized.replace(/\s+(inc|llc|ltd|corp|corporation)\.?$/i, "");
   }
   return normalized;
 }
 ```
+
 **Default (single-tenant): same name → same ID, globally. No duplicates.** Persisted `canonical_name` is produced by `formatCanonicalNameForStorage` in `src/services/entity_resolution.ts` (same structural rules as `normalizeEntityValue`, casing preserved); entity IDs still hash `normalizeEntityValue` only.
 
 **Tenant-scoped ids (opt-in).** `entities.id` is a global primary key, so without a salt two tenants writing the same `(entity_type, canonical_name)` collide on one row. For multi-tenant deployments (the public sandbox) `generateEntityId` accepts an optional `tenantSalt`, supplied by `entityIdTenantSalt(userId)` at every recompute site (resolver, identifier lookup, snapshot collision guard, entity split). The salt is applied when `isSandboxMode()` is true **or** `NEOTOMA_TENANT_SCOPED_ENTITY_IDS` is truthy (`1`/`true`/`yes`), and omitted otherwise — so single-tenant prod ids are unchanged (no migration, no id churn). Toggling the gate on a persistent store would strand existing rows, so it is intended to be set once per deployment. See [`docs/subsystems/sandbox_deployment.md`](../subsystems/sandbox_deployment.md).
+
 ## 15.2 Entity Rules
+
 Entity IDs MUST be:
+
 - Canonical (globally unique representation)
 - Stable (never change once created)
 - Deduplicated (same name → same entity)
 - Rule-based (deterministic normalization)
 - Traced to observed text (not inferred)
-Entities MUST NOT:
+  Entities MUST NOT:
 - Be inferred (only extracted from fields)
 - Be LLM-generated
 - Be renamed post-creation
 - Mutate types (person → company forbidden)
-**Entities survive across documents and sessions.**
+  **Entities survive across documents and sessions.**
+
 ## 15.3 Single-Token Prefix-Match Pass
 
 When an entity is resolved and its canonical name reduces to a **single token** (e.g. `"Simon"`), the resolver runs an additional scan against same-type entities in the database before returning.
@@ -68,7 +72,9 @@ When an entity is resolved and its canonical name reduces to a **single token** 
 
 **Threshold calibration** (measured against the Levenshtein-normalized `stringSimilarity`): `"northgate"` vs `"north gate"` (space-separated near-duplicate) scores `0.900` — collapses. `"northgate"` vs `"eastgate"` (a genuinely different company) scores `0.556` — stays separate. The 0.88 floor sits directly between these two measured cases.
 
-**Contact -> company linking.** The `contact` schema declares `organization` as a `reference_fields` entry with `target_entity_type: "company"`, `relationship_type: "works_at"`, and `resolve_target: true` (`schema_definitions.ts`). `resolve_target: true` is a general opt-in on `SchemaDefinition.reference_fields` (`schema_registry.ts`): a plain reference field only links to an *existing* target and skips when none is found ("we do not invent targets" — the pre-existing default); `resolve_target: true` instead calls a resolver that may create the target. Today only `target_entity_type: "company"` has a resolver wired (`resolveCompanyEntity`); other target types with `resolve_target: true` fall back to skip-if-missing with a one-time warning so a misconfigured schema fails loud in logs. The auto-link hook (`schema_reference_linking.ts#autoLinkReferenceFields`, invoked from both `actions.ts#storeStructuredForApi` and `server.ts#storeStructuredInternal`) only resolves/creates the target when the store call actually commits (`commit: true`) — a `store --plan`/dry-run never writes a company entity.
+**Contact -> company linking.** The `contact` schema declares `organization` as a `reference_fields` entry with `target_entity_type: "company"`, `relationship_type: "works_at"`, and `resolve_target: true` (`schema_definitions.ts`). `resolve_target: true` is a general opt-in on `SchemaDefinition.reference_fields` (`schema_registry.ts`): a plain reference field only links to an _existing_ target and skips when none is found ("we do not invent targets" — the pre-existing default); `resolve_target: true` instead calls a resolver that may create the target. Today only `target_entity_type: "company"` has a resolver wired (`resolveCompanyEntity`); other target types with `resolve_target: true` fall back to skip-if-missing with a one-time warning so a misconfigured schema fails loud in logs. The auto-link hook (`schema_reference_linking.ts#autoLinkReferenceFields`, invoked from both `actions.ts#storeStructuredForApi` and `server.ts#storeStructuredInternal`) only resolves/creates the target when the store call actually commits (`commit: true`) — a `store --plan`/dry-run never writes a company entity.
+
+**Stale-edge retraction (#1963).** Auto-linked edges are maintained, not just created. When a reference field's resolved target changes across observations (e.g. a contact's `organization` moves from company A to company B, or is cleared, or renamed to a company not yet in the graph), `autoLinkReferenceFields` retracts the prior auto-linked edge for that field in the same reduction that creates the replacement, so the snapshot and its live edge never disagree. Only edges this mechanism created (`metadata.auto_linked === true` for the same field) are retracted — manually created edges are never touched — and re-observing the same target is a no-op (no retract-and-recreate thrash). The retraction outcome is surfaced on the `store` response (both MCP `store` and REST `POST /store`) via `store_warnings`: an `AUTO_LINK_EDGE_RETRACTED` entry when a stale edge was cleaned up, and an actionable `AUTO_LINK_RETRACTION_FAILED` entry when a retraction failed — in the failure case a superseded edge may still be live despite the store succeeding, so the caller should re-run the store or retract manually via `delete_relationship`. Failures are deliberately not silent: the whole point of #1963 was that silent edge accumulation is the bug.
 
 **Company query (read path).** `src/services/company_query.ts#queryContactsAtCompany` answers "who do we have connected at company X": it resolves the company name read-only (exact-normalized, then the same fuzzy pass — never creating), then reads live `works_at` edges pointing at that company entity (`relationshipsService.getRelationshipsForEntity(companyId, "incoming")`) and returns the linked contacts. Read-only by design: a query that silently minted a company entity would violate the State-Layer rule against inference on a read path. When no company matches (exact or fuzzy), the result reports `company: null` and an empty contact list rather than guessing.
 

--- a/docs/reference/error_codes.md
+++ b/docs/reference/error_codes.md
@@ -335,9 +335,31 @@ the snapshot and its live edge were kept consistent — no caller action require
 retracted but the underlying `softDeleteRelationship` failed. Unlike the success case,
 this is _actionable_: the superseded edge may still be live even though the store
 returned `HTTP 200`, so a company-neighborhood query could still surface the stale link.
-The message enumerates the stale `target_entity_id`(s); the caller should retract each via
-`delete_relationship` (`source_entity_id` = the stored entity, `target_entity_id` = the
-listed target, `relationship_type` = the reference field's type) or re-run the store.
+The warning carries a structured `details.stale_edges` array — each entry is a ready-to-use
+`delete_relationship` argument set (`source_entity_id`, `target_entity_id`,
+`relationship_type`, `field_name`), so a caller can remediate programmatically without
+knowing its own schema, or re-run the store. Example:
+
+```json
+{
+  "code": "AUTO_LINK_RETRACTION_FAILED",
+  "entity_type": "contact",
+  "entity_id": "ent_abc…",
+  "observation_index": 0,
+  "message": "Auto-link retraction failed for 1 stale reference-field edge(s) …",
+  "details": {
+    "stale_edges": [
+      {
+        "source_entity_id": "ent_abc…",
+        "target_entity_id": "ent_dust…",
+        "relationship_type": "works_at",
+        "field_name": "organization"
+      }
+    ]
+  }
+}
+```
+
 This code exists so the retraction failure is never silent — a silently-surviving edge is
 the exact bug #1963 was filed to fix.
 

--- a/docs/reference/error_codes.md
+++ b/docs/reference/error_codes.md
@@ -49,14 +49,14 @@ interface ErrorEnvelope {
 
 ## Authentication Errors
 
-| Code             | HTTP | Retry? | Description                                     |
-| ---------------- | ---- | ------ | ----------------------------------------------- |
-| `AUTH_REQUIRED`  | 401  | No     | No bearer token provided                        |
-| `AUTH_INVALID`   | 401  | No     | Bearer token is invalid                         |
-| `AUTH_EXPIRED`   | 401  | No     | Bearer token has expired                        |
-| `AUTH_MALFORMED` | 401  | No     | Bearer token format is invalid                  |
-| `FORBIDDEN`      | 403  | No     | Insufficient permissions (RLS policy violation) |
-| `OVERRIDE_POLICY_VIOLATION` | 403 | No | Write to a policy-protected field on an `agent_definition` entity denied for the calling agent role (see `src/services/override_validation.ts`; details carry `field_name`, `agent_role`, `entity_id`) |
+| Code                        | HTTP | Retry? | Description                                                                                                                                                                                            |
+| --------------------------- | ---- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `AUTH_REQUIRED`             | 401  | No     | No bearer token provided                                                                                                                                                                               |
+| `AUTH_INVALID`              | 401  | No     | Bearer token is invalid                                                                                                                                                                                |
+| `AUTH_EXPIRED`              | 401  | No     | Bearer token has expired                                                                                                                                                                               |
+| `AUTH_MALFORMED`            | 401  | No     | Bearer token format is invalid                                                                                                                                                                         |
+| `FORBIDDEN`                 | 403  | No     | Insufficient permissions (RLS policy violation)                                                                                                                                                        |
+| `OVERRIDE_POLICY_VIOLATION` | 403  | No     | Write to a policy-protected field on an `agent_definition` entity denied for the calling agent role (see `src/services/override_validation.ts`; details carry `field_name`, `agent_role`, `entity_id`) |
 
 **Common Causes:**
 
@@ -108,10 +108,10 @@ They use the canonical standard error envelope (`{ error: { error_code,
 message, hint, details } }`, see `docs/subsystems/errors.md`) so CLI/MCP error
 handlers can pattern-match the code uniformly.
 
-| Code                              | HTTP | Retry? | Description                                                                          |
-| --------------------------------- | ---- | ------ | ------------------------------------------------------------------------------------ |
-| `ERR_NO_SCHEMA_FOR_ENTITY_TYPE`   | 200  | No     | No registered or code-defined schema exists for the given `entity_type`              |
-| `ERR_SCHEMA_MISSING_IDENTITY_CONFIG` | 200 | No     | Existing schema lacks both `canonical_name_fields` and `identity_opt_out`            |
+| Code                                 | HTTP | Retry? | Description                                                               |
+| ------------------------------------ | ---- | ------ | ------------------------------------------------------------------------- |
+| `ERR_NO_SCHEMA_FOR_ENTITY_TYPE`      | 200  | No     | No registered or code-defined schema exists for the given `entity_type`   |
+| `ERR_SCHEMA_MISSING_IDENTITY_CONFIG` | 200  | No     | Existing schema lacks both `canonical_name_fields` and `identity_opt_out` |
 
 **`ERR_NO_SCHEMA_FOR_ENTITY_TYPE`** — raised by `update_schema_incremental` when
 the target `entity_type` has no schema registered in `schema_registry` and no
@@ -255,14 +255,16 @@ agents should address. Switch on the `code` field. All ride on a successful
 `HTTP 200` store response (the write completed); `Retry?` is always `No` — the
 caller repairs in-turn via `correct` rather than re-submitting the same payload.
 
-| Code                      | HTTP | Retry? | Description                                                                                  |
-| ------------------------- | ---- | ------ | -------------------------------------------------------------------------------------------- |
-| `MISSING_CONTENT_FIELD`   | 200  | No     | A schema declares `content_field` and the stored observation omits or empties that field.    |
-| `MISSING_IDENTITY_FIELDS` | 200  | No     | A schema declares `store_warnings` identity rules and the observation omits all named fields.|
-| `UNKNOWN_FIELD`           | 200  | No     | The observation carries a field not declared on the entity's active schema. Preserved on the observation but dropped from the snapshot projection until the field is added to the schema. |
-| `MISSING_REQUIRED_FIELD`  | 200  | No     | The observation omits or empties a schema field declared `required: true`. The write is accepted; the entity is incomplete. |
-| `CONSTRAINT_VIOLATION`    | 200  | No     | An observation fails a declarative write-time value constraint whose `policy` is `"warn"`. The write is accepted and the violating value is stored as-is. |
-| `SOURCE_PRIORITY_IGNORED` | 200  | No     | The caller set a non-default `source_priority` but no field on the entity type uses a merge strategy that honours it. The write is accepted; the priority value has no effect on the stored snapshot. |
+| Code                          | HTTP | Retry? | Description                                                                                                                                                                                                                                                    |
+| ----------------------------- | ---- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `MISSING_CONTENT_FIELD`       | 200  | No     | A schema declares `content_field` and the stored observation omits or empties that field.                                                                                                                                                                      |
+| `MISSING_IDENTITY_FIELDS`     | 200  | No     | A schema declares `store_warnings` identity rules and the observation omits all named fields.                                                                                                                                                                  |
+| `UNKNOWN_FIELD`               | 200  | No     | The observation carries a field not declared on the entity's active schema. Preserved on the observation but dropped from the snapshot projection until the field is added to the schema.                                                                      |
+| `MISSING_REQUIRED_FIELD`      | 200  | No     | The observation omits or empties a schema field declared `required: true`. The write is accepted; the entity is incomplete.                                                                                                                                    |
+| `CONSTRAINT_VIOLATION`        | 200  | No     | An observation fails a declarative write-time value constraint whose `policy` is `"warn"`. The write is accepted and the violating value is stored as-is.                                                                                                      |
+| `SOURCE_PRIORITY_IGNORED`     | 200  | No     | The caller set a non-default `source_priority` but no field on the entity type uses a merge strategy that honours it. The write is accepted; the priority value has no effect on the stored snapshot.                                                          |
+| `AUTO_LINK_EDGE_RETRACTED`    | 200  | No     | A schema-declared reference field's resolved target changed, so a stale auto-linked edge (e.g. a prior `works_at`) was retracted in the same reduction that created the new one (#1963). Positive signal; no action needed.                                    |
+| `AUTO_LINK_RETRACTION_FAILED` | 200  | No     | A stale auto-linked edge should have been retracted but the soft-delete failed. The superseded edge may still be live despite the store succeeding. The message lists the stale `target_entity_id`s; clean up via `delete_relationship` (or re-run the store). |
 
 **`MISSING_CONTENT_FIELD`** — fired when an entity's `SchemaDefinition` declares
 `content_field` (e.g. `"body"` for `plan`, `"content"` for `note`) and the stored
@@ -311,15 +313,43 @@ value is stored on the observation but has no effect on the projected snapshot.
 `tie_breaker: "source_priority"`. To make priority effective, register (or update) the
 schema so the relevant fields use one of those strategies.
 
+**`AUTO_LINK_EDGE_RETRACTED`** — fired when a schema-declared `reference_fields` entry
+(e.g. `contact.organization → works_at → company`) resolves to a _different_ target than
+a prior observation did, so the previously auto-linked edge is retracted in the same
+reduction that creates the replacement (#1963). Only edges this mechanism created
+(`metadata.auto_linked === true` for the same field) are retracted; manual edges are
+untouched, and re-observing the same target is a no-op. This is a positive signal that
+the snapshot and its live edge were kept consistent — no caller action required. Example:
+
+```json
+{
+  "code": "AUTO_LINK_EDGE_RETRACTED",
+  "entity_type": "contact",
+  "entity_id": "ent_abc…",
+  "observation_index": 0,
+  "message": "Retracted 1 stale auto-linked reference-field edge(s) … (#1963)."
+}
+```
+
+**`AUTO_LINK_RETRACTION_FAILED`** — fired when a stale auto-linked edge should have been
+retracted but the underlying `softDeleteRelationship` failed. Unlike the success case,
+this is _actionable_: the superseded edge may still be live even though the store
+returned `HTTP 200`, so a company-neighborhood query could still surface the stale link.
+The message enumerates the stale `target_entity_id`(s); the caller should retract each via
+`delete_relationship` (`source_entity_id` = the stored entity, `target_entity_id` = the
+listed target, `relationship_type` = the reference field's type) or re-run the store.
+This code exists so the retraction failure is never silent — a silently-surviving edge is
+the exact bug #1963 was filed to fix.
+
 ## ERR_CONSTRAINT_VIOLATION
 
 Hard-rejection error returned by `/store` when one or more observations fail a
 declarative write-time value constraint whose `policy` is `"reject"`. No partial
 write is performed — the entire request is rejected atomically.
 
-| Code                       | HTTP | Retry? | Description                                                                               |
-| -------------------------- | ---- | ------ | ----------------------------------------------------------------------------------------- |
-| `ERR_CONSTRAINT_VIOLATION` | 400  | No     | One or more observations failed a `policy: "reject"` write-time value constraint check.  |
+| Code                       | HTTP | Retry? | Description                                                                             |
+| -------------------------- | ---- | ------ | --------------------------------------------------------------------------------------- |
+| `ERR_CONSTRAINT_VIOLATION` | 400  | No     | One or more observations failed a `policy: "reject"` write-time value constraint check. |
 
 Response shape (`ConstraintViolationErrorEnvelope`):
 

--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,8 +61,8 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **536**
-- Backend and repo Vitest files: **501**
+- Total automated test files: **537**
+- Backend and repo Vitest files: **502**
 - Frontend Vitest files: **9**
 - Playwright spec files: **26**
 
@@ -72,7 +72,7 @@ flowchart TD
 | Vitest unit tests | 149 |
 | Vitest service tests | 39 |
 | Source-adjacent tests | 64 |
-| Vitest integration tests | 154 |
+| Vitest integration tests | 155 |
 | Vitest CLI tests | 65 |
 | Vitest contract tests | 14 |
 | Vitest security tests | 4 |
@@ -382,7 +382,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm run test:integration` or `npx vitest run tests/integration`
 **Requirements:** Database configured; remote-dependent subsets additionally need `RUN_REMOTE_TESTS=1`.
-**Files (154):**
+**Files (155):**
 - `tests/integration/aauth_attribution_stamping.test.ts`
 - `tests/integration/aauth_mcp_capability_parity.test.ts`
 - `tests/integration/aauth_mcp_initialize_admission.test.ts`
@@ -400,6 +400,7 @@ flowchart TD
 - `tests/integration/agents_directory_api.test.ts`
 - `tests/integration/anonymous_write_policy.test.ts`
 - `tests/integration/attribution_parity.test.ts`
+- `tests/integration/auto_link_retraction_organization_change.test.ts`
 - `tests/integration/cli_init_bootstrap.test.ts`
 - `tests/integration/cli_to_mcp_entities.test.ts`
 - `tests/integration/cli_to_mcp_relationships.test.ts`

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -7370,6 +7370,16 @@ export async function storeStructuredForApi(params: {
   const priorSnapshotByEntityId = new Map<string, Record<string, unknown>>();
   const newSnapshotByEntityId = new Map<string, Record<string, unknown>>();
 
+  // #1963: auto-link may retract a stale reference-field edge (e.g. a contact's
+  // organization moved companies). A retraction *failure* must not be silent —
+  // that would reproduce the very silent-drift bug this fix exists to close, one
+  // layer up. Accumulate per-observation retraction outcomes here so the
+  // schemaStoreWarnings pass below can surface them on the store response.
+  const autoLinkRetractionByObsIndex = new Map<
+    number,
+    { entity_type: string; entity_id: string; retracted: number; retraction_failures: number }
+  >();
+
   for (const r of resolved) {
     let observation_id: string | null = null;
     let snapshotAfter: Record<string, unknown> | null = null;
@@ -7459,7 +7469,7 @@ export async function storeStructuredForApi(params: {
         if (schemaEntry?.schema_definition?.reference_fields?.length) {
           const { autoLinkReferenceFields } =
             await import("./services/schema_reference_linking.js");
-          await autoLinkReferenceFields({
+          const autoLinkResult = await autoLinkReferenceFields({
             entityId: r.entity_id,
             entityType: r.entity_type,
             fields: r.fields,
@@ -7468,6 +7478,14 @@ export async function storeStructuredForApi(params: {
             sourceId: observationSourceId,
             commit,
           });
+          if (autoLinkResult.retracted > 0 || autoLinkResult.retraction_failures > 0) {
+            autoLinkRetractionByObsIndex.set(r.observation_index, {
+              entity_type: r.entity_type,
+              entity_id: r.entity_id,
+              retracted: autoLinkResult.retracted,
+              retraction_failures: autoLinkResult.retraction_failures,
+            });
+          }
         }
       } catch (linkErr) {
         logger.warn(
@@ -7853,6 +7871,38 @@ export async function storeStructuredForApi(params: {
           }
         }
       }
+    }
+  }
+
+  // #1963: surface auto-link edge retractions on the store response so a
+  // retraction — and especially a retraction *failure* — is never silent. A
+  // failure means a stale reference-field edge may still be live despite the
+  // store reporting success, so it is emitted as its own actionable warning.
+  for (const [obsIndex, rec] of autoLinkRetractionByObsIndex) {
+    if (rec.retraction_failures > 0) {
+      schemaStoreWarnings.push({
+        code: "AUTO_LINK_RETRACTION_FAILED",
+        message:
+          `Auto-link retraction failed for ${rec.retraction_failures} stale ` +
+          `reference-field edge(s) on ${rec.entity_type}/${rec.entity_id}. ` +
+          `A superseded edge (e.g. a prior works_at) may still be live even though ` +
+          `the store succeeded; re-run the store or retract the stale edge manually ` +
+          `via delete_relationship.`,
+        observation_index: obsIndex,
+        entity_type: rec.entity_type,
+        entity_id: rec.entity_id,
+      });
+    } else if (rec.retracted > 0) {
+      schemaStoreWarnings.push({
+        code: "AUTO_LINK_EDGE_RETRACTED",
+        message:
+          `Retracted ${rec.retracted} stale auto-linked reference-field edge(s) on ` +
+          `${rec.entity_type}/${rec.entity_id} because the field's resolved target ` +
+          `changed (#1963).`,
+        observation_index: obsIndex,
+        entity_type: rec.entity_type,
+        entity_id: rec.entity_id,
+      });
     }
   }
 

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -7377,7 +7377,13 @@ export async function storeStructuredForApi(params: {
   // schemaStoreWarnings pass below can surface them on the store response.
   const autoLinkRetractionByObsIndex = new Map<
     number,
-    { entity_type: string; entity_id: string; retracted: number; retraction_failures: number }
+    {
+      entity_type: string;
+      entity_id: string;
+      retracted: number;
+      retraction_failures: number;
+      failed_target_entity_ids: string[];
+    }
   >();
 
   for (const r of resolved) {
@@ -7484,6 +7490,7 @@ export async function storeStructuredForApi(params: {
               entity_id: r.entity_id,
               retracted: autoLinkResult.retracted,
               retraction_failures: autoLinkResult.retraction_failures,
+              failed_target_entity_ids: autoLinkResult.failed_retraction_target_entity_ids,
             });
           }
         }
@@ -7880,14 +7887,16 @@ export async function storeStructuredForApi(params: {
   // store reporting success, so it is emitted as its own actionable warning.
   for (const [obsIndex, rec] of autoLinkRetractionByObsIndex) {
     if (rec.retraction_failures > 0) {
+      const targets = rec.failed_target_entity_ids.join(", ");
       schemaStoreWarnings.push({
         code: "AUTO_LINK_RETRACTION_FAILED",
         message:
           `Auto-link retraction failed for ${rec.retraction_failures} stale ` +
           `reference-field edge(s) on ${rec.entity_type}/${rec.entity_id}. ` +
           `A superseded edge (e.g. a prior works_at) may still be live even though ` +
-          `the store succeeded; re-run the store or retract the stale edge manually ` +
-          `via delete_relationship.`,
+          `the store succeeded. To clean up, call delete_relationship for each ` +
+          `stale target (source_entity_id=${rec.entity_id}, target_entity_id in ` +
+          `[${targets}], relationship_type of the reference field), or re-run the store.`,
         observation_index: obsIndex,
         entity_type: rec.entity_type,
         entity_id: rec.entity_id,

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -7383,6 +7383,11 @@ export async function storeStructuredForApi(params: {
       retracted: number;
       retraction_failures: number;
       failed_target_entity_ids: string[];
+      failed_retractions: Array<{
+        field: string;
+        relationship_type: string;
+        target_entity_id: string;
+      }>;
     }
   >();
 
@@ -7491,6 +7496,7 @@ export async function storeStructuredForApi(params: {
               retracted: autoLinkResult.retracted,
               retraction_failures: autoLinkResult.retraction_failures,
               failed_target_entity_ids: autoLinkResult.failed_retraction_target_entity_ids,
+              failed_retractions: autoLinkResult.failed_retractions,
             });
           }
         }
@@ -7657,6 +7663,10 @@ export async function storeStructuredForApi(params: {
     observation_index: number;
     entity_type: string;
     entity_id: string;
+    // Optional structured payload for codes whose remediation needs machine-
+    // readable fields (e.g. AUTO_LINK_RETRACTION_FAILED lists the stale edges to
+    // delete_relationship). Omitted by codes that carry no extra data.
+    details?: Record<string, unknown>;
   }> = [];
   // Issue #1552 / #1559: surface a non-fatal signal when a stored observation
   // carries fields the schema does not declare (dropped from the snapshot
@@ -7895,11 +7905,20 @@ export async function storeStructuredForApi(params: {
           `reference-field edge(s) on ${rec.entity_type}/${rec.entity_id}. ` +
           `A superseded edge (e.g. a prior works_at) may still be live even though ` +
           `the store succeeded. To clean up, call delete_relationship for each ` +
-          `stale target (source_entity_id=${rec.entity_id}, target_entity_id in ` +
-          `[${targets}], relationship_type of the reference field), or re-run the store.`,
+          `stale edge in details.stale_edges, or re-run the store.`,
         observation_index: obsIndex,
         entity_type: rec.entity_type,
         entity_id: rec.entity_id,
+        // Structured remediation: each entry is a ready-to-use delete_relationship
+        // argument set, so the caller needs no knowledge of its own schema.
+        details: {
+          stale_edges: rec.failed_retractions.map((f) => ({
+            source_entity_id: rec.entity_id,
+            target_entity_id: f.target_entity_id,
+            relationship_type: f.relationship_type,
+            field_name: f.field,
+          })),
+        },
       });
     } else if (rec.retracted > 0) {
       schemaStoreWarnings.push({

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -7897,7 +7897,6 @@ export async function storeStructuredForApi(params: {
   // store reporting success, so it is emitted as its own actionable warning.
   for (const [obsIndex, rec] of autoLinkRetractionByObsIndex) {
     if (rec.retraction_failures > 0) {
-      const targets = rec.failed_target_entity_ids.join(", ");
       schemaStoreWarnings.push({
         code: "AUTO_LINK_RETRACTION_FAILED",
         message:

--- a/src/server.ts
+++ b/src/server.ts
@@ -5963,6 +5963,11 @@ export class NeotomaServer {
         retracted: number;
         retraction_failures: number;
         failed_target_entity_ids: string[];
+        failed_retractions: Array<{
+          field: string;
+          relationship_type: string;
+          target_entity_id: string;
+        }>;
       }
     >();
     const { observationReducer } = await import("./reducers/observation_reducer.js");
@@ -6130,6 +6135,7 @@ export class NeotomaServer {
                   retracted: autoLinkResult.retracted,
                   retraction_failures: autoLinkResult.retraction_failures,
                   failed_target_entity_ids: autoLinkResult.failed_retraction_target_entity_ids,
+                  failed_retractions: autoLinkResult.failed_retractions,
                 });
               }
             } catch (linkErr) {
@@ -6207,6 +6213,10 @@ export class NeotomaServer {
       observation_index: number;
       entity_type: string;
       entity_id: string;
+      // Optional structured payload for codes whose remediation needs machine-
+      // readable fields (e.g. AUTO_LINK_RETRACTION_FAILED lists the stale edges
+      // to delete_relationship). Omitted by codes that carry no extra data.
+      details?: Record<string, unknown>;
     }> = [];
     // Issue #1559: surface a non-fatal signal when a stored observation omits a
     // field its schema marks `required: true`. Mirror of the unknown_fields
@@ -6425,7 +6435,6 @@ export class NeotomaServer {
       const rec = autoLinkRetractionByEntityId.get(createdEntities[i].entityId);
       if (!rec) continue;
       if (rec.retraction_failures > 0) {
-        const targets = rec.failed_target_entity_ids.join(", ");
         schemaStoreWarnings.push({
           code: "AUTO_LINK_RETRACTION_FAILED",
           message:
@@ -6433,11 +6442,18 @@ export class NeotomaServer {
             `reference-field edge(s) on ${rec.entity_type}/${createdEntities[i].entityId}. ` +
             `A superseded edge (e.g. a prior works_at) may still be live even though ` +
             `the store succeeded. To clean up, call delete_relationship for each stale ` +
-            `target (source_entity_id=${createdEntities[i].entityId}, target_entity_id in ` +
-            `[${targets}], relationship_type of the reference field), or re-run the store.`,
+            `edge in details.stale_edges, or re-run the store.`,
           observation_index: i,
           entity_type: rec.entity_type,
           entity_id: createdEntities[i].entityId,
+          details: {
+            stale_edges: rec.failed_retractions.map((f) => ({
+              source_entity_id: createdEntities[i].entityId,
+              target_entity_id: f.target_entity_id,
+              relationship_type: f.relationship_type,
+              field_name: f.field,
+            })),
+          },
         });
       } else if (rec.retracted > 0) {
         schemaStoreWarnings.push({

--- a/src/server.ts
+++ b/src/server.ts
@@ -5958,7 +5958,12 @@ export class NeotomaServer {
     // store_warnings loop below emits these onto the response.
     const autoLinkRetractionByEntityId = new Map<
       string,
-      { entity_type: string; retracted: number; retraction_failures: number }
+      {
+        entity_type: string;
+        retracted: number;
+        retraction_failures: number;
+        failed_target_entity_ids: string[];
+      }
     >();
     const { observationReducer } = await import("./reducers/observation_reducer.js");
     for (const createdEntity of createdEntities) {
@@ -6124,6 +6129,7 @@ export class NeotomaServer {
                   entity_type: snapshot.entity_type,
                   retracted: autoLinkResult.retracted,
                   retraction_failures: autoLinkResult.retraction_failures,
+                  failed_target_entity_ids: autoLinkResult.failed_retraction_target_entity_ids,
                 });
               }
             } catch (linkErr) {
@@ -6419,14 +6425,16 @@ export class NeotomaServer {
       const rec = autoLinkRetractionByEntityId.get(createdEntities[i].entityId);
       if (!rec) continue;
       if (rec.retraction_failures > 0) {
+        const targets = rec.failed_target_entity_ids.join(", ");
         schemaStoreWarnings.push({
           code: "AUTO_LINK_RETRACTION_FAILED",
           message:
             `Auto-link retraction failed for ${rec.retraction_failures} stale ` +
             `reference-field edge(s) on ${rec.entity_type}/${createdEntities[i].entityId}. ` +
             `A superseded edge (e.g. a prior works_at) may still be live even though ` +
-            `the store succeeded; re-run the store or retract the stale edge manually ` +
-            `via delete_relationship.`,
+            `the store succeeded. To clean up, call delete_relationship for each stale ` +
+            `target (source_entity_id=${createdEntities[i].entityId}, target_entity_id in ` +
+            `[${targets}], relationship_type of the reference field), or re-run the store.`,
           observation_index: i,
           entity_type: rec.entity_type,
           entity_id: createdEntities[i].entityId,

--- a/src/server.ts
+++ b/src/server.ts
@@ -5951,6 +5951,15 @@ export class NeotomaServer {
     // incoming null clearing a prior non-null value under highest_priority).
     const priorSnapshotByEntityId = new Map<string, Record<string, unknown>>();
     const newSnapshotByEntityId = new Map<string, Record<string, unknown>>();
+    // #1963: auto-link may retract a stale reference-field edge when a field's
+    // resolved target changes. A retraction *failure* must reach the caller —
+    // otherwise a stale duplicate edge can survive while store reports success,
+    // the exact silent-drift class this fix closes. Keyed by entity_id; the
+    // store_warnings loop below emits these onto the response.
+    const autoLinkRetractionByEntityId = new Map<
+      string,
+      { entity_type: string; retracted: number; retraction_failures: number }
+    >();
     const { observationReducer } = await import("./reducers/observation_reducer.js");
     for (const createdEntity of createdEntities) {
       try {
@@ -6101,7 +6110,7 @@ export class NeotomaServer {
             try {
               const { autoLinkReferenceFields } =
                 await import("./services/schema_reference_linking.js");
-              await autoLinkReferenceFields({
+              const autoLinkResult = await autoLinkReferenceFields({
                 entityId: snapshot.entity_id,
                 entityType: snapshot.entity_type,
                 fields: (snapshot.snapshot as Record<string, unknown>) || {},
@@ -6110,6 +6119,13 @@ export class NeotomaServer {
                 sourceId: storageResult.sourceId,
                 commit,
               });
+              if (autoLinkResult.retracted > 0 || autoLinkResult.retraction_failures > 0) {
+                autoLinkRetractionByEntityId.set(snapshot.entity_id, {
+                  entity_type: snapshot.entity_type,
+                  retracted: autoLinkResult.retracted,
+                  retraction_failures: autoLinkResult.retraction_failures,
+                });
+              }
             } catch (linkErr) {
               logger.warn(
                 `[STORE] Auto-link reference fields failed for ` +
@@ -6392,6 +6408,40 @@ export class NeotomaServer {
             if (nullWarn) schemaStoreWarnings.push(nullWarn);
           }
         }
+      }
+    }
+
+    // #1963: surface auto-link edge retractions on the MCP store response so a
+    // retraction — and especially a retraction *failure* — is never silent. A
+    // failure means a superseded reference-field edge may still be live despite
+    // store reporting success.
+    for (let i = 0; i < createdEntities.length; i++) {
+      const rec = autoLinkRetractionByEntityId.get(createdEntities[i].entityId);
+      if (!rec) continue;
+      if (rec.retraction_failures > 0) {
+        schemaStoreWarnings.push({
+          code: "AUTO_LINK_RETRACTION_FAILED",
+          message:
+            `Auto-link retraction failed for ${rec.retraction_failures} stale ` +
+            `reference-field edge(s) on ${rec.entity_type}/${createdEntities[i].entityId}. ` +
+            `A superseded edge (e.g. a prior works_at) may still be live even though ` +
+            `the store succeeded; re-run the store or retract the stale edge manually ` +
+            `via delete_relationship.`,
+          observation_index: i,
+          entity_type: rec.entity_type,
+          entity_id: createdEntities[i].entityId,
+        });
+      } else if (rec.retracted > 0) {
+        schemaStoreWarnings.push({
+          code: "AUTO_LINK_EDGE_RETRACTED",
+          message:
+            `Retracted ${rec.retracted} stale auto-linked reference-field edge(s) on ` +
+            `${rec.entity_type}/${createdEntities[i].entityId} because the field's ` +
+            `resolved target changed (#1963).`,
+          observation_index: i,
+          entity_type: rec.entity_type,
+          entity_id: createdEntities[i].entityId,
+        });
       }
     }
 

--- a/src/services/schema_reference_linking.ts
+++ b/src/services/schema_reference_linking.ts
@@ -67,6 +67,8 @@ export interface AutoLinkReferenceFieldsParams {
 export interface AutoLinkResult {
   created: number;
   skipped: number;
+  retracted: number;
+  retraction_failures: number;
   details: Array<{
     field: string;
     target_entity_type: string;
@@ -74,6 +76,7 @@ export interface AutoLinkResult {
     target_entity_id: string | null;
     relationship_type: string;
     linked: boolean;
+    retracted_target_entity_id?: string;
   }>;
 }
 
@@ -115,6 +118,13 @@ async function findPriorAutoLinkedEdges(
     }));
 }
 
+/** Result of attempting to retract a set of stale auto-linked edges. */
+export interface RetractStaleEdgesResult {
+  retracted: number;
+  failed: number;
+  retractedTargetEntityIds: string[];
+}
+
 /** Retract a set of stale auto-linked edges via softDeleteRelationship. */
 async function retractStaleAutoLinkedEdges(
   stale: Array<{ relationship_key: string; target_entity_id: string }>,
@@ -123,8 +133,9 @@ async function retractStaleAutoLinkedEdges(
   field: string,
   entityType: string,
   userId: string
-): Promise<void> {
-  if (stale.length === 0) return;
+): Promise<RetractStaleEdgesResult> {
+  const result: RetractStaleEdgesResult = { retracted: 0, failed: 0, retractedTargetEntityIds: [] };
+  if (stale.length === 0) return result;
   const { softDeleteRelationship } = await import("./deletion.js");
   for (const edge of stale) {
     const retraction = await softDeleteRelationship(
@@ -135,13 +146,18 @@ async function retractStaleAutoLinkedEdges(
       userId,
       `auto_link_retraction:${field}`
     );
-    if (!retraction.success) {
-      logger.warn(
+    if (retraction.success) {
+      result.retracted++;
+      result.retractedTargetEntityIds.push(edge.target_entity_id);
+    } else {
+      result.failed++;
+      logger.error(
         `[SCHEMA_REF_LINK] Failed to retract stale auto-linked edge ` +
           `${edge.relationship_key} for ${entityType}.${field}: ${retraction.error}`
       );
     }
   }
+  return result;
 }
 
 /**
@@ -158,7 +174,7 @@ async function retractPriorAutoLinkedEdgesSafely(
   field: string,
   entityType: string,
   userId: string
-): Promise<void> {
+): Promise<RetractStaleEdgesResult> {
   try {
     const stale = await findPriorAutoLinkedEdges(
       relationshipsService,
@@ -167,19 +183,26 @@ async function retractPriorAutoLinkedEdgesSafely(
       field,
       userId
     );
-    await retractStaleAutoLinkedEdges(stale, relationshipType, entityId, field, entityType, userId);
+    return await retractStaleAutoLinkedEdges(stale, relationshipType, entityId, field, entityType, userId);
   } catch (err) {
-    logger.warn(
+    logger.error(
       `[SCHEMA_REF_LINK] Failed to retract prior auto-linked edges for ` +
         `${entityType}.${field}: ${err instanceof Error ? err.message : String(err)}`
     );
+    return { retracted: 0, failed: 1, retractedTargetEntityIds: [] };
   }
 }
 
 export async function autoLinkReferenceFields(
   params: AutoLinkReferenceFieldsParams
 ): Promise<AutoLinkResult> {
-  const result: AutoLinkResult = { created: 0, skipped: 0, details: [] };
+  const result: AutoLinkResult = {
+    created: 0,
+    skipped: 0,
+    retracted: 0,
+    retraction_failures: 0,
+    details: [],
+  };
   const refs = params.schema?.reference_fields;
   if (!refs || refs.length === 0) return result;
 
@@ -193,7 +216,7 @@ export async function autoLinkReferenceFields(
     if (!candidate) {
       // Field cleared (null/empty): retract any prior auto-linked edge for
       // this field so the snapshot and its live edge don't disagree (#1963).
-      await retractPriorAutoLinkedEdgesSafely(
+      const clearedRetraction = await retractPriorAutoLinkedEdgesSafely(
         relationshipsService,
         relationshipTypeForField,
         params.entityId,
@@ -201,6 +224,19 @@ export async function autoLinkReferenceFields(
         params.entityType,
         params.userId
       );
+      result.retracted += clearedRetraction.retracted;
+      result.retraction_failures += clearedRetraction.failed;
+      for (const retractedTargetEntityId of clearedRetraction.retractedTargetEntityIds) {
+        result.details.push({
+          field: ref.field,
+          target_entity_type: ref.target_entity_type,
+          target_canonical_name: "",
+          target_entity_id: null,
+          relationship_type: ref.relationship_type || "REFERS_TO",
+          linked: false,
+          retracted_target_entity_id: retractedTargetEntityId,
+        });
+      }
       continue;
     }
 
@@ -279,7 +315,7 @@ export async function autoLinkReferenceFields(
       // Target no longer resolves (e.g. organization renamed to a company
       // not yet in the graph): retract any prior auto-linked edge for this
       // field so it doesn't survive as a stale duplicate (#1963).
-      await retractPriorAutoLinkedEdgesSafely(
+      const unresolvedRetraction = await retractPriorAutoLinkedEdgesSafely(
         relationshipsService,
         relationshipTypeForField,
         params.entityId,
@@ -287,15 +323,31 @@ export async function autoLinkReferenceFields(
         params.entityType,
         params.userId
       );
+      result.retracted += unresolvedRetraction.retracted;
+      result.retraction_failures += unresolvedRetraction.failed;
       result.skipped++;
-      result.details.push({
-        field: ref.field,
-        target_entity_type: ref.target_entity_type,
-        target_canonical_name: candidate,
-        target_entity_id: null,
-        relationship_type: ref.relationship_type || "REFERS_TO",
-        linked: false,
-      });
+      if (unresolvedRetraction.retractedTargetEntityIds.length > 0) {
+        for (const retractedTargetEntityId of unresolvedRetraction.retractedTargetEntityIds) {
+          result.details.push({
+            field: ref.field,
+            target_entity_type: ref.target_entity_type,
+            target_canonical_name: candidate,
+            target_entity_id: null,
+            relationship_type: ref.relationship_type || "REFERS_TO",
+            linked: false,
+            retracted_target_entity_id: retractedTargetEntityId,
+          });
+        }
+      } else {
+        result.details.push({
+          field: ref.field,
+          target_entity_type: ref.target_entity_type,
+          target_canonical_name: candidate,
+          target_entity_id: null,
+          relationship_type: ref.relationship_type || "REFERS_TO",
+          linked: false,
+        });
+      }
       continue;
     }
 
@@ -303,7 +355,7 @@ export async function autoLinkReferenceFields(
       // No self-loops, but still retract any prior auto-linked edge for this
       // field — the field's resolved target changed even though we don't
       // link to it (#1963).
-      await retractPriorAutoLinkedEdgesSafely(
+      const selfLoopRetraction = await retractPriorAutoLinkedEdgesSafely(
         relationshipsService,
         relationshipTypeForField,
         params.entityId,
@@ -311,7 +363,31 @@ export async function autoLinkReferenceFields(
         params.entityType,
         params.userId
       );
+      result.retracted += selfLoopRetraction.retracted;
+      result.retraction_failures += selfLoopRetraction.failed;
       result.skipped++;
+      if (selfLoopRetraction.retractedTargetEntityIds.length > 0) {
+        for (const retractedTargetEntityId of selfLoopRetraction.retractedTargetEntityIds) {
+          result.details.push({
+            field: ref.field,
+            target_entity_type: ref.target_entity_type,
+            target_canonical_name: candidate,
+            target_entity_id: null,
+            relationship_type: relationshipTypeForField,
+            linked: false,
+            retracted_target_entity_id: retractedTargetEntityId,
+          });
+        }
+      } else {
+        result.details.push({
+          field: ref.field,
+          target_entity_type: ref.target_entity_type,
+          target_canonical_name: candidate,
+          target_entity_id: null,
+          relationship_type: relationshipTypeForField,
+          linked: false,
+        });
+      }
       continue;
     }
 
@@ -372,7 +448,7 @@ export async function autoLinkReferenceFields(
         user_id: params.userId,
       });
 
-      await retractStaleAutoLinkedEdges(
+      const changedTargetRetraction = await retractStaleAutoLinkedEdges(
         staleAutoLinked,
         relationshipType,
         params.entityId,
@@ -380,16 +456,32 @@ export async function autoLinkReferenceFields(
         params.entityType,
         params.userId
       );
+      result.retracted += changedTargetRetraction.retracted;
+      result.retraction_failures += changedTargetRetraction.failed;
 
       result.created++;
-      result.details.push({
-        field: ref.field,
-        target_entity_type: ref.target_entity_type,
-        target_canonical_name: candidate,
-        target_entity_id: targetEntityId,
-        relationship_type: relationshipType,
-        linked: true,
-      });
+      if (changedTargetRetraction.retractedTargetEntityIds.length > 0) {
+        for (const retractedTargetEntityId of changedTargetRetraction.retractedTargetEntityIds) {
+          result.details.push({
+            field: ref.field,
+            target_entity_type: ref.target_entity_type,
+            target_canonical_name: candidate,
+            target_entity_id: targetEntityId,
+            relationship_type: relationshipType,
+            linked: true,
+            retracted_target_entity_id: retractedTargetEntityId,
+          });
+        }
+      } else {
+        result.details.push({
+          field: ref.field,
+          target_entity_type: ref.target_entity_type,
+          target_canonical_name: candidate,
+          target_entity_id: targetEntityId,
+          relationship_type: relationshipType,
+          linked: true,
+        });
+      }
     } catch (err) {
       result.skipped++;
       logger.warn(

--- a/src/services/schema_reference_linking.ts
+++ b/src/services/schema_reference_linking.ts
@@ -67,6 +67,14 @@ export interface AutoLinkResult {
   skipped: number;
   retracted: number;
   retraction_failures: number;
+  /** Target entity ids of edges successfully retracted this reduction. */
+  retracted_target_entity_ids: string[];
+  /**
+   * Target entity ids of edges that FAILED to retract — still live despite the
+   * store succeeding. A caller can pass each (with the field's relationship
+   * type + the source entity) to `delete_relationship` to clean up manually.
+   */
+  failed_retraction_target_entity_ids: string[];
   details: Array<{
     field: string;
     target_entity_type: string;
@@ -121,6 +129,7 @@ export interface RetractStaleEdgesResult {
   retracted: number;
   failed: number;
   retractedTargetEntityIds: string[];
+  failedTargetEntityIds: string[];
 }
 
 /** Retract a set of stale auto-linked edges via softDeleteRelationship. */
@@ -132,7 +141,12 @@ async function retractStaleAutoLinkedEdges(
   entityType: string,
   userId: string
 ): Promise<RetractStaleEdgesResult> {
-  const result: RetractStaleEdgesResult = { retracted: 0, failed: 0, retractedTargetEntityIds: [] };
+  const result: RetractStaleEdgesResult = {
+    retracted: 0,
+    failed: 0,
+    retractedTargetEntityIds: [],
+    failedTargetEntityIds: [],
+  };
   if (stale.length === 0) return result;
   const { softDeleteRelationship } = await import("./deletion.js");
   for (const edge of stale) {
@@ -149,9 +163,11 @@ async function retractStaleAutoLinkedEdges(
       result.retractedTargetEntityIds.push(edge.target_entity_id);
     } else {
       result.failed++;
+      result.failedTargetEntityIds.push(edge.target_entity_id);
       logger.error(
         `[SCHEMA_REF_LINK] Failed to retract stale auto-linked edge ` +
-          `${edge.relationship_key} for ${entityType}.${field}: ${retraction.error}`
+          `${edge.relationship_key} for ${entityType}.${field} ` +
+          `(target ${edge.target_entity_id}): ${retraction.error}`
       );
     }
   }
@@ -194,7 +210,7 @@ async function retractPriorAutoLinkedEdgesSafely(
       `[SCHEMA_REF_LINK] Failed to retract prior auto-linked edges for ` +
         `${entityType}.${field}: ${err instanceof Error ? err.message : String(err)}`
     );
-    return { retracted: 0, failed: 1, retractedTargetEntityIds: [] };
+    return { retracted: 0, failed: 1, retractedTargetEntityIds: [], failedTargetEntityIds: [] };
   }
 }
 
@@ -206,6 +222,8 @@ export async function autoLinkReferenceFields(
     skipped: 0,
     retracted: 0,
     retraction_failures: 0,
+    retracted_target_entity_ids: [],
+    failed_retraction_target_entity_ids: [],
     details: [],
   };
   const refs = params.schema?.reference_fields;
@@ -231,6 +249,8 @@ export async function autoLinkReferenceFields(
       );
       result.retracted += clearedRetraction.retracted;
       result.retraction_failures += clearedRetraction.failed;
+      result.retracted_target_entity_ids.push(...clearedRetraction.retractedTargetEntityIds);
+      result.failed_retraction_target_entity_ids.push(...clearedRetraction.failedTargetEntityIds);
       for (const retractedTargetEntityId of clearedRetraction.retractedTargetEntityIds) {
         result.details.push({
           field: ref.field,
@@ -330,6 +350,10 @@ export async function autoLinkReferenceFields(
       );
       result.retracted += unresolvedRetraction.retracted;
       result.retraction_failures += unresolvedRetraction.failed;
+      result.retracted_target_entity_ids.push(...unresolvedRetraction.retractedTargetEntityIds);
+      result.failed_retraction_target_entity_ids.push(
+        ...unresolvedRetraction.failedTargetEntityIds
+      );
       result.skipped++;
       if (unresolvedRetraction.retractedTargetEntityIds.length > 0) {
         for (const retractedTargetEntityId of unresolvedRetraction.retractedTargetEntityIds) {
@@ -370,6 +394,8 @@ export async function autoLinkReferenceFields(
       );
       result.retracted += selfLoopRetraction.retracted;
       result.retraction_failures += selfLoopRetraction.failed;
+      result.retracted_target_entity_ids.push(...selfLoopRetraction.retractedTargetEntityIds);
+      result.failed_retraction_target_entity_ids.push(...selfLoopRetraction.failedTargetEntityIds);
       result.skipped++;
       if (selfLoopRetraction.retractedTargetEntityIds.length > 0) {
         for (const retractedTargetEntityId of selfLoopRetraction.retractedTargetEntityIds) {
@@ -463,6 +489,10 @@ export async function autoLinkReferenceFields(
       );
       result.retracted += changedTargetRetraction.retracted;
       result.retraction_failures += changedTargetRetraction.failed;
+      result.retracted_target_entity_ids.push(...changedTargetRetraction.retractedTargetEntityIds);
+      result.failed_retraction_target_entity_ids.push(
+        ...changedTargetRetraction.failedTargetEntityIds
+      );
 
       result.created++;
       if (changedTargetRetraction.retractedTargetEntityIds.length > 0) {

--- a/src/services/schema_reference_linking.ts
+++ b/src/services/schema_reference_linking.ts
@@ -40,9 +40,7 @@ function isAutoLinkMetadataForField(
   metadata: Record<string, unknown> | null | undefined,
   field: string
 ): boolean {
-  return (
-    !!metadata && metadata.auto_linked === true && metadata.auto_link_field === field
-  );
+  return !!metadata && metadata.auto_linked === true && metadata.auto_link_field === field;
 }
 
 export interface AutoLinkReferenceFieldsParams {
@@ -183,7 +181,14 @@ async function retractPriorAutoLinkedEdgesSafely(
       field,
       userId
     );
-    return await retractStaleAutoLinkedEdges(stale, relationshipType, entityId, field, entityType, userId);
+    return await retractStaleAutoLinkedEdges(
+      stale,
+      relationshipType,
+      entityId,
+      field,
+      entityType,
+      userId
+    );
   } catch (err) {
     logger.error(
       `[SCHEMA_REF_LINK] Failed to retract prior auto-linked edges for ` +

--- a/src/services/schema_reference_linking.ts
+++ b/src/services/schema_reference_linking.ts
@@ -12,6 +12,14 @@
  * `resolve_target: true`, in which case a resolver may create the target
  * (see the `resolve_target` branch below and `company_resolution.ts`).
  *
+ * When a reference field's resolved target changes across observations (e.g.
+ * a contact's `organization` moves from Company A to Company B), the
+ * previously auto-linked edge for that field is retracted in the same
+ * reduction that creates the new one, so a stale duplicate edge never
+ * accumulates (#1963). Only edges this mechanism created
+ * (`metadata.auto_linked === true` for the same field) are retracted;
+ * manually-created edges are never touched.
+ *
  * This is the schema-agnostic replacement for hardcoded
  * "if entity.category === 'foo', link to Foo" logic.
  */
@@ -20,6 +28,22 @@ import { db } from "../db.js";
 import { logger } from "../utils/logger.js";
 import type { RelationshipType } from "./relationships.js";
 import type { SchemaDefinition } from "./schema_registry.js";
+
+/** Metadata shape written onto relationships created by this service. */
+export interface AutoLinkMetadata {
+  auto_linked: true;
+  auto_link_field: string;
+  auto_link_entity_type: string;
+}
+
+function isAutoLinkMetadataForField(
+  metadata: Record<string, unknown> | null | undefined,
+  field: string
+): boolean {
+  return (
+    !!metadata && metadata.auto_linked === true && metadata.auto_link_field === field
+  );
+}
 
 export interface AutoLinkReferenceFieldsParams {
   entityId: string;
@@ -65,6 +89,93 @@ function normalizeCandidate(value: unknown): string | null {
   return null;
 }
 
+/** Live edges this mechanism previously created for one entity+field+type. */
+async function findPriorAutoLinkedEdges(
+  relationshipsService: (typeof import("./relationships.js"))["relationshipsService"],
+  entityId: string,
+  relationshipType: RelationshipType,
+  field: string,
+  userId: string
+): Promise<Array<{ relationship_key: string; target_entity_id: string }>> {
+  const existing = await relationshipsService.getRelationshipsForEntity(
+    entityId,
+    "outgoing",
+    false,
+    userId
+  );
+  return existing
+    .filter(
+      (rel) =>
+        rel.relationship_type === relationshipType &&
+        isAutoLinkMetadataForField(rel.snapshot, field)
+    )
+    .map((rel) => ({
+      relationship_key: rel.relationship_key,
+      target_entity_id: rel.target_entity_id,
+    }));
+}
+
+/** Retract a set of stale auto-linked edges via softDeleteRelationship. */
+async function retractStaleAutoLinkedEdges(
+  stale: Array<{ relationship_key: string; target_entity_id: string }>,
+  relationshipType: RelationshipType,
+  entityId: string,
+  field: string,
+  entityType: string,
+  userId: string
+): Promise<void> {
+  if (stale.length === 0) return;
+  const { softDeleteRelationship } = await import("./deletion.js");
+  for (const edge of stale) {
+    const retraction = await softDeleteRelationship(
+      edge.relationship_key,
+      relationshipType,
+      entityId,
+      edge.target_entity_id,
+      userId,
+      `auto_link_retraction:${field}`
+    );
+    if (!retraction.success) {
+      logger.warn(
+        `[SCHEMA_REF_LINK] Failed to retract stale auto-linked edge ` +
+          `${edge.relationship_key} for ${entityType}.${field}: ${retraction.error}`
+      );
+    }
+  }
+}
+
+/**
+ * Find and retract every live auto-linked edge for one entity+field+type,
+ * swallowing lookup/retraction failures as warnings (never throws). Used on
+ * every path where this field no longer resolves to a linkable target this
+ * reduction — cleared, unresolvable, or self-referencing — so a stale edge
+ * from a prior resolution never survives (#1963).
+ */
+async function retractPriorAutoLinkedEdgesSafely(
+  relationshipsService: (typeof import("./relationships.js"))["relationshipsService"],
+  relationshipType: RelationshipType,
+  entityId: string,
+  field: string,
+  entityType: string,
+  userId: string
+): Promise<void> {
+  try {
+    const stale = await findPriorAutoLinkedEdges(
+      relationshipsService,
+      entityId,
+      relationshipType,
+      field,
+      userId
+    );
+    await retractStaleAutoLinkedEdges(stale, relationshipType, entityId, field, entityType, userId);
+  } catch (err) {
+    logger.warn(
+      `[SCHEMA_REF_LINK] Failed to retract prior auto-linked edges for ` +
+        `${entityType}.${field}: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+}
+
 export async function autoLinkReferenceFields(
   params: AutoLinkReferenceFieldsParams
 ): Promise<AutoLinkResult> {
@@ -77,7 +188,21 @@ export async function autoLinkReferenceFields(
   for (const ref of refs) {
     const rawValue = params.fields[ref.field];
     const candidate = normalizeCandidate(rawValue);
-    if (!candidate) continue;
+    const relationshipTypeForField = (ref.relationship_type || "REFERS_TO") as RelationshipType;
+
+    if (!candidate) {
+      // Field cleared (null/empty): retract any prior auto-linked edge for
+      // this field so the snapshot and its live edge don't disagree (#1963).
+      await retractPriorAutoLinkedEdgesSafely(
+        relationshipsService,
+        relationshipTypeForField,
+        params.entityId,
+        ref.field,
+        params.entityType,
+        params.userId
+      );
+      continue;
+    }
 
     // Resolve target entity by canonical_name or display name of the declared
     // target entity type. We check entity_snapshots for an exact canonical
@@ -151,6 +276,17 @@ export async function autoLinkReferenceFields(
     }
 
     if (!targetEntityId) {
+      // Target no longer resolves (e.g. organization renamed to a company
+      // not yet in the graph): retract any prior auto-linked edge for this
+      // field so it doesn't survive as a stale duplicate (#1963).
+      await retractPriorAutoLinkedEdgesSafely(
+        relationshipsService,
+        relationshipTypeForField,
+        params.entityId,
+        ref.field,
+        params.entityType,
+        params.userId
+      );
       result.skipped++;
       result.details.push({
         field: ref.field,
@@ -164,12 +300,63 @@ export async function autoLinkReferenceFields(
     }
 
     if (targetEntityId === params.entityId) {
-      // No self-loops.
+      // No self-loops, but still retract any prior auto-linked edge for this
+      // field — the field's resolved target changed even though we don't
+      // link to it (#1963).
+      await retractPriorAutoLinkedEdgesSafely(
+        relationshipsService,
+        relationshipTypeForField,
+        params.entityId,
+        ref.field,
+        params.entityType,
+        params.userId
+      );
       result.skipped++;
       continue;
     }
 
-    const relationshipType = (ref.relationship_type || "REFERS_TO") as RelationshipType;
+    const relationshipType = relationshipTypeForField;
+
+    // Find any live edges this mechanism previously created for this field,
+    // so a changed resolution target (e.g. contact.organization moving from
+    // Company A to Company B) retracts the stale edge instead of
+    // accumulating a duplicate (#1963). Manually-created edges (no
+    // auto_linked metadata, or a different field) are left untouched.
+    let priorAutoLinked: Array<{ relationship_key: string; target_entity_id: string }> = [];
+    try {
+      priorAutoLinked = await findPriorAutoLinkedEdges(
+        relationshipsService,
+        params.entityId,
+        relationshipType,
+        ref.field,
+        params.userId
+      );
+    } catch (err) {
+      logger.warn(
+        `[SCHEMA_REF_LINK] Failed to look up existing auto-linked edges for ` +
+          `${params.entityType}.${ref.field}: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+
+    const alreadyLinkedToTarget = priorAutoLinked.some(
+      (rel) => rel.target_entity_id === targetEntityId
+    );
+    const staleAutoLinked = priorAutoLinked.filter(
+      (rel) => rel.target_entity_id !== targetEntityId
+    );
+
+    if (alreadyLinkedToTarget) {
+      // Target unchanged: no-op, avoid a redundant create + retraction pair.
+      result.details.push({
+        field: ref.field,
+        target_entity_type: ref.target_entity_type,
+        target_canonical_name: candidate,
+        target_entity_id: targetEntityId,
+        relationship_type: relationshipType,
+        linked: true,
+      });
+      continue;
+    }
 
     try {
       await relationshipsService.createRelationship({
@@ -181,9 +368,19 @@ export async function autoLinkReferenceFields(
           auto_linked: true,
           auto_link_field: ref.field,
           auto_link_entity_type: params.entityType,
-        },
+        } satisfies AutoLinkMetadata,
         user_id: params.userId,
       });
+
+      await retractStaleAutoLinkedEdges(
+        staleAutoLinked,
+        relationshipType,
+        params.entityId,
+        ref.field,
+        params.entityType,
+        params.userId
+      );
+
       result.created++;
       result.details.push({
         field: ref.field,

--- a/src/services/schema_reference_linking.ts
+++ b/src/services/schema_reference_linking.ts
@@ -75,6 +75,16 @@ export interface AutoLinkResult {
    * type + the source entity) to `delete_relationship` to clean up manually.
    */
   failed_retraction_target_entity_ids: string[];
+  /**
+   * Structured detail for each failed retraction, so a caller can build the
+   * exact `delete_relationship` call without knowing its own schema: the
+   * reference `field`, its `relationship_type`, and the stale `target_entity_id`.
+   */
+  failed_retractions: Array<{
+    field: string;
+    relationship_type: string;
+    target_entity_id: string;
+  }>;
   details: Array<{
     field: string;
     target_entity_type: string;
@@ -130,6 +140,7 @@ export interface RetractStaleEdgesResult {
   failed: number;
   retractedTargetEntityIds: string[];
   failedTargetEntityIds: string[];
+  failedRetractions: Array<{ field: string; relationship_type: string; target_entity_id: string }>;
 }
 
 /** Retract a set of stale auto-linked edges via softDeleteRelationship. */
@@ -146,6 +157,7 @@ async function retractStaleAutoLinkedEdges(
     failed: 0,
     retractedTargetEntityIds: [],
     failedTargetEntityIds: [],
+    failedRetractions: [],
   };
   if (stale.length === 0) return result;
   const { softDeleteRelationship } = await import("./deletion.js");
@@ -164,6 +176,11 @@ async function retractStaleAutoLinkedEdges(
     } else {
       result.failed++;
       result.failedTargetEntityIds.push(edge.target_entity_id);
+      result.failedRetractions.push({
+        field,
+        relationship_type: relationshipType,
+        target_entity_id: edge.target_entity_id,
+      });
       logger.error(
         `[SCHEMA_REF_LINK] Failed to retract stale auto-linked edge ` +
           `${edge.relationship_key} for ${entityType}.${field} ` +
@@ -210,7 +227,13 @@ async function retractPriorAutoLinkedEdgesSafely(
       `[SCHEMA_REF_LINK] Failed to retract prior auto-linked edges for ` +
         `${entityType}.${field}: ${err instanceof Error ? err.message : String(err)}`
     );
-    return { retracted: 0, failed: 1, retractedTargetEntityIds: [], failedTargetEntityIds: [] };
+    return {
+      retracted: 0,
+      failed: 1,
+      retractedTargetEntityIds: [],
+      failedTargetEntityIds: [],
+      failedRetractions: [],
+    };
   }
 }
 
@@ -224,6 +247,7 @@ export async function autoLinkReferenceFields(
     retraction_failures: 0,
     retracted_target_entity_ids: [],
     failed_retraction_target_entity_ids: [],
+    failed_retractions: [],
     details: [],
   };
   const refs = params.schema?.reference_fields;
@@ -251,6 +275,7 @@ export async function autoLinkReferenceFields(
       result.retraction_failures += clearedRetraction.failed;
       result.retracted_target_entity_ids.push(...clearedRetraction.retractedTargetEntityIds);
       result.failed_retraction_target_entity_ids.push(...clearedRetraction.failedTargetEntityIds);
+      result.failed_retractions.push(...clearedRetraction.failedRetractions);
       for (const retractedTargetEntityId of clearedRetraction.retractedTargetEntityIds) {
         result.details.push({
           field: ref.field,
@@ -354,6 +379,7 @@ export async function autoLinkReferenceFields(
       result.failed_retraction_target_entity_ids.push(
         ...unresolvedRetraction.failedTargetEntityIds
       );
+      result.failed_retractions.push(...unresolvedRetraction.failedRetractions);
       result.skipped++;
       if (unresolvedRetraction.retractedTargetEntityIds.length > 0) {
         for (const retractedTargetEntityId of unresolvedRetraction.retractedTargetEntityIds) {
@@ -396,6 +422,7 @@ export async function autoLinkReferenceFields(
       result.retraction_failures += selfLoopRetraction.failed;
       result.retracted_target_entity_ids.push(...selfLoopRetraction.retractedTargetEntityIds);
       result.failed_retraction_target_entity_ids.push(...selfLoopRetraction.failedTargetEntityIds);
+      result.failed_retractions.push(...selfLoopRetraction.failedRetractions);
       result.skipped++;
       if (selfLoopRetraction.retractedTargetEntityIds.length > 0) {
         for (const retractedTargetEntityId of selfLoopRetraction.retractedTargetEntityIds) {
@@ -493,6 +520,7 @@ export async function autoLinkReferenceFields(
       result.failed_retraction_target_entity_ids.push(
         ...changedTargetRetraction.failedTargetEntityIds
       );
+      result.failed_retractions.push(...changedTargetRetraction.failedRetractions);
 
       result.created++;
       if (changedTargetRetraction.retractedTargetEntityIds.length > 0) {

--- a/tests/integration/auto_link_retraction_organization_change.test.ts
+++ b/tests/integration/auto_link_retraction_organization_change.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Regression + cross-surface parity tests for #1963: auto-linked `works_at`
+ * edges were never retracted when a contact's `organization` changed,
+ * leaving stale duplicate company links (Gabriel Hubert / Aki Suzuki repro
+ * from the issue — two source records disagreeing on organization left BOTH
+ * `works_at` edges live).
+ *
+ * Drives the same "contact with changing organization" scenario across both
+ * `autoLinkReferenceFields` call sites — the MCP `store` tool dispatch
+ * (src/server.ts) and the REST `POST /store` route (src/actions.ts) — per the
+ * swarm's cross_surface_contract_parity_tested_all_surfaces policy
+ * (ent_2ad0677fe23c0c1878ae43e8). Assertions are effect-level: resolved
+ * snapshot `organization` and live `works_at` edge count/target, not just
+ * that a function was invoked (fixed_means_behavior_verified_not_contract_accepted,
+ * ent_db0b7855d47012084477fb00).
+ */
+
+import { createServer } from "node:http";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { app } from "../../src/actions.js";
+import { db } from "../../src/db.js";
+import { NeotomaServer } from "../../src/server.js";
+import { cleanupEntityType } from "../helpers/cleanup_helpers.js";
+import { schemaRegistry } from "../../src/services/schema_registry.js";
+import { ENTITY_SCHEMAS } from "../../src/services/schema_definitions.js";
+
+const TEST_USER_ID = "00000000-0000-0000-0000-000000001963";
+const API_PORT = 18124;
+const API_BASE = `http://127.0.0.1:${API_PORT}`;
+
+interface StoreResponse {
+  content: Array<{ type: string; text: string }>;
+}
+
+async function getLiveWorksAtEdges(contactEntityId: string) {
+  const { data, error } = await db
+    .from("relationship_snapshots")
+    .select("relationship_key, target_entity_id, is_live, snapshot")
+    .eq("relationship_type", "works_at")
+    .eq("source_entity_id", contactEntityId)
+    .eq("is_live", 1);
+  expect(error).toBeNull();
+  return data ?? [];
+}
+
+async function getContactSnapshot(contactEntityId: string) {
+  const { data, error } = await db
+    .from("entity_snapshots")
+    .select("snapshot")
+    .eq("entity_id", contactEntityId)
+    .single();
+  expect(error).toBeNull();
+  return data?.snapshot as Record<string, unknown> | undefined;
+}
+
+describe("auto-link retraction on organization change (#1963)", () => {
+  let httpServer: ReturnType<typeof createServer>;
+  let mcpServer: NeotomaServer;
+
+  beforeAll(async () => {
+    httpServer = createServer(app);
+    await new Promise<void>((resolve, reject) => {
+      httpServer.listen(API_PORT, "127.0.0.1", () => resolve());
+      httpServer.once("error", reject);
+    });
+
+    mcpServer = new NeotomaServer();
+    (mcpServer as unknown as { authenticatedUserId: string }).authenticatedUserId =
+      TEST_USER_ID;
+
+    // The reference_fields-driven auto-link hook reads the schema via
+    // schemaRegistry.loadActiveSchema, which is DB-backed only — a dev DB may
+    // carry a stale pre-reference_fields global `contact` schema row. Register
+    // the current code-defined schema as user-scoped so this test exercises
+    // the real `organization` -> `company` `resolve_target` reference field,
+    // matching the pattern in company_entity_resolution_leads.test.ts.
+    if (!(await schemaRegistry.loadActiveSchema("contact", TEST_USER_ID))) {
+      const contactSchema = ENTITY_SCHEMAS.contact;
+      await schemaRegistry.register({
+        entity_type: "contact",
+        schema_version: contactSchema.schema_version,
+        schema_definition: contactSchema.schema_definition,
+        reducer_config: contactSchema.reducer_config,
+        user_id: TEST_USER_ID,
+        user_specific: true,
+        activate: true,
+        metadata: contactSchema.metadata,
+      });
+    }
+  });
+
+  afterAll(async () => {
+    await cleanupEntityType("contact", TEST_USER_ID);
+    await cleanupEntityType("company", TEST_USER_ID);
+    await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+  });
+
+  it("MCP store: retracts the prior auto-linked works_at edge when organization changes", async () => {
+    const idempotencyKeyBase = `issue-1963-mcp-${Date.now()}`;
+
+    const first = (await (
+      mcpServer as unknown as {
+        store: (params: Record<string, unknown>) => Promise<StoreResponse>;
+      }
+    ).store({
+      user_id: TEST_USER_ID,
+      idempotency_key: `${idempotencyKeyBase}-1`,
+      commit: true,
+      entities: [
+        {
+          entity_type: "contact",
+          name: "Gabriel Hubert MCP",
+          email: `gabriel.hubert.mcp.${idempotencyKeyBase}@example.com`,
+          organization: "Dust",
+        },
+      ],
+    })) as StoreResponse;
+    const firstBody = JSON.parse(first.content[0].text) as { entities?: Array<{ entity_id: string }> };
+    const contactEntityId = firstBody.entities?.[0]?.entity_id;
+    expect(typeof contactEntityId).toBe("string");
+    if (!contactEntityId) throw new Error("contact entity id missing from store response");
+
+    const afterFirst = await getLiveWorksAtEdges(contactEntityId);
+    expect(afterFirst).toHaveLength(1);
+    const dustEdge = afterFirst[0];
+
+    // Second observation: organization changes to Stripe (simulates a merged
+    // Gmail/LinkedIn source disagreeing with the first).
+    await (
+      mcpServer as unknown as {
+        store: (params: Record<string, unknown>) => Promise<StoreResponse>;
+      }
+    ).store({
+      user_id: TEST_USER_ID,
+      idempotency_key: `${idempotencyKeyBase}-2`,
+      commit: true,
+      entities: [
+        {
+          entity_type: "contact",
+          name: "Gabriel Hubert MCP",
+          email: `gabriel.hubert.mcp.${idempotencyKeyBase}@example.com`,
+          organization: "Stripe",
+        },
+      ],
+    });
+
+    // Effect: exactly one live works_at edge, pointing at Stripe, and the
+    // resolved snapshot's organization agrees with it (the bug's core
+    // assertion — snapshot and live edge must never disagree).
+    const afterSecond = await getLiveWorksAtEdges(contactEntityId);
+    expect(afterSecond).toHaveLength(1);
+    expect(afterSecond[0].target_entity_id).not.toBe(dustEdge.target_entity_id);
+
+    const snapshot = await getContactSnapshot(contactEntityId);
+    expect(snapshot?.organization).toBe("Stripe");
+
+    // The stale Dust edge is soft-deleted, not merely absent from the live set.
+    const { data: dustSnapshotRow } = await db
+      .from("relationship_snapshots")
+      .select("is_live")
+      .eq("relationship_key", dustEdge.relationship_key)
+      .single();
+    expect(dustSnapshotRow?.is_live).toBe(0);
+  });
+
+  it("REST POST /store: retracts the prior auto-linked works_at edge when organization changes", async () => {
+    const idempotencyKeyBase = `issue-1963-rest-${Date.now()}`;
+
+    const firstResp = await fetch(`${API_BASE}/store`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        user_id: TEST_USER_ID,
+        idempotency_key: `${idempotencyKeyBase}-1`,
+        commit: true,
+        entities: [
+          {
+            entity_type: "contact",
+            name: "Aki Suzuki REST",
+            email: `aki.suzuki.rest.${idempotencyKeyBase}@example.com`,
+            organization: "Stripe",
+          },
+        ],
+      }),
+    });
+    expect(firstResp.status).toBe(200);
+    const firstBody = (await firstResp.json()) as { entities?: Array<{ entity_id: string }> };
+    const contactEntityId = firstBody.entities?.[0]?.entity_id;
+    expect(typeof contactEntityId).toBe("string");
+    if (!contactEntityId) throw new Error("contact entity id missing from store response");
+
+    const afterFirst = await getLiveWorksAtEdges(contactEntityId);
+    expect(afterFirst).toHaveLength(1);
+    const stripeEdge = afterFirst[0];
+
+    const secondResp = await fetch(`${API_BASE}/store`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        user_id: TEST_USER_ID,
+        idempotency_key: `${idempotencyKeyBase}-2`,
+        commit: true,
+        entities: [
+          {
+            entity_type: "contact",
+            name: "Aki Suzuki REST",
+            email: `aki.suzuki.rest.${idempotencyKeyBase}@example.com`,
+            organization: "Zuqca",
+          },
+        ],
+      }),
+    });
+    expect(secondResp.status).toBe(200);
+
+    const afterSecond = await getLiveWorksAtEdges(contactEntityId);
+    expect(afterSecond).toHaveLength(1);
+    expect(afterSecond[0].target_entity_id).not.toBe(stripeEdge.target_entity_id);
+
+    const snapshot = await getContactSnapshot(contactEntityId);
+    expect(snapshot?.organization).toBe("Zuqca");
+
+    const { data: stripeSnapshotRow } = await db
+      .from("relationship_snapshots")
+      .select("is_live")
+      .eq("relationship_key", stripeEdge.relationship_key)
+      .single();
+    expect(stripeSnapshotRow?.is_live).toBe(0);
+  });
+
+  it("preserves a manually-created works_at edge when organization auto-link changes (edge case)", async () => {
+    const idempotencyKeyBase = `issue-1963-manual-preserve-${Date.now()}`;
+
+    const first = (await (
+      mcpServer as unknown as {
+        store: (params: Record<string, unknown>) => Promise<StoreResponse>;
+      }
+    ).store({
+      user_id: TEST_USER_ID,
+      idempotency_key: `${idempotencyKeyBase}-1`,
+      commit: true,
+      entities: [
+        {
+          entity_type: "contact",
+          name: "Manual Edge Contact",
+          email: `manual.edge.${idempotencyKeyBase}@example.com`,
+          organization: "Dust",
+        },
+        {
+          entity_type: "company",
+          name: `Manual Advisory Co ${idempotencyKeyBase}`,
+        },
+      ],
+    })) as StoreResponse;
+    const firstBody = JSON.parse(first.content[0].text) as {
+      entities?: Array<{ entity_id: string; entity_type: string }>;
+    };
+    const contactEntityId = firstBody.entities?.find((e) => e.entity_type === "contact")?.entity_id;
+    const manualCompanyId = firstBody.entities?.find((e) => e.entity_type === "company")?.entity_id;
+    if (!contactEntityId || !manualCompanyId) {
+      throw new Error("expected contact and company entity ids from store response");
+    }
+
+    // Manually create an unrelated works_at edge (no auto_linked metadata).
+    const { relationshipsService } = await import("../../src/services/relationships.js");
+    await relationshipsService.createRelationship({
+      relationship_type: "works_at",
+      source_entity_id: contactEntityId,
+      target_entity_id: manualCompanyId,
+      metadata: { role: "advisor" },
+      user_id: TEST_USER_ID,
+    });
+
+    const beforeChange = await getLiveWorksAtEdges(contactEntityId);
+    expect(beforeChange).toHaveLength(2); // auto-linked Dust + manual advisory edge
+
+    // Change organization: only the auto-linked Dust edge should retract.
+    await (
+      mcpServer as unknown as {
+        store: (params: Record<string, unknown>) => Promise<StoreResponse>;
+      }
+    ).store({
+      user_id: TEST_USER_ID,
+      idempotency_key: `${idempotencyKeyBase}-2`,
+      commit: true,
+      entities: [
+        {
+          entity_type: "contact",
+          name: "Manual Edge Contact",
+          email: `manual.edge.${idempotencyKeyBase}@example.com`,
+          organization: "Stripe",
+        },
+      ],
+    });
+
+    const afterChange = await getLiveWorksAtEdges(contactEntityId);
+    const afterChangeTargets = afterChange.map((r) => r.target_entity_id).sort();
+    expect(afterChange).toHaveLength(2); // new auto-linked Stripe edge + preserved manual edge
+    expect(afterChangeTargets).toContain(manualCompanyId);
+    expect(afterChangeTargets).not.toContain(beforeChange.find((r) => r.target_entity_id !== manualCompanyId)?.target_entity_id);
+  });
+});

--- a/tests/integration/auto_link_retraction_organization_change.test.ts
+++ b/tests/integration/auto_link_retraction_organization_change.test.ts
@@ -17,7 +17,30 @@
 
 import { createServer } from "node:http";
 
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+// The failure-path tests below force softDeleteRelationship to fail so we can
+// assert the AUTO_LINK_RETRACTION_FAILED store_warning reaches each response.
+// The mock is a passthrough by default (real soft-delete, so the success-path
+// tests are unaffected) and only fails when `forceRetractionFailure` is set.
+// This intercepts the dynamic `import("./deletion.js")` inside
+// schema_reference_linking.ts — the same technique the unit test uses.
+let forceRetractionFailure = false;
+const { softDeleteRelationship: realSoftDelete } = await vi.importActual<
+  typeof import("../../src/services/deletion.js")
+>("../../src/services/deletion.js");
+vi.mock("../../src/services/deletion.js", async () => {
+  const actual = await vi.importActual<typeof import("../../src/services/deletion.js")>(
+    "../../src/services/deletion.js"
+  );
+  return {
+    ...actual,
+    softDeleteRelationship: (...args: Parameters<typeof actual.softDeleteRelationship>) =>
+      forceRetractionFailure
+        ? Promise.resolve({ success: false as const, error: "forced failure (test)" })
+        : realSoftDelete(...args),
+  };
+});
 
 import { app } from "../../src/actions.js";
 import { db } from "../../src/db.js";
@@ -313,5 +336,137 @@ describe("auto-link retraction on organization change (#1963)", () => {
     expect(afterChangeTargets).not.toContain(
       beforeChange.find((r) => r.target_entity_id !== manualCompanyId)?.target_entity_id
     );
+  });
+
+  // Blocking qa finding on #1970: the AUTO_LINK_RETRACTION_FAILED warning — the
+  // PR's own "never silent" safety addition — must be proven to reach BOTH store
+  // responses. Force softDeleteRelationship to fail, then assert the warning (with
+  // the stale target ids) surfaces on the MCP and REST /store response bodies.
+  describe("retraction failure surfaces on the store response (both surfaces)", () => {
+    afterEach(() => {
+      forceRetractionFailure = false;
+    });
+
+    it("MCP store: AUTO_LINK_RETRACTION_FAILED with target ids when soft-delete fails", async () => {
+      const idempotencyKeyBase = `issue-1963-mcp-fail-${Date.now()}`;
+      const storeFn = (
+        mcpServer as unknown as {
+          store: (params: Record<string, unknown>) => Promise<StoreResponse>;
+        }
+      ).store.bind(mcpServer);
+
+      // First store links the contact to Dust (soft-delete not exercised).
+      const first = await storeFn({
+        user_id: TEST_USER_ID,
+        idempotency_key: `${idempotencyKeyBase}-1`,
+        commit: true,
+        entities: [
+          {
+            entity_type: "contact",
+            name: "Retract Fail MCP",
+            email: `retract.fail.mcp.${idempotencyKeyBase}@example.com`,
+            organization: "Dust",
+          },
+        ],
+      });
+      const contactEntityId = (
+        JSON.parse(first.content[0].text) as { entities?: Array<{ entity_id: string }> }
+      ).entities?.[0]?.entity_id;
+      if (!contactEntityId) throw new Error("contact entity id missing");
+      const [dustEdge] = await getLiveWorksAtEdges(contactEntityId);
+
+      // Second store changes org → retraction is attempted and forced to fail.
+      forceRetractionFailure = true;
+      const second = await storeFn({
+        user_id: TEST_USER_ID,
+        idempotency_key: `${idempotencyKeyBase}-2`,
+        commit: true,
+        entities: [
+          {
+            entity_type: "contact",
+            name: "Retract Fail MCP",
+            email: `retract.fail.mcp.${idempotencyKeyBase}@example.com`,
+            organization: "Stripe",
+          },
+        ],
+      });
+      const body = JSON.parse(second.content[0].text) as {
+        store_warnings?: Array<{
+          code: string;
+          entity_id: string;
+          details?: {
+            stale_edges?: Array<{ target_entity_id: string; relationship_type: string }>;
+          };
+        }>;
+      };
+      const warn = (body.store_warnings ?? []).find(
+        (w) => w.code === "AUTO_LINK_RETRACTION_FAILED" && w.entity_id === contactEntityId
+      );
+      expect(warn).toBeDefined();
+      // The stale target id is exposed as a structured, delete_relationship-ready field.
+      expect(warn?.details?.stale_edges?.[0]?.target_entity_id).toBe(dustEdge.target_entity_id);
+      expect(warn?.details?.stale_edges?.[0]?.relationship_type).toBe("works_at");
+    });
+
+    it("REST POST /store: AUTO_LINK_RETRACTION_FAILED with target ids when soft-delete fails", async () => {
+      const idempotencyKeyBase = `issue-1963-rest-fail-${Date.now()}`;
+
+      const firstResp = await fetch(`${API_BASE}/store`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          user_id: TEST_USER_ID,
+          idempotency_key: `${idempotencyKeyBase}-1`,
+          commit: true,
+          entities: [
+            {
+              entity_type: "contact",
+              name: "Retract Fail REST",
+              email: `retract.fail.rest.${idempotencyKeyBase}@example.com`,
+              organization: "Stripe",
+            },
+          ],
+        }),
+      });
+      const contactEntityId = (
+        (await firstResp.json()) as { entities?: Array<{ entity_id: string }> }
+      ).entities?.[0]?.entity_id;
+      if (!contactEntityId) throw new Error("contact entity id missing");
+      const [stripeEdge] = await getLiveWorksAtEdges(contactEntityId);
+
+      forceRetractionFailure = true;
+      const secondResp = await fetch(`${API_BASE}/store`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          user_id: TEST_USER_ID,
+          idempotency_key: `${idempotencyKeyBase}-2`,
+          commit: true,
+          entities: [
+            {
+              entity_type: "contact",
+              name: "Retract Fail REST",
+              email: `retract.fail.rest.${idempotencyKeyBase}@example.com`,
+              organization: "Zuqca",
+            },
+          ],
+        }),
+      });
+      const body = (await secondResp.json()) as {
+        store_warnings?: Array<{
+          code: string;
+          entity_id: string;
+          details?: {
+            stale_edges?: Array<{ target_entity_id: string; relationship_type: string }>;
+          };
+        }>;
+      };
+      const warn = (body.store_warnings ?? []).find(
+        (w) => w.code === "AUTO_LINK_RETRACTION_FAILED" && w.entity_id === contactEntityId
+      );
+      expect(warn).toBeDefined();
+      expect(warn?.details?.stale_edges?.[0]?.target_entity_id).toBe(stripeEdge.target_entity_id);
+      expect(warn?.details?.stale_edges?.[0]?.relationship_type).toBe("works_at");
+    });
   });
 });

--- a/tests/integration/auto_link_retraction_organization_change.test.ts
+++ b/tests/integration/auto_link_retraction_organization_change.test.ts
@@ -67,8 +67,7 @@ describe("auto-link retraction on organization change (#1963)", () => {
     });
 
     mcpServer = new NeotomaServer();
-    (mcpServer as unknown as { authenticatedUserId: string }).authenticatedUserId =
-      TEST_USER_ID;
+    (mcpServer as unknown as { authenticatedUserId: string }).authenticatedUserId = TEST_USER_ID;
 
     // The reference_fields-driven auto-link hook reads the schema via
     // schemaRegistry.loadActiveSchema, which is DB-backed only — a dev DB may
@@ -117,7 +116,9 @@ describe("auto-link retraction on organization change (#1963)", () => {
         },
       ],
     })) as StoreResponse;
-    const firstBody = JSON.parse(first.content[0].text) as { entities?: Array<{ entity_id: string }> };
+    const firstBody = JSON.parse(first.content[0].text) as {
+      entities?: Array<{ entity_id: string }>;
+    };
     const contactEntityId = firstBody.entities?.[0]?.entity_id;
     expect(typeof contactEntityId).toBe("string");
     if (!contactEntityId) throw new Error("contact entity id missing from store response");
@@ -214,6 +215,17 @@ describe("auto-link retraction on organization change (#1963)", () => {
     });
     expect(secondResp.status).toBe(200);
 
+    // #1963: the retraction must not be silent — the store response surfaces it
+    // via store_warnings so a caller can observe that a stale edge was cleaned
+    // up (and, in the failure case, that one may still be live).
+    const secondBody = (await secondResp.json()) as {
+      store_warnings?: Array<{ code: string; entity_id: string }>;
+    };
+    const retractionWarning = (secondBody.store_warnings ?? []).find(
+      (w) => w.code === "AUTO_LINK_EDGE_RETRACTED" && w.entity_id === contactEntityId
+    );
+    expect(retractionWarning).toBeDefined();
+
     const afterSecond = await getLiveWorksAtEdges(contactEntityId);
     expect(afterSecond).toHaveLength(1);
     expect(afterSecond[0].target_entity_id).not.toBe(stripeEdge.target_entity_id);
@@ -298,6 +310,8 @@ describe("auto-link retraction on organization change (#1963)", () => {
     const afterChangeTargets = afterChange.map((r) => r.target_entity_id).sort();
     expect(afterChange).toHaveLength(2); // new auto-linked Stripe edge + preserved manual edge
     expect(afterChangeTargets).toContain(manualCompanyId);
-    expect(afterChangeTargets).not.toContain(beforeChange.find((r) => r.target_entity_id !== manualCompanyId)?.target_entity_id);
+    expect(afterChangeTargets).not.toContain(
+      beforeChange.find((r) => r.target_entity_id !== manualCompanyId)?.target_entity_id
+    );
   });
 });

--- a/tests/services/schema_reference_linking.test.ts
+++ b/tests/services/schema_reference_linking.test.ts
@@ -36,11 +36,20 @@ vi.mock("../../src/db.js", () => {
 });
 
 const createRelationshipMock = vi.fn();
+const getRelationshipsForEntityMock = vi.fn();
 vi.mock("../../src/services/relationships.js", () => {
   return {
     relationshipsService: {
       createRelationship: createRelationshipMock,
+      getRelationshipsForEntity: getRelationshipsForEntityMock,
     },
+  };
+});
+
+const softDeleteRelationshipMock = vi.fn();
+vi.mock("../../src/services/deletion.js", () => {
+  return {
+    softDeleteRelationship: (...args: unknown[]) => softDeleteRelationshipMock(...args),
   };
 });
 
@@ -55,6 +64,10 @@ describe("autoLinkReferenceFields", () => {
   beforeEach(() => {
     createRelationshipMock.mockReset();
     createRelationshipMock.mockResolvedValue({ id: "rel_1" });
+    getRelationshipsForEntityMock.mockReset();
+    getRelationshipsForEntityMock.mockResolvedValue([]);
+    softDeleteRelationshipMock.mockReset();
+    softDeleteRelationshipMock.mockResolvedValue({ success: true, observation_id: "obs_1" });
     resolveCompanyEntityMock.mockReset();
   });
 
@@ -249,6 +262,339 @@ describe("autoLinkReferenceFields", () => {
       });
 
       expect(resolveCompanyEntityMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("retraction on organization change (#1963)", () => {
+    const orgSchema = {
+      fields: {},
+      reference_fields: [
+        {
+          field: "organization",
+          target_entity_type: "company",
+          relationship_type: "works_at" as const,
+          resolve_target: true,
+        },
+      ],
+    };
+
+    function mockCompanyResolution(entityId: string, canonicalName: string) {
+      resolveCompanyEntityMock.mockResolvedValueOnce({
+        entityId,
+        normalizedName: canonicalName.toLowerCase(),
+        canonicalName,
+        basis: "created",
+        created: true,
+      });
+    }
+
+    it("retracts the prior auto-linked edge when organization changes to a new company", async () => {
+      // Contact already has a live auto-linked works_at edge to Dust.
+      getRelationshipsForEntityMock.mockResolvedValueOnce([
+        {
+          relationship_key: "works_at:ent_contact_1:ent_company_dust",
+          relationship_type: "works_at",
+          source_entity_id: "ent_contact_1",
+          target_entity_id: "ent_company_dust",
+          snapshot: {
+            auto_linked: true,
+            auto_link_field: "organization",
+            auto_link_entity_type: "contact",
+          },
+        },
+      ]);
+      mockCompanyResolution("ent_company_stripe", "Stripe");
+
+      const { autoLinkReferenceFields } =
+        await import("../../src/services/schema_reference_linking.js");
+      const result = await autoLinkReferenceFields({
+        entityId: "ent_contact_1",
+        entityType: "contact",
+        fields: { organization: "Stripe" },
+        schema: orgSchema,
+        userId: "u1",
+      });
+
+      expect(createRelationshipMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          relationship_type: "works_at",
+          source_entity_id: "ent_contact_1",
+          target_entity_id: "ent_company_stripe",
+        })
+      );
+      expect(softDeleteRelationshipMock).toHaveBeenCalledWith(
+        "works_at:ent_contact_1:ent_company_dust",
+        "works_at",
+        "ent_contact_1",
+        "ent_company_dust",
+        "u1",
+        expect.stringContaining("organization")
+      );
+      expect(result.created).toBe(1);
+      expect(result.details[0]).toMatchObject({
+        target_entity_id: "ent_company_stripe",
+        linked: true,
+      });
+    });
+
+    it("preserves a manually-created works_at edge to a different company", async () => {
+      // Manual edge (no auto_linked metadata) to Company A, plus an
+      // auto-linked edge to Company B that must be retracted.
+      getRelationshipsForEntityMock.mockResolvedValueOnce([
+        {
+          relationship_key: "works_at:ent_contact_1:ent_company_a",
+          relationship_type: "works_at",
+          source_entity_id: "ent_contact_1",
+          target_entity_id: "ent_company_a",
+          snapshot: {},
+        },
+        {
+          relationship_key: "works_at:ent_contact_1:ent_company_b",
+          relationship_type: "works_at",
+          source_entity_id: "ent_contact_1",
+          target_entity_id: "ent_company_b",
+          snapshot: {
+            auto_linked: true,
+            auto_link_field: "organization",
+            auto_link_entity_type: "contact",
+          },
+        },
+      ]);
+      mockCompanyResolution("ent_company_c", "Company C");
+
+      const { autoLinkReferenceFields } =
+        await import("../../src/services/schema_reference_linking.js");
+      await autoLinkReferenceFields({
+        entityId: "ent_contact_1",
+        entityType: "contact",
+        fields: { organization: "Company C" },
+        schema: orgSchema,
+        userId: "u1",
+      });
+
+      // Only the auto-linked Company B edge is retracted.
+      expect(softDeleteRelationshipMock).toHaveBeenCalledTimes(1);
+      expect(softDeleteRelationshipMock).toHaveBeenCalledWith(
+        "works_at:ent_contact_1:ent_company_b",
+        "works_at",
+        "ent_contact_1",
+        "ent_company_b",
+        "u1",
+        expect.any(String)
+      );
+    });
+
+    it("is a no-op when organization is re-observed with the same value", async () => {
+      getRelationshipsForEntityMock.mockResolvedValueOnce([
+        {
+          relationship_key: "works_at:ent_contact_1:ent_company_stripe",
+          relationship_type: "works_at",
+          source_entity_id: "ent_contact_1",
+          target_entity_id: "ent_company_stripe",
+          snapshot: {
+            auto_linked: true,
+            auto_link_field: "organization",
+            auto_link_entity_type: "contact",
+          },
+        },
+      ]);
+      mockCompanyResolution("ent_company_stripe", "Stripe");
+
+      const { autoLinkReferenceFields } =
+        await import("../../src/services/schema_reference_linking.js");
+      const result = await autoLinkReferenceFields({
+        entityId: "ent_contact_1",
+        entityType: "contact",
+        fields: { organization: "Stripe" },
+        schema: orgSchema,
+        userId: "u1",
+      });
+
+      expect(createRelationshipMock).not.toHaveBeenCalled();
+      expect(softDeleteRelationshipMock).not.toHaveBeenCalled();
+      expect(result.details[0]).toMatchObject({
+        target_entity_id: "ent_company_stripe",
+        linked: true,
+      });
+    });
+
+    it("retracts the prior auto-linked edge and creates nothing when organization is cleared", async () => {
+      getRelationshipsForEntityMock.mockResolvedValueOnce([
+        {
+          relationship_key: "works_at:ent_contact_1:ent_company_stripe",
+          relationship_type: "works_at",
+          source_entity_id: "ent_contact_1",
+          target_entity_id: "ent_company_stripe",
+          snapshot: {
+            auto_linked: true,
+            auto_link_field: "organization",
+            auto_link_entity_type: "contact",
+          },
+        },
+      ]);
+
+      const { autoLinkReferenceFields } =
+        await import("../../src/services/schema_reference_linking.js");
+      const result = await autoLinkReferenceFields({
+        entityId: "ent_contact_1",
+        entityType: "contact",
+        fields: { organization: "" },
+        schema: orgSchema,
+        userId: "u1",
+      });
+
+      expect(createRelationshipMock).not.toHaveBeenCalled();
+      expect(resolveCompanyEntityMock).not.toHaveBeenCalled();
+      expect(softDeleteRelationshipMock).toHaveBeenCalledWith(
+        "works_at:ent_contact_1:ent_company_stripe",
+        "works_at",
+        "ent_contact_1",
+        "ent_company_stripe",
+        "u1",
+        expect.any(String)
+      );
+      expect(result.created).toBe(0);
+    });
+
+    it("does not retract when the target resolves to the same company despite casing/whitespace differences", async () => {
+      // Simulates "Stripe" -> "stripe " both resolving to the same company
+      // entity id: the canonical lookup in autoLinkReferenceFields already
+      // case/whitespace-normalizes, so the resolved targetEntityId matches
+      // the prior auto-linked edge's target and no thrash occurs.
+      getRelationshipsForEntityMock.mockResolvedValueOnce([
+        {
+          relationship_key: "works_at:ent_contact_1:ent_company_stripe",
+          relationship_type: "works_at",
+          source_entity_id: "ent_contact_1",
+          target_entity_id: "ent_company_stripe",
+          snapshot: {
+            auto_linked: true,
+            auto_link_field: "organization",
+            auto_link_entity_type: "contact",
+          },
+        },
+      ]);
+      mockCompanyResolution("ent_company_stripe", "Stripe");
+
+      const { autoLinkReferenceFields } =
+        await import("../../src/services/schema_reference_linking.js");
+      await autoLinkReferenceFields({
+        entityId: "ent_contact_1",
+        entityType: "contact",
+        fields: { organization: "stripe " },
+        schema: orgSchema,
+        userId: "u1",
+      });
+
+      expect(createRelationshipMock).not.toHaveBeenCalled();
+      expect(softDeleteRelationshipMock).not.toHaveBeenCalled();
+    });
+
+    it("no-ops safely when the stale auto-linked edge was already retracted (softDeleteRelationship idempotency)", async () => {
+      // getRelationshipsForEntity defaults to live-only (includeDeleted=false),
+      // so an already-deleted edge simply never appears here — retraction is
+      // naturally idempotent because there's nothing stale left to retract.
+      getRelationshipsForEntityMock.mockResolvedValueOnce([]);
+      mockCompanyResolution("ent_company_stripe", "Stripe");
+
+      const { autoLinkReferenceFields } =
+        await import("../../src/services/schema_reference_linking.js");
+      const result = await autoLinkReferenceFields({
+        entityId: "ent_contact_1",
+        entityType: "contact",
+        fields: { organization: "Stripe" },
+        schema: orgSchema,
+        userId: "u1",
+      });
+
+      expect(softDeleteRelationshipMock).not.toHaveBeenCalled();
+      expect(result.created).toBe(1);
+    });
+
+    it("retracts the prior auto-linked edge when the field's new value cannot be resolved to any target", async () => {
+      // organization renamed to a company not yet in the graph, and
+      // resolve_target's resolver call itself fails (e.g. transient error) —
+      // the field is non-empty but yields no target, so the prior Dust edge
+      // must still be retracted rather than surviving indefinitely.
+      getRelationshipsForEntityMock.mockResolvedValueOnce([
+        {
+          relationship_key: "works_at:ent_contact_1:ent_company_dust",
+          relationship_type: "works_at",
+          source_entity_id: "ent_contact_1",
+          target_entity_id: "ent_company_dust",
+          snapshot: {
+            auto_linked: true,
+            auto_link_field: "organization",
+            auto_link_entity_type: "contact",
+          },
+        },
+      ]);
+      resolveCompanyEntityMock.mockRejectedValueOnce(new Error("resolution unavailable"));
+
+      const { autoLinkReferenceFields } =
+        await import("../../src/services/schema_reference_linking.js");
+      const result = await autoLinkReferenceFields({
+        entityId: "ent_contact_1",
+        entityType: "contact",
+        fields: { organization: "Unresolvable New Co" },
+        schema: orgSchema,
+        userId: "u1",
+      });
+
+      expect(createRelationshipMock).not.toHaveBeenCalled();
+      expect(softDeleteRelationshipMock).toHaveBeenCalledWith(
+        "works_at:ent_contact_1:ent_company_dust",
+        "works_at",
+        "ent_contact_1",
+        "ent_company_dust",
+        "u1",
+        expect.any(String)
+      );
+      expect(result.created).toBe(0);
+      expect(result.skipped).toBe(1);
+      expect(result.details[0].linked).toBe(false);
+    });
+
+    it("retracts the prior auto-linked edge when the field resolves to a self-loop", async () => {
+      // targetEntityId === entityId is skipped as a link (no self-loops),
+      // but the prior auto-linked edge for this field must still retract —
+      // the field's resolved target changed even though nothing new links.
+      getRelationshipsForEntityMock.mockResolvedValueOnce([
+        {
+          relationship_key: "works_at:ent_contact_1:ent_company_dust",
+          relationship_type: "works_at",
+          source_entity_id: "ent_contact_1",
+          target_entity_id: "ent_company_dust",
+          snapshot: {
+            auto_linked: true,
+            auto_link_field: "organization",
+            auto_link_entity_type: "contact",
+          },
+        },
+      ]);
+      mockCompanyResolution("ent_contact_1", "Self Co");
+
+      const { autoLinkReferenceFields } =
+        await import("../../src/services/schema_reference_linking.js");
+      const result = await autoLinkReferenceFields({
+        entityId: "ent_contact_1",
+        entityType: "contact",
+        fields: { organization: "Self Co" },
+        schema: orgSchema,
+        userId: "u1",
+      });
+
+      expect(createRelationshipMock).not.toHaveBeenCalled();
+      expect(softDeleteRelationshipMock).toHaveBeenCalledWith(
+        "works_at:ent_contact_1:ent_company_dust",
+        "works_at",
+        "ent_contact_1",
+        "ent_company_dust",
+        "u1",
+        expect.any(String)
+      );
+      expect(result.created).toBe(0);
+      expect(result.skipped).toBe(1);
     });
   });
 });

--- a/tests/services/schema_reference_linking.test.ts
+++ b/tests/services/schema_reference_linking.test.ts
@@ -763,6 +763,64 @@ describe("autoLinkReferenceFields", () => {
       expect(result.retracted_target_entity_ids).toEqual(["ent_company_dust"]);
     });
 
+    it("partitions results correctly when multiple stale edges retract with mixed success/failure", async () => {
+      // Non-blocking qa finding on #1970: cover >1 stale auto-linked edge for the
+      // same field where one soft-delete succeeds and one fails. The succeeding
+      // and failing target ids must land in the right buckets.
+      getRelationshipsForEntityMock.mockResolvedValueOnce([
+        {
+          relationship_key: "works_at:ent_contact_1:ent_company_dust",
+          relationship_type: "works_at",
+          source_entity_id: "ent_contact_1",
+          target_entity_id: "ent_company_dust",
+          snapshot: {
+            auto_linked: true,
+            auto_link_field: "organization",
+            auto_link_entity_type: "contact",
+          },
+        },
+        {
+          relationship_key: "works_at:ent_contact_1:ent_company_acme",
+          relationship_type: "works_at",
+          source_entity_id: "ent_contact_1",
+          target_entity_id: "ent_company_acme",
+          snapshot: {
+            auto_linked: true,
+            auto_link_field: "organization",
+            auto_link_entity_type: "contact",
+          },
+        },
+      ]);
+      // First retraction (Dust) succeeds; second (Acme) fails.
+      softDeleteRelationshipMock
+        .mockResolvedValueOnce({ success: true, observation_id: "obs_1" })
+        .mockResolvedValueOnce({ success: false, error: "db unavailable" });
+      mockCompanyResolution("ent_company_stripe", "Stripe");
+
+      const { autoLinkReferenceFields } =
+        await import("../../src/services/schema_reference_linking.js");
+      const result = await autoLinkReferenceFields({
+        entityId: "ent_contact_1",
+        entityType: "contact",
+        fields: { organization: "Stripe" },
+        schema: orgSchema,
+        userId: "u1",
+      });
+
+      expect(result.created).toBe(1);
+      expect(result.retracted).toBe(1);
+      expect(result.retraction_failures).toBe(1);
+      expect(result.retracted_target_entity_ids).toEqual(["ent_company_dust"]);
+      expect(result.failed_retraction_target_entity_ids).toEqual(["ent_company_acme"]);
+      expect(result.failed_retractions).toEqual([
+        {
+          field: "organization",
+          relationship_type: "works_at",
+          target_entity_id: "ent_company_acme",
+        },
+      ]);
+    });
+
     it("survives out-of-order delivery: the last-write-winning organization value wins even when the older observation is stored second", async () => {
       // Regression for the PM review on #1970: autoLinkReferenceFields treats
       // params.fields[ref.field] as an opaque given value with no internal

--- a/tests/services/schema_reference_linking.test.ts
+++ b/tests/services/schema_reference_linking.test.ts
@@ -1,8 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  ObservationReducer,
-  type Observation,
-} from "../../src/reducers/observation_reducer.js";
+import { ObservationReducer, type Observation } from "../../src/reducers/observation_reducer.js";
 
 vi.mock("../../src/db.js", () => {
   const snapshots: Array<Record<string, unknown>> = [];
@@ -83,13 +80,11 @@ vi.mock("../../src/services/schema_definitions.js", () => ({
   getSchemaDefinition: vi.fn().mockReturnValue(null),
 }));
 vi.mock("../../src/services/field_validation.js", () => ({
-  validateFieldWithConverters: vi
-    .fn()
-    .mockImplementation((_field: string, value: unknown) => ({
-      isValid: true,
-      value,
-      shouldRouteToRawFragments: false,
-    })),
+  validateFieldWithConverters: vi.fn().mockImplementation((_field: string, value: unknown) => ({
+    isValid: true,
+    value,
+    shouldRouteToRawFragments: false,
+  })),
 }));
 
 describe("autoLinkReferenceFields", () => {
@@ -689,6 +684,10 @@ describe("autoLinkReferenceFields", () => {
       expect(result.created).toBe(1);
       expect(result.retracted).toBe(0);
       expect(result.retraction_failures).toBe(1);
+      // The failed target id must be surfaced so a caller can follow the
+      // remediation (delete_relationship needs the target_entity_id).
+      expect(result.failed_retraction_target_entity_ids).toEqual(["ent_company_dust"]);
+      expect(result.retracted_target_entity_ids).toEqual([]);
       expect(errorSpy).toHaveBeenCalledWith(
         expect.stringContaining("Failed to retract stale auto-linked edge")
       );
@@ -698,6 +697,70 @@ describe("autoLinkReferenceFields", () => {
 
       errorSpy.mockRestore();
       warnSpy.mockRestore();
+    });
+
+    it("retracts on target change keyed on the field, not hardcoded to organization (generic reference field)", async () => {
+      // PM review on #1970: the fix is generic to any schema-declared reference
+      // field, but coverage only exercised the `organization`/`works_at` pair.
+      // This proves the retraction is keyed on `auto_link_field` (the schema's
+      // field name), not the literal string "organization": a differently-named
+      // reference field (`primary_employer`) with a different relationship_type
+      // (`member_of`) retracts its own prior edge and leaves nothing else.
+      const employerSchema = {
+        fields: {},
+        reference_fields: [
+          {
+            field: "primary_employer",
+            target_entity_type: "company",
+            relationship_type: "member_of" as const,
+            resolve_target: true,
+          },
+        ],
+      };
+
+      getRelationshipsForEntityMock.mockResolvedValueOnce([
+        {
+          relationship_key: "member_of:ent_contact_1:ent_company_dust",
+          relationship_type: "member_of",
+          source_entity_id: "ent_contact_1",
+          target_entity_id: "ent_company_dust",
+          snapshot: {
+            auto_linked: true,
+            auto_link_field: "primary_employer",
+            auto_link_entity_type: "contact",
+          },
+        },
+      ]);
+      mockCompanyResolution("ent_company_stripe", "Stripe");
+
+      const { autoLinkReferenceFields } =
+        await import("../../src/services/schema_reference_linking.js");
+      const result = await autoLinkReferenceFields({
+        entityId: "ent_contact_1",
+        entityType: "contact",
+        fields: { primary_employer: "Stripe" },
+        schema: employerSchema,
+        userId: "u1",
+      });
+
+      expect(createRelationshipMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          relationship_type: "member_of",
+          source_entity_id: "ent_contact_1",
+          target_entity_id: "ent_company_stripe",
+        })
+      );
+      expect(softDeleteRelationshipMock).toHaveBeenCalledWith(
+        "member_of:ent_contact_1:ent_company_dust",
+        "member_of",
+        "ent_contact_1",
+        "ent_company_dust",
+        "u1",
+        expect.stringContaining("primary_employer")
+      );
+      expect(result.created).toBe(1);
+      expect(result.retracted).toBe(1);
+      expect(result.retracted_target_entity_ids).toEqual(["ent_company_dust"]);
     });
 
     it("survives out-of-order delivery: the last-write-winning organization value wins even when the older observation is stored second", async () => {

--- a/tests/services/schema_reference_linking.test.ts
+++ b/tests/services/schema_reference_linking.test.ts
@@ -1,4 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ObservationReducer,
+  type Observation,
+} from "../../src/reducers/observation_reducer.js";
 
 vi.mock("../../src/db.js", () => {
   const snapshots: Array<Record<string, unknown>> = [];
@@ -59,6 +63,34 @@ vi.mock("../../src/services/company_resolution.js", () => {
     resolveCompanyEntity: (...args: unknown[]) => resolveCompanyEntityMock(...args),
   };
 });
+
+// Used only by the replay/out-of-order delivery test below, which drives the
+// real ObservationReducer to prove last-write-wins is order-independent.
+const loadActiveSchemaMock = vi.fn();
+vi.mock("../../src/services/schema_registry.js", () => ({
+  DEFAULT_OBSERVATION_SOURCE_PRIORITY: [
+    "sensor",
+    "workflow_state",
+    "llm_summary",
+    "human",
+    "import",
+  ] as const,
+  schemaRegistry: {
+    loadActiveSchema: (...args: unknown[]) => loadActiveSchemaMock(...args),
+  },
+}));
+vi.mock("../../src/services/schema_definitions.js", () => ({
+  getSchemaDefinition: vi.fn().mockReturnValue(null),
+}));
+vi.mock("../../src/services/field_validation.js", () => ({
+  validateFieldWithConverters: vi
+    .fn()
+    .mockImplementation((_field: string, value: unknown) => ({
+      isValid: true,
+      value,
+      shouldRouteToRawFragments: false,
+    })),
+}));
 
 describe("autoLinkReferenceFields", () => {
   beforeEach(() => {
@@ -331,9 +363,12 @@ describe("autoLinkReferenceFields", () => {
         expect.stringContaining("organization")
       );
       expect(result.created).toBe(1);
+      expect(result.retracted).toBe(1);
+      expect(result.retraction_failures).toBe(0);
       expect(result.details[0]).toMatchObject({
         target_entity_id: "ent_company_stripe",
         linked: true,
+        retracted_target_entity_id: "ent_company_dust",
       });
     });
 
@@ -454,6 +489,12 @@ describe("autoLinkReferenceFields", () => {
         expect.any(String)
       );
       expect(result.created).toBe(0);
+      expect(result.retracted).toBe(1);
+      expect(result.retraction_failures).toBe(0);
+      expect(result.details[0]).toMatchObject({
+        linked: false,
+        retracted_target_entity_id: "ent_company_stripe",
+      });
     });
 
     it("does not retract when the target resolves to the same company despite casing/whitespace differences", async () => {
@@ -552,7 +593,12 @@ describe("autoLinkReferenceFields", () => {
       );
       expect(result.created).toBe(0);
       expect(result.skipped).toBe(1);
-      expect(result.details[0].linked).toBe(false);
+      expect(result.retracted).toBe(1);
+      expect(result.retraction_failures).toBe(0);
+      expect(result.details[0]).toMatchObject({
+        linked: false,
+        retracted_target_entity_id: "ent_company_dust",
+      });
     });
 
     it("retracts the prior auto-linked edge when the field resolves to a self-loop", async () => {
@@ -595,6 +641,183 @@ describe("autoLinkReferenceFields", () => {
       );
       expect(result.created).toBe(0);
       expect(result.skipped).toBe(1);
+      expect(result.retracted).toBe(1);
+      expect(result.retraction_failures).toBe(0);
+      expect(result.details[0]).toMatchObject({
+        linked: false,
+        retracted_target_entity_id: "ent_company_dust",
+      });
+    });
+
+    it("surfaces retraction failures on the result instead of only logging, and escalates to logger.error", async () => {
+      // ux review acceptance check: mock softDeleteRelationship to fail and
+      // assert (a) logger.error was called, not logger.warn, and (b)
+      // result.retraction_failures reflects the failure count.
+      const { logger } = await import("../../src/utils/logger.js");
+      const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => undefined);
+      const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => undefined);
+
+      getRelationshipsForEntityMock.mockResolvedValueOnce([
+        {
+          relationship_key: "works_at:ent_contact_1:ent_company_dust",
+          relationship_type: "works_at",
+          source_entity_id: "ent_contact_1",
+          target_entity_id: "ent_company_dust",
+          snapshot: {
+            auto_linked: true,
+            auto_link_field: "organization",
+            auto_link_entity_type: "contact",
+          },
+        },
+      ]);
+      softDeleteRelationshipMock.mockResolvedValueOnce({
+        success: false,
+        error: "db unavailable",
+      });
+      mockCompanyResolution("ent_company_stripe", "Stripe");
+
+      const { autoLinkReferenceFields } =
+        await import("../../src/services/schema_reference_linking.js");
+      const result = await autoLinkReferenceFields({
+        entityId: "ent_contact_1",
+        entityType: "contact",
+        fields: { organization: "Stripe" },
+        schema: orgSchema,
+        userId: "u1",
+      });
+
+      expect(result.created).toBe(1);
+      expect(result.retracted).toBe(0);
+      expect(result.retraction_failures).toBe(1);
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Failed to retract stale auto-linked edge")
+      );
+      expect(warnSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining("Failed to retract stale auto-linked edge")
+      );
+
+      errorSpy.mockRestore();
+      warnSpy.mockRestore();
+    });
+
+    it("survives out-of-order delivery: the last-write-winning organization value wins even when the older observation is stored second", async () => {
+      // Regression for the PM review on #1970: autoLinkReferenceFields treats
+      // params.fields[ref.field] as an opaque given value with no internal
+      // awareness of observation timestamps or delivery order. That is by
+      // design — ordering is the reducer's job, not this function's. This
+      // test proves the full contract end to end: (1) the reducer's
+      // last-write-wins merge is order-independent (sorts by observed_at
+      // DESC regardless of array/delivery order), and (2) whatever value the
+      // reducer resolves is exactly what autoLinkReferenceFields acts on.
+      //
+      // Delivery order: the NEWER observation (Stripe, 2025-02-01) is stored
+      // in the array BEFORE the OLDER observation (Dust, 2025-01-01) — i.e.
+      // the older observation is "delivered second" (a backfill/replay
+      // scenario). last_write must still resolve to Stripe.
+      loadActiveSchemaMock.mockResolvedValueOnce({
+        id: "schema-contact",
+        entity_type: "contact",
+        schema_version: "1.0.0",
+        schema_definition: {
+          fields: { organization: { type: "string" as const, required: false } },
+          identity_opt_out: "heuristic_canonical_name",
+        },
+        reducer_config: {
+          merge_policies: { organization: { strategy: "last_write" as const } },
+        },
+        active: true,
+      });
+
+      const observations: Observation[] = [
+        {
+          id: "obs_newer_stripe",
+          entity_id: "ent_contact_1",
+          entity_type: "contact",
+          schema_version: "1.0",
+          source_id: "src_1",
+          observed_at: "2025-02-01T00:00:00Z",
+          specificity_score: 1.0,
+          source_priority: 100,
+          fields: { organization: "Stripe" },
+          created_at: "2025-02-01T00:00:00Z",
+          user_id: "u1",
+        },
+        {
+          id: "obs_older_dust",
+          entity_id: "ent_contact_1",
+          entity_type: "contact",
+          schema_version: "1.0",
+          source_id: "src_1",
+          observed_at: "2025-01-01T00:00:00Z",
+          specificity_score: 1.0,
+          source_priority: 100,
+          fields: { organization: "Dust" },
+          created_at: "2025-01-01T00:00:00Z",
+          user_id: "u1",
+        },
+      ];
+
+      const reducer = new ObservationReducer();
+      const snap = await reducer.computeSnapshot("ent_contact_1", observations);
+      expect(snap).not.toBeNull();
+      // The older observation was stored/delivered second (later array
+      // position corresponds to earlier observed_at is irrelevant here —
+      // observations[0] IS the newer one; what matters is the reducer sorts
+      // by observed_at, not array position). Assert last-write-wins picked
+      // the later observed_at value regardless of array order.
+      expect(snap!.snapshot.organization).toBe("Stripe");
+      expect(snap!.provenance.organization).toBe("obs_newer_stripe");
+
+      // Now feed the reducer's resolved (winning) value into
+      // autoLinkReferenceFields, proving it links/retracts against the
+      // correct last-write-winning value rather than an intermediate one.
+      getRelationshipsForEntityMock.mockResolvedValueOnce([
+        {
+          relationship_key: "works_at:ent_contact_1:ent_company_dust",
+          relationship_type: "works_at",
+          source_entity_id: "ent_contact_1",
+          target_entity_id: "ent_company_dust",
+          snapshot: {
+            auto_linked: true,
+            auto_link_field: "organization",
+            auto_link_entity_type: "contact",
+          },
+        },
+      ]);
+      mockCompanyResolution("ent_company_stripe", "Stripe");
+
+      const { autoLinkReferenceFields } =
+        await import("../../src/services/schema_reference_linking.js");
+      const result = await autoLinkReferenceFields({
+        entityId: "ent_contact_1",
+        entityType: "contact",
+        fields: snap!.snapshot,
+        schema: orgSchema,
+        userId: "u1",
+      });
+
+      expect(createRelationshipMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          relationship_type: "works_at",
+          source_entity_id: "ent_contact_1",
+          target_entity_id: "ent_company_stripe",
+        })
+      );
+      expect(softDeleteRelationshipMock).toHaveBeenCalledWith(
+        "works_at:ent_contact_1:ent_company_dust",
+        "works_at",
+        "ent_contact_1",
+        "ent_company_dust",
+        "u1",
+        expect.any(String)
+      );
+      expect(result.created).toBe(1);
+      expect(result.retracted).toBe(1);
+      expect(result.details[0]).toMatchObject({
+        target_entity_id: "ent_company_stripe",
+        linked: true,
+        retracted_target_entity_id: "ent_company_dust",
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary

Closes #1963.

Auto-linked `works_at` edges were never retracted when a contact's resolved `organization` target changed, so contacts accumulated duplicate/stale company links over time. `autoLinkReferenceFields` (`src/services/schema_reference_linking.ts`) now retracts the prior `auto_linked:true` edge for a reference field in the same reduction that creates the new one — reusing the existing `softDeleteRelationship` tombstone primitive rather than adding a new deletion mechanism.

Retraction fires on every path where the field's resolved target changes:
- organization changes from Company A → Company B (the primary bug repro)
- organization is cleared (null/empty)
- organization resolves to a target that doesn't exist / resolution fails
- organization resolves to a self-loop (the contact's own entity)

It is a no-op when the resolved target is unchanged (including casing/whitespace variants that resolve to the same canonical company), and manually-created `works_at` edges (no `auto_linked` metadata, or a different field) are always left untouched.

## Scope

Per the issue's PM sign-off: hard-delete retraction via the existing `softDeleteRelationship` primitive, no `is_current` flag. Instance repair (~705 stale edges) and multi-employer modeling are explicitly out of scope for this issue.

## Testing

- `tests/services/schema_reference_linking.test.ts` — 15 unit tests: retraction on target change, manual-edge preservation, no-op on unchanged value, org-cleared retraction, casing/whitespace no-thrash, idempotent retraction of already-deleted edges, unresolvable-target retraction, self-loop retraction.
- `tests/integration/auto_link_retraction_organization_change.test.ts` — new integration suite reproducing the exact Gabriel Hubert / Aki Suzuki repro from the issue (two observations with disagreeing `organization`), driven across **both** call sites (MCP `store` in `src/server.ts` and REST `POST /store` in `src/actions.ts`) per the swarm's cross-surface parity policy. Assertions are effect-level: live `works_at` edge count/target and resolved snapshot `organization` agreement, plus a manual-edge-preservation case.
- `docs/testing/automated_test_catalog.md` regenerated (`npm run generate:test-catalog`) and validated (`npm run validate:test-catalog`).
- `npx tsc --noEmit` and `npx eslint` clean on all touched files.

## Test plan

- [x] Regression test: org change retracts stale edge, creates new one, in the same reduction
- [x] Integration fixture reproducing the issue's exact merged-source repro scenario
- [x] Edge case: manual edge preserved
- [x] Edge case: no-op on unchanged value (including casing/whitespace)
- [x] Edge case: org cleared retracts with no new edge
- [x] Edge case: out-of-order/idempotent retraction of an already-deleted edge
- [x] Edge case: unresolvable target retracts prior edge (found during self-review, not in original QA spec)
- [x] Edge case: self-loop retracts prior edge (found during self-review, not in original QA spec)
- [x] Cross-surface parity: MCP and REST both exercised with identical assertions

🤖 Generated by Cicada (Ateles swarm, implementation build)