### PR TITLE
fix(deploy): wire schema seeding into every deploy path, safely — closes #1968

### DIFF
--- a/docs/developer/schema_initialization.md
+++ b/docs/developer/schema_initialization.md
@@ -23,6 +23,31 @@ Entity schemas defined in `src/services/schema_definitions.ts` should be initial
 - Database becomes single source of truth
 - Runtime code only queries database (no fallback needed)
 
+## When Seeding Runs (deploy contract)
+
+Seeding is **not** a manual step you have to remember (issue #1968). It runs
+automatically on every deploy path:
+
+| Path | Mechanism |
+|---|---|
+| Any server start (all deploy paths, incl. future ones) | `seedSchemaRegistryIfEmpty()` in `startHTTPServer()` — `src/services/schema_registry_bootstrap.ts` |
+| Fly.io deploys (`fly.toml`, `fly.sandbox.toml`) | `[deploy] release_command = "node dist/seed_schemas_entry.js"` |
+| Rolling-main RC autodeploy | `node dist/seed_schemas_entry.js` step in `scripts/redeploy_rc_from_main.sh` |
+| Local / manual | `npm run schema:init` |
+
+Boot-time seeding is the backstop that covers every path, including deploy
+paths not yet written; the explicit `release_command` and RC-script steps run
+seeding *before* the new release takes traffic and surface a failure in the
+deploy log rather than a single warn line in the server log. Running several
+of these is harmless — whichever gets there first registers, the rest skip.
+
+Boot seeding is deliberately **non-blocking**: it is wrapped in try/catch, so a
+briefly-unavailable database yields a warn log and the server still starts. It
+logs either `registry empty for N type(s) → seeding: …` or `all N built-in
+schema(s) already registered; nothing to seed`.
+
+**All of these paths are additive** — see the skip-if-present guard below.
+
 ## Initialization Script
 
 ### Usage
@@ -43,14 +68,23 @@ tsx scripts/initialize-schemas.ts --force
 1. **Reads schemas** from `src/services/schema_definitions.ts`:
    - All schemas from `ENTITY_SCHEMAS` (unified structure)
 
-2. **Checks database** for existing schemas:
-   - If schema exists and is active → skip
-   - If schema exists but is inactive → activate it
-   - If schema doesn't exist → register and activate it
+2. **Checks database** for an existing ACTIVE schema (skip-if-present):
+   - If the entity type already has an active schema → skip, whatever
+     version it is. The script never re-registers or re-activates over it.
+   - If the entity type has no active schema → register and activate it
+
+   This guard exists because an operator may deliberately register a **custom
+   schema** that overrides a built-in (via `register_schema` /
+   `update_schema_incremental`). Before issue #1968 the script decided by
+   matching the built-in's `schema_version` *string* and called `activate()`
+   whenever that version was registered-but-inactive — which deactivated the
+   operator's custom schema and reverted the type to the built-in on every
+   run. Keying on "is anything active?" removes that hazard.
 
 3. **Activates schemas**:
    - Only one schema version per entity type can be active
-   - Activation automatically deactivates other versions
+   - Activation automatically deactivates other versions — which is exactly
+     why the skip-if-present guard above matters
 
 4. **Reports results**:
    - Shows which schemas were registered, activated, or skipped
@@ -170,6 +204,12 @@ For existing deployments:
 If you see "duplicate key" or "unique constraint" errors:
 - The schema is already registered
 - Use `--force` flag to re-register: `tsx scripts/initialize-schemas.ts --force`
+
+> **`--force` overrides the skip-if-present guard.** It re-registers and
+> activates the built-in over whatever is currently active, which will
+> **deactivate an operator-registered custom schema** for that entity type.
+> Check `SELECT entity_type, schema_version, active FROM schema_registry
+> WHERE active = true` for unexpected versions before running it.
 
 ### Schema Not Found After Initialization
 - Check that the schema was actually registered: query `schema_registry` table

--- a/docs/developer/schema_initialization.md
+++ b/docs/developer/schema_initialization.md
@@ -7,6 +7,7 @@ Entity schemas defined in `src/services/schema_definitions.ts` should be initial
 ## Why Initialize Schemas?
 
 **Benefits:**
+
 - **Transparency**: Schemas are visible and queryable in the database
 - **Consistency**: Single source of truth (database) instead of code fallbacks
 - **Versioning**: Database tracks schema versions and history
@@ -14,11 +15,13 @@ Entity schemas defined in `src/services/schema_definitions.ts` should be initial
 - **Auditability**: Schema changes are tracked in database
 
 **Current Approach:**
+
 - Schemas in `schema_definitions.ts` are used as runtime fallbacks
 - Fallback logic adds complexity to `interpretation.ts`
 - Schemas are not visible in database until explicitly registered
 
 **Recommended Approach:**
+
 - Initialize all schemas from `schema_definitions.ts` into database
 - Database becomes single source of truth
 - Runtime code only queries database (no fallback needed)
@@ -28,16 +31,16 @@ Entity schemas defined in `src/services/schema_definitions.ts` should be initial
 Seeding is **not** a manual step you have to remember (issue #1968). It runs
 automatically on every deploy path:
 
-| Path | Mechanism |
-|---|---|
+| Path                                                   | Mechanism                                                                                          |
+| ------------------------------------------------------ | -------------------------------------------------------------------------------------------------- |
 | Any server start (all deploy paths, incl. future ones) | `seedSchemaRegistryIfEmpty()` in `startHTTPServer()` — `src/services/schema_registry_bootstrap.ts` |
-| Fly.io deploys (`fly.toml`, `fly.sandbox.toml`) | `[deploy] release_command = "node dist/seed_schemas_entry.js"` |
-| Rolling-main RC autodeploy | `node dist/seed_schemas_entry.js` step in `scripts/redeploy_rc_from_main.sh` |
-| Local / manual | `npm run schema:init` |
+| Fly.io deploys (`fly.toml`, `fly.sandbox.toml`)        | `[deploy] release_command = "node dist/seed_schemas_entry.js"`                                     |
+| Rolling-main RC autodeploy                             | `node dist/seed_schemas_entry.js` step in `scripts/redeploy_rc_from_main.sh`                       |
+| Local / manual                                         | `npm run schema:init`                                                                              |
 
 Boot-time seeding is the backstop that covers every path, including deploy
 paths not yet written; the explicit `release_command` and RC-script steps run
-seeding *before* the new release takes traffic and surface a failure in the
+seeding _before_ the new release takes traffic and surface a failure in the
 deploy log rather than a single warn line in the server log. Running several
 of these is harmless — whichever gets there first registers, the rest skip.
 
@@ -76,7 +79,7 @@ tsx scripts/initialize-schemas.ts --force
    This guard exists because an operator may deliberately register a **custom
    schema** that overrides a built-in (via `register_schema` /
    `update_schema_incremental`). Before issue #1968 the script decided by
-   matching the built-in's `schema_version` *string* and called `activate()`
+   matching the built-in's `schema_version` _string_ and called `activate()`
    whenever that version was registered-but-inactive — which deactivated the
    operator's custom schema and reverted the type to the built-in on every
    run. Keying on "is anything active?" removes that hazard.
@@ -121,18 +124,23 @@ Total schemas processed: 32
 ## When to Run
 
 ### Initial Setup
+
 Run after:
+
 - Setting up a new database
 - Running migrations that create `schema_registry` table
 - Cloning the repository for the first time
 
 ### After Schema Changes
+
 Run after:
+
 - Adding new entity types to `schema_definitions.ts`
 - Updating existing schema definitions
 - Adding new schema versions
 
 ### Development Workflow
+
 ```bash
 # 1. Make changes to schema_definitions.ts
 # 2. Initialize schemas
@@ -150,8 +158,9 @@ The runtime code in `src/services/interpretation.ts` still includes fallback log
 - **Production**: Should rely on database schemas only
 
 **Warning in Development:**
+
 ```
-[Schema Fallback] No database schema found for entity type "invoice". 
+[Schema Fallback] No database schema found for entity type "invoice".
 Using code fallback. Run 'npm run schema:init' to register schemas in the database.
 ```
 
@@ -182,15 +191,17 @@ CREATE TABLE schema_registry (
 For existing deployments:
 
 1. **Run initialization script:**
+
    ```bash
    npm run schema:init
    ```
 
 2. **Verify schemas are active:**
+
    ```sql
-   SELECT entity_type, schema_version, active 
-   FROM schema_registry 
-   WHERE active = true 
+   SELECT entity_type, schema_version, active
+   FROM schema_registry
+   WHERE active = true
    ORDER BY entity_type;
    ```
 
@@ -201,7 +212,9 @@ For existing deployments:
 ## Troubleshooting
 
 ### Schema Already Exists Error
+
 If you see "duplicate key" or "unique constraint" errors:
+
 - The schema is already registered
 - Use `--force` flag to re-register: `tsx scripts/initialize-schemas.ts --force`
 
@@ -209,14 +222,16 @@ If you see "duplicate key" or "unique constraint" errors:
 > activates the built-in over whatever is currently active, which will
 > **deactivate an operator-registered custom schema** for that entity type.
 > Check `SELECT entity_type, schema_version, active FROM schema_registry
-> WHERE active = true` for unexpected versions before running it.
+WHERE active = true` for unexpected versions before running it.
 
 ### Schema Not Found After Initialization
+
 - Check that the schema was actually registered: query `schema_registry` table
 - Verify the entity type name matches exactly (case-sensitive)
 - Check for errors in the initialization output
 
 ### Fallback Still Being Used
+
 - Verify schemas are active: `SELECT * FROM schema_registry WHERE active = true`
 - Check that `entity_type` matches exactly (case-sensitive)
 - Run initialization again: `npm run schema:init`

--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,8 +61,8 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **551**
-- Backend and repo Vitest files: **516**
+- Total automated test files: **552**
+- Backend and repo Vitest files: **517**
 - Frontend Vitest files: **9**
 - Playwright spec files: **26**
 
@@ -70,7 +70,7 @@ flowchart TD
 | Suite | Files |
 |---|---:|
 | Vitest unit tests | 151 |
-| Vitest service tests | 40 |
+| Vitest service tests | 41 |
 | Source-adjacent tests | 65 |
 | Vitest integration tests | 157 |
 | Vitest CLI tests | 72 |
@@ -267,7 +267,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/services`
 **Requirements:** Basic `.env` if required by the module under test.
-**Files (40):**
+**Files (41):**
 - `tests/services/auto_enhancement_converter_detection.test.ts`
 - `tests/services/auto_enhancement_processor.test.ts`
 - `tests/services/capability_registry.test.ts`

--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,8 +61,8 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **552**
-- Backend and repo Vitest files: **517**
+- Total automated test files: **554**
+- Backend and repo Vitest files: **519**
 - Frontend Vitest files: **9**
 - Playwright spec files: **26**
 
@@ -70,9 +70,9 @@ flowchart TD
 | Suite | Files |
 |---|---:|
 | Vitest unit tests | 151 |
-| Vitest service tests | 41 |
+| Vitest service tests | 42 |
 | Source-adjacent tests | 65 |
-| Vitest integration tests | 157 |
+| Vitest integration tests | 158 |
 | Vitest CLI tests | 72 |
 | Vitest contract tests | 15 |
 | Vitest security tests | 4 |
@@ -267,12 +267,13 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/services`
 **Requirements:** Basic `.env` if required by the module under test.
-**Files (41):**
+**Files (42):**
 - `tests/services/auto_enhancement_converter_detection.test.ts`
 - `tests/services/auto_enhancement_processor.test.ts`
 - `tests/services/capability_registry.test.ts`
 - `tests/services/company_resolution.test.ts`
 - `tests/services/converter_detection_unit.test.ts`
+- `tests/services/deploy_seed_wiring.test.ts`
 - `tests/services/embed_cross_origin.test.ts`
 - `tests/services/encryption_service.test.ts`
 - `tests/services/entity_id_tenant_scope_resolution.test.ts`
@@ -387,7 +388,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm run test:integration` or `npx vitest run tests/integration`
 **Requirements:** Database configured; remote-dependent subsets additionally need `RUN_REMOTE_TESTS=1`.
-**Files (157):**
+**Files (158):**
 - `tests/integration/aauth_attribution_stamping.test.ts`
 - `tests/integration/aauth_mcp_capability_parity.test.ts`
 - `tests/integration/aauth_mcp_initialize_admission.test.ts`
@@ -515,6 +516,7 @@ flowchart TD
 - `tests/integration/sandbox_seed_token_bypass.test.ts`
 - `tests/integration/sandbox_stale_bearer_fallback.test.ts`
 - `tests/integration/schema_recommendation_integration.test.ts`
+- `tests/integration/seed_then_works_at_e2e.test.ts`
 - `tests/integration/session_introspection.test.ts`
 - `tests/integration/snapshot_ingestion_cutoff.test.ts`
 - `tests/integration/store_builtin_identity_opt_out_schemas.test.ts`

--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -302,6 +302,7 @@ flowchart TD
 - `tests/services/schema_recommendation.test.ts`
 - `tests/services/schema_reference_fields_resolve_target_validation.test.ts`
 - `tests/services/schema_reference_linking.test.ts`
+- `tests/services/schema_registry_bootstrap.test.ts`
 - `tests/services/schema_registry_incremental.test.ts`
 - `tests/services/schema_seeding_fresh_instance_gap.test.ts`
 - `tests/services/summary.test.ts`

--- a/fly.sandbox.toml
+++ b/fly.sandbox.toml
@@ -21,6 +21,13 @@ primary_region = 'lhr'
 [build]
   dockerfile = "Dockerfile"
 
+# Seed the schema_registry on every deploy, before the new release takes
+# traffic (issue #1968). Complements the idempotent boot-time seeding in
+# src/services/schema_registry_bootstrap.ts by surfacing a seeding failure in
+# the deploy log. Skips any entity type that already has an active schema.
+[deploy]
+  release_command = "node dist/seed_schemas_entry.js"
+
 [build.args]
   VITE_NEOTOMA_SANDBOX_UI = "1"
   # The sandbox serves the Inspector SPA at the site root, so build it with a

--- a/fly.toml
+++ b/fly.toml
@@ -8,6 +8,16 @@ primary_region = 'lhr'
 
 [build]
 
+# Seed the schema_registry on every deploy, before the new release takes
+# traffic (issue #1968). The server also seeds idempotently at boot
+# (src/services/schema_registry_bootstrap.ts); this makes the step explicit
+# and surfaces a seeding failure in the deploy log rather than a warn line.
+#
+# Safe to re-run: seed_schemas_entry.js skips entity types that already have
+# an active registration and never overwrites a custom operator schema.
+[deploy]
+  release_command = "node dist/seed_schemas_entry.js"
+
 [env]
   NODE_ENV = "production"
   NEOTOMA_ENV = "production"

--- a/scripts/initialize-schemas.ts
+++ b/scripts/initialize-schemas.ts
@@ -1,15 +1,15 @@
 #!/usr/bin/env tsx
 /**
  * Initialize Schema Registry from schema_definitions.ts
- * 
+ *
  * Loads all entity schemas from src/services/schema_definitions.ts into the
  * schema_registry database table. This makes schemas available in the database
  * instead of relying on runtime fallbacks.
- * 
+ *
  * Usage:
  *   npm run schema:init
  *   tsx scripts/initialize-schemas.ts [--dry-run] [--force]
- * 
+ *
  * Safe to re-run, including on an instance carrying CUSTOM schemas: an entity
  * type that already has an active global registration is SKIPPED outright —
  * not re-registered and not re-activated (issue #1968). Use --force to
@@ -24,10 +24,7 @@
  */
 
 // Use dynamic imports to handle missing database config gracefully
-import {
-  ENTITY_SCHEMAS,
-  type EntitySchema,
-} from "../src/services/schema_definitions.js";
+import { ENTITY_SCHEMAS, type EntitySchema } from "../src/services/schema_definitions.js";
 
 interface RegistrationResult {
   entity_type: string;
@@ -129,10 +126,7 @@ async function loadSchemaRegistry(): Promise<any | null> {
     const { schemaRegistry } = await import("../src/services/schema_registry.js");
     return schemaRegistry;
   } catch (error: any) {
-    if (
-      error.message?.includes("Missing database") ||
-      error.message?.includes("configuration")
-    ) {
+    if (error.message?.includes("Missing database") || error.message?.includes("configuration")) {
       return null;
     }
     throw error;
@@ -174,43 +168,21 @@ async function initializeSchemas(dryRun: boolean, force: boolean): Promise<void>
   // Try to load schema registry (may fail if DB config missing)
   const schemaRegistry = await loadSchemaRegistry();
   const dbAccessible = await checkDatabaseAccessible(schemaRegistry);
-  
+
   if (!dbAccessible) {
     if (dryRun) {
-      console.log(
-        "⚠️  Database not accessible - showing all schemas that would be registered\n"
-      );
-      console.log(
-        "   (Configure NEOTOMA_DATA_DIR to check existing schemas)\n"
-      );
+      console.log("⚠️  Database not accessible - showing all schemas that would be registered\n");
+      console.log("   (Configure NEOTOMA_DATA_DIR to check existing schemas)\n");
     } else {
-      console.error(
-        "❌ Error: Database not accessible. Please configure NEOTOMA_DATA_DIR.\n"
-      );
-      console.error(
-        "   Required environment variables:\n"
-      );
-      console.error(
-        "   - NEOTOMA_DATA_DIR (for local SQLite)\n"
-      );
-      console.error(
-        "\n   Options to configure:\n"
-      );
-      console.error(
-        "   1. Sync from 1Password (recommended):\n"
-      );
-      console.error(
-        "      npm run sync:env\n"
-      );
-      console.error(
-        "      (Requires 1Password CLI and mappings configured)\n"
-      );
-      console.error(
-        "   2. Manually add to .env file:\n"
-      );
-      console.error(
-        "      NEOTOMA_DATA_DIR=./data\n"
-      );
+      console.error("❌ Error: Database not accessible. Please configure NEOTOMA_DATA_DIR.\n");
+      console.error("   Required environment variables:\n");
+      console.error("   - NEOTOMA_DATA_DIR (for local SQLite)\n");
+      console.error("\n   Options to configure:\n");
+      console.error("   1. Sync from 1Password (recommended):\n");
+      console.error("      npm run sync:env\n");
+      console.error("      (Requires 1Password CLI and mappings configured)\n");
+      console.error("   2. Manually add to .env file:\n");
+      console.error("      NEOTOMA_DATA_DIR=./data\n");
       console.error(
         "\n   💡 Tip: Run 'npm run schema:init:dry-run' to preview schemas without database access.\n"
       );
@@ -224,9 +196,7 @@ async function initializeSchemas(dryRun: boolean, force: boolean): Promise<void>
   console.log("Processing schemas...");
   for (const schema of Object.values(ENTITY_SCHEMAS)) {
     if (!schema.entity_type || !schema.schema_version) {
-      console.warn(
-        `⚠️  Skipping invalid schema: missing entity_type or schema_version`
-      );
+      console.warn(`⚠️  Skipping invalid schema: missing entity_type or schema_version`);
       continue;
     }
 
@@ -256,9 +226,7 @@ async function initializeSchemas(dryRun: boolean, force: boolean): Promise<void>
             ? "skipped (already active)"
             : `error: ${result.error}`;
 
-    console.log(
-      `  ${icon} ${schema.entity_type} v${schema.schema_version} - ${actionLabel}`
-    );
+    console.log(`  ${icon} ${schema.entity_type} v${schema.schema_version} - ${actionLabel}`);
   }
 
   // Summary

--- a/scripts/initialize-schemas.ts
+++ b/scripts/initialize-schemas.ts
@@ -10,9 +10,17 @@
  *   npm run schema:init
  *   tsx scripts/initialize-schemas.ts [--dry-run] [--force]
  * 
+ * Safe to re-run, including on an instance carrying CUSTOM schemas: an entity
+ * type that already has an active global registration is SKIPPED outright —
+ * not re-registered and not re-activated (issue #1968). Use --force to
+ * deliberately re-register built-ins over whatever is currently active.
+ *
  * Options:
  *   --dry-run    Show what would be registered without making changes
- *   --force      Re-register and activate schemas even if they exist
+ *   --force      Re-register and activate schemas even if they exist.
+ *                WARNING: this overrides the skip-if-present guard and will
+ *                deactivate an operator-registered custom schema in favor of
+ *                the built-in.
  */
 
 // Use dynamic imports to handle missing database config gracefully
@@ -28,28 +36,6 @@ interface RegistrationResult {
   error?: string;
 }
 
-async function checkSchemaExists(
-  schemaRegistry: any,
-  entityType: string,
-  version: string
-): Promise<boolean | null> {
-  try {
-    const versions = await schemaRegistry.getSchemaVersions(entityType);
-    return versions.some((v) => v.schema_version === version);
-  } catch (error: any) {
-    // If error is due to missing config, return null to indicate unknown
-    if (
-      error.message?.includes("Missing database") ||
-      error.message?.includes("configuration") ||
-      error.code === "PGRST301" // Connection error
-    ) {
-      return null; // Unknown - database not accessible
-    }
-    // Other errors - assume it doesn't exist
-    return false;
-  }
-}
-
 async function registerSchema(
   schemaRegistry: any,
   schema: EntitySchema,
@@ -60,11 +46,7 @@ async function registerSchema(
   const { entity_type, schema_version } = schema;
 
   try {
-    // Check if schema already exists (only if database is accessible)
-    let exists: boolean | null = false;
-    if (dbAccessible && schemaRegistry) {
-      exists = await checkSchemaExists(schemaRegistry, entity_type, schema_version);
-    } else {
+    if (!dbAccessible || !schemaRegistry) {
       // Database not accessible - return early to show what would be registered
       return {
         entity_type,
@@ -73,47 +55,25 @@ async function registerSchema(
       };
     }
 
-    // If database check returned null (unknown), assume schema needs to be registered
-    if (exists === null) {
-      return {
-        entity_type,
-        schema_version,
-        action: "registered",
-      };
-    }
-
-    if (exists && !force) {
-      // Check if it's active (only if database is accessible)
-      if (dbAccessible && schemaRegistry) {
-        try {
-          const activeSchema = await schemaRegistry.loadActiveSchema(entity_type);
-          if (activeSchema?.schema_version === schema_version) {
-            return {
-              entity_type,
-              schema_version,
-              action: "skipped",
-            };
-          } else {
-            // Exists but not active - activate it
-            if (!dryRun) {
-              await schemaRegistry.activate(entity_type, schema_version);
-            }
-            return {
-              entity_type,
-              schema_version,
-              action: "activated",
-            };
-          }
-        } catch (error: any) {
-          // If we can't check active status, assume needs activation
-          if (!dryRun && dbAccessible && schemaRegistry) {
-            try {
-              await schemaRegistry.activate(entity_type, schema_version);
-            } catch (activateError) {
-              // Ignore activation errors in dry-run or if db not accessible
-            }
-          }
-        }
+    // Skip-if-present, keyed on whatever is ACTIVE rather than on a
+    // schema_version string match (issue #1968).
+    //
+    // Previously this activated the built-in version whenever it was
+    // registered-but-inactive. On an instance where an operator had
+    // deliberately registered and activated a CUSTOM schema for this entity
+    // type, that call flipped the built-in back to active — and activate()
+    // deactivates every other version for the type, so the operator's schema
+    // was silently switched off. Reading the active row and leaving it alone
+    // removes that hazard; `--force` remains the explicit opt-in for
+    // re-registering built-ins over whatever is present.
+    if (!force && dbAccessible && schemaRegistry) {
+      const activeSchema = await schemaRegistry.loadGlobalSchema(entity_type);
+      if (activeSchema) {
+        return {
+          entity_type,
+          schema_version,
+          action: "skipped",
+        };
       }
     }
 

--- a/scripts/redeploy_rc_from_main.sh
+++ b/scripts/redeploy_rc_from_main.sh
@@ -130,6 +130,24 @@ if ! npm run build:inspector:prod-target; then
 fi
 log "build:inspector complete."
 
+# Seed the schema_registry from the freshly-built dist (issue #1968).
+#
+# `schemaRegistry.loadActiveSchema` is DB-only with no code fallback, so an
+# unseeded registry silently disables store-time auto-linking. The server also
+# seeds idempotently at boot (src/services/schema_registry_bootstrap.ts), so
+# this step is belt-and-braces — but running it here surfaces a seeding failure
+# in the deploy log instead of a single warn line in the server log.
+#
+# Non-fatal by design: seeding only ADDS schemas for entity types that have
+# none, and the server will retry at boot, so a transient failure must not
+# block shipping the new build.
+log "seeding schema_registry…"
+if node dist/seed_schemas_entry.js; then
+  log "schema seeding complete."
+else
+  log "WARNING: schema seeding failed; continuing (server re-seeds idempotently at boot)."
+fi
+
 # HARD restart: kickstart -k kills the existing job instance and relaunches it,
 # forcing tsx/node --watch to re-import modules from the updated source.
 log "hard-restarting $PROD_LABEL…"

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -11807,6 +11807,41 @@ export async function startHTTPServer() {
   // Initialize encryption service
   await initServerKeys();
 
+  // Seed the built-in schema registry from ENTITY_SCHEMAS (issue #1968).
+  //
+  // Runs FIRST among the boot-time seeders so an unseeded instance has its
+  // core types registered before the service-specific seeders below extend
+  // them. `loadActiveSchema` is DB-only with no code fallback, so without this
+  // a fresh instance silently loses store-time auto-linking. Seeding here (as
+  // opposed to only in a Fly `release_command` or the RC redeploy script)
+  // covers every deploy path, including ones not yet written.
+  //
+  // Strictly additive: entity types that already have an active global schema
+  // are left untouched, so an operator's custom schema is never reverted.
+  try {
+    const { seedSchemaRegistryIfEmpty } = await import("./services/schema_registry_bootstrap.js");
+    const summary = await seedSchemaRegistryIfEmpty();
+    if (summary.registered.length > 0) {
+      logger.info(
+        `[SchemaRegistry] registry empty for ${summary.registered.length} type(s) → seeding: ` +
+          `${summary.registered.join(", ")} (preserved ${summary.preserved.length} existing)`
+      );
+    } else {
+      logger.info(
+        `[SchemaRegistry] all ${summary.preserved.length} built-in schema(s) already registered; nothing to seed`
+      );
+    }
+    if (summary.failed.length > 0) {
+      logger.warn(
+        `[SchemaRegistry] ${summary.failed.length} schema(s) failed to seed: ` +
+          summary.failed.map((f) => `${f.entity_type} (${f.error})`).join("; ")
+      );
+    }
+  } catch (err) {
+    // Never block boot — a briefly-unavailable DB must not stop the server.
+    logger.warn(`[SchemaRegistry] failed to seed built-in schemas: ${(err as Error).message}`);
+  }
+
   // Seed `issue` schema for the GitHub Issues integration.
   try {
     const { seedIssueSchema } = await import("./services/issues/seed_schema.js");

--- a/src/seed_schemas_entry.ts
+++ b/src/seed_schemas_entry.ts
@@ -14,12 +14,20 @@
  * tsconfig.scripts.json with rootDir: ./scripts, which cannot resolve deep
  * src/ import chains — see initialize-schemas.ts's failed migration there).
  *
- * Intended to run as a Fly.io `release_command` on every deploy, against
- * the target machine's database, after the image is built. Mirrors the
- * registration logic of scripts/initialize-schemas.ts and is safe to run
- * repeatedly: schemas already registered+active are skipped, schemas
- * registered but not active are activated, and anything missing is
- * registered then activated.
+ * Wired as the Fly.io `release_command` in fly.toml / fly.sandbox.toml, so it
+ * runs on every deploy against the target machine's database after the image
+ * is built (issue #1968). The server ALSO seeds idempotently at boot via
+ * src/services/schema_registry_bootstrap.ts, which covers deploy paths that
+ * do not go through Fly (e.g. scripts/redeploy_rc_from_main.sh) as well as
+ * ones not yet written. Running both is harmless — whichever gets there first
+ * registers, and the other skips.
+ *
+ * Safe to run repeatedly, and safe on an instance carrying CUSTOM schemas:
+ * an entity type that already has an active global registration is skipped
+ * outright — not re-registered, not re-activated, not merged. Only types with
+ * nothing active are registered. This deliberately does NOT "activate the
+ * built-in version if it is registered but inactive": doing so used to revert
+ * an operator's deliberately-activated custom schema on every deploy.
  *
  * Usage:
  *   node dist/seed_schemas_entry.js
@@ -41,57 +49,58 @@ async function seedSchema(
   const { entity_type, schema_version } = schema;
 
   try {
-    let versions: Array<{ schema_version: string }> = [];
+    // Skip-if-present, keyed on the ACTIVE GLOBAL row rather than on a
+    // schema_version string match (issue #1968).
+    //
+    // The previous implementation compared `schema_version` strings from
+    // getSchemaVersions() and called activate() whenever the built-in version
+    // was registered-but-inactive. On an instance where an operator had
+    // deliberately registered and activated a CUSTOM schema for an entity
+    // type, that flipped the built-in row back to active and deactivated the
+    // operator's — silently reverting their customization on every deploy.
+    // Reading whatever is currently active, and leaving it alone, removes the
+    // whole class of hazard: a custom schema is preserved regardless of what
+    // version string it carries.
+    let activeSchema: { schema_version: string } | null = null;
     try {
-      versions = await schemaRegistry.getSchemaVersions(entity_type);
+      activeSchema = await schemaRegistry.loadGlobalSchema(entity_type);
     } catch (error: any) {
       return {
         entity_type,
         schema_version,
         action: "error",
-        error: `getSchemaVersions failed: ${error.message || String(error)}`,
+        error: `loadGlobalSchema failed: ${error.message || String(error)}`,
       };
     }
 
-    const exists = versions.some((v) => v.schema_version === schema_version);
-
-    if (exists) {
-      // Already registered - check if it's the active version.
-      try {
-        const activeSchema = await schemaRegistry.loadActiveSchema(entity_type);
-        if (activeSchema?.schema_version === schema_version) {
-          return { entity_type, schema_version, action: "skipped" };
-        }
-        // Registered but not active - activate it.
-        await schemaRegistry.activate(entity_type, schema_version);
-        return { entity_type, schema_version, action: "activated" };
-      } catch {
-        // Could not determine active status - attempt activation anyway.
-        await schemaRegistry.activate(entity_type, schema_version);
-        return { entity_type, schema_version, action: "activated" };
-      }
+    if (activeSchema) {
+      return { entity_type, schema_version, action: "skipped" };
     }
 
-    // Not registered yet - register then activate.
+    // Nothing active for this type - register and activate in one call.
     try {
       await schemaRegistry.register({
         entity_type,
         schema_version,
         schema_definition: schema.schema_definition,
         reducer_config: schema.reducer_config,
+        user_specific: false,
+        activate: true,
+        ...(schema.metadata ? { metadata: schema.metadata } : {}),
       });
-      await schemaRegistry.activate(entity_type, schema_version);
       return { entity_type, schema_version, action: "registered" };
     } catch (error: any) {
-      // Race with a concurrent registration (e.g. duplicate key) - fall
-      // back to activation so a re-run stays idempotent.
+      // Race with a concurrent registration (e.g. another machine's release
+      // command, or a second instance booting). Someone else already put a
+      // row in place, so treat it as done and leave whatever they activated
+      // alone — deliberately NOT calling activate() here, which would risk
+      // overriding a concurrently-registered custom schema.
       if (
         error.message?.includes("duplicate key") ||
         error.message?.includes("unique constraint") ||
         error.message?.includes("already exists")
       ) {
-        await schemaRegistry.activate(entity_type, schema_version);
-        return { entity_type, schema_version, action: "activated" };
+        return { entity_type, schema_version, action: "skipped" };
       }
       throw error;
     }

--- a/src/services/schema_registry_bootstrap.ts
+++ b/src/services/schema_registry_bootstrap.ts
@@ -1,0 +1,132 @@
+/**
+ * Idempotent registry-wide schema seeding (issue #1968).
+ *
+ * `schemaRegistry.loadActiveSchema` is DB-only: it has NO fallback to the
+ * code-defined `ENTITY_SCHEMAS` (see loadGlobalSchema / loadUserSpecificSchema,
+ * both pure `db.from("schema_registry")` lookups). So on an instance whose
+ * `schema_registry` table was never seeded, the store-time auto-link hook
+ * (`autoLinkReferenceFields`) reads `null` and silently stops linking — the
+ * failure this module exists to prevent. See
+ * tests/services/schema_seeding_fresh_instance_gap.test.ts.
+ *
+ * Before this module, seeding ran ONLY via `npm run schema:init` or an
+ * explicit `node dist/seed_schemas_entry.js`, and neither was wired into any
+ * deploy path (no fly.toml `release_command`; scripts/redeploy_rc_from_main.sh
+ * never called it; the Dockerfile CMD is just `node dist/actions.js`). Seeding
+ * at boot closes every deploy path at once, including paths not yet written.
+ *
+ * ── SAFETY CONTRACT ────────────────────────────────────────────────────────
+ * This seeder is strictly ADDITIVE and NEVER overwrites, downgrades, or
+ * re-activates over an existing registration:
+ *
+ *   - If a GLOBAL active schema already exists for an entity_type, it is left
+ *     completely untouched — no register(), no activate(), no field merge.
+ *     That is deliberate: an operator may have deliberately registered a
+ *     CUSTOM schema (via the `register_schema` / `update_schema_incremental`
+ *     tools) that intentionally overrides the built-in, sometimes at the very
+ *     same `schema_version` string. Re-seeding such an instance must not
+ *     revert their customization.
+ *   - Only entity types with NO active global schema are registered.
+ *
+ * This is a narrower contract than `src/seed_schemas_entry.ts` /
+ * `scripts/initialize-schemas.ts`, which decide by matching the
+ * `schema_version` STRING only and call `activate()` when the version is
+ * registered-but-inactive — steps that can resurrect a built-in over an
+ * operator's deliberately-activated custom schema. See the module docs there.
+ *
+ * Boot-safety: seeding is best-effort and must never block or break startup.
+ * The caller wraps this in try/catch (matching the other boot-time seeders in
+ * src/actions.ts), a DB that is briefly unavailable simply yields a warn log,
+ * and concurrent instances racing to register the same type are absorbed by
+ * the duplicate-key fallback below rather than crashing a boot.
+ */
+
+import { schemaRegistry } from "./schema_registry.js";
+import { ENTITY_SCHEMAS } from "./schema_definitions.js";
+
+export interface RegistryBootstrapSummary {
+  /** Entity types newly registered because no active global schema existed. */
+  registered: string[];
+  /** Entity types left untouched because an active global schema already exists. */
+  preserved: string[];
+  /** Entity types that failed to seed (non-fatal; boot continues). */
+  failed: Array<{ entity_type: string; error: string }>;
+}
+
+function isDuplicateRegistrationError(error: unknown): boolean {
+  const message = (error as { message?: string })?.message ?? "";
+  return (
+    message.includes("duplicate key") ||
+    message.includes("unique constraint") ||
+    message.includes("already exists")
+  );
+}
+
+/**
+ * Register every built-in schema that has no active global registration.
+ *
+ * Idempotent and safe to run on an already-seeded instance: a second run
+ * reports every type as `preserved` and issues no writes.
+ */
+export async function seedSchemaRegistryIfEmpty(options?: {
+  registry?: Pick<typeof schemaRegistry, "loadGlobalSchema" | "register">;
+  /**
+   * Schemas to seed. Defaults to the built-in `ENTITY_SCHEMAS`; overridden in
+   * tests so the seeder's real decision logic can be exercised against scratch
+   * entity types without touching the shared registry.
+   */
+  schemas?: Iterable<(typeof ENTITY_SCHEMAS)[string]>;
+}): Promise<RegistryBootstrapSummary> {
+  const registry = options?.registry ?? schemaRegistry;
+  const schemas = options?.schemas ?? Object.values(ENTITY_SCHEMAS);
+
+  const summary: RegistryBootstrapSummary = {
+    registered: [],
+    preserved: [],
+    failed: [],
+  };
+
+  for (const schema of schemas) {
+    const { entity_type, schema_version } = schema;
+    if (!entity_type || !schema_version) continue;
+
+    try {
+      // Skip-if-present. Reading the ACTIVE GLOBAL row (rather than matching a
+      // version string via getSchemaVersions) is what makes a custom operator
+      // schema safe: whatever is active stays active, even when it shares a
+      // schema_version with the built-in or carries an unrelated version.
+      const existing = await registry.loadGlobalSchema(entity_type);
+      if (existing) {
+        summary.preserved.push(entity_type);
+        continue;
+      }
+
+      await registry.register({
+        entity_type,
+        schema_version,
+        schema_definition: schema.schema_definition,
+        reducer_config: schema.reducer_config,
+        user_specific: false,
+        // Activate in the same call: register() only flips `active` when
+        // asked, and an inactive row still leaves loadActiveSchema null.
+        activate: true,
+        ...(schema.metadata ? { metadata: schema.metadata } : {}),
+      });
+      summary.registered.push(entity_type);
+    } catch (error) {
+      // Another instance booting concurrently may have registered this type
+      // between our read and our write. That is a success for our purposes —
+      // the registry now has a row — so record it as preserved, not failed.
+      if (isDuplicateRegistrationError(error)) {
+        summary.preserved.push(entity_type);
+        continue;
+      }
+      summary.failed.push({
+        entity_type,
+        error: (error as Error)?.message ?? String(error),
+      });
+    }
+  }
+
+  return summary;
+}

--- a/tests/integration/seed_then_works_at_e2e.test.ts
+++ b/tests/integration/seed_then_works_at_e2e.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Issue #1968 — effect-verified end-to-end test (pm/QA acceptance criterion).
+ *
+ * The bootstrap unit tests prove the seeding *contract* (skip-if-present,
+ * idempotency, custom-schema preservation). This test proves the *user-visible
+ * effect the bug report was about*: after a fresh/plain deploy runs seeding,
+ * storing a `contact` with an `organization` fires `organization -> company`
+ * `works_at` auto-linking end-to-end. Maps to the standing quality gate
+ * `fixed_means_behavior_verified_not_contract_accepted`.
+ *
+ *  - NEGATIVE CONTROL: with the contact schema unseeded (no active GLOBAL row),
+ *    storing produces no `works_at` edge — i.e. the exact original bug. If a
+ *    change made linking fire without the seeded binding, this would fail.
+ *  - POSITIVE: after the SEEDER (seedSchemaRegistryIfEmpty, the deploy-time
+ *    step) registers the built-in contact schema, the same store produces a
+ *    `works_at` edge to a real `company` entity.
+ *
+ * The seeder registers GLOBAL schemas (user_specific:false, keyed on
+ * loadGlobalSchema). This suite therefore owns the global `contact` schema row
+ * for its duration: it removes any pre-existing row in beforeEach, matching the
+ * global-row manipulation pattern in schema_registry_bootstrap.test.ts.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import { NeotomaServer } from "../../src/server.js";
+import { cleanupEntityType } from "../helpers/cleanup_helpers.js";
+import { relationshipsService } from "../../src/services/relationships.js";
+import { schemaRegistry } from "../../src/services/schema_registry.js";
+import { seedSchemaRegistryIfEmpty } from "../../src/services/schema_registry_bootstrap.js";
+import { ENTITY_SCHEMAS } from "../../src/services/schema_definitions.js";
+import { db } from "../../src/db.js";
+
+const TEST_USER_ID = "00000000-0000-0000-0000-0000000019be";
+
+type StoreResponse = {
+  error?: unknown;
+  entities?: Array<{ entity_id?: string }>;
+};
+
+async function removeGlobalContactSchema(): Promise<void> {
+  await db.from("schema_registry").delete().eq("entity_type", "contact").is("user_id", null);
+}
+
+describe("seed -> works_at auto-link, end-to-end (#1968 effect verification)", () => {
+  let storeAs: {
+    store: (params: Record<string, unknown>) => Promise<{ content: Array<{ text: string }> }>;
+  };
+
+  beforeAll(() => {
+    const server = new NeotomaServer();
+    // Inject the authenticated user directly (matches
+    // company_entity_resolution_leads.test.ts) so the MCP store path does not
+    // require a NEOTOMA_CONNECTION_ID env in the test harness.
+    (server as unknown as Record<string, unknown>).authenticatedUserId = TEST_USER_ID;
+    storeAs = server as unknown as typeof storeAs;
+  });
+
+  beforeEach(async () => {
+    await cleanupEntityType("contact", TEST_USER_ID);
+    await cleanupEntityType("company", TEST_USER_ID);
+    await removeGlobalContactSchema();
+  });
+
+  afterAll(async () => {
+    await cleanupEntityType("contact", TEST_USER_ID);
+    await cleanupEntityType("company", TEST_USER_ID);
+    await removeGlobalContactSchema();
+  });
+
+  async function storeContact(name: string, organization: string): Promise<string | null> {
+    const result = await storeAs.store({
+      user_id: TEST_USER_ID,
+      idempotency_key: `seed-e2e-${name}-${Date.now()}-${Math.random()}`,
+      commit: true,
+      entities: [{ entity_type: "contact", name, organization, schema_version: "1.0" }],
+    });
+    const body = JSON.parse(result.content[0].text) as StoreResponse;
+    return body.entities?.[0]?.entity_id ?? null;
+  }
+
+  async function worksAtCount(contactId: string): Promise<number> {
+    const outgoing = await relationshipsService.getRelationshipsForEntity(
+      contactId,
+      "outgoing",
+      false,
+      TEST_USER_ID
+    );
+    return outgoing.filter((r) => r.relationship_type === "works_at").length;
+  }
+
+  it("NEGATIVE CONTROL: contact schema unseeded => storing produces no works_at edge", async () => {
+    expect(await schemaRegistry.loadGlobalSchema("contact")).toBeNull();
+
+    const contactId = await storeContact("Unseeded Ursula", "Northgate");
+
+    // The regression signal: no works_at edge without a seeded reference
+    // binding. If a future change made auto-linking fire absent the seeded
+    // schema, this assertion fails and flags it.
+    if (contactId) {
+      expect(await worksAtCount(contactId)).toBe(0);
+    }
+  });
+
+  it("POSITIVE: after seeding, storing a contact with organization fires works_at to a real company", async () => {
+    // Run the SEEDER under test over the real built-in contact schema — the
+    // code path a plain deploy exercises.
+    const summary = await seedSchemaRegistryIfEmpty({ schemas: [ENTITY_SCHEMAS.contact] });
+    expect(summary.failed).toEqual([]);
+
+    const active = await schemaRegistry.loadGlobalSchema("contact");
+    expect(active).not.toBeNull();
+    // The seeded schema must carry the reference binding that makes linking fire.
+    expect(active!.schema_definition.reference_fields ?? []).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          field: "organization",
+          target_entity_type: "company",
+          relationship_type: "works_at",
+        }),
+      ])
+    );
+
+    const contactId = await storeContact("Jamie Founder", "Northgate");
+    expect(typeof contactId).toBe("string");
+
+    const outgoing = await relationshipsService.getRelationshipsForEntity(
+      contactId as string,
+      "outgoing",
+      false,
+      TEST_USER_ID
+    );
+    const worksAt = outgoing.filter((r) => r.relationship_type === "works_at");
+    expect(worksAt).toHaveLength(1);
+
+    const { data: companyRow } = await db
+      .from("entities")
+      .select("id, entity_type, canonical_name")
+      .eq("id", worksAt[0].target_entity_id)
+      .single();
+    expect(companyRow.entity_type).toBe("company");
+    expect(String(companyRow.canonical_name).toLowerCase()).toContain("northgate");
+  });
+});

--- a/tests/services/deploy_seed_wiring.test.ts
+++ b/tests/services/deploy_seed_wiring.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Issue #1968 — regression guard on the deploy-config artifacts themselves.
+ *
+ * History this guards against (cited in the #1968 PR): the Fly `release_command`
+ * that runs schema seeding was added in commit 8d0f09bd1 and silently stripped
+ * back out in 399f81fd2 — with no test catching it — which is what re-introduced
+ * the unseeded-registry bug #1968 fixes. These assertions parse the actual
+ * deploy artifacts so a future change that drops the seed step fails CI instead
+ * of shipping and silently regressing on the next deploy.
+ *
+ * Deliberately string/-config level (not behavioral): the seeding *behavior* is
+ * covered by schema_registry_bootstrap.test.ts. This file's job is only to pin
+ * that every deploy path still invokes the seed entrypoint.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const SEED_ENTRYPOINT = "node dist/seed_schemas_entry.js";
+
+function read(rel: string): string {
+  return readFileSync(join(REPO_ROOT, rel), "utf8");
+}
+
+/**
+ * Match a TOML `release_command = "..."` whose value contains the seed
+ * entrypoint, tolerating quoting/whitespace variation but NOT matching a
+ * commented-out (`#`) line.
+ */
+function hasUncommentedReleaseCommand(toml: string): boolean {
+  return toml.split("\n").some((line) => {
+    const trimmed = line.trim();
+    if (trimmed.startsWith("#")) return false;
+    return /^release_command\s*=/.test(trimmed) && trimmed.includes(SEED_ENTRYPOINT);
+  });
+}
+
+describe("deploy seed wiring (#1968 regression guard)", () => {
+  it("fly.toml wires the seed entrypoint as an active release_command", () => {
+    expect(hasUncommentedReleaseCommand(read("fly.toml"))).toBe(true);
+  });
+
+  it("fly.sandbox.toml wires the seed entrypoint as an active release_command", () => {
+    expect(hasUncommentedReleaseCommand(read("fly.sandbox.toml"))).toBe(true);
+  });
+
+  it("redeploy_rc_from_main.sh invokes the seed entrypoint (not commented out)", () => {
+    const script = read("scripts/redeploy_rc_from_main.sh");
+    const invokes = script.split("\n").some((line) => {
+      const trimmed = line.trim();
+      if (trimmed.startsWith("#")) return false;
+      return trimmed.includes(SEED_ENTRYPOINT);
+    });
+    expect(invokes).toBe(true);
+  });
+});

--- a/tests/services/schema_registry_bootstrap.test.ts
+++ b/tests/services/schema_registry_bootstrap.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Issue #1968: schema seeding is part of the deploy contract, and re-seeding
+ * an already-seeded instance must never clobber a CUSTOM operator schema.
+ *
+ * The hazard being regression-tested: the pre-fix seeding path decided by
+ * matching the built-in `schema_version` STRING via getSchemaVersions(), and
+ * called `activate()` whenever that version was registered-but-inactive. On an
+ * instance where an operator had registered a custom schema for an entity type
+ * (via register_schema / update_schema_incremental) and activated it, a deploy
+ * re-seed flipped the built-in row back to active — and `activate()`
+ * deactivates every other version for the entity type, so the operator's
+ * custom schema was silently switched off on every single deploy.
+ *
+ * These tests drive the real SchemaRegistryService against the shared local
+ * SQLite test DB (vitest.setup.ts), using scratch entity types so they neither
+ * depend on nor disturb the real registry state — matching the isolation
+ * pattern in schema_seeding_fresh_instance_gap.test.ts.
+ */
+
+import { describe, it, expect, afterAll, beforeEach } from "vitest";
+import { schemaRegistry } from "../../src/services/schema_registry.js";
+import { seedSchemaRegistryIfEmpty } from "../../src/services/schema_registry_bootstrap.js";
+import { db } from "../../src/db.js";
+import type {
+  SchemaDefinition,
+  SchemaRegistryEntry,
+} from "../../src/services/schema_registry.js";
+
+const BUILTIN_TYPE = "bootstrap_test_builtin_type";
+const CUSTOM_TYPE = "bootstrap_test_custom_type";
+
+/**
+ * A stand-in for ENTITY_SCHEMAS built-ins, so these tests exercise the seeder's
+ * decision logic without registering (or perturbing) real entity types in the
+ * shared test DB.
+ */
+const FAKE_BUILTINS = {
+  [BUILTIN_TYPE]: {
+    entity_type: BUILTIN_TYPE,
+    schema_version: "1.0",
+    schema_definition: {
+      fields: { schema_version: { type: "string", required: true } },
+      // Required by validateSchemaDefinition (schema_agnostic_design_rules R2).
+      identity_opt_out: "heuristic_canonical_name",
+    } as SchemaDefinition,
+    reducer_config: { merge_policies: {} },
+  },
+  [CUSTOM_TYPE]: {
+    entity_type: CUSTOM_TYPE,
+    schema_version: "1.0",
+    schema_definition: {
+      fields: {
+        schema_version: { type: "string", required: true },
+        builtin_only_field: { type: "string", required: false },
+      },
+      identity_opt_out: "heuristic_canonical_name",
+    } as SchemaDefinition,
+    reducer_config: { merge_policies: {} },
+  },
+};
+
+/**
+ * Runs the REAL seedSchemaRegistryIfEmpty against the real registry, but over
+ * FAKE_BUILTINS instead of the live ENTITY_SCHEMAS. The decision logic under
+ * test is therefore genuinely the shipped one — a hand-rolled copy of the
+ * skip-if-present check here would keep passing even if the seeder regressed.
+ */
+async function seedFakeBuiltins() {
+  return await seedSchemaRegistryIfEmpty({ schemas: Object.values(FAKE_BUILTINS) });
+}
+
+async function cleanup(): Promise<void> {
+  for (const type of [BUILTIN_TYPE, CUSTOM_TYPE]) {
+    await db.from("schema_registry").delete().eq("entity_type", type);
+  }
+}
+
+describe("schema registry bootstrap seeding (#1968)", () => {
+  beforeEach(cleanup);
+  afterAll(cleanup);
+
+  it("seeds entity types that have no active schema (closes the fresh-instance gap)", async () => {
+    expect(await schemaRegistry.loadActiveSchema(BUILTIN_TYPE)).toBeNull();
+
+    const summary = await seedFakeBuiltins();
+
+    // Assert `failed` explicitly: the seeder collects registration errors
+    // rather than throwing, so without this a validation failure would look
+    // like a silent no-op.
+    expect(summary.failed).toEqual([]);
+    expect(summary.registered).toContain(BUILTIN_TYPE);
+    const seeded = await schemaRegistry.loadActiveSchema(BUILTIN_TYPE);
+    expect(seeded).not.toBeNull();
+    expect(seeded!.schema_version).toBe("1.0");
+  });
+
+  it("is idempotent: a second run registers nothing and leaves the row identical", async () => {
+    await seedFakeBuiltins();
+    const afterFirst = await schemaRegistry.loadActiveSchema(BUILTIN_TYPE);
+
+    const secondRun = await seedFakeBuiltins();
+
+    expect(secondRun.registered).toEqual([]);
+    expect(secondRun.preserved).toContain(BUILTIN_TYPE);
+
+    const afterSecond = await schemaRegistry.loadActiveSchema(BUILTIN_TYPE);
+    // Same row (same id), not a new registration stacked on top.
+    expect(afterSecond!.id).toBe(afterFirst!.id);
+
+    const versions = await schemaRegistry.getSchemaVersions(BUILTIN_TYPE);
+    expect(versions).toHaveLength(1);
+  });
+
+  it("does NOT overwrite or deactivate a CUSTOM operator schema sharing the built-in's version string", async () => {
+    // An operator registers their own schema for CUSTOM_TYPE, deliberately
+    // overriding the built-in — and at the SAME schema_version "1.0", which is
+    // precisely the case the old version-string match got wrong.
+    const customDefinition: SchemaDefinition = {
+      fields: {
+        schema_version: { type: "string", required: true },
+        operator_custom_field: { type: "string", required: false },
+      },
+      identity_opt_out: "heuristic_canonical_name",
+      reference_fields: [
+        {
+          field: "operator_custom_field",
+          target_entity_type: "company",
+          relationship_type: "works_at",
+          resolve_target: true,
+        },
+      ],
+    };
+
+    await schemaRegistry.register({
+      entity_type: CUSTOM_TYPE,
+      schema_version: "1.0",
+      schema_definition: customDefinition,
+      reducer_config: { merge_policies: {} },
+      user_specific: false,
+      activate: true,
+    });
+
+    const before = (await schemaRegistry.loadActiveSchema(CUSTOM_TYPE)) as SchemaRegistryEntry;
+    expect(before.schema_definition.fields).toHaveProperty("operator_custom_field");
+
+    // Deploy re-seed.
+    const summary = await seedFakeBuiltins();
+    expect(summary.preserved).toContain(CUSTOM_TYPE);
+    expect(summary.registered).not.toContain(CUSTOM_TYPE);
+
+    const after = (await schemaRegistry.loadActiveSchema(CUSTOM_TYPE)) as SchemaRegistryEntry;
+
+    // The operator's schema is still the active one, byte-for-byte.
+    expect(after.id).toBe(before.id);
+    expect(after.active).toBe(true);
+    expect(after.schema_definition.fields).toHaveProperty("operator_custom_field");
+    expect(after.schema_definition.reference_fields).toEqual(
+      customDefinition.reference_fields
+    );
+    // The built-in's field was NOT merged in, and no built-in row was added.
+    expect(after.schema_definition.fields).not.toHaveProperty("builtin_only_field");
+    expect(await schemaRegistry.getSchemaVersions(CUSTOM_TYPE)).toHaveLength(1);
+  });
+
+  it("preserves a custom schema that carries a DIFFERENT version string", async () => {
+    await schemaRegistry.register({
+      entity_type: CUSTOM_TYPE,
+      schema_version: "9.9-operator",
+      schema_definition: {
+        fields: {
+          schema_version: { type: "string", required: true },
+          operator_custom_field: { type: "string", required: false },
+        },
+        identity_opt_out: "heuristic_canonical_name",
+      },
+      reducer_config: { merge_policies: {} },
+      user_specific: false,
+      activate: true,
+    });
+
+    await seedFakeBuiltins();
+
+    const after = await schemaRegistry.loadActiveSchema(CUSTOM_TYPE);
+    expect(after!.schema_version).toBe("9.9-operator");
+    expect(after!.active).toBe(true);
+    // Critically: the built-in "1.0" was not registered alongside and
+    // activated over it.
+    expect(await schemaRegistry.getSchemaVersions(CUSTOM_TYPE)).toHaveLength(1);
+  });
+
+  it("real seedSchemaRegistryIfEmpty preserves everything on an already-seeded registry", async () => {
+    // Run against the real ENTITY_SCHEMAS twice. Whatever the shared test DB
+    // already had must survive, and the second pass must be a pure no-op.
+    const first = await seedSchemaRegistryIfEmpty();
+    const second = await seedSchemaRegistryIfEmpty();
+
+    expect(second.registered).toEqual([]);
+    expect(second.failed).toEqual([]);
+    expect(second.preserved.length).toBeGreaterThan(0);
+    // Every type the first pass touched is preserved by the second.
+    for (const type of first.registered) {
+      expect(second.preserved).toContain(type);
+    }
+  });
+});

--- a/tests/services/schema_registry_bootstrap.test.ts
+++ b/tests/services/schema_registry_bootstrap.test.ts
@@ -21,10 +21,7 @@ import { describe, it, expect, afterAll, beforeEach } from "vitest";
 import { schemaRegistry } from "../../src/services/schema_registry.js";
 import { seedSchemaRegistryIfEmpty } from "../../src/services/schema_registry_bootstrap.js";
 import { db } from "../../src/db.js";
-import type {
-  SchemaDefinition,
-  SchemaRegistryEntry,
-} from "../../src/services/schema_registry.js";
+import type { SchemaDefinition, SchemaRegistryEntry } from "../../src/services/schema_registry.js";
 
 const BUILTIN_TYPE = "bootstrap_test_builtin_type";
 const CUSTOM_TYPE = "bootstrap_test_custom_type";
@@ -154,9 +151,7 @@ describe("schema registry bootstrap seeding (#1968)", () => {
     expect(after.id).toBe(before.id);
     expect(after.active).toBe(true);
     expect(after.schema_definition.fields).toHaveProperty("operator_custom_field");
-    expect(after.schema_definition.reference_fields).toEqual(
-      customDefinition.reference_fields
-    );
+    expect(after.schema_definition.reference_fields).toEqual(customDefinition.reference_fields);
     // The built-in's field was NOT merged in, and no built-in row was added.
     expect(after.schema_definition.fields).not.toHaveProperty("builtin_only_field");
     expect(await schemaRegistry.getSchemaVersions(CUSTOM_TYPE)).toHaveLength(1);


### PR DESCRIPTION
Closes #1968.

## Problem

A plain deploy of `main` ships with the schema registry **unseeded**. Seeding is wired into neither the Fly config nor the production redeploy script: `fly.toml`/`fly.sandbox.toml` have no `release_command`, `scripts/redeploy_rc_from_main.sh` never calls it, and the container CMD is just `node dist/actions.js`. Since `loadActiveSchema` is DB-only with no code fallback on the store/auto-link path, an unseeded registry silently disables schema-dependent behavior — most visibly `organization → company` `works_at` auto-linking — even though the code for it is fully deployed.

## ⚠️ The bigger finding: re-seeding silently reverted custom schemas

While fixing the above I found that **both existing seeding paths could destroy an operator's custom schema**, and verified it empirically against a real SQLite database rather than by reading alone.

Mechanism:
1. They tested existence by matching the **built-in's `schema_version` string**.
2. If that version existed but wasn't active, they called `schemaRegistry.activate(entity_type, built_in_version)`.
3. `activate()` (`src/services/schema_registry.ts:1810-1823`) **deactivates every other version for that entity type first**.

So on any instance where an operator registered and activated a custom schema, **every deploy that ran seeding silently switched it off** and restored the built-in.

Reproduced on a real DB seeded with all 79 schemas, with `contact` set to a custom `99.0-operator-custom` (active) and built-in `1.1` inactive:

```
pre-fix:   ~ contact v1.1 - activated   →  ('1.1', 1)  ('99.0-operator-custom', 0)   ❌ custom deactivated
post-fix:  . contact v1.1 - skipped     →  ('99.0-operator-custom', 1)  ('1.1', 0)   ✅ preserved
```

The hazard only bites when the custom schema carries a *different* version string — if it happens to share `1.0`, `activate("1.0")` re-activates the same row harmlessly, which is why this went unnoticed.

**This is why the safety fix and the deploy wiring must land together.** Wiring seeding into every deploy path *without* the skip-if-present fix would have actively destroyed custom schemas on live instances that are currently fine only because seeding never ran there.

## Fix

Skip-if-present keyed on `loadGlobalSchema()` — whatever is active stays active, regardless of version string. Belt-and-braces across three layers, since each covers a different failure mode:

- **(c) boot-time seeding** (primary) — `src/services/schema_registry_bootstrap.ts`, wired into `startHTTPServer()` as a fail-open try/catch, following the existing `src/services/*/seed_schema.ts` convention. Covers every deploy path, including ones not yet written.
- **(a) Fly `release_command`** — seeds before the release takes traffic.
- **(b) redeploy script step** — surfaces failures in the deploy log rather than one warn line in the server log.

Running several is harmless: whichever arrives first registers, the rest skip.

`--force` still overwrites deliberately (it's the explicit opt-in), now documented as hazardous. `docs/developer/schema_initialization.md` corrected — it previously described the hazardous behavior as intended.

## Tests

New `tests/services/schema_registry_bootstrap.test.ts` (5 tests). Verified the key test actually catches the bug: reverting the seeder to the old logic fails `preserves a custom schema that carries a DIFFERENT version string` with `expected '1.0' to be '9.9-operator'`.

```
tests/services/schema_registry_bootstrap.test.ts — 5 passed
6 schema test files — 87 passed
tests/services (34 files) — 467 passed | 2 skipped
```
Typecheck clean on both tsconfigs; eslint 0 errors.

## Operational note

**Existing instances may already be damaged.** Any instance that had a custom schema and has been deployed via `npm run schema:init` has likely already had it reverted. This prevents recurrence but does not repair past damage. Worth auditing:

```sql
SELECT entity_type, schema_version, active FROM schema_registry WHERE active = true;
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
