### PR TITLE
fix(oauth): give sign-in sessions their own TTL and bound-user lifetime

### DIFF
--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,15 +61,15 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **537**
-- Backend and repo Vitest files: **502**
+- Total automated test files: **538**
+- Backend and repo Vitest files: **503**
 - Frontend Vitest files: **9**
 - Playwright spec files: **26**
 
 ### Suite counts
 | Suite | Files |
 |---|---:|
-| Vitest unit tests | 149 |
+| Vitest unit tests | 150 |
 | Vitest service tests | 39 |
 | Source-adjacent tests | 64 |
 | Vitest integration tests | 155 |
@@ -109,7 +109,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/unit`
 **Requirements:** Basic `.env` if required by the module under test.
-**Files (149):**
+**Files (150):**
 - `tests/unit/aauth_admission.test.ts`
 - `tests/unit/aauth_attestation_apple_se.test.ts`
 - `tests/unit/aauth_attestation_revocation.test.ts`
@@ -241,6 +241,7 @@ flowchart TD
 - `tests/unit/security_hardening.test.ts`
 - `tests/unit/seo_metadata.test.ts`
 - `tests/unit/session_info.test.ts`
+- `tests/unit/sign_in_session_wiring.test.ts`
 - `tests/unit/site_page_markdown.test.ts`
 - `tests/unit/source_priority_ignored_warning.test.ts`
 - `tests/unit/spa_path.test.ts`

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1383,15 +1383,20 @@ const OAUTH_KEY_SESSION_COOKIE = "neotoma_oauth_key_session";
 const oauthKeySessions = new OAuthKeySessionStore();
 
 /**
- * Maps an OAuth key-session token to the user_id resolved via Google
- * sign-in for that browser session. Populated only by the
- * `/mcp/oauth/google/callback` route; every other credential path
- * (private key / mnemonic / bearer) never writes here, so
- * `/mcp/oauth/local-login` falls through to `ensureLocalDevUser()`
- * exactly as before when this map has no entry — behavior for every
- * existing deploy (Google flag off) is unchanged.
+ * Lifetime of a SIGN-IN session (Google). Distinct from the key-entry gate's
+ * short default: a user who signs in expects to stay signed in, whereas the
+ * key-entry gate deliberately closes fast. Reusing the 15-minute gate TTL for
+ * sign-in is what logged hosted-instance users out every quarter hour (#2005).
+ *
+ * Override with NEOTOMA_SIGN_IN_SESSION_TTL_MIN (minutes). Default 7 days.
  */
-const googleVerifiedUserBySessionToken = new Map<string, string>();
+const SIGN_IN_SESSION_TTL_MS =
+  Math.max(
+    1,
+    Number.parseInt(process.env.NEOTOMA_SIGN_IN_SESSION_TTL_MIN || "", 10) || 7 * 24 * 60
+  ) *
+  60 *
+  1000;
 
 function readCookie(req: express.Request, name: string): string | undefined {
   const header = (req.headers["cookie"] || req.headers["Cookie"] || "") as string;
@@ -1623,8 +1628,19 @@ function hasValidOAuthKeySession(req: express.Request): boolean {
   return oauthKeySessions.isValid(token);
 }
 
-function setOAuthKeySessionCookie(req: express.Request, res: express.Response): string {
-  const token = oauthKeySessions.create();
+/**
+ * Issue an OAuth key-session cookie. `ttlMs` covers BOTH the server-side
+ * session and the cookie's own maxAge — they must agree, or the browser keeps
+ * presenting a cookie the server has already forgotten (or vice versa).
+ * Omit it for the short key-entry gate; pass SIGN_IN_SESSION_TTL_MS for
+ * sign-in (#2005).
+ */
+function setOAuthKeySessionCookie(
+  req: express.Request,
+  res: express.Response,
+  ttlMs?: number
+): string {
+  const token = oauthKeySessions.create(Date.now(), ttlMs);
   const forwardedProto =
     ((req.headers["x-forwarded-proto"] || req.headers["X-Forwarded-Proto"]) as string | undefined)
       ?.split(",")[0]
@@ -1636,7 +1652,7 @@ function setOAuthKeySessionCookie(req: express.Request, res: express.Response): 
     sameSite: "lax",
     secure,
     path: "/mcp/oauth",
-    maxAge: 15 * 60 * 1000,
+    maxAge: ttlMs != null && ttlMs > 0 ? ttlMs : 15 * 60 * 1000,
   });
   return token;
 }
@@ -1644,8 +1660,9 @@ function setOAuthKeySessionCookie(req: express.Request, res: express.Response): 
 /** Resolve the local-auth user_id a Google-verified session (if any) mapped to this request. */
 function getGoogleVerifiedUserId(req: express.Request): string | undefined {
   const token = readCookie(req, OAUTH_KEY_SESSION_COOKIE);
-  if (!token || !oauthKeySessions.isValid(token)) return undefined;
-  return googleVerifiedUserBySessionToken.get(token);
+  // getBoundUser enforces session validity itself, so an expired session can
+  // never resolve a user even if a binding is still in memory.
+  return oauthKeySessions.getBoundUser(token);
 }
 
 /**
@@ -2781,8 +2798,10 @@ app.get("/mcp/oauth/google/callback", async (req, res) => {
     // mnemonic/bearer path sets. `/mcp/oauth/authorize` -> `/mcp/oauth/
     // local-login` then runs completely unmodified, except local-login now
     // resolves the user via this session instead of always ensureLocalDevUser().
-    const sessionToken = setOAuthKeySessionCookie(req, res);
-    googleVerifiedUserBySessionToken.set(sessionToken, resolvedUserId);
+    // Sign-in gets the long session TTL, not the key-entry gate's 15 minutes,
+    // and the user binding lives in the same store so it expires with it (#2005).
+    const sessionToken = setOAuthKeySessionCookie(req, res, SIGN_IN_SESSION_TTL_MS);
+    oauthKeySessions.bindUser(sessionToken, resolvedUserId);
 
     return res.redirect(nextPath);
   } catch (error: any) {

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1380,7 +1380,9 @@ export function isLocalRequest(req: express.Request): boolean {
 }
 
 const OAUTH_KEY_SESSION_COOKIE = "neotoma_oauth_key_session";
-const oauthKeySessions = new OAuthKeySessionStore();
+/** Exported for tests asserting the cookie maxAge and the server-side session
+ *  expiry agree — the invariant setOAuthKeySessionCookie's docstring names. */
+export const oauthKeySessions = new OAuthKeySessionStore();
 
 /**
  * Lifetime of a SIGN-IN session (Google). Distinct from the key-entry gate's
@@ -1390,13 +1392,27 @@ const oauthKeySessions = new OAuthKeySessionStore();
  *
  * Override with NEOTOMA_SIGN_IN_SESSION_TTL_MIN (minutes). Default 7 days.
  */
-const SIGN_IN_SESSION_TTL_MS =
-  Math.max(
-    1,
-    Number.parseInt(process.env.NEOTOMA_SIGN_IN_SESSION_TTL_MIN || "", 10) || 7 * 24 * 60
-  ) *
-  60 *
-  1000;
+export const DEFAULT_SIGN_IN_SESSION_TTL_MIN = 7 * 24 * 60;
+
+/**
+ * Parse NEOTOMA_SIGN_IN_SESSION_TTL_MIN into milliseconds. Exported (and pure)
+ * so the override's precedence and malformed-input behavior are directly
+ * testable — a silently-wrong TTL here reintroduces exactly the desync class
+ * this change fixes.
+ *
+ * Precedence: a positive integer wins; unset / non-numeric / zero / negative
+ * all fall back to the 7-day default rather than producing a degenerate
+ * (e.g. 1-minute) session.
+ */
+export function resolveSignInSessionTtlMs(raw: string | undefined): number {
+  const parsed = Number.parseInt(raw || "", 10);
+  const minutes = Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_SIGN_IN_SESSION_TTL_MIN;
+  return minutes * 60 * 1000;
+}
+
+const SIGN_IN_SESSION_TTL_MS = resolveSignInSessionTtlMs(
+  process.env.NEOTOMA_SIGN_IN_SESSION_TTL_MIN
+);
 
 function readCookie(req: express.Request, name: string): string | undefined {
   const header = (req.headers["cookie"] || req.headers["Cookie"] || "") as string;
@@ -1635,7 +1651,7 @@ function hasValidOAuthKeySession(req: express.Request): boolean {
  * Omit it for the short key-entry gate; pass SIGN_IN_SESSION_TTL_MS for
  * sign-in (#2005).
  */
-function setOAuthKeySessionCookie(
+export function setOAuthKeySessionCookie(
   req: express.Request,
   res: express.Response,
   ttlMs?: number
@@ -1658,7 +1674,7 @@ function setOAuthKeySessionCookie(
 }
 
 /** Resolve the local-auth user_id a Google-verified session (if any) mapped to this request. */
-function getGoogleVerifiedUserId(req: express.Request): string | undefined {
+export function getGoogleVerifiedUserId(req: express.Request): string | undefined {
   const token = readCookie(req, OAUTH_KEY_SESSION_COOKIE);
   // getBoundUser enforces session validity itself, so an expired session can
   // never resolve a user even if a binding is still in memory.

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1394,19 +1394,33 @@ export const oauthKeySessions = new OAuthKeySessionStore();
  */
 export const DEFAULT_SIGN_IN_SESSION_TTL_MIN = 7 * 24 * 60;
 
+/** Upper bound for the sign-in TTL override: 365 days in minutes. A value past
+ *  this is a typo (an extra zero), not an intent — without a ceiling,
+ *  "9999999999999" yields a ~19-million-year session. Mirrors the low-end
+ *  guard rather than guarding only one side (#2007 qa lens). */
+export const MAX_SIGN_IN_SESSION_TTL_MIN = 365 * 24 * 60;
+
 /**
  * Parse NEOTOMA_SIGN_IN_SESSION_TTL_MIN into milliseconds. Exported (and pure)
  * so the override's precedence and malformed-input behavior are directly
  * testable — a silently-wrong TTL here reintroduces exactly the desync class
  * this change fixes.
  *
- * Precedence: a positive integer wins; unset / non-numeric / zero / negative
- * all fall back to the 7-day default rather than producing a degenerate
- * (e.g. 1-minute) session.
+ * Precedence: an integer within (0, MAX_SIGN_IN_SESSION_TTL_MIN] wins.
+ * Everything else — unset, non-numeric, zero, negative, or above the ceiling —
+ * falls back to the 7-day default rather than producing a degenerate session.
+ *
+ * Note on parseInt semantics, deliberately kept: "7.5" truncates to 7 minutes
+ * and "1e10" parses as 1 minute (parseInt stops at the 'e'). Both are accepted
+ * as-is because they are in-range integers after parsing; the fallback exists
+ * for values that are absent, unparseable, or out of range, not to second-guess
+ * a caller who wrote a decimal. Asserted in tests so the behavior is documented
+ * rather than incidental.
  */
 export function resolveSignInSessionTtlMs(raw: string | undefined): number {
   const parsed = Number.parseInt(raw || "", 10);
-  const minutes = Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_SIGN_IN_SESSION_TTL_MIN;
+  const inRange = Number.isFinite(parsed) && parsed > 0 && parsed <= MAX_SIGN_IN_SESSION_TTL_MIN;
+  const minutes = inRange ? parsed : DEFAULT_SIGN_IN_SESSION_TTL_MIN;
   return minutes * 60 * 1000;
 }
 

--- a/src/services/__tests__/oauth_key_gate.test.ts
+++ b/src/services/__tests__/oauth_key_gate.test.ts
@@ -61,4 +61,74 @@ describe("oauth_key_gate", () => {
     expect(store.isValid(token, createdAt + 5)).toBe(true);
     expect(store.isValid(token, createdAt + 11)).toBe(false);
   });
+
+  // #2005 — sign-in sessions must not inherit the key-entry gate's short TTL,
+  // and a bound user must never outlive the session it belongs to.
+  describe("sign-in session TTL + user binding (#2005)", () => {
+    it("honors a per-session TTL override longer than the store default", async () => {
+      const mod = await loadOauthKeyGateModule(String(Date.now() + 2));
+      const store = new mod.OAuthKeySessionStore(10); // short gate default
+      const createdAt = Date.now();
+      const token = store.create(createdAt, 10_000); // sign-in override
+
+      // Past the 10ms gate default, still valid on the override.
+      expect(store.isValid(token, createdAt + 500)).toBe(true);
+      expect(store.isValid(token, createdAt + 9_999)).toBe(true);
+      expect(store.isValid(token, createdAt + 10_001)).toBe(false);
+    });
+
+    it("does not widen the default TTL for sessions that pass no override", async () => {
+      const mod = await loadOauthKeyGateModule(String(Date.now() + 2));
+      const store = new mod.OAuthKeySessionStore(10);
+      const createdAt = Date.now();
+      const gateToken = store.create(createdAt); // no override
+
+      expect(store.isValid(gateToken, createdAt + 11)).toBe(false);
+    });
+
+    it("resolves a bound user while the session is live", async () => {
+      const mod = await loadOauthKeyGateModule(String(Date.now() + 2));
+      const store = new mod.OAuthKeySessionStore(10);
+      const createdAt = Date.now();
+      const token = store.create(createdAt, 10_000);
+
+      expect(store.bindUser(token, "user-abc", createdAt)).toBe(true);
+      expect(store.getBoundUser(token, createdAt + 5_000)).toBe("user-abc");
+    });
+
+    it("stops resolving the bound user once the session expires", async () => {
+      const mod = await loadOauthKeyGateModule(String(Date.now() + 2));
+      const store = new mod.OAuthKeySessionStore(10);
+      const createdAt = Date.now();
+      const token = store.create(createdAt, 1_000);
+      store.bindUser(token, "user-abc", createdAt);
+
+      expect(store.getBoundUser(token, createdAt + 500)).toBe("user-abc");
+      // The binding must not survive its session — this is the unbounded-map
+      // leak the old module-level Map had.
+      expect(store.getBoundUser(token, createdAt + 1_001)).toBeUndefined();
+    });
+
+    it("refuses to bind a user to an expired or unknown session", async () => {
+      const mod = await loadOauthKeyGateModule(String(Date.now() + 2));
+      const store = new mod.OAuthKeySessionStore(10);
+      const createdAt = Date.now();
+      const token = store.create(createdAt, 1_000);
+
+      expect(store.bindUser(token, "user-abc", createdAt + 2_000)).toBe(false);
+      expect(store.getBoundUser(token, createdAt + 2_000)).toBeUndefined();
+      expect(store.bindUser("never-issued", "user-abc", createdAt)).toBe(false);
+    });
+
+    it("evicts bound users during cleanup so the map cannot grow unbounded", async () => {
+      const mod = await loadOauthKeyGateModule(String(Date.now() + 2));
+      const store = new mod.OAuthKeySessionStore(10);
+      const createdAt = Date.now();
+      const token = store.create(createdAt, 1_000);
+      store.bindUser(token, "user-abc", createdAt);
+
+      store.cleanup(createdAt + 5_000);
+      expect(store.getBoundUser(token, createdAt + 5_000)).toBeUndefined();
+    });
+  });
 });

--- a/src/services/oauth_key_gate.ts
+++ b/src/services/oauth_key_gate.ts
@@ -3,6 +3,16 @@ import { randomUUID, timingSafeEqual } from "node:crypto";
 import { config } from "../config.js";
 import { deriveMcpAuthToken, hexToKey, mnemonicToSeed } from "../crypto/key_derivation.js";
 
+/**
+ * Default lifetime for a KEY-ENTRY gate session — the short window in which a
+ * user pastes a private key / mnemonic / bearer token. Deliberately brief.
+ *
+ * Sign-in sessions are a different concern with a different expectation (a user
+ * signed in with Google expects to stay signed in), so callers pass their own
+ * TTL rather than inheriting this one. See SIGN_IN_SESSION_TTL_MS in actions.ts
+ * and issue #2005 — reusing this 15-minute default for Google sign-in is what
+ * logged hosted-instance users out every quarter hour.
+ */
 const DEFAULT_SESSION_TTL_MS = 15 * 60 * 1000;
 
 export type OAuthKeyCredentials = {
@@ -14,16 +24,25 @@ export type OAuthKeyCredentials = {
 
 export class OAuthKeySessionStore {
   private readonly sessions = new Map<string, number>();
+  /**
+   * Optional user binding for a session (set by the Google sign-in callback).
+   * Kept in the SAME store as the expiry so a bound user can never outlive its
+   * session — a separate module-level map had no TTL and grew unbounded (#2005).
+   */
+  private readonly boundUsers = new Map<string, string>();
   private readonly ttlMs: number;
 
   constructor(ttlMs: number = DEFAULT_SESSION_TTL_MS) {
     this.ttlMs = ttlMs;
   }
 
-  create(nowMs: number = Date.now()): string {
+  /** Create a session. `ttlMsOverride` lets a caller (e.g. sign-in) use a
+   *  longer lifetime than the short key-entry default. */
+  create(nowMs: number = Date.now(), ttlMsOverride?: number): string {
     this.cleanup(nowMs);
     const token = randomUUID();
-    this.sessions.set(token, nowMs + this.ttlMs);
+    const ttl = ttlMsOverride != null && ttlMsOverride > 0 ? ttlMsOverride : this.ttlMs;
+    this.sessions.set(token, nowMs + ttl);
     return token;
   }
 
@@ -33,14 +52,34 @@ export class OAuthKeySessionStore {
     if (expiresAt == null) return false;
     if (expiresAt <= nowMs) {
       this.sessions.delete(token);
+      this.boundUsers.delete(token);
       return false;
     }
     return true;
   }
 
+  /** Bind a resolved user_id to a live session. No-op for an invalid token, so
+   *  a binding can never resurrect or outlast an expired session. */
+  bindUser(token: string, userId: string, nowMs: number = Date.now()): boolean {
+    if (!this.isValid(token, nowMs)) return false;
+    this.boundUsers.set(token, userId);
+    return true;
+  }
+
+  /** Resolve the bound user for a session, or undefined when the session is
+   *  absent/expired. Expiry is enforced here, not just at write time. */
+  getBoundUser(token: string | undefined, nowMs: number = Date.now()): string | undefined {
+    if (!token) return undefined;
+    if (!this.isValid(token, nowMs)) return undefined;
+    return this.boundUsers.get(token);
+  }
+
   cleanup(nowMs: number = Date.now()): void {
     for (const [token, expiresAt] of this.sessions.entries()) {
-      if (expiresAt <= nowMs) this.sessions.delete(token);
+      if (expiresAt <= nowMs) {
+        this.sessions.delete(token);
+        this.boundUsers.delete(token);
+      }
     }
   }
 }

--- a/tests/unit/sign_in_session_wiring.test.ts
+++ b/tests/unit/sign_in_session_wiring.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   DEFAULT_SIGN_IN_SESSION_TTL_MIN,
+  MAX_SIGN_IN_SESSION_TTL_MIN,
   getGoogleVerifiedUserId,
   oauthKeySessions,
   resolveSignInSessionTtlMs,
@@ -60,6 +61,24 @@ describe("sign-in session TTL wiring (#2005)", () => {
       // have produced a near-unusable session from a typo'd env value.
       expect(resolveSignInSessionTtlMs("0")).toBe(defaultMs);
       expect(resolveSignInSessionTtlMs("-5")).toBe(defaultMs);
+    });
+
+    // The low end was guarded but the high end was not (#2007 qa lens): without
+    // a ceiling, an extra zero produced a session outliving the server itself.
+    it("falls back to the default above the ceiling rather than an unbounded session", () => {
+      expect(resolveSignInSessionTtlMs(String(MAX_SIGN_IN_SESSION_TTL_MIN))).toBe(
+        MAX_SIGN_IN_SESSION_TTL_MIN * 60 * 1000
+      );
+      expect(resolveSignInSessionTtlMs(String(MAX_SIGN_IN_SESSION_TTL_MIN + 1))).toBe(defaultMs);
+      // ~19 million years before the ceiling existed.
+      expect(resolveSignInSessionTtlMs("9999999999999")).toBe(defaultMs);
+    });
+
+    it("documents parseInt semantics for decimals and scientific notation", () => {
+      // Both are in-range integers after parsing, so they are accepted as-is.
+      // Asserted so the behavior is documented rather than incidental.
+      expect(resolveSignInSessionTtlMs("7.5")).toBe(7 * 60 * 1000);
+      expect(resolveSignInSessionTtlMs("1e10")).toBe(60 * 1000);
     });
   });
 

--- a/tests/unit/sign_in_session_wiring.test.ts
+++ b/tests/unit/sign_in_session_wiring.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_SIGN_IN_SESSION_TTL_MIN,
+  getGoogleVerifiedUserId,
+  oauthKeySessions,
+  resolveSignInSessionTtlMs,
+  setOAuthKeySessionCookie,
+} from "../../src/actions.js";
+
+/**
+ * #2005 — wiring-level coverage for the sign-in session TTL.
+ *
+ * The store itself is unit-tested in src/services/__tests__/oauth_key_gate.test.ts.
+ * These tests cover the layer where the bug actually shipped: the actions.ts
+ * functions that connect the TTL to the cookie's maxAge and to the user
+ * binding. The invariant under test is the one setOAuthKeySessionCookie's own
+ * docstring names — the cookie lifetime and the server-side session expiry MUST
+ * agree, or the browser keeps presenting a cookie the server has forgotten
+ * (or the reverse).
+ */
+
+/** Minimal express req/res doubles: we only need cookie capture + header reads. */
+function makeReqRes(cookieHeader?: string) {
+  const cookies: Array<{ name: string; value: string; options: Record<string, unknown> }> = [];
+  const req = {
+    headers: cookieHeader ? { cookie: cookieHeader } : {},
+    secure: true,
+    protocol: "https",
+  } as never;
+  const res = {
+    cookie(name: string, value: string, options: Record<string, unknown>) {
+      cookies.push({ name, value, options });
+    },
+  } as never;
+  return { req, res, cookies };
+}
+
+describe("sign-in session TTL wiring (#2005)", () => {
+  describe("resolveSignInSessionTtlMs — NEOTOMA_SIGN_IN_SESSION_TTL_MIN parsing", () => {
+    const defaultMs = DEFAULT_SIGN_IN_SESSION_TTL_MIN * 60 * 1000;
+
+    it("defaults to 7 days when the override is unset", () => {
+      expect(resolveSignInSessionTtlMs(undefined)).toBe(defaultMs);
+      expect(resolveSignInSessionTtlMs("")).toBe(defaultMs);
+    });
+
+    it("honors a positive integer override", () => {
+      expect(resolveSignInSessionTtlMs("30")).toBe(30 * 60 * 1000);
+      expect(resolveSignInSessionTtlMs("1")).toBe(60 * 1000);
+    });
+
+    it("falls back to the default on a non-numeric value", () => {
+      expect(resolveSignInSessionTtlMs("not-a-number")).toBe(defaultMs);
+      expect(resolveSignInSessionTtlMs("abc123")).toBe(defaultMs);
+    });
+
+    it("falls back to the default on zero or negative rather than a degenerate session", () => {
+      // A prior draft clamped these to 1 minute via Math.max(1, …), which would
+      // have produced a near-unusable session from a typo'd env value.
+      expect(resolveSignInSessionTtlMs("0")).toBe(defaultMs);
+      expect(resolveSignInSessionTtlMs("-5")).toBe(defaultMs);
+    });
+  });
+
+  describe("setOAuthKeySessionCookie — cookie maxAge matches server-side expiry", () => {
+    it("uses the short key-entry default when no ttl is passed", () => {
+      const { req, res, cookies } = makeReqRes();
+      const token = setOAuthKeySessionCookie(req, res);
+
+      expect(cookies).toHaveLength(1);
+      expect(cookies[0]!.options.maxAge).toBe(15 * 60 * 1000);
+
+      // Server agrees: valid inside the window, expired past it.
+      const now = Date.now();
+      expect(oauthKeySessions.isValid(token, now + 5 * 60 * 1000)).toBe(true);
+      expect(oauthKeySessions.isValid(token, now + 16 * 60 * 1000)).toBe(false);
+    });
+
+    it("applies a sign-in ttl override to BOTH the cookie and the session", () => {
+      const ttlMs = 7 * 24 * 60 * 60 * 1000;
+      const { req, res, cookies } = makeReqRes();
+      const token = setOAuthKeySessionCookie(req, res, ttlMs);
+
+      // The invariant: cookie lifetime == server session lifetime.
+      expect(cookies[0]!.options.maxAge).toBe(ttlMs);
+
+      const now = Date.now();
+      // Far past the 15-minute gate default — this is the regression.
+      expect(oauthKeySessions.isValid(token, now + 60 * 60 * 1000)).toBe(true);
+      expect(oauthKeySessions.isValid(token, now + ttlMs - 1000)).toBe(true);
+      expect(oauthKeySessions.isValid(token, now + ttlMs + 1000)).toBe(false);
+    });
+
+    it("sets the cookie with hardening flags on an https request", () => {
+      const { req, res, cookies } = makeReqRes();
+      setOAuthKeySessionCookie(req, res, 60_000);
+      const opts = cookies[0]!.options;
+      expect(opts.httpOnly).toBe(true);
+      expect(opts.secure).toBe(true);
+      expect(opts.sameSite).toBe("lax");
+    });
+  });
+
+  describe("getGoogleVerifiedUserId — binding resolves only for a live session", () => {
+    const COOKIE = "neotoma_oauth_key_session";
+
+    it("resolves the bound user while the session is live", () => {
+      const { req, res } = makeReqRes();
+      const token = setOAuthKeySessionCookie(req, res, 60_000);
+      oauthKeySessions.bindUser(token, "user-live");
+
+      const { req: readReq } = makeReqRes(`${COOKIE}=${token}`);
+      expect(getGoogleVerifiedUserId(readReq)).toBe("user-live");
+    });
+
+    it("returns undefined when no session cookie is present", () => {
+      const { req } = makeReqRes();
+      expect(getGoogleVerifiedUserId(req)).toBeUndefined();
+    });
+
+    it("returns undefined for a token that was never issued", () => {
+      const { req } = makeReqRes(`${COOKIE}=never-issued-token`);
+      expect(getGoogleVerifiedUserId(req)).toBeUndefined();
+    });
+
+    it("does not resolve a user once the session has expired", () => {
+      const { req, res } = makeReqRes();
+      // 1ms session: expired by the time we read it back.
+      const token = setOAuthKeySessionCookie(req, res, 1);
+      oauthKeySessions.bindUser(token, "user-expired");
+      oauthKeySessions.cleanup(Date.now() + 1000);
+
+      const { req: readReq } = makeReqRes(`${COOKIE}=${token}`);
+      expect(getGoogleVerifiedUserId(readReq)).toBeUndefined();
+    });
+
+    it("keeps bindings separate across concurrent sessions", () => {
+      const a = setOAuthKeySessionCookie(makeReqRes().req, makeReqRes().res, 60_000);
+      const b = setOAuthKeySessionCookie(makeReqRes().req, makeReqRes().res, 60_000);
+      oauthKeySessions.bindUser(a, "user-a");
+      oauthKeySessions.bindUser(b, "user-b");
+
+      expect(getGoogleVerifiedUserId(makeReqRes(`${COOKIE}=${a}`).req)).toBe("user-a");
+      expect(getGoogleVerifiedUserId(makeReqRes(`${COOKIE}=${b}`).req)).toBe("user-b");
+    });
+
+    it("overwrites the binding when the same token is bound twice", () => {
+      const { req, res } = makeReqRes();
+      const token = setOAuthKeySessionCookie(req, res, 60_000);
+      oauthKeySessions.bindUser(token, "user-first");
+      oauthKeySessions.bindUser(token, "user-second");
+
+      expect(getGoogleVerifiedUserId(makeReqRes(`${COOKIE}=${token}`).req)).toBe("user-second");
+    });
+  });
+});


### PR DESCRIPTION
Closes #2005.

## Symptom

Google-signed-in users on a hosted instance are silently logged out and must re-authenticate.

Initially assumed to be the same cause as the MCP session drops fixed by #2002 (machine idling to zero). **It is not** — the affected machine is confirmed always-on (`autostop: False`) and sessions still cleared.

## Root cause

**1. Sign-in reused the key-entry gate's TTL.** `OAuthKeySessionStore` defaults to `15 * 60 * 1000`, a sensible lifetime for the brief window in which a user pastes a private key / mnemonic / bearer token. The Google sign-in path reuses the same store, inheriting a TTL chosen for a different purpose. The store already accepted `ttlMs` in its constructor — the call site (`actions.ts`) just never passed one.

**2. The verified-user map had no lifetime at all.** `googleVerifiedUserBySessionToken` was a module-level `Map<string,string>`: no TTL, no eviction, entries only ever added. On a long-lived always-on instance that grows unbounded, and an expired session could still resolve a bound user straight out of memory.

## Changes

- `setOAuthKeySessionCookie` takes an optional `ttlMs` covering **both** the server-side session and the cookie's `maxAge`, so the two cannot desync (the browser presenting a cookie the server has forgotten, or vice versa).
- `SIGN_IN_SESSION_TTL_MS` — default **7 days**, override with `NEOTOMA_SIGN_IN_SESSION_TTL_MIN` — passed **only** on the sign-in path. The key-entry gate keeps its 15-minute default; this deliberately does not widen it.
- The user binding moves into `OAuthKeySessionStore` (`bindUser` / `getBoundUser`) so it expires with its session and is evicted by the existing `cleanup()`. `bindUser` refuses expired/unknown tokens; `getBoundUser` re-checks validity rather than trusting the map.

## Testing

5 new cases, each **verified to fail against the prior implementation** and pass with the fix, per `fixed_means_behavior_verified_not_contract_accepted`:

```
× honors a per-session TTL override longer than the store default
× resolves a bound user while the session is live
× stops resolving the bound user once the session expires
× refuses to bind a user to an expired or unknown session
× evicts bound users during cleanup so the map cannot grow unbounded
```

10/10 pass with the fix. Typecheck clean. Deterministic clocks — no wall-time sleeps.

## Note on restart behavior

Sessions remain **in-process**, so a redeploy still signs everyone out. That's unchanged here and defensible for a single-machine deploy, but #2005 flags it as worth an explicit decision rather than an implicit one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)