### PR TITLE
test: identifier limit boundary + empty-identifier coverage (#1981/#1982 follow-up)

### DIFF
--- a/tests/integration/entity_identifier_handler.test.ts
+++ b/tests/integration/entity_identifier_handler.test.ts
@@ -813,4 +813,192 @@ describe("retrieveEntityByIdentifierWithFallback", () => {
     expect(result.entities[0]?.id).toBe(entityId);
     expect(result.match_mode).toBe("snapshot_field");
   });
+
+  // Follow-up to the #1981/#1982 review (flagged NON-BLOCKING): the exact
+  // pre-pass and the JS-scan fallback are bounded independently — each
+  // per-field exact query carries `.limit(limit)`, while the JS scan is capped
+  // at a fixed 500 rows and appends every additional match it finds. Nothing
+  // between them re-applies `limit` to the merged `snapshotMatches` array, so
+  // the caller-facing bound rests entirely on the final `queryEntities({limit})`
+  // call. This pins that the combined result is correctly bounded AND
+  // deterministic across the two passes.
+  it("#1982 bounds and deterministically orders results across the exact and JS-scan passes", async () => {
+    const userId = "identifier-user-limit-boundary";
+    const now = new Date().toISOString();
+    // Fixed (not Date.now()-derived) ids so the expected ordering is explicit:
+    // queryEntities' default sort is `.order("id", { ascending: true })`, so
+    // the bounded slice must be the lowest ids, in ascending order.
+    const idA = "ent_limit_boundary_aaa0000000";
+    const idB = "ent_limit_boundary_bbb0000000";
+    const idC = "ent_limit_boundary_ccc0000000";
+    testEntityIds.push(idA, idB, idC);
+    // One shared email across all three contacts: more matches than `limit`.
+    const sharedEmail = "limit.boundary@example.com";
+
+    await serviceRoleClient.from("entities").insert(
+      [idA, idB, idC].map((id, index) => ({
+        id,
+        user_id: userId,
+        // canonical_name deliberately does NOT contain the email, so the
+        // canonical/alias stage misses and resolution goes through the
+        // snapshot-field passes under test.
+        canonical_name: `Limit Boundary Person ${index}`,
+        entity_type: "contact",
+      }))
+    );
+    await serviceRoleClient.from("entity_snapshots").upsert(
+      [idA, idB, idC].map((id, index) => ({
+        entity_id: id,
+        user_id: userId,
+        entity_type: "contact",
+        schema_version: "1.0",
+        canonical_name: `Limit Boundary Person ${index}`,
+        snapshot: { name: `Limit Boundary Person ${index}`, email: sharedEmail },
+        provenance: {},
+        observation_count: 1,
+        last_observation_at: now,
+        computed_at: now,
+      }))
+    );
+
+    const callWithLimit = (limit: number) =>
+      retrieveEntityByIdentifierWithFallback({
+        identifier: sharedEmail,
+        entityType: "contact",
+        userId,
+        by: "email",
+        limit,
+      });
+
+    // Sanity: unbounded, all three resolve — so a capped call below is really
+    // exercising the bound, not a seeding failure.
+    const uncapped = await callWithLimit(100);
+    expect(uncapped.match_mode).toBe("snapshot_field");
+    expect(uncapped.entities).toHaveLength(3);
+    expect(uncapped.total).toBe(3);
+
+    const capped = await callWithLimit(1);
+    expect(capped.match_mode).toBe("snapshot_field");
+    // The caller-facing bound holds even though 3 rows matched.
+    expect(capped.entities.length).toBeLessThanOrEqual(1);
+    expect(capped.entities).toHaveLength(1);
+
+    // `total` SEMANTICS (caller-facing contract, verified here rather than
+    // assumed): for the snapshot-field pass, `total` is the size of the
+    // CAPPED, returned set — NOT the true number of matching entities. The
+    // handler returns `total: withObservations.length`, so `limit: 1` against
+    // 3 genuine matches reports `total: 1`, and `limit: 2` reports `total: 2`.
+    // Callers therefore CANNOT use `total` to detect truncation or to
+    // paginate: `total === limit` is indistinguishable from "exactly `limit`
+    // matches exist". (This differs from the `semantic` pass, which returns
+    // the search's own `total` and can exceed `entities.length`.)
+    expect(capped.total).toBe(1);
+    expect(capped.total).toBe(capped.entities.length);
+
+    const cappedAtTwo = await callWithLimit(2);
+    expect(cappedAtTwo.entities).toHaveLength(2);
+    expect(cappedAtTwo.total).toBe(2);
+
+    // Determinism: the capped set must be a stable, ordered prefix — not an
+    // arbitrary subset that varies per call. Repeated identical calls return
+    // identical ids, and the bounded slice is the ascending-id prefix.
+    const repeat = await callWithLimit(1);
+    expect(repeat.entities.map((entity) => entity.id)).toEqual(
+      capped.entities.map((entity) => entity.id)
+    );
+    expect(capped.entities[0]?.id).toBe(idA);
+    expect(cappedAtTwo.entities.map((entity) => entity.id)).toEqual([idA, idB]);
+    expect(uncapped.entities.map((entity) => entity.id)).toEqual([idA, idB, idC]);
+  });
+
+  // Follow-up to the #1981/#1982 review (flagged NON-BLOCKING). An identifier
+  // that trims to empty is not a meaningful lookup key and must resolve to
+  // nothing. Two distinct ways it can wrongly match:
+  //   1. The canonical/alias stage builds `canonical_name.ilike.%${normalized}%`
+  //      — with an empty needle that degrades to `%%`, which matches EVERY
+  //      entity row for the user.
+  //   2. The exact pre-pass runs `.eq(lower(snapshot->>field), "")`, which
+  //      matches any snapshot row storing that field as an empty string.
+  // Seeds one contact with `email: ""` plus a normal contact and asserts the
+  // correct contract: an empty/whitespace identifier resolves to nothing.
+  it("#1982 does not match anything for an empty or whitespace-only identifier", async () => {
+    const userId = "identifier-user-empty-identifier";
+    const emptyFieldId = `ent_empty_field_${Date.now()}`;
+    const normalId = `ent_empty_normal_${Date.now()}`;
+    testEntityIds.push(emptyFieldId, normalId);
+    const now = new Date().toISOString();
+
+    await serviceRoleClient.from("entities").insert([
+      {
+        id: emptyFieldId,
+        user_id: userId,
+        entity_type: "contact",
+        canonical_name: "Empty Email Person",
+      },
+      {
+        id: normalId,
+        user_id: userId,
+        entity_type: "contact",
+        canonical_name: "Normal Person",
+      },
+    ]);
+    await serviceRoleClient.from("entity_snapshots").upsert([
+      {
+        entity_id: emptyFieldId,
+        user_id: userId,
+        entity_type: "contact",
+        schema_version: "1.0",
+        canonical_name: "Empty Email Person",
+        // The false-positive bait: `email` stored as an empty string, which
+        // `.eq(lower(snapshot->>email), "")` would match for an empty needle.
+        snapshot: { name: "Empty Email Person", email: "" },
+        provenance: {},
+        observation_count: 1,
+        last_observation_at: now,
+        computed_at: now,
+      },
+      {
+        entity_id: normalId,
+        user_id: userId,
+        entity_type: "contact",
+        schema_version: "1.0",
+        canonical_name: "Normal Person",
+        snapshot: { name: "Normal Person", email: "normal.person@example.com" },
+        provenance: {},
+        observation_count: 1,
+        last_observation_at: now,
+        computed_at: now,
+      },
+    ]);
+
+    for (const identifier of ["", "   "]) {
+      const result = await retrieveEntityByIdentifierWithFallback({
+        identifier,
+        entityType: "contact",
+        userId,
+        limit: 100,
+      });
+
+      // An empty identifier must never resolve the empty-string-field contact.
+      expect(result.entities.some((entity) => entity.id === emptyFieldId)).toBe(false);
+      // Nor may it act as a wildcard that dumps every entity for the user.
+      expect(result.entities.some((entity) => entity.id === normalId)).toBe(false);
+      expect(result.total).toBe(0);
+      expect(result.entities).toHaveLength(0);
+      expect(result.match_mode).toBe("none");
+    }
+
+    // Pinning the same contract when the field is explicitly pinned via `by`,
+    // which routes straight to the `.eq(lower(snapshot->>email), "")` query.
+    const byEmail = await retrieveEntityByIdentifierWithFallback({
+      identifier: "",
+      entityType: "contact",
+      userId,
+      by: "email",
+      limit: 100,
+    });
+    expect(byEmail.entities.some((entity) => entity.id === emptyFieldId)).toBe(false);
+    expect(byEmail.total).toBe(0);
+    expect(byEmail.match_mode).toBe("none");
+  });
 });


### PR DESCRIPTION
Follow-up to the review of #1982 (merged), adding the two tests flagged **NON-BLOCKING**. Both target `retrieveEntityByIdentifierWithFallback` in `src/shared/action_handlers/entity_identifier_handler.ts`.

**No production source is changed by this PR.**

## Test A — `limit` boundary across the two snapshot passes

The identifier handler bounds its two snapshot passes independently: the exact pre-pass applies `.limit(limit)` to each per-field query, while the JS-scan fallback is separately capped at a fixed `.limit(500)` and appends every further match it finds. Nothing in between re-applies `limit` to the merged `snapshotMatches` array, so the caller-facing bound rests entirely on the final `queryEntities({ limit })` call.

The test seeds 3 contacts sharing one `email` value (whose `canonical_name` deliberately omits the email, so resolution must go through the snapshot passes) and asserts:

- the result is bounded — `entities.length <= limit` at `limit: 1`, and exactly 2 at `limit: 2`;
- the result is deterministic — repeated identical calls return the same ids, and the capped set is a stable **ascending-`entity_id` prefix** (`queryEntities`' default sort is `.order("id", { ascending: true })`), not an arbitrary subset;
- an uncapped call resolves all 3, so a capped call is genuinely exercising the bound rather than a seeding failure.

### `total` semantics (caller-facing contract)

Verified empirically rather than assumed. For the **snapshot-field** pass, `total` is the size of the **capped, returned set** — not the true number of matching entities. The handler returns `total: withObservations.length`, so against 3 genuine matches:

| `limit` | `entities.length` | `total` |
|---|---|---|
| 1 | 1 | **1** |
| 2 | 2 | **2** |
| 100 | 3 | 3 |

Consequence: **callers cannot use `total` to detect truncation or to paginate** — `total === limit` is indistinguishable from "exactly `limit` matches exist". This differs from the `semantic` pass, which returns the search's own `total` and *can* exceed `entities.length`. Documented in a comment on the test.

## Test B — empty / whitespace-only identifier (FAILING — live bug)

This test currently **fails**, deliberately. Per the review instruction, it asserts the *correct* behavior rather than encoding the buggy behavior.

The bug is real but sits **earlier in the pipeline than the review predicted**. The review anticipated a false positive in the exact pre-pass, where `.eq(lower(snapshot->>field), "")` would match snapshot rows storing that field as an empty string. That failure mode is masked by a broader one at the canonical/alias stage:

```
.or(`canonical_name.ilike.%${normalized}%,aliases.cs.["${normalized}"]`)
```

With an identifier that trims to empty, `normalized` is `""` and the pattern degrades to `%%` — which **matches every entity row for the user**. Resolution never reaches the snapshot passes at all.

Observed behavior for both `identifier: ""` and `identifier: "   "`, with two seeded contacts:

- **actual:** `total: 2`, `match_mode: "direct"`, returning *both* contacts — i.e. an empty identifier acts as a wildcard that dumps the caller's entities.
- **expected:** `total: 0`, `match_mode: "none"`.

Failing assertion (`tests/integration/entity_identifier_handler.test.ts:983`):

```
AssertionError: expected true to be false // Object.is equality
  expect(result.entities.some((entity) => entity.id === emptyFieldId)).toBe(false);
```

The test seeds a contact with `email: ""` plus a normal contact, so it guards **both** failure modes: the wildcard `%%` dump and the `.eq(lower(snapshot->>email), "")` empty-string-field false positive (the latter additionally pinned via an explicit `by: "email"` call, which routes straight to that query).

Isolating the stages confirms the mechanism — with an `entityType` that has no matching entity rows, the empty identifier correctly returns `total: 0` / `"none"`, so the wildcard is unambiguously the canonical/alias `ilike` stage.

### Suggested fix (not applied here)

Guard early in `retrieveEntityByIdentifierWithFallback`: if `identifier.trim()` is empty, return `{ entities: [], total: 0, match_mode: "none" }` before the canonical/alias query. That fixes the wildcard dump and, being ahead of the pre-pass, the empty-string-field false positive too. Left to a follow-up so this PR stays test-only and the bug is reviewed on its own merits.

## Verification

- `npx tsc --noEmit` — clean (exit 0, repo-wide)
- `npx prettier --write` on the touched file
- `npx vitest run tests/integration/entity_identifier_handler.test.ts --testTimeout=60000` — **20 passed, 1 failed (21 total)**; the single failure is Test B, documenting the bug above. All 19 pre-existing tests still pass, plus Test A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)