### PR TITLE
fix(schema): carry SchemaMetadata (guest_access_policy) forward on incremental update (#1977)

### DIFF
--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,8 +61,8 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **530**
-- Backend and repo Vitest files: **495**
+- Total automated test files: **531**
+- Backend and repo Vitest files: **496**
 - Frontend Vitest files: **9**
 - Playwright spec files: **26**
 
@@ -72,7 +72,7 @@ flowchart TD
 | Vitest unit tests | 147 |
 | Vitest service tests | 36 |
 | Source-adjacent tests | 64 |
-| Vitest integration tests | 153 |
+| Vitest integration tests | 154 |
 | Vitest CLI tests | 65 |
 | Vitest contract tests | 14 |
 | Vitest security tests | 4 |
@@ -377,7 +377,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm run test:integration` or `npx vitest run tests/integration`
 **Requirements:** Database configured; remote-dependent subsets additionally need `RUN_REMOTE_TESTS=1`.
-**Files (153):**
+**Files (154):**
 - `tests/integration/aauth_attribution_stamping.test.ts`
 - `tests/integration/aauth_mcp_capability_parity.test.ts`
 - `tests/integration/aauth_mcp_initialize_admission.test.ts`
@@ -501,6 +501,7 @@ flowchart TD
 - `tests/integration/sandbox_report.test.ts`
 - `tests/integration/sandbox_seed_token_bypass.test.ts`
 - `tests/integration/sandbox_stale_bearer_fallback.test.ts`
+- `tests/integration/schema_metadata_carry_forward.test.ts`
 - `tests/integration/schema_recommendation_integration.test.ts`
 - `tests/integration/session_introspection.test.ts`
 - `tests/integration/snapshot_ingestion_cutoff.test.ts`

--- a/src/cli/access.ts
+++ b/src/cli/access.ts
@@ -77,6 +77,22 @@ function warnOnEnvMismatch(target: { sqlite_path: string; env_flag_mismatch: boo
   }
 }
 
+/**
+ * Resolve the write target once per command invocation and warn on mismatch.
+ * Shared by every mutating helper (setViaMetadata/resetViaMetadata) so
+ * accessSet, accessReset, accessEnableIssues, and accessDisableIssues all get
+ * the same DB-target visibility, instead of only accessSet (#1979 follow-up).
+ */
+async function resolveTargetAndWarnOnce(): Promise<{
+  sqlite_path: string;
+  environment: string;
+  env_flag_mismatch: boolean;
+}> {
+  const target = await resolveAccessTarget();
+  warnOnEnvMismatch(target);
+  return target;
+}
+
 function output(data: unknown, json: boolean): void {
   if (json) {
     process.stdout.write(JSON.stringify(data, null, 2) + "\n");
@@ -139,7 +155,7 @@ export async function accessSet(
 
   await setViaMetadata(entityType, mode as AccessPolicyMode);
 
-  const target = await resolveAccessTarget();
+  const target = await resolveTargetAndWarnOnce();
   if (opts.json) {
     output(
       {
@@ -158,7 +174,6 @@ export async function accessSet(
         `(${target.environment} DB: ${target.sqlite_path}).\n`
     );
   }
-  warnOnEnvMismatch(target);
 }
 
 export async function accessList(opts: AccessListOpts): Promise<void> {
@@ -191,6 +206,7 @@ export async function accessList(opts: AccessListOpts): Promise<void> {
 
 export async function accessReset(entityType: string, opts: AccessResetOpts): Promise<void> {
   const effective = await resetViaMetadata(entityType);
+  const target = await resolveTargetAndWarnOnce();
 
   if (opts.json) {
     output(
@@ -200,18 +216,23 @@ export async function accessReset(entityType: string, opts: AccessResetOpts): Pr
         status: "reset",
         effective_mode: effective.mode,
         effective_source: effective.source,
+        sqlite_path: target.sqlite_path,
+        environment: target.environment,
+        env_flag_mismatch: target.env_flag_mismatch,
       },
       true
     );
   } else {
     if (effective.mode === DEFAULT_MODE) {
       process.stdout.write(
-        `Access policy for "${entityType}" reset to default ("${DEFAULT_MODE}").\n`
+        `Access policy for "${entityType}" reset to default ("${DEFAULT_MODE}") ` +
+          `(${target.environment} DB: ${target.sqlite_path}).\n`
       );
     } else {
       process.stdout.write(
         `Access policy for "${entityType}" reset, but effective policy remains ` +
-          `"${effective.mode}" from ${effective.source}.\n`
+          `"${effective.mode}" from ${effective.source} ` +
+          `(${target.environment} DB: ${target.sqlite_path}).\n`
       );
     }
   }
@@ -222,6 +243,7 @@ export async function accessEnableIssues(opts: AccessIssuesOpts): Promise<void> 
   for (const et of ISSUE_SUBMISSION_ENTITY_TYPES) {
     await setViaMetadata(et, mode);
   }
+  const target = await resolveTargetAndWarnOnce();
 
   if (opts.json) {
     output(
@@ -229,12 +251,16 @@ export async function accessEnableIssues(opts: AccessIssuesOpts): Promise<void> 
         entity_types: [...ISSUE_SUBMISSION_ENTITY_TYPES],
         mode,
         status: "set",
+        sqlite_path: target.sqlite_path,
+        environment: target.environment,
+        env_flag_mismatch: target.env_flag_mismatch,
       },
       true
     );
   } else {
     process.stdout.write(
-      `Access policies set to "${mode}" for: ${ISSUE_SUBMISSION_ENTITY_TYPES.join(", ")}.\n` +
+      `Access policies set to "${mode}" for: ${ISSUE_SUBMISSION_ENTITY_TYPES.join(", ")} ` +
+        `(${target.environment} DB: ${target.sqlite_path}).\n` +
         "External agents can now submit issues to this instance.\n"
     );
   }
@@ -244,6 +270,7 @@ export async function accessDisableIssues(opts: AccessIssuesOpts): Promise<void>
   for (const et of ISSUE_SUBMISSION_ENTITY_TYPES) {
     await resetViaMetadata(et);
   }
+  const target = await resolveTargetAndWarnOnce();
 
   if (opts.json) {
     output(
@@ -251,12 +278,16 @@ export async function accessDisableIssues(opts: AccessIssuesOpts): Promise<void>
         entity_types: [...ISSUE_SUBMISSION_ENTITY_TYPES],
         mode: DEFAULT_MODE,
         status: "reset",
+        sqlite_path: target.sqlite_path,
+        environment: target.environment,
+        env_flag_mismatch: target.env_flag_mismatch,
       },
       true
     );
   } else {
     process.stdout.write(
-      `Access policies reset to "${DEFAULT_MODE}" for: ${ISSUE_SUBMISSION_ENTITY_TYPES.join(", ")}.\n` +
+      `Access policies reset to "${DEFAULT_MODE}" for: ${ISSUE_SUBMISSION_ENTITY_TYPES.join(", ")} ` +
+        `(${target.environment} DB: ${target.sqlite_path}).\n` +
         "External agents can no longer submit issues to this instance.\n"
     );
   }

--- a/src/cli/access.ts
+++ b/src/cli/access.ts
@@ -37,6 +37,46 @@ export interface AccessIssuesOpts {
   json?: boolean;
 }
 
+/**
+ * Resolve which DB file and environment these `access` mutations actually
+ * target. `access set/reset` write to the local store selected by config, which
+ * keys the DB filename off `NEOTOMA_ENV` (production → neotoma.prod.db, else
+ * neotoma.db). The CLI `--env prod` transport flag does NOT set `NEOTOMA_ENV`,
+ * so `neotoma --env prod access set …` silently writes the *dev* file while a
+ * prod server serves from neotoma.prod.db — the write looks successful but has
+ * no effect on prod. Surfacing the target path (and warning on the mismatch)
+ * makes that trap visible. (#1977)
+ */
+async function resolveAccessTarget(): Promise<{
+  sqlite_path: string;
+  environment: string;
+  env_flag_mismatch: boolean;
+}> {
+  const { config } = await import("../config.js");
+  const envFlagPassed = process.argv.some(
+    (a) => a === "--env" || a === "prod" || a === "production"
+  );
+  const isProd = config.environment === "production";
+  return {
+    sqlite_path: config.sqlitePath,
+    environment: config.environment,
+    // The trap: caller signalled prod intent but config did not resolve to prod,
+    // so the write targets the dev DB the prod server does not read.
+    env_flag_mismatch: envFlagPassed && !isProd,
+  };
+}
+
+function warnOnEnvMismatch(target: { sqlite_path: string; env_flag_mismatch: boolean }): void {
+  if (target.env_flag_mismatch) {
+    process.stderr.write(
+      `Warning: this wrote to "${target.sqlite_path}" (development DB). The ` +
+        `--env/prod flag does not select the production DB for local access ` +
+        `commands — set NEOTOMA_ENV=production to target neotoma.prod.db, then ` +
+        `re-run. As written, a production server will NOT see this change.\n`
+    );
+  }
+}
+
 function output(data: unknown, json: boolean): void {
   if (json) {
     process.stdout.write(JSON.stringify(data, null, 2) + "\n");
@@ -99,11 +139,26 @@ export async function accessSet(
 
   await setViaMetadata(entityType, mode as AccessPolicyMode);
 
+  const target = await resolveAccessTarget();
   if (opts.json) {
-    output({ entity_type: entityType, mode, status: "set" }, true);
+    output(
+      {
+        entity_type: entityType,
+        mode,
+        status: "set",
+        sqlite_path: target.sqlite_path,
+        environment: target.environment,
+        env_flag_mismatch: target.env_flag_mismatch,
+      },
+      true
+    );
   } else {
-    process.stdout.write(`Access policy for "${entityType}" set to "${mode}".\n`);
+    process.stdout.write(
+      `Access policy for "${entityType}" set to "${mode}" ` +
+        `(${target.environment} DB: ${target.sqlite_path}).\n`
+    );
   }
+  warnOnEnvMismatch(target);
 }
 
 export async function accessList(opts: AccessListOpts): Promise<void> {

--- a/src/services/schema_registry.ts
+++ b/src/services/schema_registry.ts
@@ -900,6 +900,32 @@ export class SchemaRegistryService {
 
     const scope = config.user_specific ? "user" : "global";
 
+    // When reactivating over an existing active version and the caller didn't
+    // pass metadata explicitly, carry the prior active row's metadata forward.
+    // Without this, reactivating via register_schema (unlike
+    // updateSchemaIncremental, which already does this carry-forward) resets
+    // metadata to {}, silently dropping guest_access_policy and other
+    // schema-level settings. (#1977)
+    let metadata = config.metadata;
+    if (config.activate && metadata === undefined) {
+      let priorActiveQuery = db
+        .from("schema_registry")
+        .select("metadata")
+        .eq("entity_type", config.entity_type)
+        .eq("active", true);
+
+      if (scope === "user" && config.user_specific && config.user_id) {
+        priorActiveQuery = priorActiveQuery.eq("scope", "user").eq("user_id", config.user_id);
+      } else {
+        priorActiveQuery = priorActiveQuery.eq("scope", "global").is("user_id", null);
+      }
+
+      const { data: priorActive } = await priorActiveQuery.single();
+      if (priorActive?.metadata) {
+        metadata = priorActive.metadata as SchemaMetadata;
+      }
+    }
+
     const { data, error } = await db
       .from("schema_registry")
       .insert({
@@ -910,7 +936,7 @@ export class SchemaRegistryService {
         active: config.activate || false, // New schemas start inactive unless specified
         user_id: config.user_specific ? config.user_id || null : null,
         scope: scope,
-        metadata: config.metadata || {},
+        metadata: metadata || {},
       })
       .select()
       .single();
@@ -951,7 +977,7 @@ export class SchemaRegistryService {
     }
 
     // Auto-generate icon if not provided (non-blocking)
-    this.generateIconAsync(registeredSchema.entity_type, config.metadata);
+    this.generateIconAsync(registeredSchema.entity_type, metadata);
 
     // Automatically export schema snapshots (non-blocking)
     this.exportSnapshotsAsync();

--- a/src/services/schema_registry.ts
+++ b/src/services/schema_registry.ts
@@ -1388,7 +1388,16 @@ export class SchemaRegistryService {
       delete preserved.content_field;
     }
 
-    // 5. Register new version (start inactive, we'll activate separately if needed)
+    // 5. Register new version (start inactive, we'll activate separately if needed).
+    // Carry the prior active row's SchemaMetadata forward. register() defaults
+    // metadata to {} when omitted, which silently dropped schema-level settings
+    // that live in metadata rather than schema_definition — most importantly
+    // guest_access_policy. Losing it on a version bump reset the whole entity
+    // type to the "closed" default and 500'd every guest/token read of that type
+    // (e.g. all rendered_page share links). Metadata (guest_access_policy, label,
+    // description, category, icon, bundle) is orthogonal to field evolution and
+    // must survive it. (Fixes #1977)
+    const carriedMetadata: SchemaMetadata = { ...(currentSchema.metadata ?? {}) };
     const newSchema = await this.register({
       entity_type: options.entity_type,
       schema_version: newVersion,
@@ -1396,6 +1405,7 @@ export class SchemaRegistryService {
       reducer_config: { merge_policies: mergedReducerPolicies },
       user_id: userId,
       user_specific: options.user_specific,
+      metadata: carriedMetadata,
       activate: false, // Register as inactive first
     });
 

--- a/tests/cli/cli_access_commands.test.ts
+++ b/tests/cli/cli_access_commands.test.ts
@@ -1,7 +1,48 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { promises as fs } from "node:fs";
+import { promises as fs, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { spawnSync } from "node:child_process";
 import os from "node:os";
 import path from "node:path";
+import { WIN_SHELL } from "../../src/shared/spawn_platform.js";
+
+const REPO_ROOT = path.resolve(__dirname, "../..");
+const TSX_BIN = path.join(REPO_ROOT, "node_modules/.bin/tsx");
+const BOOTSTRAP_PATH = path.join(REPO_ROOT, "src/cli/bootstrap.ts");
+
+/**
+ * Runs the real `neotoma` entrypoint (bootstrap.ts, not runCli directly) so
+ * the `neotoma prod ...` / `neotoma dev ...` shorthand's NEOTOMA_ENV-before-
+ * config-load ordering is exercised faithfully (#1979 qa follow-up: this
+ * ordering means the shorthand can never trigger env_flag_mismatch, only the
+ * literal `--env prod` spelling can).
+ */
+function runBootstrap(argvSuffix: string[]): { stdout: string; stderr: string } {
+  const testHome = path.join(os.tmpdir(), "neotoma-bootstrap-test-" + Date.now() + "-" + Math.random().toString(36).slice(2));
+  const configDir = path.join(testHome, ".config", "neotoma");
+  const dataDir = path.join(testHome, "data");
+  try {
+    mkdirSync(configDir, { recursive: true });
+    mkdirSync(dataDir, { recursive: true });
+    writeFileSync(path.join(configDir, "config.json"), "{}", "utf8");
+    const result = spawnSync(TSX_BIN, [BOOTSTRAP_PATH, ...argvSuffix], {
+      cwd: REPO_ROOT,
+      encoding: "utf-8",
+      timeout: 20000,
+      env: { HOME: testHome, PATH: process.env.PATH ?? "", NEOTOMA_DATA_DIR: dataDir },
+      stdio: ["pipe", "pipe", "pipe"],
+      ...WIN_SHELL,
+    });
+    if (result.error) {
+      throw new Error(
+        `Failed to spawn tsx for bootstrap test: ${result.error.message}. ` +
+          `Ensure dependencies are installed (npm install).`
+      );
+    }
+    return { stdout: result.stdout ?? "", stderr: result.stderr ?? "" };
+  } finally {
+    rmSync(testHome, { recursive: true, force: true });
+  }
+}
 
 const schemaRegistryMockState = vi.hoisted(() => ({
   schemas: new Map<string, {
@@ -81,6 +122,9 @@ describe("neotoma access CLI helpers", () => {
       status: "reset",
       effective_mode: "closed",
       effective_source: "schema_metadata",
+      sqlite_path: expect.any(String),
+      environment: expect.any(String),
+      env_flag_mismatch: false,
     });
     await expect(loadAccessPolicies()).resolves.toEqual({});
   });
@@ -101,8 +145,113 @@ describe("neotoma access CLI helpers", () => {
       status: "reset",
       effective_mode: "open",
       effective_source: "env",
+      sqlite_path: expect.any(String),
+      environment: expect.any(String),
+      env_flag_mismatch: false,
     });
     await expect(loadAccessPolicies()).resolves.toEqual({ issue: "open" });
+  });
+
+  it("set reports the resolved DB target and warns on --env prod mismatch", async () => {
+    const originalArgv = process.argv;
+    process.argv = [...originalArgv, "--env", "prod"];
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    try {
+      const { accessSet } = await import("../../src/cli/access.js");
+
+      await accessSet("issue", "open", { json: true });
+
+      const payload = JSON.parse(String(stdoutSpy.mock.calls[0][0]));
+      expect(payload).toMatchObject({
+        entity_type: "issue",
+        mode: "open",
+        status: "set",
+        env_flag_mismatch: true,
+      });
+      expect(payload.sqlite_path).toEqual(expect.any(String));
+      expect(payload.environment).toEqual(expect.any(String));
+      const warning = stderrSpy.mock.calls.map((c) => String(c[0])).join("");
+      expect(warning).toMatch(/development DB/i);
+      expect(warning).toMatch(/production server will NOT see this change/i);
+    } finally {
+      process.argv = originalArgv;
+      stderrSpy.mockRestore();
+    }
+  });
+
+  it("set reports the resolved DB target without warning when no env flag is passed", async () => {
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    try {
+      const { accessSet } = await import("../../src/cli/access.js");
+
+      await accessSet("issue", "open", { json: true });
+
+      const payload = JSON.parse(String(stdoutSpy.mock.calls[0][0]));
+      expect(payload).toMatchObject({
+        entity_type: "issue",
+        mode: "open",
+        status: "set",
+        env_flag_mismatch: false,
+      });
+      const warning = stderrSpy.mock.calls.map((c) => String(c[0])).join("");
+      expect(warning).not.toMatch(/development DB/i);
+    } finally {
+      stderrSpy.mockRestore();
+    }
+  });
+
+  it("set non-JSON output includes the resolved environment DB suffix", async () => {
+    const { accessSet } = await import("../../src/cli/access.js");
+
+    await accessSet("issue", "open", { json: false });
+
+    const text = stdoutSpy.mock.calls.map((c) => String(c[0])).join("");
+    expect(text).toMatch(/Access policy for "issue" set to "open"/);
+    expect(text).toMatch(/DB: .*neotoma.*\.db/);
+  });
+
+  it("enable-issues and disable-issues warn on env mismatch exactly once, not once per entity type", async () => {
+    const originalArgv = process.argv;
+    process.argv = [...originalArgv, "--env", "prod"];
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    try {
+      const { accessEnableIssues, accessDisableIssues } = await import("../../src/cli/access.js");
+      const { ISSUE_SUBMISSION_ENTITY_TYPES } = await import(
+        "../../src/services/access_policy.js"
+      );
+      for (const et of ISSUE_SUBMISSION_ENTITY_TYPES) {
+        schemaRegistryMockState.schemas.set(et, {
+          entity_type: et,
+          metadata: { guest_access_policy: "closed" },
+        });
+      }
+      expect(ISSUE_SUBMISSION_ENTITY_TYPES.length).toBeGreaterThan(1);
+
+      await accessEnableIssues({ json: true });
+      const enablePayload = JSON.parse(String(stdoutSpy.mock.calls[0][0]));
+      expect(enablePayload.entity_types).toEqual([...ISSUE_SUBMISSION_ENTITY_TYPES]);
+      expect(enablePayload.mode).toBe("submitter_scoped");
+      expect(enablePayload.env_flag_mismatch).toBe(true);
+      const enableWarnings = stderrSpy.mock.calls.filter((c) =>
+        String(c[0]).match(/development DB/i)
+      );
+      expect(enableWarnings).toHaveLength(1);
+
+      stdoutSpy.mockClear();
+      stderrSpy.mockClear();
+      await accessDisableIssues({ json: true });
+      const disablePayload = JSON.parse(String(stdoutSpy.mock.calls[0][0]));
+      expect(disablePayload.entity_types).toEqual([...ISSUE_SUBMISSION_ENTITY_TYPES]);
+      expect(disablePayload.mode).toBe("closed");
+      expect(disablePayload.env_flag_mismatch).toBe(true);
+      const disableWarnings = stderrSpy.mock.calls.filter((c) =>
+        String(c[0]).match(/development DB/i)
+      );
+      expect(disableWarnings).toHaveLength(1);
+    } finally {
+      process.argv = originalArgv;
+      stderrSpy.mockRestore();
+    }
   });
 });
 
@@ -232,5 +381,45 @@ describe("CLI access commands", () => {
     expect(payload.error).toMatch(/mutate local state only/i);
     expect(payload.error).toMatch(/NEOTOMA_API_ONLY/);
     expect(payload.error).toMatch(/NEOTOMA_BASE_URL/);
+  });
+});
+
+describe("neotoma prod/dev shorthand vs --env prod flag (#1979 env mismatch reach)", () => {
+  it("`neotoma prod access set` never reports env_flag_mismatch: NEOTOMA_ENV is set before config loads", () => {
+    const { stdout, stderr } = runBootstrap([
+      "prod",
+      "access",
+      "set",
+      "issue",
+      "open",
+      "--json",
+      "--no-log-file",
+    ]);
+
+    const payload = JSON.parse(stdout);
+    expect(payload.environment).toBe("production");
+    expect(payload.sqlite_path).toMatch(/neotoma\.prod\.db$/);
+    expect(payload.env_flag_mismatch).toBe(false);
+    expect(stderr).not.toMatch(/development DB/i);
+  });
+
+  it("literal `--env prod` (no `prod` positional) resolves to dev DB and reports env_flag_mismatch: true", () => {
+    const { stdout, stderr } = runBootstrap([
+      "--env",
+      "prod",
+      "access",
+      "set",
+      "issue",
+      "open",
+      "--json",
+      "--no-log-file",
+    ]);
+
+    const payload = JSON.parse(stdout);
+    expect(payload.environment).toBe("development");
+    expect(payload.sqlite_path).toMatch(/neotoma\.db$/);
+    expect(payload.env_flag_mismatch).toBe(true);
+    expect(stderr).toMatch(/development DB/i);
+    expect(stderr).toMatch(/production server will NOT see this change/i);
   });
 });

--- a/tests/integration/schema_metadata_carry_forward.test.ts
+++ b/tests/integration/schema_metadata_carry_forward.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Effect-level regression test for #1977: an incremental schema update must
+ * not drop `guest_access_policy`, and the fix must hold across every surface
+ * that can reactivate a schema version (updateSchemaIncremental AND
+ * register_schema / register()).
+ *
+ * Unlike tests/services/schema_registry_incremental.test.ts (which mocks the
+ * DB and asserts on the insert payload), this test drives a real HTTP server
+ * and a real SQLite-backed SchemaRegistryService, and asserts on the actual
+ * production symptom: a guest-token read of a rendered_page entity returning
+ * 200, not 500.
+ */
+
+import { createServer, type Server } from "node:http";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { db } from "../../src/db.js";
+import { NeotomaServer } from "../../src/server.js";
+import { generateGuestAccessToken, hashGuestAccessToken } from "../../src/services/guest_access_token.js";
+import { SchemaRegistryService } from "../../src/services/schema_registry.js";
+import { TestIdTracker } from "../helpers/cleanup_helpers.js";
+
+const ENTITY_TYPE = "rendered_page";
+const tracker = new TestIdTracker();
+
+async function withRealServer<T>(callback: (baseUrl: string) => Promise<T>): Promise<T> {
+  const { app } = await import("../../src/actions.js");
+  const server: Server = createServer(app);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("test server did not bind to a TCP port");
+  }
+  try {
+    return await callback(`http://127.0.0.1:${address.port}`);
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function guestTokenFor(userId: string): Promise<string> {
+  const token = await generateGuestAccessToken({ entityIds: [], userId });
+  tracker.trackEntity(`guest_token_${hashGuestAccessToken(token).slice(0, 16)}`);
+  return token;
+}
+
+async function insertRenderedPageEntity(userId: string): Promise<string> {
+  const entityId = `ent_test_rp_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+  tracker.trackEntity(entityId);
+  await db.from("entities").insert({
+    id: entityId,
+    user_id: userId,
+    entity_type: ENTITY_TYPE,
+    canonical_name: `rendered_page:${entityId}`,
+  });
+  await db.from("entity_snapshots").upsert({
+    entity_id: entityId,
+    user_id: userId,
+    entity_type: ENTITY_TYPE,
+    schema_version: "1.0",
+    canonical_name: `rendered_page:${entityId}`,
+    snapshot: { title: "Test page", html_body: "<p>hello</p>" },
+  });
+  return entityId;
+}
+
+describe("Schema metadata carry-forward — effect + cross-surface (#1977)", () => {
+  const registryService = new SchemaRegistryService();
+  let server: NeotomaServer;
+
+  beforeEach(async () => {
+    server = new NeotomaServer();
+    await db.from("schema_registry").delete().eq("entity_type", ENTITY_TYPE);
+  });
+
+  afterEach(async () => {
+    await db.from("schema_registry").delete().eq("entity_type", ENTITY_TYPE);
+    await tracker.cleanup();
+  });
+
+  it("guest-token HTTP read returns 200 (not 500) after update_schema_incremental adds a field (surface: HTTP route + updateSchemaIncremental)", async () => {
+    const userId = `user-1977-http-${Date.now()}`;
+
+    await registryService.register({
+      entity_type: ENTITY_TYPE,
+      schema_version: "1.0",
+      schema_definition: {
+        fields: { html_body: { type: "string" }, title: { type: "string" } },
+        identity_opt_out: "heuristic_canonical_name",
+      },
+      reducer_config: {
+        merge_policies: {
+          html_body: { strategy: "last_write" },
+          title: { strategy: "last_write" },
+        },
+      },
+      activate: true,
+      metadata: { label: "Rendered page", guest_access_policy: "read_only" },
+    });
+
+    // The bug: updateSchemaIncremental used to register the new version
+    // without metadata, dropping guest_access_policy and resetting the type
+    // to "closed" — every guest read 500'd afterward.
+    await registryService.updateSchemaIncremental({
+      entity_type: ENTITY_TYPE,
+      fields_to_add: [{ field_name: "markdown_source", field_type: "string" }],
+      activate: true,
+    });
+
+    const entityId = await insertRenderedPageEntity(userId);
+    const token = await guestTokenFor(userId);
+
+    await withRealServer(async (baseUrl) => {
+      const response = await fetch(`${baseUrl}/entities/${entityId}/html?access_token=${token}`);
+      expect(response.status).toBe(200);
+    });
+  });
+
+  it("register_schema reactivating an existing active version with no explicit metadata preserves guest_access_policy (surface: MCP tool handler + register())", async () => {
+    const userId = `user-1977-mcp-${Date.now()}`;
+
+    const baseSchema = await registryService.register({
+      entity_type: ENTITY_TYPE,
+      schema_version: "1.0",
+      schema_definition: {
+        fields: { html_body: { type: "string" } },
+        identity_opt_out: "heuristic_canonical_name",
+      },
+      reducer_config: { merge_policies: { html_body: { strategy: "last_write" } } },
+      activate: true,
+      metadata: { label: "Rendered page", guest_access_policy: "read_only" },
+    });
+    expect(baseSchema.metadata?.guest_access_policy).toBe("read_only");
+
+    // Drive through the actual MCP tool dispatch surface (register_schema via
+    // executeToolForCli, the same entry point CLI/MCP callers use), and — per
+    // the finding — omit metadata entirely, the exact shape that dropped
+    // guest_access_policy via this surface.
+    const mcpResponse = await server.executeToolForCli(
+      "register_schema",
+      {
+        entity_type: ENTITY_TYPE,
+        schema_version: "1.1",
+        schema_definition: {
+          fields: { html_body: { type: "string" }, extra_field: { type: "string" } },
+          identity_opt_out: "heuristic_canonical_name",
+        },
+        reducer_config: {
+          merge_policies: {
+            html_body: { strategy: "last_write" },
+            extra_field: { strategy: "last_write" },
+          },
+        },
+        activate: true,
+        user_specific: false,
+      },
+      userId
+    );
+    const parsed = JSON.parse(mcpResponse.content[0].text);
+    expect(parsed.success).toBe(true);
+
+    const activeSchema = await registryService.loadActiveSchema(ENTITY_TYPE);
+    expect(activeSchema?.metadata?.guest_access_policy).toBe("read_only");
+
+    // Confirm at the effect level too: a guest read must still succeed.
+    const entityId = await insertRenderedPageEntity(userId);
+    const token = await guestTokenFor(userId);
+    await withRealServer(async (baseUrl) => {
+      const response = await fetch(`${baseUrl}/entities/${entityId}/html?access_token=${token}`);
+      expect(response.status).toBe(200);
+    });
+  });
+});

--- a/tests/services/schema_registry_incremental.test.ts
+++ b/tests/services/schema_registry_incremental.test.ts
@@ -40,7 +40,7 @@ describe("SchemaRegistryService - Incremental Updates", () => {
         mock[key].mockReturnValue(mock);
       }
     });
-    
+
     // Make the mock awaitable (thenable) - DB queries are awaitable
     mock.then = vi.fn((resolve) => {
       // Default resolution if no custom then handler
@@ -50,13 +50,13 @@ describe("SchemaRegistryService - Incremental Updates", () => {
       return Promise.resolve({ data: null, error: null }).then(resolve);
     });
     mock.catch = vi.fn((reject) => Promise.reject(reject));
-    
+
     // Override with provided methods AFTER setting up defaults
     // This ensures methods like 'then' can override, but others like 'update' still chain
     Object.keys(methods).forEach((key) => {
-      if (key !== 'then' && key !== 'catch') {
+      if (key !== "then" && key !== "catch") {
         // For non-then/catch methods, merge with existing mock
-        if (typeof methods[key] === 'function') {
+        if (typeof methods[key] === "function") {
           mock[key] = methods[key];
         } else {
           mock[key] = methods[key];
@@ -65,14 +65,14 @@ describe("SchemaRegistryService - Incremental Updates", () => {
         mock[key] = methods[key];
       }
     });
-    
+
     // Ensure update/insert/select/eq/is/range/not still return mock for chaining (unless overridden)
-    ['update', 'insert', 'select', 'eq', 'is', 'range', 'not'].forEach((method) => {
-      if (!methods[method] || typeof methods[method] !== 'function') {
+    ["update", "insert", "select", "eq", "is", "range", "not"].forEach((method) => {
+      if (!methods[method] || typeof methods[method] !== "function") {
         // Only set if not already a function that returns something
-        if (typeof mock[method] === 'function' && !mock[method].mock) {
+        if (typeof mock[method] === "function" && !mock[method].mock) {
           // Already set up
-        } else if (typeof mock[method] !== 'function') {
+        } else if (typeof mock[method] !== "function") {
           mock[method] = vi.fn().mockReturnValue(mock);
         } else {
           // It's a vi.fn(), ensure it returns mock
@@ -82,7 +82,7 @@ describe("SchemaRegistryService - Incremental Updates", () => {
         }
       }
     });
-    
+
     return mock;
   };
 
@@ -93,7 +93,7 @@ describe("SchemaRegistryService - Incremental Updates", () => {
         data: { scope: "global", user_id: null },
       }),
     });
-    
+
     // For deactivate: create chainable query where update() returns the query itself
     const mockUpdateDeactivate: any = {
       update: vi.fn(),
@@ -106,7 +106,7 @@ describe("SchemaRegistryService - Incremental Updates", () => {
     mockUpdateDeactivate.update.mockReturnValue(mockUpdateDeactivate);
     mockUpdateDeactivate.eq.mockReturnValue(mockUpdateDeactivate);
     mockUpdateDeactivate.is.mockReturnValue(mockUpdateDeactivate);
-    
+
     // For activate: similar setup
     const mockUpdateActivate: any = {
       update: vi.fn(),
@@ -116,7 +116,7 @@ describe("SchemaRegistryService - Incremental Updates", () => {
     };
     mockUpdateActivate.update.mockReturnValue(mockUpdateActivate);
     mockUpdateActivate.eq.mockReturnValue(mockUpdateActivate);
-    
+
     return { mockSelect, mockUpdateDeactivate, mockUpdateActivate };
   };
 
@@ -198,9 +198,7 @@ describe("SchemaRegistryService - Incremental Updates", () => {
         }),
       };
 
-      mockFrom
-        .mockReturnValueOnce(mockUserSchema)
-        .mockReturnValueOnce(mockGlobalSchema);
+      mockFrom.mockReturnValueOnce(mockUserSchema).mockReturnValueOnce(mockGlobalSchema);
 
       const result = await service.loadActiveSchema("transaction", "test-user-id");
 
@@ -229,9 +227,7 @@ describe("SchemaRegistryService - Incremental Updates", () => {
         }),
       };
 
-      mockFrom
-        .mockReturnValueOnce(mockUserSchema)
-        .mockReturnValueOnce(mockGlobalSchema);
+      mockFrom.mockReturnValueOnce(mockUserSchema).mockReturnValueOnce(mockGlobalSchema);
 
       const result = await service.loadActiveSchema("transaction", "test-user-id");
 
@@ -365,9 +361,7 @@ describe("SchemaRegistryService - Incremental Updates", () => {
 
       const result = await service.updateSchemaIncremental({
         entity_type: "transaction",
-        fields_to_add: [
-          { field_name: "new_field", field_type: "string" },
-        ],
+        fields_to_add: [{ field_name: "new_field", field_type: "string" }],
       });
 
       expect(service.loadActiveSchema).toHaveBeenCalledWith("transaction", undefined);
@@ -389,8 +383,7 @@ describe("SchemaRegistryService - Incremental Updates", () => {
           },
         }),
       });
-      const { mockSelect, mockUpdateDeactivate, mockUpdateActivate } =
-        mockActivateCalls();
+      const { mockSelect, mockUpdateDeactivate, mockUpdateActivate } = mockActivateCalls();
 
       mockFrom
         .mockReturnValueOnce(mockInsert)
@@ -400,9 +393,7 @@ describe("SchemaRegistryService - Incremental Updates", () => {
 
       const result = await service.updateSchemaIncremental({
         entity_type: "conversation_message",
-        fields_to_add: [
-          { field_name: "raw_fragment_promoted_field", field_type: "string" },
-        ],
+        fields_to_add: [{ field_name: "raw_fragment_promoted_field", field_type: "string" }],
         migrate_existing: false,
       });
 
@@ -443,9 +434,7 @@ describe("SchemaRegistryService - Incremental Updates", () => {
 
       const result = await service.updateSchemaIncremental({
         entity_type: "transaction",
-        fields_to_add: [
-          { field_name: "new_field", field_type: "string" },
-        ],
+        fields_to_add: [{ field_name: "new_field", field_type: "string" }],
       });
 
       expect(result.schema_version).toBe("1.1");
@@ -498,14 +487,62 @@ describe("SchemaRegistryService - Incremental Updates", () => {
 
       const result = await service.updateSchemaIncremental({
         entity_type: "transaction",
-        fields_to_add: [
-          { field_name: "new_field", field_type: "number" },
-        ],
+        fields_to_add: [{ field_name: "new_field", field_type: "number" }],
       });
 
       const insertedData = mockInsert.insert.mock.calls[0][0];
       expect(insertedData.schema_definition.fields.existing_field).toBeDefined();
       expect(insertedData.schema_definition.fields.new_field).toBeDefined();
+    });
+
+    it("carries prior SchemaMetadata (guest_access_policy) forward to the new version (#1977)", async () => {
+      // Regression: adding a field must NOT reset schema-level metadata. Before
+      // the fix, register() was called without metadata, defaulting it to {},
+      // which dropped guest_access_policy → the type fell back to the "closed"
+      // default and every guest/token read of that type 500'd.
+      const currentSchema = {
+        id: "schema-id",
+        entity_type: "rendered_page",
+        schema_version: "1.0",
+        schema_definition: {
+          fields: { html_body: { type: "string" } },
+          identity_opt_out: "heuristic_canonical_name",
+        },
+        reducer_config: { merge_policies: { html_body: { strategy: "last_write" } } },
+        active: true,
+        scope: "global",
+        user_id: null,
+        metadata: {
+          label: "Rendered page",
+          description: "A bespoke HTML expression.",
+          category: "knowledge",
+          guest_access_policy: "submitter_scoped",
+        },
+      };
+
+      vi.spyOn(service, "loadActiveSchema").mockResolvedValue(currentSchema as any);
+
+      const mockInsert = createChainableQuery({
+        single: vi.fn().mockResolvedValue({ data: currentSchema }),
+      });
+      const { mockSelect, mockUpdateDeactivate, mockUpdateActivate } = mockActivateCalls();
+      mockFrom
+        .mockReturnValueOnce(mockInsert)
+        .mockReturnValueOnce(mockSelect)
+        .mockReturnValueOnce(mockUpdateDeactivate)
+        .mockReturnValueOnce(mockUpdateActivate);
+
+      await service.updateSchemaIncremental({
+        entity_type: "rendered_page",
+        fields_to_add: [{ field_name: "markdown_source", field_type: "string" }],
+      });
+
+      const insertedData = mockInsert.insert.mock.calls[0][0];
+      expect(insertedData.metadata).toBeDefined();
+      expect(insertedData.metadata.guest_access_policy).toBe("submitter_scoped");
+      // The rest of the descriptor metadata should survive too.
+      expect(insertedData.metadata.label).toBe("Rendered page");
+      expect(insertedData.metadata.category).toBe("knowledge");
     });
 
     it("should skip fields that already exist", async () => {
@@ -550,14 +587,10 @@ describe("SchemaRegistryService - Incremental Updates", () => {
 
       await service.updateSchemaIncremental({
         entity_type: "transaction",
-        fields_to_add: [
-          { field_name: "existing_field", field_type: "string" },
-        ],
+        fields_to_add: [{ field_name: "existing_field", field_type: "string" }],
       });
 
-      expect(stderrSpy).toHaveBeenCalledWith(
-        expect.stringContaining("already exists in schema"),
-      );
+      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("already exists in schema"));
 
       stderrSpy.mockRestore();
     });
@@ -593,9 +626,7 @@ describe("SchemaRegistryService - Incremental Updates", () => {
 
       const result = await service.updateSchemaIncremental({
         entity_type: "transaction",
-        fields_to_add: [
-          { field_name: "new_field", field_type: "string" },
-        ],
+        fields_to_add: [{ field_name: "new_field", field_type: "string" }],
       });
 
       // Verify activate was called (indirectly via the update calls)
@@ -628,9 +659,7 @@ describe("SchemaRegistryService - Incremental Updates", () => {
 
       await service.updateSchemaIncremental({
         entity_type: "transaction",
-        fields_to_add: [
-          { field_name: "new_field", field_type: "string" },
-        ],
+        fields_to_add: [{ field_name: "new_field", field_type: "string" }],
         activate: false,
       });
 
@@ -676,9 +705,7 @@ describe("SchemaRegistryService - Incremental Updates", () => {
 
       await service.updateSchemaIncremental({
         entity_type: "transaction",
-        fields_to_add: [
-          { field_name: "new_field", field_type: "string" },
-        ],
+        fields_to_add: [{ field_name: "new_field", field_type: "string" }],
         migrate_existing: true,
       });
 
@@ -695,11 +722,9 @@ describe("SchemaRegistryService - Incremental Updates", () => {
       await expect(
         service.updateSchemaIncremental({
           entity_type: "no_such_builtin_type_xyz",
-          fields_to_add: [
-            { field_name: "new_field", field_type: "string" },
-          ],
+          fields_to_add: [{ field_name: "new_field", field_type: "string" }],
           force: true,
-        }),
+        })
       ).rejects.toThrow("No active schema found");
     });
   });
@@ -887,9 +912,7 @@ describe("SchemaRegistryService - Incremental Updates", () => {
         fields_to_remove: ["nonexistent_field"],
       });
 
-      expect(stderrSpy).toHaveBeenCalledWith(
-        expect.stringContaining("not found in schema"),
-      );
+      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("not found in schema"));
 
       stderrSpy.mockRestore();
     });
@@ -919,7 +942,7 @@ describe("SchemaRegistryService - Incremental Updates", () => {
         service.updateSchemaIncremental({
           entity_type: "transaction",
           fields_to_remove: ["only_field"],
-        }),
+        })
       ).rejects.toThrow("Cannot remove all fields");
     });
 
@@ -962,9 +985,7 @@ describe("SchemaRegistryService - Incremental Updates", () => {
 
       await service.updateSchemaIncremental({
         entity_type: "transaction",
-        fields_to_add: [
-          { field_name: "new_field", field_type: "number" },
-        ],
+        fields_to_add: [{ field_name: "new_field", field_type: "number" }],
         fields_to_remove: ["old_field"],
       });
 
@@ -982,14 +1003,15 @@ describe("SchemaRegistryService - Incremental Updates", () => {
       // Mock batch 1 - range() returns mock, mock is awaitable
       const mockBatch1 = createChainableQuery({
         range: vi.fn().mockReturnValue(undefined),
-        then: (resolve: any) => Promise.resolve({
-          data: Array(100).fill({
-            id: "frag-id",
-            fragment_key: "field1",
-            fragment_value: "value1",
-          }),
-          error: null,
-        }).then(resolve),
+        then: (resolve: any) =>
+          Promise.resolve({
+            data: Array(100).fill({
+              id: "frag-id",
+              fragment_key: "field1",
+              fragment_value: "value1",
+            }),
+            error: null,
+          }).then(resolve),
       });
       mockBatch1.range.mockReturnValue(mockBatch1);
 
@@ -1000,9 +1022,7 @@ describe("SchemaRegistryService - Incremental Updates", () => {
       });
       mockBatch2.range.mockReturnValue(mockBatch2);
 
-      mockFrom
-        .mockReturnValueOnce(mockBatch1)
-        .mockReturnValueOnce(mockBatch2);
+      mockFrom.mockReturnValueOnce(mockBatch1).mockReturnValueOnce(mockBatch2);
 
       const result = await service.migrateRawFragmentsToObservations({
         entity_type: "transaction",
@@ -1039,10 +1059,10 @@ describe("SchemaRegistryService - Incremental Updates", () => {
         range: vi.fn().mockReturnValue(undefined), // Will be overridden below
         then: (resolve: any) => Promise.resolve({ data: [], error: null }).then(resolve),
       });
-      
+
       // Override range to return the mock itself (for chaining)
       mockQuery.range.mockReturnValue(mockQuery);
-      
+
       // Ensure eq() returns the same mock (for query reassignment: query = query.eq(...))
       mockQuery.eq.mockImplementation((...args) => {
         // Return the same mock so reassignment works
@@ -1179,7 +1199,7 @@ describe("SchemaRegistryService - Incremental Updates", () => {
       const mockDeactivate = createChainableQuery({});
 
       mockFrom
-        .mockReturnValueOnce(mockInsert)     // insert call
+        .mockReturnValueOnce(mockInsert) // insert call
         .mockReturnValueOnce(mockDeactivate); // deactivate prior active versions
 
       const result = await service.register({

--- a/tests/services/schema_registry_incremental.test.ts
+++ b/tests/services/schema_registry_incremental.test.ts
@@ -1194,11 +1194,18 @@ describe("SchemaRegistryService - Incremental Updates", () => {
         }),
       });
 
+      // When activate: true and no metadata is passed, register() first looks
+      // up the prior active row's metadata to carry it forward (#1977).
+      const mockPriorActiveLookup = createChainableQuery({
+        single: vi.fn().mockResolvedValue({ data: null }),
+      });
+
       // When activate: true, register() also calls db.from("schema_registry").update(...)
       // to deactivate prior active schemas. Provide a mock for that call.
       const mockDeactivate = createChainableQuery({});
 
       mockFrom
+        .mockReturnValueOnce(mockPriorActiveLookup) // prior-active metadata lookup
         .mockReturnValueOnce(mockInsert) // insert call
         .mockReturnValueOnce(mockDeactivate); // deactivate prior active versions
 
@@ -1214,6 +1221,82 @@ describe("SchemaRegistryService - Incremental Updates", () => {
       expect(insertedData.active).toBe(true);
       // Verify deactivation was attempted for prior active schemas
       expect(mockDeactivate.update).toHaveBeenCalledWith({ active: false });
+    });
+
+    it("carries prior active row's metadata forward when reactivating with no explicit metadata (register_schema / register(), #1979 finding 2)", async () => {
+      // Regression: register_schema (the MCP tool / CLI entry point) calls
+      // register() directly with activate: true and no metadata when
+      // reactivating an existing entity_type. Before this fix, that dropped
+      // guest_access_policy just like the updateSchemaIncremental bug did,
+      // just via a different call path.
+      const mockPriorActiveLookup = createChainableQuery({
+        single: vi.fn().mockResolvedValue({
+          data: { metadata: { guest_access_policy: "submitter_scoped", label: "Rendered page" } },
+        }),
+      });
+
+      const mockInsert = createChainableQuery({
+        single: vi.fn().mockResolvedValue({
+          data: {
+            id: "schema-id",
+            entity_type: "rendered_page",
+            schema_version: "1.1",
+            active: true,
+          },
+        }),
+      });
+
+      const mockDeactivate = createChainableQuery({});
+
+      mockFrom
+        .mockReturnValueOnce(mockPriorActiveLookup)
+        .mockReturnValueOnce(mockInsert)
+        .mockReturnValueOnce(mockDeactivate);
+
+      await service.register({
+        entity_type: "rendered_page",
+        schema_version: "1.1",
+        schema_definition: {
+          fields: { html_body: { type: "string" } },
+          identity_opt_out: "heuristic_canonical_name",
+        },
+        reducer_config: { merge_policies: { html_body: { strategy: "last_write" } } },
+        activate: true,
+        // No metadata passed — this is the exact shape register_schema uses.
+      });
+
+      const insertedData = mockInsert.insert.mock.calls[0][0];
+      expect(insertedData.metadata.guest_access_policy).toBe("submitter_scoped");
+      expect(insertedData.metadata.label).toBe("Rendered page");
+    });
+
+    it("does not override explicitly-passed metadata when reactivating", async () => {
+      // When metadata IS explicitly passed, register() must skip the
+      // prior-active lookup entirely (no extra db.from() call) and use the
+      // caller's metadata as-is.
+      const mockInsert = createChainableQuery({
+        single: vi.fn().mockResolvedValue({
+          data: { id: "schema-id", entity_type: "rendered_page", schema_version: "1.1", active: true },
+        }),
+      });
+      const mockDeactivate = createChainableQuery({});
+
+      mockFrom.mockReturnValueOnce(mockInsert).mockReturnValueOnce(mockDeactivate);
+
+      await service.register({
+        entity_type: "rendered_page",
+        schema_version: "1.1",
+        schema_definition: {
+          fields: { html_body: { type: "string" } },
+          identity_opt_out: "heuristic_canonical_name",
+        },
+        reducer_config: { merge_policies: { html_body: { strategy: "last_write" } } },
+        activate: true,
+        metadata: { guest_access_policy: "closed" },
+      });
+
+      const insertedData = mockInsert.insert.mock.calls[0][0];
+      expect(insertedData.metadata.guest_access_policy).toBe("closed");
     });
 
     it("should not activate by default", async () => {


### PR DESCRIPTION
Closes #1977

Fixes the production root cause of #1977 (the `rendered_page` guest-access outage) plus the silent-wrong-DB trap encountered during recovery.

## The bug (root cause, confirmed at the DB level)

`updateSchemaIncremental` registered the new schema version **without passing `metadata`**, so `register()` defaulted it to `{}` — silently dropping schema-level settings that live in `metadata` rather than `schema_definition`, most importantly **`guest_access_policy`**.

Losing that on a version bump reset the entity type to the `closed` default (resolution chain: env → SchemaMetadata → config → `closed`), which **500'd every guest/token read of the type**. Adding one optional field (`markdown_source`) to `rendered_page` took down every share link at once. Verified in the live DB: the old active row's metadata had `{label, description, category, guest_access_policy: "submitter_scoped", icon}`; the new active row had `{icon}` only.

## Fix 1 — carry metadata forward on every reactivation path

`src/services/schema_registry.ts`:

- `updateSchemaIncremental` passes `currentSchema.metadata` into the new version's `register()` call. Metadata (`guest_access_policy`, `label`, `description`, `category`, `icon`, `bundle`) is orthogonal to field evolution and must survive it. This matches how the method already preserves non-field `schema_definition` declarations (`canonical_name_fields`, `temporal_fields`, …).
- `register()` itself now closes the same gap on its own reactivation path: when `activate: true` and the caller does not pass `metadata` explicitly, it looks up the prior active row for `(entity_type, scope[, user_id])` and carries that row's `metadata` forward instead of defaulting to `{}`. This matters because `register_schema` — the MCP tool / CLI command that calls `register()` directly (not through `updateSchemaIncremental`) — had no equivalent carry-forward, so reactivating an existing `entity_type` via `register_schema` with `activate: true` and no explicit `metadata` reproduced today's bug through a different entry point. Round-2 review (per pm gate finding, verified against `schema_registry.ts:877-960`) confirmed this was reachable directly, not just theoretically.

## Fix 3 — make the wrong-DB write visible (`src/cli/access.ts`)

During recovery, `neotoma --env prod access set …` **looked** like it succeeded but was a no-op: the `--env prod` transport flag does not set `NEOTOMA_ENV`, so config resolved the DB filename to the **dev** `neotoma.db` while the prod server serves from `neotoma.prod.db` (`config.ts:162`). `access set`/`reset` now report the resolved `sqlite_path` + `environment` they mutate, and warn when a `--env prod`/`prod` flag was passed but config did not resolve to production.

## Tests

- `tests/services/schema_registry_incremental.test.ts`: regression asserting `guest_access_policy` (plus `label`/`category`) survives an incremental field add (mocked DB, asserts on the insert payload). Two new unit tests cover `register()`'s own reactivation carry-forward: one confirming the prior row's metadata is carried forward when the caller omits `metadata`, one confirming explicitly-passed metadata is never overridden.
- `tests/integration/schema_metadata_carry_forward.test.ts` (new): effect-level regression driven against a real HTTP server and real SQLite-backed `SchemaRegistryService` — no DB mocking. Two tests:
  - Registers a `rendered_page` schema with `guest_access_policy: "read_only"`, calls `updateSchemaIncremental` to add a field, then performs an actual guest-token `GET /entities/:id/html?access_token=...` and asserts **HTTP 200, not 500** — the literal reproduction steps from #1977, not a contract-acceptance proxy.
  - Drives `register_schema` through the real MCP tool dispatch surface (`server.executeToolForCli`, the same entry point CLI/MCP callers use) reactivating an existing active version with no explicit `metadata`, and asserts both that the stored schema's `guest_access_policy` survives and that a subsequent guest HTTP read still returns 200.
- Both new tests were verified to fail without the corresponding fix (confirmed by temporarily reverting the `register()` change and re-running: 3 tests fail with exactly the dropped-metadata symptom).
- Full incremental suite: 34/34. Repo typecheck: 0 errors.

## Deliberately deferred to a follow-up PR

- **Fix 2** — exposing access-policy **set/list/reset on the MCP + HTTP API surface** — is a security-surface feature (new authenticated, role-scoped mutation) and is tracked separately. It's the piece that would make a policy restore possible **in-band remotely**; today it requires shell access to the prod host. Not needed to close the outage cause, which this PR does.
- **`access_policy` response-contract field** — round-2 review asked for an `access_policy: {guest_access_policy, source, changed}` field on the `update_schema_incremental` and `register_schema` tool responses, so a *different* future code path that drops metadata would fail loudly in the response instead of silently. This is detection/defense-in-depth, not the outage-causing bug itself (which Fix 1 closes at the source). Adding it is an `openapi.yaml`-first change (new response field on two operations, regenerated types, contract test coverage) that's out of scope for this outage-fix PR; tracked as a follow-up rather than silently dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
