### PR TITLE
ci(review): arm native auto-merge when the swarm approves a PR

### DIFF
--- a/.github/workflows/claude_pr_review.yml
+++ b/.github/workflows/claude_pr_review.yml
@@ -3,7 +3,7 @@ name: Claude PR Review
 # DISABLED for automatic PR review (2026-06-24).
 #
 # PR review is now owned by the Ateles swarm review panel (Anthus-dispatched
-# gates: pm/Pavo, ux/Accipiter, arch/Bombycilla, qa/Phoenicurus,
+# gates: pm/Pavo, ux/Accipiter, arch/Waxwing, qa/Phoenicurus,
 # pr_review/Vanellus, legal/Buteo), governed by the neotoma|feature
 # workflow_definition and the `code_review` agent_policy "Swarm PR review: full
 # diff + role-based depth". The swarm reviews every PR in depth by role against
@@ -150,6 +150,22 @@ jobs:
             after the blocking findings were fixed. The non-blocking notes still ship in the
             review body. (Only a true NEEDS-CHANGES verdict — i.e. at least one BLOCKING
             finding — may request changes.)
+
+            Auto-merge on approval: immediately after submitting an APPROVED or
+            APPROVED-WITH-NOTES review (the `--approve` cases ONLY — never after
+            NEEDS-CHANGES), arm GitHub native auto-merge so the PR merges itself once
+            all required gates pass, without a human step:
+              `gh pr merge <PR> --auto --squash`
+            `--auto` only ARMS auto-merge; it does not merge immediately. GitHub still
+            holds the merge until `main`'s branch protection is satisfied — the required
+            approving review (this very review) AND the required status checks
+            (security_gates, graph_render_smoke) all green. So a PR can only auto-merge
+            when the swarm has actually approved the current head and CI is clean; a
+            later `--request-changes` (or a new push that leaves checks pending) keeps it
+            un-merged. If `gh pr merge --auto` errors because auto-merge is disabled on
+            the repo or the PR is already merged/closed, log it and continue — do not
+            fail the review over it. Never pass `--admin` and never merge directly here;
+            arming auto-merge is the only merge action this workflow takes.
             Resolve `<PR>` as `${{ github.event.pull_request.number || github.event.issue.number }}`.
             Include the line `Reviewed commit: <full head SHA>` (from `gh pr view --json headRefOid`)
             at the top of the body, so a later force-push makes it plainly visible that the


### PR DESCRIPTION
Makes ready PRs merge automatically, gated by the swarm's own approval — no human merge step.

## What
After the review workflow submits an **APPROVED / APPROVED-WITH-NOTES** review (the `--approve` cases only, never NEEDS-CHANGES), it now also runs `gh pr merge <PR> --auto --squash`.

`--auto` **arms** native auto-merge; it does not merge immediately. GitHub holds the merge until `main`'s branch protection is satisfied.

## Repo settings applied out-of-band (recorded here)
1. `allow_auto_merge` enabled on the repo.
2. `main` branch protection now requires **1 approving review** —
   - `dismiss_stale_reviews: false` so a swarm fix-round push doesn't dismiss its own approval (which would loop forever);
   - `enforce_admins: false` so an admin can still merge manually when needed.

## Net effect
GitHub itself now enforces **"merge only on swarm approval + green required checks."** The swarm's `gh pr review --approve` is the approving review; `security_gates` + `graph_render_smoke` are the required checks. A `--request-changes`, or a new push that leaves checks pending, keeps the PR un-merged.

## Safety
- The workflow **never merges directly** and never uses `--admin`; arming auto-merge is its only merge action.
- `gh pr merge --auto` errors (auto-merge disabled, PR already closed) are logged, not fatal.
- Because the gate is a real GitHub required review, the swarm cannot merge anything it hasn't formally approved on the current head.

## Dogfood
This very PR is subject to the new gate — it will auto-merge once the swarm approves it. #2020 already has auto-merge armed and is correctly held at `BLOCKED / REVIEW_REQUIRED` pending a formal approval on its head, demonstrating the gate works.