### PR TITLE
fix(embeddings): generate embeddings on the primary store path — closes #1965

### DIFF
--- a/src/embeddings.ts
+++ b/src/embeddings.ts
@@ -4,6 +4,19 @@ import { config } from "./config.js";
 const openai = config.openaiApiKey ? new OpenAI({ apiKey: config.openaiApiKey }) : null;
 
 /**
+ * Whether any embedding provider is configured.
+ *
+ * Lets hot paths (notably the store-path snapshot upsert) skip the work that
+ * only exists to feed `generateEmbedding` — canonical_name lookup and JSON
+ * serialization of the snapshot — instead of paying for it and discarding a
+ * guaranteed null. `generateEmbedding` remains safe to call regardless; this
+ * is purely an optimization guard.
+ */
+export function hasEmbeddingProvider(): boolean {
+  return openai !== null;
+}
+
+/**
  * Generate an embedding vector from text.
  *
  * Supports multiple providers (priority order):

--- a/src/services/entity_snapshot_embedding.ts
+++ b/src/services/entity_snapshot_embedding.ts
@@ -2,7 +2,7 @@
 // Embeds structured output (entity_type + canonical_name + snapshot) at upsert time
 
 import { config } from "../config.js";
-import { generateEmbedding, getEntitySearchableText } from "../embeddings.js";
+import { generateEmbedding, getEntitySearchableText, hasEmbeddingProvider } from "../embeddings.js";
 import { db } from "../db.js";
 import { storeLocalEntityEmbedding } from "./local_entity_embedding.js";
 
@@ -49,6 +49,14 @@ export async function prepareEntitySnapshotWithEmbedding(
 ): Promise<EntitySnapshotRowWithEmbedding> {
   // Generate embedding for both pgvector and local (sqlite-vec)
   // Skip only when OPENAI_API_KEY is not configured
+  if (!hasEmbeddingProvider()) {
+    // No provider: short-circuit before the canonical_name lookup and the
+    // snapshot JSON serialization, both of which exist only to build text for
+    // an embedding that would be null anyway. Keeps the no-provider store path
+    // at the same cost as the pre-embedding raw upsert.
+    return { ...snapshotRow, embedding: null };
+  }
+
   const name = canonicalName ?? (await fetchCanonicalName(snapshotRow.entity_id));
   const effectiveName = name ?? snapshotRow.entity_id;
 
@@ -71,12 +79,19 @@ export async function prepareEntitySnapshotWithEmbedding(
  * Single entry point for all entity_snapshots upserts to ensure local embedding storage.
  */
 export async function upsertEntitySnapshotWithEmbedding(
-  row: EntitySnapshotRowWithEmbedding
+  row: EntitySnapshotRowWithEmbedding,
+  options?: { throwOnError?: boolean }
 ): Promise<void> {
   const payload = getEntitySnapshotUpsertPayload(row);
-  await db
+  const { error } = await db
     .from("entity_snapshots")
     .upsert(payload as Record<string, unknown>, { onConflict: "entity_id" });
+  // Existing repair-loop callers relied on this never throwing; only the
+  // primary store path opts into strict error propagation, which is what the
+  // raw upsert it replaced already did.
+  if (error && options?.throwOnError) {
+    throw new Error(error.message);
+  }
   if (config.storageBackend === "local" && row.embedding) {
     storeLocalEntityEmbedding({
       entity_id: row.entity_id,

--- a/src/services/snapshot_computation.ts
+++ b/src/services/snapshot_computation.ts
@@ -9,6 +9,10 @@ import { db } from "../db.js";
 import { logger } from "../utils/logger.js";
 import { observationReducer } from "../reducers/observation_reducer.js";
 import {
+  prepareEntitySnapshotWithEmbedding,
+  upsertEntitySnapshotWithEmbedding,
+} from "./entity_snapshot_embedding.js";
+import {
   CanonicalNameUnresolvedError,
   deriveCanonicalNameFromFieldsWithTrace,
   entityIdTenantSalt,
@@ -71,11 +75,60 @@ export async function recomputeSnapshot(
     return null;
   }
 
-  const { error: upsertError } = await db
-    .from("entity_snapshots")
-    .upsert({ ...computed } as Record<string, unknown>);
+  // Route the primary snapshot write through the embedding-aware upsert so
+  // store/correct/split-path entities are semantically searchable by default
+  // (issue #1965). Every other snapshot writer (health-check repair, schema-lag
+  // repair, schema_registry migration, interpretation) already used this
+  // pipeline; this path did a raw upsert and silently produced null embeddings.
+  //
+  // Embedding generation is awaited inline, matching every existing caller.
+  // The provider call is a network round-trip on a promise — it yields the
+  // event loop rather than blocking it, so it does not compound the sync-DB
+  // main-thread sensitivity tracked in #1945. With no provider configured
+  // `prepareEntitySnapshotWithEmbedding` short-circuits before any I/O, so the
+  // unconfigured path costs no more than the raw upsert it replaces.
+  let rowWithEmbedding;
+  try {
+    rowWithEmbedding = await prepareEntitySnapshotWithEmbedding({
+      entity_id: computed.entity_id,
+      entity_type: computed.entity_type,
+      schema_version: computed.schema_version,
+      snapshot: computed.snapshot,
+      computed_at: computed.computed_at,
+      observation_count: computed.observation_count,
+      last_observation_at: computed.last_observation_at,
+      provenance: computed.provenance,
+      user_id: computed.user_id || userId,
+    });
+  } catch (err) {
+    // An embedding provider outage must never fail a store. Fall back to
+    // writing the snapshot without an embedding; backfill can repair it later
+    // (scripts/backfill_entity_embeddings.ts).
+    logger.warn(
+      `[SNAPSHOT] Embedding preparation failed for ${entityId}; storing without embedding: ` +
+        (err instanceof Error ? err.message : String(err))
+    );
+    rowWithEmbedding = {
+      entity_id: computed.entity_id,
+      entity_type: computed.entity_type,
+      schema_version: computed.schema_version,
+      snapshot: computed.snapshot,
+      computed_at: computed.computed_at,
+      observation_count: computed.observation_count,
+      last_observation_at: computed.last_observation_at,
+      provenance: computed.provenance,
+      user_id: computed.user_id || userId,
+      embedding: null,
+    };
+  }
 
-  if (upsertError) throw new Error(`Failed to upsert snapshot: ${upsertError.message}`);
+  try {
+    await upsertEntitySnapshotWithEmbedding(rowWithEmbedding, { throwOnError: true });
+  } catch (err) {
+    throw new Error(
+      `Failed to upsert snapshot: ` + (err instanceof Error ? err.message : String(err))
+    );
+  }
 
   const sourceId =
     typeof (observations[0] as { source_id?: string | null }).source_id === "string"

--- a/tests/services/store_path_snapshot_embedding.test.ts
+++ b/tests/services/store_path_snapshot_embedding.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Regression tests for issue #1965: the primary store path never generated
+ * embeddings, so semantic search silently degraded to lexical.
+ *
+ * `recomputeSnapshot` is the single snapshot writer behind the `store`,
+ * `correct`, and `split_entity` paths. It used to do a raw
+ * `db.from("entity_snapshots").upsert(...)`, which never populated the
+ * `embedding` column — while every *repair* path (health check, schema-lag
+ * repair, schema_registry migration, interpretation) went through the
+ * embedding-aware helpers.
+ *
+ * These tests drive `recomputeSnapshot` against a mocked db + mocked embedding
+ * provider and assert:
+ *   (a) with a provider configured, the snapshot row is written WITH an
+ *       embedding derived from the entity's searchable text;
+ *   (b) with NO provider configured, the store still succeeds and the row is
+ *       written with a null embedding — never throwing, never blocking, and
+ *       without paying for the canonical_name lookup that only exists to feed
+ *       the embedding.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const EMBEDDING_DIM = 1536;
+
+/** A deterministic, valid-dimension embedding. */
+function makeEmbedding(seed = 1): number[] {
+  const arr = new Array(EMBEDDING_DIM).fill(0) as number[];
+  arr[seed % EMBEDDING_DIM] = 1;
+  return arr;
+}
+
+const USER_ID = "00000000-0000-0000-0000-000000000000";
+const ENTITY_ID = "ent_1965_store_path";
+
+/**
+ * Shared capture buffers. `vi.mock` factories are hoisted above const
+ * initialization, so they must reach these through `vi.hoisted` rather than
+ * closing over module-level bindings.
+ */
+const captured = vi.hoisted(() => ({
+  /** Rows captured from `entity_snapshots` upserts. */
+  upsertedSnapshotRows: [] as Array<Record<string, unknown>>,
+  /** Tables touched with a select, so we can assert the no-provider fast path. */
+  selectedTables: [] as string[],
+  entityId: "ent_1965_store_path",
+  userId: "00000000-0000-0000-0000-000000000000",
+}));
+
+const upsertedSnapshotRows = captured.upsertedSnapshotRows;
+const selectedTables = captured.selectedTables;
+
+vi.mock("../../src/db.js", () => {
+  const ENTITY_ID = captured.entityId;
+  const USER_ID = captured.userId;
+  const { upsertedSnapshotRows, selectedTables } = captured;
+  const observationRow = {
+    id: "obs_1965_1",
+    entity_id: ENTITY_ID,
+    entity_type: "contact",
+    user_id: USER_ID,
+    source_id: "src_1965",
+    observed_at: "2026-07-22T00:00:00.000Z",
+    source_priority: 1,
+    fields: { name: "Ada Lovelace", email: "ada@example.com" },
+  };
+  function table(name: string): any {
+    const chain: any = {
+      select: () => {
+        selectedTables.push(name);
+        return chain;
+      },
+      eq: () => chain,
+      not: () => chain,
+      limit: async () => ({ data: [], error: null }),
+      order: () => chain,
+      maybeSingle: async () => {
+        if (name === "entities") {
+          return {
+            data: {
+              id: ENTITY_ID,
+              canonical_name: "Ada Lovelace",
+              aliases: [],
+              user_id: USER_ID,
+            },
+            error: null,
+          };
+        }
+        return { data: null, error: null };
+      },
+      single: async () => {
+        if (name === "entities") {
+          return { data: { canonical_name: "Ada Lovelace" }, error: null };
+        }
+        return { data: null, error: null };
+      },
+      update: () => chain,
+      delete: () => chain,
+      upsert: async (payload: Record<string, unknown>) => {
+        if (name === "entity_snapshots") upsertedSnapshotRows.push(payload);
+        return { data: null, error: null };
+      },
+      then: undefined,
+    };
+    // `observations` is awaited directly after .select().eq().eq()
+    if (name === "observations") {
+      chain.eq = () => {
+        const obsChain: any = {
+          eq: () => obsChain,
+          order: () => obsChain,
+          then: (resolve: (v: unknown) => unknown) =>
+            resolve({ data: [observationRow], error: null }),
+        };
+        return obsChain;
+      };
+    }
+    return chain;
+  }
+  return { db: { from: (name: string) => table(name) } };
+});
+
+// Keep the reducer deterministic: recomputeSnapshot's job here is the WRITE,
+// not the merge semantics (covered by the reducer's own tests).
+vi.mock("../../src/reducers/observation_reducer.js", () => ({
+  observationReducer: {
+    computeSnapshot: vi.fn().mockResolvedValue({
+      entity_id: captured.entityId,
+      entity_type: "contact",
+      schema_version: "1.0",
+      snapshot: { name: "Ada Lovelace", email: "ada@example.com" },
+      computed_at: "2026-07-22T00:00:00.000Z",
+      observation_count: 1,
+      last_observation_at: "2026-07-22T00:00:00.000Z",
+      provenance: { name: "obs_1965_1" },
+      user_id: captured.userId,
+    }),
+  },
+}));
+
+// Timeline + schema lookups are orthogonal to the embedding fix.
+vi.mock("../../src/services/timeline_events.js", () => ({
+  upsertTimelineEventsForEntitySnapshot: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("../../src/services/schema_registry.js", () => ({
+  schemaRegistry: { loadActiveSchema: vi.fn().mockResolvedValue(null) },
+}));
+
+// The embedding provider under our control.
+const spies = vi.hoisted(() => ({
+  generateEmbedding: vi.fn(),
+  hasEmbeddingProvider: vi.fn(),
+}));
+const generateEmbedding = spies.generateEmbedding;
+const hasEmbeddingProvider = spies.hasEmbeddingProvider;
+vi.mock("../../src/embeddings.js", () => ({
+  generateEmbedding: (text: string) => spies.generateEmbedding(text),
+  hasEmbeddingProvider: () => spies.hasEmbeddingProvider(),
+  getEntitySearchableText: (
+    entityType: string,
+    canonicalName: string,
+    snapshot: Record<string, unknown>
+  ) => `${entityType} ${canonicalName} ${JSON.stringify(snapshot)}`,
+}));
+
+// Force the non-local branch so `embedding` is actually included in the payload
+// (the local/SQLite backend has no embedding column and stores vectors
+// out-of-band via sqlite-vec).
+vi.mock("../../src/config.js", () => ({
+  config: { storageBackend: "postgres", openaiApiKey: "test-key" },
+}));
+
+import { recomputeSnapshot } from "../../src/services/snapshot_computation.js";
+
+describe("store path generates entity embeddings (issue #1965)", () => {
+  beforeEach(() => {
+    upsertedSnapshotRows.length = 0;
+    selectedTables.length = 0;
+    generateEmbedding.mockReset();
+    hasEmbeddingProvider.mockReset();
+  });
+
+  it("writes an embedding when a provider is configured", async () => {
+    hasEmbeddingProvider.mockReturnValue(true);
+    generateEmbedding.mockResolvedValue(makeEmbedding(7));
+
+    const result = await recomputeSnapshot(ENTITY_ID, USER_ID);
+
+    expect(result).not.toBeNull();
+    expect(upsertedSnapshotRows).toHaveLength(1);
+
+    const row = upsertedSnapshotRows[0];
+    expect(row.entity_id).toBe(ENTITY_ID);
+    // The regression: this used to be absent entirely.
+    expect(Array.isArray(row.embedding)).toBe(true);
+    expect((row.embedding as number[]).length).toBe(EMBEDDING_DIM);
+    expect(row.embedding).toEqual(makeEmbedding(7));
+
+    // The embedded text is the structured output: type + canonical_name + snapshot.
+    expect(generateEmbedding).toHaveBeenCalledTimes(1);
+    const embeddedText = generateEmbedding.mock.calls[0][0] as string;
+    expect(embeddedText).toContain("contact");
+    expect(embeddedText).toContain("Ada Lovelace");
+    expect(embeddedText).toContain("ada@example.com");
+  });
+
+  it("still stores successfully when no provider is configured", async () => {
+    hasEmbeddingProvider.mockReturnValue(false);
+
+    const result = await recomputeSnapshot(ENTITY_ID, USER_ID);
+
+    // Storing must succeed with the embedding simply absent.
+    expect(result).not.toBeNull();
+    expect(upsertedSnapshotRows).toHaveLength(1);
+
+    const row = upsertedSnapshotRows[0];
+    expect(row.entity_id).toBe(ENTITY_ID);
+    expect(row.snapshot).toEqual({ name: "Ada Lovelace", email: "ada@example.com" });
+    expect(row.embedding).toBeNull();
+
+    // No provider means no provider call at all.
+    expect(generateEmbedding).not.toHaveBeenCalled();
+  });
+
+  it("does not pay for the canonical_name lookup when no provider is configured", async () => {
+    hasEmbeddingProvider.mockReturnValue(false);
+    await recomputeSnapshot(ENTITY_ID, USER_ID);
+    const noProviderEntitySelects = selectedTables.filter((t) => t === "entities").length;
+
+    upsertedSnapshotRows.length = 0;
+    selectedTables.length = 0;
+
+    hasEmbeddingProvider.mockReturnValue(true);
+    generateEmbedding.mockResolvedValue(makeEmbedding(3));
+    await recomputeSnapshot(ENTITY_ID, USER_ID);
+    const providerEntitySelects = selectedTables.filter((t) => t === "entities").length;
+
+    // The provider path does at least one extra `entities` read (canonical_name
+    // for the searchable text); the no-provider path must short-circuit before it.
+    expect(noProviderEntitySelects).toBeLessThan(providerEntitySelects);
+  });
+
+  it("does not fail the store when the embedding provider throws", async () => {
+    hasEmbeddingProvider.mockReturnValue(true);
+    generateEmbedding.mockRejectedValue(new Error("provider outage"));
+
+    // A provider outage must degrade to a snapshot without an embedding,
+    // never propagate out of the store path.
+    const result = await recomputeSnapshot(ENTITY_ID, USER_ID);
+
+    expect(result).not.toBeNull();
+    expect(upsertedSnapshotRows).toHaveLength(1);
+    expect(upsertedSnapshotRows[0].embedding).toBeNull();
+  });
+});

--- a/tests/services/store_path_snapshot_embedding_local.test.ts
+++ b/tests/services/store_path_snapshot_embedding_local.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Regression tests for issue #1965 — SQLite/local backend branch.
+ *
+ * Companion to `store_path_snapshot_embedding.test.ts`, which forces
+ * `storageBackend: "postgres"` so the `embedding` lands in the upsert payload.
+ * That leaves the branch that actually runs in production untested: the local
+ * SQLite backend has no `embedding` column, so vectors are stored out-of-band
+ * in sqlite-vec via `storeLocalEntityEmbedding`.
+ *
+ * The mocked `config` is module-level and cannot be re-mocked per test, so the
+ * local branch needs its own file.
+ *
+ * Asserts, on the local backend:
+ *   (a) an embedding generated on the store path is handed to sqlite-vec;
+ *   (b) the `embedding` key is NOT written into the entity_snapshots payload
+ *       (the column does not exist there — including it would break the write);
+ *   (c) with no provider configured, nothing is handed to sqlite-vec and the
+ *       store still succeeds.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const EMBEDDING_DIM = 1536;
+
+/** A deterministic, valid-dimension embedding. */
+function makeEmbedding(seed = 1): number[] {
+  const arr = new Array(EMBEDDING_DIM).fill(0) as number[];
+  arr[seed % EMBEDDING_DIM] = 1;
+  return arr;
+}
+
+const USER_ID = "00000000-0000-0000-0000-000000000000";
+const ENTITY_ID = "ent_1965_store_path_local";
+
+const captured = vi.hoisted(() => ({
+  upsertedSnapshotRows: [] as Array<Record<string, unknown>>,
+  selectedTables: [] as string[],
+  entityId: "ent_1965_store_path_local",
+  userId: "00000000-0000-0000-0000-000000000000",
+}));
+
+const upsertedSnapshotRows = captured.upsertedSnapshotRows;
+
+vi.mock("../../src/db.js", () => {
+  const ENTITY_ID = captured.entityId;
+  const USER_ID = captured.userId;
+  const { upsertedSnapshotRows, selectedTables } = captured;
+  const observationRow = {
+    id: "obs_1965_local_1",
+    entity_id: ENTITY_ID,
+    entity_type: "contact",
+    user_id: USER_ID,
+    source_id: "src_1965_local",
+    observed_at: "2026-07-22T00:00:00.000Z",
+    source_priority: 1,
+    fields: { name: "Ada Lovelace", email: "ada@example.com" },
+  };
+  function table(name: string): any {
+    const chain: any = {
+      select: () => {
+        selectedTables.push(name);
+        return chain;
+      },
+      eq: () => chain,
+      not: () => chain,
+      limit: async () => ({ data: [], error: null }),
+      order: () => chain,
+      maybeSingle: async () => {
+        if (name === "entities") {
+          return {
+            data: {
+              id: ENTITY_ID,
+              canonical_name: "Ada Lovelace",
+              aliases: [],
+              user_id: USER_ID,
+            },
+            error: null,
+          };
+        }
+        return { data: null, error: null };
+      },
+      single: async () => {
+        if (name === "entities") {
+          return { data: { canonical_name: "Ada Lovelace" }, error: null };
+        }
+        return { data: null, error: null };
+      },
+      update: () => chain,
+      delete: () => chain,
+      upsert: async (payload: Record<string, unknown>) => {
+        if (name === "entity_snapshots") upsertedSnapshotRows.push(payload);
+        return { data: null, error: null };
+      },
+      then: undefined,
+    };
+    if (name === "observations") {
+      chain.eq = () => {
+        const obsChain: any = {
+          eq: () => obsChain,
+          order: () => obsChain,
+          then: (resolve: (v: unknown) => unknown) =>
+            resolve({ data: [observationRow], error: null }),
+        };
+        return obsChain;
+      };
+    }
+    return chain;
+  }
+  return { db: { from: (name: string) => table(name) } };
+});
+
+vi.mock("../../src/reducers/observation_reducer.js", () => ({
+  observationReducer: {
+    computeSnapshot: vi.fn().mockResolvedValue({
+      entity_id: captured.entityId,
+      entity_type: "contact",
+      schema_version: "1.0",
+      snapshot: { name: "Ada Lovelace", email: "ada@example.com" },
+      computed_at: "2026-07-22T00:00:00.000Z",
+      observation_count: 1,
+      last_observation_at: "2026-07-22T00:00:00.000Z",
+      provenance: { name: "obs_1965_local_1" },
+      user_id: captured.userId,
+    }),
+  },
+}));
+
+vi.mock("../../src/services/timeline_events.js", () => ({
+  upsertTimelineEventsForEntitySnapshot: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("../../src/services/schema_registry.js", () => ({
+  schemaRegistry: { loadActiveSchema: vi.fn().mockResolvedValue(null) },
+}));
+
+const spies = vi.hoisted(() => ({
+  generateEmbedding: vi.fn(),
+  hasEmbeddingProvider: vi.fn(),
+  storeLocalEntityEmbedding: vi.fn(),
+}));
+const generateEmbedding = spies.generateEmbedding;
+const hasEmbeddingProvider = spies.hasEmbeddingProvider;
+const storeLocalEntityEmbedding = spies.storeLocalEntityEmbedding;
+
+vi.mock("../../src/embeddings.js", () => ({
+  generateEmbedding: (text: string) => spies.generateEmbedding(text),
+  hasEmbeddingProvider: () => spies.hasEmbeddingProvider(),
+  getEntitySearchableText: (
+    entityType: string,
+    canonicalName: string,
+    snapshot: Record<string, unknown>
+  ) => `${entityType} ${canonicalName} ${JSON.stringify(snapshot)}`,
+}));
+
+// The sqlite-vec sink: on the local backend this is where vectors actually go.
+vi.mock("../../src/services/local_entity_embedding.js", () => ({
+  storeLocalEntityEmbedding: (row: unknown) => spies.storeLocalEntityEmbedding(row),
+}));
+
+// The branch under test: the backend Bottega8 and every default install run.
+vi.mock("../../src/config.js", () => ({
+  config: { storageBackend: "local", openaiApiKey: "test-key" },
+}));
+
+import { recomputeSnapshot } from "../../src/services/snapshot_computation.js";
+
+describe("store path embeddings on the local/SQLite backend (issue #1965)", () => {
+  beforeEach(() => {
+    upsertedSnapshotRows.length = 0;
+    generateEmbedding.mockReset();
+    hasEmbeddingProvider.mockReset();
+    storeLocalEntityEmbedding.mockReset();
+  });
+
+  it("routes the embedding to sqlite-vec and keeps it out of the snapshot payload", async () => {
+    hasEmbeddingProvider.mockReturnValue(true);
+    generateEmbedding.mockResolvedValue(makeEmbedding(11));
+
+    const result = await recomputeSnapshot(ENTITY_ID, USER_ID);
+
+    expect(result).not.toBeNull();
+    expect(upsertedSnapshotRows).toHaveLength(1);
+
+    // The regression this file exists for: on SQLite the vector must reach
+    // sqlite-vec, not be silently dropped.
+    expect(storeLocalEntityEmbedding).toHaveBeenCalledTimes(1);
+    const stored = storeLocalEntityEmbedding.mock.calls[0][0] as Record<string, unknown>;
+    expect(stored.entity_id).toBe(ENTITY_ID);
+    expect(stored.user_id).toBe(USER_ID);
+    expect(stored.entity_type).toBe("contact");
+    expect(stored.embedding).toEqual(makeEmbedding(11));
+
+    // entity_snapshots has no `embedding` column on SQLite; including the key
+    // would break the write.
+    expect("embedding" in upsertedSnapshotRows[0]).toBe(false);
+  });
+
+  it("stores nothing in sqlite-vec when no provider is configured, and still succeeds", async () => {
+    hasEmbeddingProvider.mockReturnValue(false);
+
+    const result = await recomputeSnapshot(ENTITY_ID, USER_ID);
+
+    expect(result).not.toBeNull();
+    expect(upsertedSnapshotRows).toHaveLength(1);
+    expect(generateEmbedding).not.toHaveBeenCalled();
+    expect(storeLocalEntityEmbedding).not.toHaveBeenCalled();
+    expect("embedding" in upsertedSnapshotRows[0]).toBe(false);
+  });
+
+  it("does not fail the store when the provider throws", async () => {
+    hasEmbeddingProvider.mockReturnValue(true);
+    generateEmbedding.mockRejectedValue(new Error("provider unavailable"));
+
+    const result = await recomputeSnapshot(ENTITY_ID, USER_ID);
+
+    expect(result).not.toBeNull();
+    expect(upsertedSnapshotRows).toHaveLength(1);
+    expect(storeLocalEntityEmbedding).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #1965.

## Problem

The primary `store` path wrote entity snapshots **without ever generating embeddings**. `recomputeSnapshot` (`src/services/snapshot_computation.ts:74-78`) did a raw `db.from("entity_snapshots").upsert(...)`, while every *repair* path (health check, schema-lag repair, schema_registry migration, interpretation) went through the embedding-aware helpers.

Net effect: normally-stored entities got a snapshot but no embedding until something re-processed them or `scripts/backfill_entity_embeddings.ts` ran. Semantic search then silently degraded to `lexical_fallback` — the root cause behind "semantic search unreliable" reports from live instances, independent of whether an API key is present.

Two refinements found while confirming the diagnosis:

- `recomputeSnapshot` is the **only** remaining raw `entity_snapshots` upsert in `src/`, so this one chokepoint covers `store`, `correct`, and `split_entity` simultaneously — one edit, not three.
- `src/actions.ts:11419-11423` already carried a comment asserting embedding preparation ran through the shared pipeline. That was false before this change; it is now accurate.

## Fix

- `src/embeddings.ts` — added `hasEmbeddingProvider()`, exposing the existing module-level provider check.
- `src/services/entity_snapshot_embedding.ts` — `prepareEntitySnapshotWithEmbedding` short-circuits to `{...row, embedding: null}` when no provider is configured, *before* the `fetchCanonicalName` round-trip and snapshot `JSON.stringify` that exist only to build embedding text. `upsertEntitySnapshotWithEmbedding` gained an opt-in `{throwOnError}` so the primary path keeps the raw upsert's throwing behavior while existing repair-loop callers keep theirs.
- `src/services/snapshot_computation.ts` — the core fix: raw upsert replaced by prepare + embedding-aware upsert, with try/catch degrading to a null-embedding snapshot on provider failure.

**Awaited inline**, matching all five existing embedding callers. On the #1945 concern: `generateEmbedding` awaits an HTTP call, which *yields* the event loop rather than blocking it — that issue is about synchronous DB driver calls. Fire-and-forget would have been strictly worse, detaching the write from the snapshot upsert and losing ordering for no benefit.

With no provider the path now costs *less* than the raw upsert it replaces (no extra I/O at all).

## Tests

`tests/services/store_path_snapshot_embedding.test.ts` (4 tests) — provider configured writes a 1536-dim vector; no provider still succeeds with `embedding: null` and never calls the provider; no-provider path does strictly fewer reads; a throwing provider does not fail the store.

`tests/services/store_path_snapshot_embedding_local.test.ts` (3 tests) — **covers the local/SQLite backend**, which is what default installs and hosted instances actually run. The first file forces `storageBackend: "postgres"` so the `embedding` lands in the payload; since the mocked `config` is module-level, the local branch needs its own file. Asserts the embedding reaches sqlite-vec via `storeLocalEntityEmbedding`, that the `embedding` key stays *out* of the snapshot payload (no such column on SQLite), and the no-provider/throwing-provider cases.

Verified this test catches the regression rather than passing vacuously: disabling the sqlite-vec routing makes it fail with `expected "vi.fn()" to be called 1 times, but got 0 times`.

```
store_path_snapshot_embedding.test.ts — 4 passed
store_path_snapshot_embedding_local.test.ts — 3 passed
tests/services + src/services/__tests__ — 621 passed
tests/unit contract cli subscriptions agent security — 2581 passed
```
`tsc --noEmit` clean; eslint 0 errors; prettier clean.

`scripts/backfill_entity_embeddings.ts` is untouched and still compiles — the new `options` param is optional.

## Not verified

End-to-end against a live pgvector instance with a real `OPENAI_API_KEY` (neither available here). The unit-level proof is that the embedding reaches the upsert payload on Postgres and the sqlite-vec sink on local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
