### PR TITLE
chore(manifest): regenerate stale capability_manifest.json

### DIFF
--- a/src/shared/capability_manifest.json
+++ b/src/shared/capability_manifest.json
@@ -126,6 +126,9 @@
     "publish_rendered_page": {
       "addedInVersion": "v0.16.0"
     },
+    "query_contacts_at_company": {
+      "addedInVersion": "v0.19.0"
+    },
     "register_schema": {
       "addedInVersion": "v0.4.3"
     },


### PR DESCRIPTION
## What

Regenerates `src/shared/capability_manifest.json` — a 3-line addition for `query_contacts_at_company` (added in v0.19.0) that was never committed when the tool landed.

## Why now

The **`baseline` CI lane is red on `main` itself** (not on any PR's diff): `validate:capability-manifest --check` exits 1 because the manifest is stale. This blocks the swarm's review pipeline for every open PR — the dispatcher routes each one to a CI-fix round that can't succeed, because the failure isn't in the PR.

Verified: `baseline` fails on unmodified `origin/main`; `npm run generate:capability-manifest` produces exactly the one missing entry and nothing else.

(The pre-existing `fix/test-catalog-stale-main` branch / closed PR #1804 is not a usable fix — it's diverged by -30k lines and deletes hundreds of files. This is the minimal correct regen instead.)

## Effect

No behavior change. Turns `baseline` green on main, unblocking CI (and therefore the swarm review gate) on the open PR queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)