### PR TITLE
fix(deploy): drop the stale app name from fly.toml so --app is required

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -1,9 +1,26 @@
-# fly.toml app configuration file generated for neotoma on 2025-10-30T11:26:06+01:00
+# Default Fly config for a Neotoma deployment.
 #
-# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+# See https://fly.io/docs/reference/configuration/ for how to use this file.
 #
+# NO `app` FIELD ON PURPOSE — always pass `--app <name>`.
+#
+# This file previously declared `app = 'neotoma-sandbox'`, which was wrong and
+# actively harmful: the public sandbox deploys from fly.sandbox.toml (its own
+# build args, env, and volume), and no automated workflow uses this file at all.
+# The stale name only ever mis-targeted MANUAL deploys — a `flyctl deploy` run
+# in the repo to ship some other instance would silently retarget the sandbox
+# and succeed, giving no signal that the wrong app had been updated.
+#
+# Omitting `app` converts that silent mis-target into an explicit failure:
+#   $ flyctl deploy -c fly.toml
+#   Error: the config for your app is missing an app name, add an app field to
+#          the fly.toml file or specify with the -a flag
+#
+# Per-instance values (app name, region, secrets) belong with the instance, not
+# in this shared file — see docs/infrastructure/client_instance_deployment.md.
+# `primary_region` below is only a default for new apps; existing apps keep
+# whatever region their machines already run in.
 
-app = 'neotoma-sandbox'
 primary_region = 'lhr'
 
 [build]


### PR DESCRIPTION
## What

Removes `app = 'neotoma-sandbox'` from `fly.toml`, so `flyctl deploy` requires an explicit `--app`.

## Why

That declaration was **wrong**, and wrong in a way that fails silently.

- The public sandbox does **not** deploy from `fly.toml` — it uses `fly.sandbox.toml`, which is self-contained (own build args, env, `persistent_sandbox` volume).
- **No automated workflow references `fly.toml`.** Verified: every `flyctl deploy` invocation in the repo already passes `--app` or `-c`.

So the stale name only ever affected **manual** deploys — and it made the worst case succeed. A `flyctl deploy` run in the repo intending some other instance would silently retarget the sandbox and report success, with no signal the wrong app had been updated.

This is the last remaining footgun in the per-client deploy path; `docs/infrastructure/client_instance_deployment.md` rule 1 exists solely to warn about it.

## After

The silent mis-target becomes an explicit failure:

```
$ flyctl deploy -c fly.toml
Error: the config for your app is missing an app name, add an app field to the fly.toml file or specify with the -a flag
```

## Verification

- `flyctl config validate -c fly.toml --app <name>` → **valid**
- `flyctl config validate -c fly.toml` (no app) → **rejected**, as intended
- `flyctl config validate -c fly.sandbox.toml` → **valid**, unaffected
- Repo-wide grep confirms no deploy invocation relied on the implicit app name

Config + comments only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)