### PR TITLE
fix: resolve identifiers by email/phone at scale (server-side exact pass) — closes #1981

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+node_modules
 dist/
 
 # Neotoma plan mirrors (local only, regenerated via `npm run mirror:plans`)

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/markmhendrickson/repos/neotoma/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/markmhendrickson/repos/neotoma/node_modules

--- a/src/repositories/sqlite/local_db_adapter.ts
+++ b/src/repositories/sqlite/local_db_adapter.ts
@@ -302,6 +302,20 @@ function normalizeColumnName(table: string, column: string): string {
   // Compatibility aliases used by tests and older codepaths.
   if (table === "entities" && column === "merged_into") return "merged_to_entity_id";
   if (table === "observations" && column === "priority") return "source_priority";
+  // `lower(col->>field)` pseudo-column: case-insensitive equality against a
+  // JSONB text projection (e.g. exact-match identifier lookups that must
+  // match the case-insensitive contract of other snapshot-field matching
+  // paths, #1981). Recurses into the same ->> handling below, then wraps in
+  // SQL LOWER() on both the comparison sides; callers must also lowercase
+  // their bound value.
+  const lowerJsonPathMatch = column.match(
+    /^lower\(([A-Za-z_][A-Za-z0-9_]*)->>([A-Za-z_][A-Za-z0-9_]*)\)$/
+  );
+  if (lowerJsonPathMatch) {
+    const [, jsonColumn, jsonField] = lowerJsonPathMatch;
+    const inner = normalizeColumnName(table, `${jsonColumn}->>${jsonField}`);
+    return `LOWER(${inner})`;
+  }
   // PostgREST-style JSON path projection used in query code:
   //   snapshot->>published_date
   // Convert to SQLite-compatible json_extract(snapshot, '$.published_date').

--- a/src/shared/action_handlers/entity_identifier_handler.ts
+++ b/src/shared/action_handlers/entity_identifier_handler.ts
@@ -299,9 +299,48 @@ export async function retrieveEntityByIdentifierWithFallback(
   }
 
   if (directEntities.length === 0) {
-    // Snapshot-field pass: walk entity_snapshots (optionally filtered by type)
-    // and JS-match name/title/email/domain/company so identifiers that never
-    // reached canonical_name or aliases still resolve.
+    // Snapshot-field pass: resolve identifiers that never reached
+    // canonical_name or aliases (e.g. an email/phone that isn't the
+    // canonical_name) by matching declared identity fields in the snapshot.
+    //
+    // #1963-adjacent scale bug: the JS scan below loads an *unordered,
+    // 500-row* window of entity_snapshots and filters in memory. On an
+    // instance with thousands of entities, an exact email/phone whose row
+    // sits outside that arbitrary window is never examined, so by="email"
+    // /by="phone" lookups (and identify_entity_by_signals, which sits on
+    // this) silently return nothing even for values present verbatim in a
+    // snapshot. First do a targeted, index-friendly server-side exact match
+    // on the known identity fields via `snapshot->>{field}`, which the DB can
+    // satisfy from any row regardless of the window; keep the bounded JS scan
+    // only as a fuzzy/token fallback.
+    const snapshotMatches: SnapshotRow[] = [];
+
+    // Server-side exact-equality pre-pass. Only fields we know up front are
+    // scanned this way: an explicit `by`, or — when no `by` — the base
+    // identity set (name/full_name/title/email/domain/company). Composite or
+    // schema-declared fields still flow through the JS scan below.
+    const exactFields = explicitFields ?? [...BASE_SNAPSHOT_SEARCH_FIELDS];
+    const exactMatchIds = new Set<string>();
+    for (const field of exactFields) {
+      let exactQuery = db
+        .from("entity_snapshots")
+        .select("entity_id, entity_type, snapshot")
+        .eq("user_id", userId)
+        .eq(`snapshot->>${field}`, identifier.trim());
+      if (entityType) {
+        exactQuery = exactQuery.eq("entity_type", entityType);
+      }
+      const { data: exactRows } = await exactQuery.limit(limit);
+      for (const row of (exactRows as SnapshotRow[] | null) || []) {
+        if (exactMatchIds.has(row.entity_id)) continue;
+        exactMatchIds.add(row.entity_id);
+        snapshotMatches.push(row);
+      }
+    }
+
+    // Bounded JS scan for fuzzy/substring/token matches the exact pre-pass
+    // can't express. Still capped, but now it only needs to catch the
+    // non-exact cases — exact identifiers are already resolved above.
     let snapshotQuery = db
       .from("entity_snapshots")
       .select("entity_id, entity_type, snapshot")
@@ -310,8 +349,8 @@ export async function retrieveEntityByIdentifierWithFallback(
       snapshotQuery = snapshotQuery.eq("entity_type", entityType);
     }
     const { data: snapshotRows } = await snapshotQuery.limit(500);
-    const snapshotMatches: SnapshotRow[] = [];
     for (const row of (snapshotRows as SnapshotRow[] | null) || []) {
+      if (exactMatchIds.has(row.entity_id)) continue;
       const fields = await snapshotFieldsForType(row.entity_type);
       if (snapshotFieldsMatch(row.snapshot, needleLower, fields)) {
         snapshotMatches.push(row);

--- a/src/shared/action_handlers/entity_identifier_handler.ts
+++ b/src/shared/action_handlers/entity_identifier_handler.ts
@@ -110,6 +110,22 @@ type SnapshotRow = {
   snapshot: Record<string, unknown> | null;
 };
 
+/**
+ * Field names that may be interpolated into a SQL column path.
+ *
+ * The exact pre-pass builds `lower(snapshot->>${field})` and hands it to the
+ * query builder, which splices the column side into SQL literally (only the
+ * compared *value* is parameterised). Any field name reaching that path must
+ * therefore be a plain SQL identifier. This mirrors the pattern the sqlite
+ * adapter's `normalizeColumnName` recognises — names outside it fall through
+ * that function unchanged and would be interpolated raw.
+ */
+const SAFE_SNAPSHOT_FIELD_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+function isSafeSnapshotFieldName(field: unknown): field is string {
+  return typeof field === "string" && SAFE_SNAPSHOT_FIELD_PATTERN.test(field);
+}
+
 function snapshotFieldsMatch(
   snapshot: Record<string, unknown> | null,
   needleLower: string,
@@ -239,6 +255,25 @@ export async function retrieveEntityByIdentifierWithFallback(
   // during the snapshot-field pass below (generic base + declared
   // identity_search_fields), so a financial_account's institution/account_name
   // are scanned without hardcoding finance fields here (#1495).
+  //
+  // SECURITY: `by` is caller-supplied at the MCP surface and is interpolated
+  // into a SQL column path (`lower(snapshot->>${field})`) by the exact pre-pass
+  // below. The sqlite adapter's normalizeColumnName only recognises that shape
+  // for `[A-Za-z_][A-Za-z0-9_]*` field names and otherwise returns the string
+  // unchanged, which is then spliced raw into the filter clause (only the
+  // *value* side is parameterised). An unvalidated `by` is therefore a SQL
+  // injection vector. Reject anything that is not a plain identifier before it
+  // can reach a query builder — the exact-pass is the only place `by` becomes
+  // a column expression, so validating here covers every downstream use.
+  // Validate on `by` itself rather than on the derived array: `by: ""` is
+  // falsy, so a truthiness check would skip validation and silently fall
+  // through to the no-`by` path instead of rejecting a malformed pin.
+  if (by !== undefined && by !== null && !isSafeSnapshotFieldName(by)) {
+    throw new Error(
+      `Invalid \`by\` field name: ${JSON.stringify(by)}. ` +
+        `Must match ${SAFE_SNAPSHOT_FIELD_PATTERN.source}.`
+    );
+  }
   const explicitFields = by ? [by] : null;
   // Cache resolved field sets per entity_type for the duration of one call so
   // a cross-type snapshot scan does not re-load the same schema repeatedly.
@@ -352,7 +387,11 @@ export async function retrieveEntityByIdentifierWithFallback(
     } else if (entityType) {
       // Known type up front: resolve its identity_search_fields once and
       // query only those fields, exactly like the JS-scan fallback does.
-      const fields = await snapshotFieldsForType(entityType);
+      // Defence in depth: these come from the schema registry rather than the
+      // caller, but they still become SQL column paths, so any name that isn't
+      // a plain identifier is skipped here and left to the JS-scan fallback
+      // (which does a safe in-memory property lookup) rather than interpolated.
+      const fields = (await snapshotFieldsForType(entityType)).filter(isSafeSnapshotFieldName);
       for (const field of fields) {
         const { data: exactRows } = await db
           .from("entity_snapshots")

--- a/src/shared/action_handlers/entity_identifier_handler.ts
+++ b/src/shared/action_handlers/entity_identifier_handler.ts
@@ -315,26 +315,75 @@ export async function retrieveEntityByIdentifierWithFallback(
     // only as a fuzzy/token fallback.
     const snapshotMatches: SnapshotRow[] = [];
 
-    // Server-side exact-equality pre-pass. Only fields we know up front are
-    // scanned this way: an explicit `by`, or — when no `by` — the base
-    // identity set (name/full_name/title/email/domain/company). Composite or
-    // schema-declared fields still flow through the JS scan below.
-    const exactFields = explicitFields ?? [...BASE_SNAPSHOT_SEARCH_FIELDS];
+    // Server-side exact-equality pre-pass. When an explicit `by` is given,
+    // only that field is scanned. Otherwise the field set must go through the
+    // same per-type resolution as the JS-scan fallback (`snapshotFieldsForType`)
+    // so type-declared identity_search_fields (e.g. financial_account's
+    // institution/account_name, #1495) get exact-pass coverage too — not just
+    // the generic base set. When `entityType` is filtered, the type is known
+    // up front and its fields are resolved once; when it is not, the fields
+    // are resolved per matched row's entity_type after fetching.
+    //
+    // Case-insensitive match: compares `lower(snapshot->>field)` against the
+    // lowercased identifier so this pre-pass has the same case-insensitive
+    // contract as the JS-scan fallback (`snapshotFieldsMatch` lowercases both
+    // sides). Without this, a snapshot value stored with different casing
+    // than the query (e.g. `Mixed.Case@Example.com` vs a lowercase query)
+    // would silently fail to resolve via the exact pass, regressing the
+    // scale-safety this fix exists to provide for mixed-case data (#1981).
     const exactMatchIds = new Set<string>();
-    for (const field of exactFields) {
-      let exactQuery = db
-        .from("entity_snapshots")
-        .select("entity_id, entity_type, snapshot")
-        .eq("user_id", userId)
-        .eq(`snapshot->>${field}`, identifier.trim());
-      if (entityType) {
-        exactQuery = exactQuery.eq("entity_type", entityType);
+    if (explicitFields) {
+      for (const field of explicitFields) {
+        let exactQuery = db
+          .from("entity_snapshots")
+          .select("entity_id, entity_type, snapshot")
+          .eq("user_id", userId)
+          .eq(`lower(snapshot->>${field})`, needleLower);
+        if (entityType) {
+          exactQuery = exactQuery.eq("entity_type", entityType);
+        }
+        const { data: exactRows } = await exactQuery.limit(limit);
+        for (const row of (exactRows as SnapshotRow[] | null) || []) {
+          if (exactMatchIds.has(row.entity_id)) continue;
+          exactMatchIds.add(row.entity_id);
+          snapshotMatches.push(row);
+        }
       }
-      const { data: exactRows } = await exactQuery.limit(limit);
-      for (const row of (exactRows as SnapshotRow[] | null) || []) {
-        if (exactMatchIds.has(row.entity_id)) continue;
-        exactMatchIds.add(row.entity_id);
-        snapshotMatches.push(row);
+    } else if (entityType) {
+      // Known type up front: resolve its identity_search_fields once and
+      // query only those fields, exactly like the JS-scan fallback does.
+      const fields = await snapshotFieldsForType(entityType);
+      for (const field of fields) {
+        const { data: exactRows } = await db
+          .from("entity_snapshots")
+          .select("entity_id, entity_type, snapshot")
+          .eq("user_id", userId)
+          .eq("entity_type", entityType)
+          .eq(`lower(snapshot->>${field})`, needleLower)
+          .limit(limit);
+        for (const row of (exactRows as SnapshotRow[] | null) || []) {
+          if (exactMatchIds.has(row.entity_id)) continue;
+          exactMatchIds.add(row.entity_id);
+          snapshotMatches.push(row);
+        }
+      }
+    } else {
+      // No `by`, no entityType filter: the base set is queried directly
+      // (cheap, index-friendly), but any row that only matches on a
+      // type-declared field (not in the base set) is picked up by the
+      // bounded JS-scan fallback below via snapshotFieldsForType per row.
+      for (const field of BASE_SNAPSHOT_SEARCH_FIELDS) {
+        const { data: exactRows } = await db
+          .from("entity_snapshots")
+          .select("entity_id, entity_type, snapshot")
+          .eq("user_id", userId)
+          .eq(`lower(snapshot->>${field})`, needleLower)
+          .limit(limit);
+        for (const row of (exactRows as SnapshotRow[] | null) || []) {
+          if (exactMatchIds.has(row.entity_id)) continue;
+          exactMatchIds.add(row.entity_id);
+          snapshotMatches.push(row);
+        }
       }
     }
 

--- a/tests/integration/entity_identifier_handler.test.ts
+++ b/tests/integration/entity_identifier_handler.test.ts
@@ -669,4 +669,89 @@ describe("retrieveEntityByIdentifierWithFallback", () => {
     expect(result.entities[0]?.id).toBe(entityId);
     expect(result.hint).toBeUndefined();
   });
+
+  it("rejects a malformed `by` field name instead of interpolating it into SQL", async () => {
+    // SECURITY regression. `by` is caller-supplied at the MCP surface and is
+    // interpolated into a SQL column path (`lower(snapshot->>${field})`) by the
+    // exact pre-pass. The sqlite adapter's normalizeColumnName only recognises
+    // that shape for plain identifiers and otherwise returns the string
+    // unchanged, which is spliced raw into the filter clause (only the compared
+    // value is parameterised). Without validation, a `by` carrying SQL
+    // metacharacters would reach the query builder verbatim.
+    const userId = "identifier-user-malformed-by";
+
+    const malformed = [
+      "email) OR 1=1 --",
+      "email; DROP TABLE entities",
+      "email'",
+      "email field",
+      "",
+      "snapshot->>email",
+    ];
+
+    for (const by of malformed) {
+      await expect(
+        retrieveEntityByIdentifierWithFallback({
+          identifier: "someone@example.com",
+          entityType: "contact",
+          userId,
+          by,
+          limit: 100,
+        })
+      ).rejects.toThrow(/Invalid `by` field name/);
+    }
+
+    // A well-formed field name still works (guard is not over-broad).
+    const ok = await retrieveEntityByIdentifierWithFallback({
+      identifier: "someone@example.com",
+      entityType: "contact",
+      userId,
+      by: "email",
+      limit: 100,
+    });
+    expect(ok.match_mode).toBe("none");
+  });
+
+  it("dedupes a single entity that matches the needle on two snapshot fields at once", async () => {
+    // The no-`by` exact pass runs one query per field and dedupes via
+    // exactMatchIds. An entity whose snapshot matches the same needle on two of
+    // those fields (here `name` and `company`) must appear exactly once — a
+    // regression would surface silently as a duplicate row and inflated total.
+    const userId = "identifier-user-crossfield-dedupe";
+    const entityId = `ent_crossfield_${Date.now()}`;
+    testEntityIds.push(entityId);
+    const now = new Date().toISOString();
+    const needle = "Northgate";
+
+    await serviceRoleClient.from("entities").insert({
+      id: entityId,
+      user_id: userId,
+      entity_type: "contact",
+      canonical_name: "opaque-canonical-crossfield",
+    });
+    await serviceRoleClient.from("entity_snapshots").upsert({
+      entity_id: entityId,
+      user_id: userId,
+      entity_type: "contact",
+      schema_version: "1.0",
+      canonical_name: "opaque-canonical-crossfield",
+      // Same value in two scanned fields.
+      snapshot: { name: needle, company: needle, email: "crossfield@example.com" },
+      provenance: {},
+      observation_count: 1,
+      last_observation_at: now,
+      computed_at: now,
+    });
+
+    const result = await retrieveEntityByIdentifierWithFallback({
+      identifier: needle,
+      entityType: "contact",
+      userId,
+      limit: 100,
+    });
+
+    const occurrences = result.entities.filter((e) => e.id === entityId).length;
+    expect(occurrences).toBe(1);
+    expect(result.total).toBe(1);
+  });
 });

--- a/tests/integration/entity_identifier_handler.test.ts
+++ b/tests/integration/entity_identifier_handler.test.ts
@@ -754,4 +754,63 @@ describe("retrieveEntityByIdentifierWithFallback", () => {
     expect(occurrences).toBe(1);
     expect(result.total).toBe(1);
   });
+
+  it("no-`by`/no-`entityType` exact pass defers a type-declared identity field (financial_account institution) to the JS-scan fallback", async () => {
+    // QA regression (review round 2, ent_db0b7855d47012084477fb00 /
+    // ent_2ad0677fe23c0c1878ae43e8): every existing institution-field test
+    // passes entityType explicitly, which resolves the known-type branch
+    // (snapshotFieldsForType(entityType) queried directly). When BOTH `by`
+    // and `entityType` are omitted, the exact pre-pass only queries
+    // BASE_SNAPSHOT_SEARCH_FIELDS (the `else` branch) and leaves
+    // type-declared fields like financial_account's `institution` to the
+    // bounded JS-scan fallback below it. This test pins that the deferral
+    // still resolves the entity at all — match_mode can't distinguish
+    // "resolved by exact pass" from "resolved by JS-scan fallback" here,
+    // since both merge into the same snapshotMatches array and report
+    // match_mode "snapshot_field". The real value of this test is coverage
+    // of the previously-untested no-`by`/no-`entityType` code path, not a
+    // precise assertion on which pass produced the hit.
+    const userId = "identifier-user-no-by-no-entitytype";
+    const entityId = `ent_fa_no_by_no_type_${Date.now()}`;
+    testEntityIds.push(entityId);
+    const now = new Date().toISOString();
+
+    await serviceRoleClient.from("entities").insert({
+      id: entityId,
+      user_id: userId,
+      entity_type: "financial_account",
+      // canonical_name carries no institution token, so neither
+      // canonical_name.ilike nor the base snapshot fields (name/full_name/
+      // title/email/domain/company) can resolve "institution".
+      canonical_name: "Secondary Checking",
+    });
+    await serviceRoleClient.from("entity_snapshots").upsert({
+      entity_id: entityId,
+      user_id: userId,
+      entity_type: "financial_account",
+      schema_version: "1.0",
+      canonical_name: "Secondary Checking",
+      snapshot: {
+        account_name: "Secondary Checking",
+        institution: "Ibercaja Regular",
+      },
+      provenance: {},
+      observation_count: 1,
+      last_observation_at: now,
+      computed_at: now,
+    });
+
+    // No `by`, no `entityType`: the exact pre-pass's else branch queries
+    // only BASE_SNAPSHOT_SEARCH_FIELDS, so this row must be picked up by the
+    // bounded JS-scan fallback (which resolves per-row identity_search_fields
+    // via snapshotFieldsForType) instead.
+    const result = await retrieveEntityByIdentifierWithFallback({
+      identifier: "Ibercaja Regular",
+      userId,
+      limit: 100,
+    });
+    expect(result.total).toBe(1);
+    expect(result.entities[0]?.id).toBe(entityId);
+    expect(result.match_mode).toBe("snapshot_field");
+  });
 });

--- a/tests/integration/entity_identifier_handler.test.ts
+++ b/tests/integration/entity_identifier_handler.test.ts
@@ -177,6 +177,69 @@ describe("retrieveEntityByIdentifierWithFallback", () => {
     expect(result.entities[0]?.snapshot).toBeTruthy();
   });
 
+  it("resolves by=email via the server-side exact pass when the email is NOT the canonical_name", async () => {
+    // Regression for the scale bug: the snapshot-field pass previously only
+    // JS-scanned an unordered 500-row window, so an exact email whose row sits
+    // outside that window (or whose canonical_name is something else entirely,
+    // e.g. a title) silently returned nothing — even though the email is
+    // present verbatim in the snapshot. This reproduces the live Bottega8
+    // failure (a contact whose canonical_name is "General Manager" but whose
+    // snapshot email is the real identifier). The server-side snapshot->>email
+    // exact pass must find it regardless of scan-window position.
+    const userId = "identifier-user-email-not-canonical";
+    const entityId = `ent_email_noncanon_${Date.now()}`;
+    testEntityIds.push(entityId);
+    const now = new Date().toISOString();
+
+    await serviceRoleClient.from("entities").insert({
+      id: entityId,
+      user_id: userId,
+      entity_type: "contact",
+      // canonical_name is a TITLE, not the name or email — so neither the
+      // canonical_name.ilike query nor an aliases match can resolve the email.
+      canonical_name: "General Manager",
+    });
+    await serviceRoleClient.from("entity_snapshots").upsert({
+      entity_id: entityId,
+      user_id: userId,
+      entity_type: "contact",
+      schema_version: "1.0",
+      canonical_name: "General Manager",
+      snapshot: {
+        name: "Email Noncanon Person",
+        email: "email.noncanon@example.com",
+        phone: "+15551230000",
+      },
+      provenance: {},
+      observation_count: 1,
+      last_observation_at: now,
+      computed_at: now,
+    });
+
+    // by="email" — the exact case that returned zero before the fix.
+    const byEmail = await retrieveEntityByIdentifierWithFallback({
+      identifier: "email.noncanon@example.com",
+      entityType: "contact",
+      userId,
+      by: "email",
+      limit: 100,
+    });
+    expect(byEmail.total).toBe(1);
+    expect(byEmail.entities[0]?.id).toBe(entityId);
+    expect(byEmail.match_mode).toBe("snapshot_field");
+
+    // by="phone" likewise resolves via the exact server-side pass.
+    const byPhone = await retrieveEntityByIdentifierWithFallback({
+      identifier: "+15551230000",
+      entityType: "contact",
+      userId,
+      by: "phone",
+      limit: 100,
+    });
+    expect(byPhone.total).toBe(1);
+    expect(byPhone.entities[0]?.id).toBe(entityId);
+  });
+
   it("#1495 resolves via the snapshot-field pass when canonical_name omits the institution token", async () => {
     // Hardest #1495 case: the canonical_name carries no institution/account
     // token at all (an opaque id), so the only path to the row is the

--- a/tests/integration/entity_identifier_handler.test.ts
+++ b/tests/integration/entity_identifier_handler.test.ts
@@ -4,6 +4,7 @@ import {
   ENTITY_ID_NOT_FOUND_HINT,
   retrieveEntityByIdentifierWithFallback,
 } from "../../src/shared/action_handlers/entity_identifier_handler.js";
+import { identifyEntityBySignals } from "../../src/services/entity_signal_resolver.js";
 
 const serviceRoleClient = getServiceRoleClient();
 
@@ -238,6 +239,170 @@ describe("retrieveEntityByIdentifierWithFallback", () => {
     });
     expect(byPhone.total).toBe(1);
     expect(byPhone.entities[0]?.id).toBe(entityId);
+  });
+
+  it("resolves by=email via the exact pass case-insensitively", async () => {
+    // Regression for the case-sensitivity divergence flagged on PR review:
+    // the exact-equality pre-pass previously used raw `.eq()` on
+    // `snapshot->>email`, which is case-sensitive, while the JS-scan
+    // fallback (`snapshotFieldsMatch`) lowercases both sides before
+    // comparing. A snapshot email stored with different casing than the
+    // query would silently resolve only via the (window-capped) JS scan and
+    // not the exact pass — regressing the scale guarantee for mixed-case
+    // data, which GDPR accuracy concerns tie to duplicate PII records.
+    const userId = "identifier-user-email-case-insensitive";
+    const entityId = `ent_email_case_${Date.now()}`;
+    testEntityIds.push(entityId);
+    const now = new Date().toISOString();
+
+    await serviceRoleClient.from("entities").insert({
+      id: entityId,
+      user_id: userId,
+      entity_type: "contact",
+      canonical_name: "Case Sensitivity Person",
+    });
+    await serviceRoleClient.from("entity_snapshots").upsert({
+      entity_id: entityId,
+      user_id: userId,
+      entity_type: "contact",
+      schema_version: "1.0",
+      canonical_name: "Case Sensitivity Person",
+      snapshot: {
+        name: "Case Sensitivity Person",
+        // Mixed-case email stored in the snapshot.
+        email: "Mixed.Case@Example.com",
+      },
+      provenance: {},
+      observation_count: 1,
+      last_observation_at: now,
+      computed_at: now,
+    });
+
+    // Query with a different case than stored — must still resolve via the
+    // exact pass (match_mode: "snapshot_field"), not fall through to
+    // semantic search.
+    const result = await retrieveEntityByIdentifierWithFallback({
+      identifier: "mixed.case@example.com",
+      entityType: "contact",
+      userId,
+      by: "email",
+      limit: 100,
+    });
+    expect(result.total).toBe(1);
+    expect(result.entities[0]?.id).toBe(entityId);
+    expect(result.match_mode).toBe("snapshot_field");
+  });
+
+  it("no-`by` exact pass resolves a type-declared identity field (financial_account institution) via resolveIdentitySearchFields, not just the base field set", async () => {
+    // Regression for the eng-lens finding: the exact pre-pass's no-`by`
+    // field resolution previously used the hardcoded BASE_SNAPSHOT_SEARCH_
+    // FIELDS regardless of entity_type, bypassing resolveIdentitySearchFields
+    // — the same mechanism the JS-scan fallback already used via
+    // snapshotFieldsForType. This meant a type with declared identity_
+    // search_fields (e.g. financial_account's institution/account_name,
+    // #1495) lost exact-pass coverage for those fields whenever no `by` was
+    // given, silently falling back to the capped 500-row JS scan and
+    // reintroducing the scale bug for that narrower field set.
+    const userId = "identifier-user-no-by-institution";
+    const entityId = `ent_fa_no_by_${Date.now()}`;
+    testEntityIds.push(entityId);
+    const now = new Date().toISOString();
+
+    await serviceRoleClient.from("entities").insert({
+      id: entityId,
+      user_id: userId,
+      entity_type: "financial_account",
+      // canonical_name carries no institution token, so neither
+      // canonical_name.ilike nor the base snapshot fields (name/full_name/
+      // title/email/domain/company) can resolve "institution" — only the
+      // type-declared identity_search_fields path can.
+      canonical_name: "Primary Checking",
+    });
+    await serviceRoleClient.from("entity_snapshots").upsert({
+      entity_id: entityId,
+      user_id: userId,
+      entity_type: "financial_account",
+      schema_version: "1.0",
+      canonical_name: "Primary Checking",
+      snapshot: {
+        account_name: "Primary Checking",
+        institution: "Ibercaja Regular",
+      },
+      provenance: {},
+      observation_count: 1,
+      last_observation_at: now,
+      computed_at: now,
+    });
+
+    // No `by` — entityType is given so the fix's known-type branch resolves
+    // identity_search_fields (institution/account_name) for the exact pass.
+    const result = await retrieveEntityByIdentifierWithFallback({
+      identifier: "Ibercaja Regular",
+      entityType: "financial_account",
+      userId,
+      limit: 100,
+    });
+    expect(result.total).toBe(1);
+    expect(result.entities[0]?.id).toBe(entityId);
+    expect(result.match_mode).toBe("snapshot_field");
+  });
+
+  it("identify_entity_by_signals resolves email + company signals against a real (unmocked) handler when canonical_name carries neither", async () => {
+    // Effect-level regression for the issue's second reported symptom:
+    // identify_entity_by_signals sits on retrieveEntityByIdentifierWithFallback,
+    // so the scale bug degraded multi-signal resolution to name-only (email/
+    // company contributions never registered). This exercises the real
+    // handler (no mocks) end-to-end, unlike entity_signal_resolver.test.ts's
+    // scoring-table unit tests, which mock the handler and only verify
+    // corroboration math in isolation.
+    const userId = "identifier-user-multisignal";
+    const entityId = `ent_multisignal_${Date.now()}`;
+    testEntityIds.push(entityId);
+    const now = new Date().toISOString();
+
+    await serviceRoleClient.from("entities").insert({
+      id: entityId,
+      user_id: userId,
+      entity_type: "contact",
+      // canonical_name is a title again — email/company only live in the
+      // snapshot, so only the exact-pass fix makes them resolvable at all.
+      canonical_name: "VP of Sales",
+    });
+    await serviceRoleClient.from("entity_snapshots").upsert({
+      entity_id: entityId,
+      user_id: userId,
+      entity_type: "contact",
+      schema_version: "1.0",
+      canonical_name: "VP of Sales",
+      snapshot: {
+        name: "Multisignal Person",
+        email: "multisignal.person@example.com",
+        company: "Acme Corp",
+      },
+      provenance: {},
+      observation_count: 1,
+      last_observation_at: now,
+      computed_at: now,
+    });
+
+    const result = await identifyEntityBySignals({
+      signals: {
+        name: "Multisignal Person",
+        email: "multisignal.person@example.com",
+        company: "Acme Corp",
+      },
+      entity_type: "contact",
+      userId,
+    });
+
+    expect(result.best_match).not.toBeNull();
+    expect(result.best_match?.entity_id).toBe(entityId);
+    // Before the fix, email/company never resolved (name-only via
+    // canonical_name), so matched_signals would be ["name"] and band "low".
+    // After the fix, email and company both contribute.
+    expect(result.best_match?.matched_signals).toContain("email");
+    expect(result.best_match?.matched_signals).toContain("company");
+    expect(result.resolution_band).not.toBe("unresolved");
   });
 
   it("#1495 resolves via the snapshot-field pass when canonical_name omits the institution token", async () => {


### PR DESCRIPTION
Closes #1981.

## Problem
`retrieveEntityByIdentifierWithFallback` (behind `retrieve_entity_by_identifier` and `identify_entity_by_signals`) resolved non-`name` identifiers only via an **unordered, in-memory scan of a 500-row window** of `entity_snapshots`. On an instance with thousands of entities, an exact email/phone whose row sits outside that window is never examined — so `by:"email"`/`by:"phone"` silently return `total: 0`, and multi-signal resolution degrades to name-only, defeating reliable-identifier dedup for multi-source imports.

Live repro (Bottega8, ~14k entities): `retrieve_entity_by_identifier("markmhendrickson@gmail.com", by:"email")` → `match_mode: "none"`, despite that email being verbatim in a contact's snapshot.

## Fix
Server-side exact-equality pre-pass using `snapshot->>{field}` (the JSONB-filter pattern already used in `entity_queries.ts`) over the known identity fields — the explicit `by`, or the base identity set when none. The DB satisfies it from any row regardless of window position. The bounded 500-row JS scan is kept only as a fuzzy/substring/token fallback.

## Test
Added a regression: a contact whose `canonical_name` is a *title* (not name/email) resolves by `email` and by `phone` via the exact pass (`match_mode: "snapshot_field"`) — the exact live failure. All 13 handler tests pass; `tsc` clean.

## Note
Likely compounds #1964 (name being the only working resolution path). This fix restores email/phone/company/domain resolution, which is the prerequisite for `identify_entity_by_signals` to actually dedupe contact imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)