### PR TITLE
fix(deploy): keep one machine running so MCP sessions survive idle

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -18,9 +18,20 @@ primary_region = 'lhr'
 [http_service]
   internal_port = 3180
   force_https = true
-  auto_stop_machines = 'stop'
+  # Keep one machine running. MCP-over-HTTP transport sessions are held in
+  # process memory (`mcpTransports` in src/actions.ts), so ANY machine
+  # stop/start silently invalidates every live session. Idle clients then hit
+  # "MCP session is unknown or expired on this API instance" and have to
+  # re-initialize — which surfaces to a user as an unexplained auth/session
+  # timeout after a quiet period. Letting the last machine stop trades a
+  # trivial amount of compute for a client-visible failure.
+  #
+  # fly.sandbox.toml already runs min_machines_running = 1 for this reason;
+  # this aligns the default so any instance deployed from this config inherits
+  # the safe behavior instead of having to rediscover it.
+  auto_stop_machines = 'off'
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = 1
   processes = ['app']
 
 [[vm]]


### PR DESCRIPTION
## What

`fly.toml`: `auto_stop_machines = 'off'`, `min_machines_running = 1` (plus a comment explaining why). Config only — no code change.

## Why

MCP-over-HTTP transport sessions are held **in process memory**:

```ts
// src/actions.ts:986
const mcpTransports = new Map<string, StreamableHTTPServerTransport>();
```

Any machine stop/start wipes that map. With `auto_stop_machines='stop'` + `min_machines_running=0`, an instance that goes quiet stops its last machine, and the next request from an idle client gets the server's own error:

> `Not Found: MCP session is unknown or expired on this API instance. The client should re-initialize by sending a new InitializeRequest without a session ID.`

To a user, that reads as an **unexplained auth/session timeout after a period of inactivity** — the client was connected, went idle, and came back to a dead session.

## Why this is a generic fix, not a per-deployment tweak

The session map is per-process and unconditional — it isn't gated on any deployment, tenant, or flag. Every instance serving MCP over HTTP has this property.

`fly.sandbox.toml` **already** sets `min_machines_running = 1`, so the sandbox doesn't have the bug. This aligns the default config so any instance deployed from `fly.toml` inherits the same safe behavior instead of rediscovering the failure in production.

## Trade-off

One small shared-cpu machine kept warm, versus a client-visible session drop. Instances that genuinely don't serve MCP, or that tolerate re-initialization, can still override in their own config.

## Verification

- `flyctl config validate` → **Configuration is valid**
- Diff is config + comment only; introduces no client-identifying content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)