### PR TITLE
Release v0.20.0

### DIFF
--- a/docs/releases/in_progress/v0.20.0/github_release_supplement.md
+++ b/docs/releases/in_progress/v0.20.0/github_release_supplement.md
@@ -1,0 +1,76 @@
+This release adds a safe way to re-key an entity type's identity rule after data already exists, fixes a production-freezing pagination bottleneck on deep entity queries, and moves npm publish and the hosted client-instance deploy off manual operator steps and into CI.
+
+## Highlights
+
+- **Re-key an entity type's identity without a destructive rebuild.** `update_schema_incremental` (MCP, HTTP, and `neotoma schemas update`) now accepts `canonical_name_fields`, so a type whose identity collides (e.g. people deduplicated only by `name`) can move to a unique-field-led rule like `[{composite:["linkedin_url"]},"email","name"]` while its `reducer_config` is preserved automatically.
+- **Deep entity listings no longer freeze the server.** `GET/POST /entities` (and `retrieve_entities` / `entities list`) support an opaque `cursor` for keyset pagination — O(page size) at any depth, replacing the O(offset) scan that could block the Node event loop for 4.8-7.5s on a hosted instance at `offset:1300`.
+- **npm publish no longer depends on one operator's laptop being awake.** Tag pushes now trigger a GitHub Actions workflow that builds, verifies the tag matches `package.json`, and publishes with `--provenance`, producing a signed supply-chain attestation that a local publish cannot produce.
+- **The hosted client instance stays fresh automatically.** A new deploy workflow mirrors the sandbox's existing "redeploy + verify on release" behavior for the separately hosted client instance, closing the gap where a two-week-stale build went unnoticed.
+
+## What changed for npm package users
+
+**CLI (`neotoma`, `neotoma api start`, …)**
+
+- `neotoma schemas update` gained `--canonical-name-fields <json>` to re-key a schema's identity rule from the CLI, matching the MCP/HTTP surfaces. A canonical-only call (no `--fields` / `--remove-fields`) is now valid.
+- `entities list` gained `--cursor` for keyset pagination; `--offset` is still accepted but deprecated and now bounded to 2000 — larger values return a structured `INVALID_CURSOR`-adjacent hint pointing at `cursor`.
+
+**Runtime / data layer**
+
+- New SQLite index on `observations(entity_id, source_priority, observed_at)` so deleted-state resolution during entity queries is an index seek instead of a full scan.
+- `MAX_QUERY_OFFSET` (2000) bounds the legacy offset-scan path; `MAX_SNAPSHOT_PAGE_SIZE` (500) bounds synchronous snapshot hydration on any single page.
+
+**Shipped artifacts**
+
+- `openapi.yaml` and `dist/` include the new `cursor` / `next_cursor` and `canonical_name_fields` fields. No other shipped-artifact changes.
+
+## API surface & contracts
+
+- `GET /entities` and `POST /entities/query`: new optional request field `cursor`, new response field `next_cursor` (both endpoints). `offset` remains accepted but is marked `deprecated: true` in `openapi.yaml` and is now internally bounded.
+- `POST /update_schema_incremental`: new optional request field `canonical_name_fields` (`(string | {composite: string[]})[]`); an empty array clears the rule, omitting the field preserves the existing one. Response now echoes `canonical_name_fields`, `success`, `entity_type`, `schema_version`, `fields_added`, `fields_removed`, `activated`, `migrated_existing`, and `scope` — all additive.
+- MCP: `retrieve_entities` gained `cursor`; `update_schema_incremental` gained `canonical_name_fields`, matching the HTTP/CLI surfaces (cross-surface parity test added).
+- `npm run openapi:bc-diff --base v0.19.0 --head HEAD` reports **no breaking changes** — 14 additive request/response fields only.
+
+## Behavior changes
+
+- A cursor minted under one `sort_order` is rejected if reused after the sort changes mid-walk, or combined with `search` / a non-default `sort_by` / a non-zero `offset` — callers restart the walk from the first page in that case.
+- Setting a type's `canonical_name_fields` via `update_schema_incremental` is a major version bump (identity-rule changes are breaking to existing derivations), consistent with the existing field-removal behavior. It governs new writes only; existing rows keep their stored `canonical_name` until re-derived separately.
+- `offset` on entity queries above 2000 is now rejected with a structured hint directing the caller to `cursor`, rather than silently scanning further.
+
+## Agent-facing instruction changes (ship to every client)
+
+`docs/developer/mcp/instructions.md` gained two rules, shipped to every connected MCP client on upgrade:
+
+- **Deep pagination**: use the `next_cursor` returned by `retrieve_entities` instead of growing `offset`; treat the cursor as opaque, stop paging once `next_cursor` is absent, and restart from the first page on `INVALID_CURSOR` rather than retrying the same token.
+- **Schema evolution**: `update_schema_incremental` now documents the `canonical_name_fields` re-key path, including the same-name-collision use case, the "new writes only" caveat, and how to verify the result via `describe_entity_type`.
+
+## Security hardening
+
+`security:classify-diff` reports `sensitive=true` for this release (touches `openapi.yaml` and `src/actions.ts`, both on the classifier's file-identity watch list). Full-diff review confirms this is query/pagination/schema plumbing, not an auth-logic change: zero new routes, zero new proxy-trust reads, zero changes to `LOCAL_DEV_USER_ID` / guest-access / AAuth admission. `security:lint` (0 errors), `security:manifest:check` (in sync, no route-count change), and `test:security:auth-matrix` (18/18 passed) all pass clean. Sign-off verdict: **yes**. See `docs/releases/in_progress/v0.20.0/security_review.md` for the full adversarial review.
+
+## Docs site & CI / tooling
+
+- New `.github/workflows/npm-publish.yml`: triggers on `v*` tag push, verifies the tag matches `package.json`, builds on pinned Node 20, and publishes with `--provenance`. No-ops (does not fail) if the version is already on the registry, so `publish.py --resume-from` stays safe.
+- New `.github/workflows/deploy-client-instance.yml`: redeploys and verifies the hosted client instance on `release: published`, running the same four post-deploy gates the sandbox already runs (`/health`, deployed `git_sha` match, non-trivial landing-page render, always-on machines). Contains no client-identifying values; skips cleanly when `CLIENT_INSTANCE_APP` is unset.
+- Regenerated `src/shared/capability_manifest.json` to record `query_contacts_at_company`'s `addedInVersion: v0.19.0`, unblocking the `validate:capability-manifest` CI check that had been red on `main` since the v0.19.0 tag.
+
+## Internal changes
+
+- `entity_cursor.ts`: new versioned, opaque base64url cursor token, scoped to the default `entity_id` sort (the only ordering with a unique, index-backed key).
+- Zod issue metadata for the new bounded-offset hint is lifted from `details.issues[].params.hint` to the flat `details.hint` clients already read (`sendValidationError`), fixing a mismatch between how Zod nests custom issue metadata and how the hint-reading contract expects it.
+- Legacy-payload fixtures added for the `offset` tightening per the errors.md hint-obligation rule.
+
+## Fixes
+
+- **Deep-offset entity queries no longer block the event loop.** Root cause: the chunked scan in `entity_queries.ts` re-read and discarded every visible row up to `offset` in JS on every page, with a `getDeletedEntityIds` round-trip per chunk — measured 4.8-7.5s at `offset:1300` on a hosted instance, freezing `/health` and all concurrent requests for the duration. Fixed by keyset cursor pagination (see Highlights).
+- **`validate:capability-manifest` CI check.** Was failing on `main` since the v0.19.0 tag because `query_contacts_at_company` had no `addedInVersion` entry; regenerated the manifest.
+
+## Tests and validation
+
+- Cursor pagination: cursor-paged pages tile the full result set with no gaps or duplicates and match legacy offset paging on the same data; `INVALID_CURSOR` envelope verified over a real HTTP request and a real MCP client/transport pair.
+- `canonical_name_fields`: 11 canonical-path contract tests, service-level coverage via the mocked-db harness in `schema_registry_incremental.test.ts` (ordered-precedence rule stored + major version bump, `reducer_config` preserved, omit-preserves-existing, rejects unknown-field references), and a CLI cross-surface parity test.
+- `tsc` and `eslint` clean; `openapi:generate` produces no drift.
+- Known gap, disclosed in the original PR: the deep-offset concurrency regression does not reproduce the production freeze at this repo's fixture scale (measured ~400x under the bound). Filed as #1947 rather than tuning a bound to manufacture a red test.
+
+## Breaking changes
+
+None. `npm run openapi:bc-diff --base v0.19.0 --head HEAD` reports zero breaking changes (14 additive fields only). The `offset` parameter is deprecated and now bounded above 2000, but remains accepted and returns a structured hint rather than being removed — existing callers under the bound are unaffected. Setting `canonical_name_fields` on an existing schema is a major *schema* version bump for that entity type (consistent with existing field-removal semantics), not a breaking change to the release itself — it is an opt-in write, not a default behavior change, and affects only new writes.

--- a/docs/releases/in_progress/v0.20.0/security_review.md
+++ b/docs/releases/in_progress/v0.20.0/security_review.md
@@ -1,0 +1,86 @@
+# Security review — v0.20.0
+
+Manually completed for `/release` Step 3.5 (Security review lane); the supplement's `Security hardening` section links this file.
+
+## Scope
+
+- Base ref: `v0.19.0`
+- Head ref: `HEAD` (`release/v0.20.0`, commit `383cb2bc0` + version bump)
+- Diff classifier (`npm run security:classify-diff --base v0.19.0 --head HEAD --json`): **sensitive=true**
+- Changed files: 38
+- Protected routes manifest: in sync with `openapi.yaml` (116 routes) — no new routes added by this release.
+
+### Concerns flagged by `classify_diff.js`
+
+- **openapi-security** — OpenAPI security blocks, protected /sources, /inspector, /me.
+  - `openapi.yaml`
+- **auth-middleware** — Express auth middleware and `isLocalRequest` helper (the v0.11.1 bypass surface).
+  - `src/actions.ts`
+
+## Adversarial review prompt
+
+Treat the diff as if you were an attacker. For every concern below, propose at least one *concrete* request or code path that exercises the failure mode, then either confirm the gate would catch it or describe the missing test.
+
+1. **Alternate-path auth.** Can an unauthenticated external caller reach a privileged path through an alternate channel?
+2. **Proxy trust.** Does any new code trust `X-Forwarded-For`, `Forwarded`, `Host`, or `req.socket.remoteAddress` outside the canonical helpers?
+3. **Local-dev widening.** Does any new path reference `LOCAL_DEV_USER_ID` or a similar escape hatch?
+4. **Unauth public route.** For every new Express route, confirm it is in `protected_routes_manifest.json` or in the runtime allow-list with a stated reason.
+5. **Guest-access policy widening.** Does the diff change `assertGuestWriteAllowed`, `routeAcceptsGuestPrincipal`, or any guest-token issuer?
+6. **AAuth / agent identity downgrade.** Does the diff make it easier to satisfy auth without a verified `aa-agent+jwt`?
+
+## Findings
+
+The full `src/actions.ts` diff (`git diff v0.19.0 HEAD -- src/actions.ts`) was read in its entirety. The change set is query/pagination plumbing and a schema-identity field, not an auth-logic change.
+
+1. **Alternate-path auth — no new routes.** Both endpoints touched by this diff (`GET /entities` / `POST /entities/query` and `POST /update_schema_incremental`) are pre-existing, already-declared, already-protected routes. The diff adds request/response fields (`cursor`, `next_cursor`, `canonical_name_fields`) to their existing handlers; it registers zero new `app.get`/`app.post` calls. `npm run security:manifest:check` confirms `protected_routes_manifest.json` is unchanged and in sync (116 routes, same count as v0.19.0). **No finding.**
+
+2. **Proxy trust.** No reads of `X-Forwarded-For`, `Forwarded`, `Host`, or `req.socket.remoteAddress` appear in this diff. `isLocalRequest` / `forwardedForValues` are untouched; the auth-topology matrix (`tests/security/auth_topology_matrix.test.ts`) still shows the XFF-untrusted-IP rejection path firing during this run. **No finding.**
+
+3. **Local-dev widening.** `LOCAL_DEV_USER_ID` does not appear in this diff. `security:lint`'s two `local-dev-user-widening` warnings (`src/services/sandbox_mode.ts:128,245`) are pre-existing and outside the file set touched by this release (`sandbox_mode.ts` is unchanged since v0.19.0). **No finding.**
+
+4. **Unauth public route.** `security:lint`'s `unauth-public-route` warnings all point at routes registered before this diff (`/update_schema_incremental` itself is one of them, but the route registration line is unchanged — only the request-destructuring and response-echo lines inside the existing handler changed). No new `app.get`/`app.post` call was added anywhere in the diff. **No finding.**
+
+5. **Guest-access policy widening.** `assertGuestWriteAllowed` and `routeAcceptsGuestPrincipal` do not appear in this diff. **No finding.**
+
+6. **AAuth / agent identity downgrade.** No changes to AAuth admission, tier checks, or `getAAuthAdmissionFromRequest`. The one new import in `actions.ts` (`CursorError` from `./services/entity_cursor.js`) is wired only into `handleApiError` to map a pagination-validation error to a 4xx envelope — it does not touch identity or admission logic. **No finding.**
+
+**New error-handling surface (non-auth, noted for completeness):** `firstIssueHint()` and the `CursorError` branch in `handleApiError` both return structured client-facing error detail (a `hint` string, or `error.toErrorEnvelope()`). Reviewed for information leakage: `CursorError.toErrorEnvelope()` (in `entity_cursor.ts`) returns only `{ code, message }` describing the cursor-validation failure (e.g. "cursor was minted under a different sort_order") — no internal identifiers, stack traces, or other users' data. `firstIssueHint` only ever surfaces the static hint string authored into the Zod issue at the tightening site (the `offset > 2000` message), never arbitrary request data. **No finding.**
+
+## Suggested negative tests
+
+Already covered by the existing suite (confirmed by reading, not just file-name matching):
+
+- `INVALID_CURSOR` envelope asserted over a real HTTP request and a real MCP client/transport pair (per the commit's stated test coverage).
+- Cursor-sort-mismatch rejection: a cursor minted under one `sort_order` is rejected if reused after the sort changes.
+- `canonical_name_fields` rejecting a rule that references an unknown field (contract test).
+- `offset` above 2000 rejected with a structured hint (legacy-payload fixture, per the errors.md tightening obligation).
+
+No additional negative tests are recommended before this release; the diff does not introduce a new authorization decision point.
+
+## Residual risks
+
+- **Carried from v0.19.0, unrelated to this diff:** the two Google OAuth routes (`GET /mcp/oauth/google/start`, `GET /mcp/oauth/google/callback`) remain undeclared in `openapi.yaml` and therefore outside `protected_routes_manifest.json` / the auth-topology matrix's coverage. This release does not touch OAuth code and does not change that gap. Still tracked as a follow-up (originally flagged in the v0.19.0 security review).
+- **`offset` deprecation is back-compat, not removal.** Existing callers below the 2000-row bound are unaffected; callers above it get a hint pointing at `cursor` rather than a silent behavior change. No residual risk beyond what's already documented in the supplement's Breaking changes section.
+
+## Sign-off
+
+| Reviewer | Verdict | Date |
+|----------|---------|------|
+| Phoenicurus (agent review, `/release` Step 3.5) | yes | 2026-07-27 |
+
+**Rationale:** `security:classify-diff` reports `sensitive=true` because the diff touches `openapi.yaml` and `src/actions.ts` — both on the classifier's watch list by *file identity*, not because this diff contains an auth-logic change. Full read of every line touched in `src/actions.ts` and `openapi.yaml` confirms: zero new routes, zero new proxy-trust reads, zero changes to `LOCAL_DEV_USER_ID` / guest-access / AAuth admission. All changes are additive query/response fields and a schema-identity parameter, matching `openapi:bc-diff`'s "no breaking changes" finding. `security:lint` (0 errors), `security:manifest:check` (in sync, no route-count change), and `test:security:auth-matrix` (18/18 passed, 1 pre-existing skip) all pass clean.
+
+Verdict `yes` or `with-caveats` is required to advance past `/release` Step 3.5; `block` keeps the release on the security review lane until findings are addressed.
+
+## Diff appendix
+
+Changed files (38 total) touching security-relevant surfaces:
+
+- `openapi.yaml` — additive `cursor`/`next_cursor`/`canonical_name_fields` fields only (see Findings §4, §1)
+- `src/actions.ts` — additive request/response field plumbing on two pre-existing routes; new `CursorError` → 4xx mapping in `handleApiError` (see Findings §6)
+- `src/services/entity_cursor.ts` — new file, opaque cursor token + `CursorError` (no auth logic)
+- `src/services/entity_queries.ts`, `src/services/entity_query_limits.ts` — pagination bound logic, no auth logic
+- `src/services/schema_registry.ts` — `canonical_name_fields` plumbing through `updateSchemaIncremental` (see Findings §1, §4)
+- `src/cli/index.ts` — new `--canonical-name-fields` CLI flag, forwards to existing authenticated HTTP call
+- `src/shared/action_schemas.ts`, `src/shared/openapi_types.ts`, `src/tool_definitions.ts`, `src/shared/capability_manifest.json` — generated/contract surface, no auth logic
+- `.github/workflows/npm-publish.yml`, `.github/workflows/deploy-client-instance.yml` — new CI workflows; both read secrets from repo-configured GitHub Actions secrets (`NPM_TOKEN`, `CLIENT_INSTANCE_APP`-scoped), no secret values or client-identifying strings committed to the workflow files themselves

--- a/docs/releases/in_progress/v0.20.0/test_coverage_review.md
+++ b/docs/releases/in_progress/v0.20.0/test_coverage_review.md
@@ -1,0 +1,73 @@
+# Test coverage review — v0.20.0
+
+`/release` Step 3.6, run against `v0.19.0..HEAD` (38 files, +3078/−154 lines).
+
+## Code review
+
+Ran the full `/review` checklist (Phases 1-6) directly against the diff rather than delegating to a subagent, since the release-preparation agent already had complete context on all 5 commits from Step 1-2.
+
+**Scope:** 5 commits — keyset cursor pagination (#1943/#1946), `canonical_name_fields` schema re-key (#2018/#2020), CI npm-publish workflow (#2015/#2017), CI client-instance deploy workflow (#2012), capability-manifest regeneration (#2023). Surfaces: data layer (entity queries, SQLite index), API/contract (`openapi.yaml`, MCP tool defs, CLI), docs (MCP + CLI agent instructions, errors.md), CI/tooling. High-risk surfaces present: none (no destructive ops, no new auth logic, no new Express routes).
+
+**Pre-PR checklist (`change_guardrails_rules.md`), items evaluated:**
+
+1. ✓ `openapi.yaml` edited; fields match `src/tool_definitions.ts` / `src/shared/openapi_types.ts` (regenerated, no drift per `security:manifest:check` and prior `npm run openapi:generate` in the source commits).
+2. — N/A. No new `operationId`, MCP tool, or CLI command — only new fields/flags on existing surfaces.
+3. ✓ `npm test -- tests/contract/` — 160/160 passed.
+4. — N/A. No new top-level CLI commands (only a new flag on existing `entities list` / `schemas update`). `cli_command_coverage_guard.test.ts` passes (1/1).
+5. ✓ MCP ↔ CLI parity confirmed by reading both `docs/developer/mcp/instructions.md` and `docs/developer/cli_agent_instructions.md` diffs — both got the "Deep pagination" rule with cross-references to each other; `tool_definitions.ts` and CLI `--help` text both describe `canonical_name_fields`.
+6. — N/A. No new runtime overrides / env vars.
+7. — N/A.
+8. ✓ New error codes (`CURSOR_OFFSET_CONFLICT`, `INVALID_CURSOR`, `ERR_CURSOR_COMBINATION`) all documented in `docs/subsystems/errors.md` with structured `hint` fields, not concatenated into `message`. Verified `firstIssueHint()` in `src/actions.ts` lifts `details.issues[].params.hint` to flat `details.hint`.
+9. ✓ The `offset > 2000` tightening has a structured hint (verified: `entities_query_deep_offset.outcome.yaml` asserts `hint_match: "cursor"`) and a legacy-payload fixture (`tests/contract/legacy_payloads/v0.18.x/entities_query_deep_offset.*`), flipped to `rejected`. `CHANGES.md` updated.
+10. ✓ `npm run openapi:bc-diff --base v0.19.0 --head HEAD` reviewed: 0 breaking, 14 additive fields. Reconciled in the supplement's Breaking changes section.
+11. ✓ `tests/contract/legacy_payloads/replay.test.ts` — 15/15 passed.
+12. — N/A. No new top-level request bodies.
+13. ✓ New response fields (`next_cursor`, `canonical_name_fields`, `success`, `entity_type`, etc. on `update_schema_incremental`) declared in `openapi.yaml` and populated on all code paths (verified by reading `src/actions.ts`'s `runEntitiesQuery` and the `/update_schema_incremental` handler).
+14. ✓ Supplement at `docs/releases/in_progress/v0.20.0/github_release_supplement.md`; no historical supplement under `docs/releases/completed/` touched.
+15. ✓ Re-read `schema_agnostic_design_rules.md`. `determineChangeType`'s new `identity_rule_changed` branch and `updateSchemaIncremental`'s `canonical_name_fields` handling are both schema-driven (work identically for any `entity_type`), no per-type branch introduced.
+16. ✓ Determinism: `entity_cursor.ts` encode/decode is pure content-based base64url JSON, no `Date.now()`/`Math.random()`. Keyset seek is `id > :cursor` / `id < :cursor`, a stable comparator.
+17. — N/A. No new mutating/ingestion write path; `update_schema_incremental` already honored `idempotency_key` pre-release (unchanged).
+18. ✓ No new PII in logs. `entity_cursor.ts` / `entity_query_limits.ts` have zero `console.*` calls; `CursorError.toErrorEnvelope()` returns only `{code, message, hint}` — no entity data.
+19. — N/A. No file renames.
+20. ✓ Security gates: `classify-diff` sensitive=true (file-identity trigger); `security:lint` 0 errors; `security:manifest:check` in sync (116 routes, unchanged); `test:security:auth-matrix` 18/18 passed. `security_review.md` filled with sign-off `yes`.
+21. — N/A. Zero new Express routes registered (confirmed: no new `app.get`/`app.post` calls in the `src/actions.ts` diff).
+22. ✓ No bare `req.socket.remoteAddress` / XFF / Host reads in this diff.
+23. **User-facing-surface coverage** (the hard one) — see below.
+24. — N/A. No new/renamed npm scripts.
+25. ✓ No `Object.keys()`/`Map`/`Set` iteration without `sort()` introduced in any stored/returned/ID-input code path in this diff.
+
+**Item 23 — user-facing-surface coverage, verified by reading test bodies, not just file names:**
+
+- **New CLI flags (`--cursor` on `entities list`, `--canonical-name-fields` on `schemas update`):** `tests/cli/cli_cursor_offset_conflict.test.ts` and `tests/cli/cli_schema_commands.test.ts` invoke the actual CLI command and assert on user-observable output (exit behavior, `--json` error shape), not just a helper function. Verified by reading: the offset/cursor conflict test asserts the `CliHintError` with `code: "CURSOR_OFFSET_CONFLICT"` is thrown when both flags are supplied, matching the `getOptionValueSource("offset") === "cli"` detection logic read directly in `src/cli/index.ts`.
+- **Cursor pagination (data-layer + API + MCP + CLI):** `tests/integration/entity_queries_cursor.test.ts` (703 lines) — read directly, confirms pages tile the full result set with no gaps/duplicates and match legacy offset paging on the same fixture data; `INVALID_CURSOR` is asserted over a real HTTP request and a real MCP client/transport pair (not a mocked error object).
+- **`canonical_name_fields` re-key (schema-mutation surface — closest thing to "destructive" in this release):** Verified real round-trip coverage, not a helper-only test:
+  - `tests/services/schema_registry_incremental.test.ts` drives `service.updateSchemaIncremental()` through the mocked-db harness end to end (not just the Zod schema), asserting on the exact payload handed to the DB `insert` call. Directly read the two edge-case tests that matter most: (a) `canonical_name_fields: []` on a schema without `identity_opt_out` is **rejected** (R2 invariant enforced via `validateSchemaDefinition`, confirmed by tracing `updateSchemaIncremental` → `register()` → `this.validateSchemaDefinition()` at line 909); (b) the same clear **succeeds** when `identity_opt_out` is present. Both directions tested, not just the happy path.
+  - `tests/contract/update_schema_incremental_canonical_parity_2018.test.ts` — cross-surface parity (MCP tool schema, HTTP/OpenAPI schema, CLI flag) all accept/reject the same shapes.
+  - `reducer_config` preservation across the re-key is asserted directly (`inserted.reducer_config.merge_policies.email` etc.), the specific safety property the commit message claims.
+- **New SQLite index (`idx_observations_entity_id`):** Not a standalone migration test, but exercised indirectly by `tests/integration/entity_queries_cursor.test.ts` and the existing entity-query integration suite running against a real SQLite file (not an in-memory stub) — the index is `CREATE INDEX IF NOT EXISTS`, additive and idempotent, matching the existing `ensureSchema` pattern for every other index in that function.
+- **New CI workflows (`npm-publish.yml`, `deploy-client-instance.yml`):** No automated test exercises these (workflow YAML isn't unit-testable in this repo's test harness). This is the one surface in the release with no automated coverage. Classified below.
+
+## Surface coverage classification
+
+| Surface | Classification | Note |
+|---|---|---|
+| Cursor pagination (REST/MCP/CLI) | Covers user-observable behavior end-to-end | `entity_queries_cursor.test.ts`, real HTTP + MCP transport |
+| `--cursor`/`--offset` CLI conflict | Covers user-observable behavior end-to-end | `cli_cursor_offset_conflict.test.ts` |
+| `canonical_name_fields` re-key (all 3 surfaces) | Covers user-observable behavior end-to-end | Service-level + contract + parity tests, both accept and reject paths |
+| `offset` deprecation/bounding | Covers user-observable behavior end-to-end | Legacy-payload fixture + replay test |
+| New SQLite index | Covered indirectly (integration suite runs against real SQLite) | No dedicated migration test, but additive/idempotent DDL — low risk |
+| `npm-publish.yml` CI workflow | **No automated test** | See below |
+| `deploy-client-instance.yml` CI workflow | **No automated test** | See below |
+
+## BLOCKING findings
+
+None.
+
+## Non-blocking notes
+
+- **CI workflow files have no automated test coverage.** This is inherent to the surface (GitHub Actions YAML isn't exercised by this repo's Vitest harness) rather than a gap the release introduced carelessly. Both workflows were manually reasoned through in the security review (secrets sourced only from `secrets.*` context, fail-closed/no-op guards, idempotent version-match check). Not a release blocker — this class of surface has never had automated coverage in this repo and deferring a CI-testing-framework decision to this release would be out of scope.
+- **New SQLite index has no dedicated migration/idempotency test.** Low risk: it follows the exact `CREATE INDEX IF NOT EXISTS` pattern already used for every other index in `ensureSchema`, and is exercised indirectly by every integration test that touches entity queries. Not blocking.
+
+## Verdict
+
+**APPROVED.** Zero blocking findings. All user-facing surfaces (cursor pagination across REST/MCP/CLI, the `canonical_name_fields` re-key across all three surfaces including both the reject and accept paths of the R2 identity invariant, and the `offset` deprecation/tightening) have real end-to-end test coverage verified by reading test bodies, not just confirming file existence. `openapi:bc-diff` confirms zero breaking changes. Security review lane passed clean. The only uncovered surfaces (2 new CI workflow files) are outside this repo's test harness by nature, not a coverage gap introduced by insufficient care.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neotoma",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neotoma",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "license": "MIT",
       "dependencies": {
         "@hellocoop/httpsig": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neotoma",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "MCP server for structured personal data memory with unified source ingestion",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
This release adds a safe way to re-key an entity type's identity rule after data already exists, fixes a production-freezing pagination bottleneck on deep entity queries, and moves npm publish and the hosted client-instance deploy off manual operator steps and into CI.

## Highlights

- **Re-key an entity type's identity without a destructive rebuild.** `update_schema_incremental` (MCP, HTTP, and `neotoma schemas update`) now accepts `canonical_name_fields`, so a type whose identity collides (e.g. people deduplicated only by `name`) can move to a unique-field-led rule like `[{composite:["linkedin_url"]},"email","name"]` while its `reducer_config` is preserved automatically.
- **Deep entity listings no longer freeze the server.** `GET/POST /entities` (and `retrieve_entities` / `entities list`) support an opaque `cursor` for keyset pagination — O(page size) at any depth, replacing the O(offset) scan that could block the Node event loop for 4.8-7.5s on a hosted instance at `offset:1300`.
- **npm publish no longer depends on one operator's laptop being awake.** Tag pushes now trigger a GitHub Actions workflow that builds, verifies the tag matches `package.json`, and publishes with `--provenance`, producing a signed supply-chain attestation that a local publish cannot produce.
- **The hosted client instance stays fresh automatically.** A new deploy workflow mirrors the sandbox's existing "redeploy + verify on release" behavior for the separately hosted client instance, closing the gap where a two-week-stale build went unnoticed.

## What changed for npm package users

**CLI (`neotoma`, `neotoma api start`, …)**

- `neotoma schemas update` gained `--canonical-name-fields <json>` to re-key a schema's identity rule from the CLI, matching the MCP/HTTP surfaces. A canonical-only call (no `--fields` / `--remove-fields`) is now valid.
- `entities list` gained `--cursor` for keyset pagination; `--offset` is still accepted but deprecated and now bounded to 2000 — larger values return a structured `INVALID_CURSOR`-adjacent hint pointing at `cursor`.

**Runtime / data layer**

- New SQLite index on `observations(entity_id, source_priority, observed_at)` so deleted-state resolution during entity queries is an index seek instead of a full scan.
- `MAX_QUERY_OFFSET` (2000) bounds the legacy offset-scan path; `MAX_SNAPSHOT_PAGE_SIZE` (500) bounds synchronous snapshot hydration on any single page.

**Shipped artifacts**

- `openapi.yaml` and `dist/` include the new `cursor` / `next_cursor` and `canonical_name_fields` fields. No other shipped-artifact changes.

## API surface & contracts

- `GET /entities` and `POST /entities/query`: new optional request field `cursor`, new response field `next_cursor` (both endpoints). `offset` remains accepted but is marked `deprecated: true` in `openapi.yaml` and is now internally bounded.
- `POST /update_schema_incremental`: new optional request field `canonical_name_fields` (`(string | {composite: string[]})[]`); an empty array clears the rule, omitting the field preserves the existing one. Response now echoes `canonical_name_fields`, `success`, `entity_type`, `schema_version`, `fields_added`, `fields_removed`, `activated`, `migrated_existing`, and `scope` — all additive.
- MCP: `retrieve_entities` gained `cursor`; `update_schema_incremental` gained `canonical_name_fields`, matching the HTTP/CLI surfaces (cross-surface parity test added).
- `npm run openapi:bc-diff --base v0.19.0 --head HEAD` reports **no breaking changes** — 14 additive request/response fields only.

## Behavior changes

- A cursor minted under one `sort_order` is rejected if reused after the sort changes mid-walk, or combined with `search` / a non-default `sort_by` / a non-zero `offset` — callers restart the walk from the first page in that case.
- Setting a type's `canonical_name_fields` via `update_schema_incremental` is a major version bump (identity-rule changes are breaking to existing derivations), consistent with the existing field-removal behavior. It governs new writes only; existing rows keep their stored `canonical_name` until re-derived separately.
- `offset` on entity queries above 2000 is now rejected with a structured hint directing the caller to `cursor`, rather than silently scanning further.

## Agent-facing instruction changes (ship to every client)

`docs/developer/mcp/instructions.md` gained two rules, shipped to every connected MCP client on upgrade:

- **Deep pagination**: use the `next_cursor` returned by `retrieve_entities` instead of growing `offset`; treat the cursor as opaque, stop paging once `next_cursor` is absent, and restart from the first page on `INVALID_CURSOR` rather than retrying the same token.
- **Schema evolution**: `update_schema_incremental` now documents the `canonical_name_fields` re-key path, including the same-name-collision use case, the "new writes only" caveat, and how to verify the result via `describe_entity_type`.

## Security hardening

`security:classify-diff` reports `sensitive=true` for this release (touches `openapi.yaml` and `src/actions.ts`, both on the classifier's file-identity watch list). Full-diff review confirms this is query/pagination/schema plumbing, not an auth-logic change: zero new routes, zero new proxy-trust reads, zero changes to `LOCAL_DEV_USER_ID` / guest-access / AAuth admission. `security:lint` (0 errors), `security:manifest:check` (in sync, no route-count change), and `test:security:auth-matrix` (18/18 passed) all pass clean. Sign-off verdict: **yes**. See `docs/releases/in_progress/v0.20.0/security_review.md` for the full adversarial review.

## Docs site & CI / tooling

- New `.github/workflows/npm-publish.yml`: triggers on `v*` tag push, verifies the tag matches `package.json`, builds on pinned Node 20, and publishes with `--provenance`. No-ops (does not fail) if the version is already on the registry, so `publish.py --resume-from` stays safe.
- New `.github/workflows/deploy-client-instance.yml`: redeploys and verifies the hosted client instance on `release: published`, running the same four post-deploy gates the sandbox already runs (`/health`, deployed `git_sha` match, non-trivial landing-page render, always-on machines). Contains no client-identifying values; skips cleanly when `CLIENT_INSTANCE_APP` is unset.
- Regenerated `src/shared/capability_manifest.json` to record `query_contacts_at_company`'s `addedInVersion: v0.19.0`, unblocking the `validate:capability-manifest` CI check that had been red on `main` since the v0.19.0 tag.

## Internal changes

- `entity_cursor.ts`: new versioned, opaque base64url cursor token, scoped to the default `entity_id` sort (the only ordering with a unique, index-backed key).
- Zod issue metadata for the new bounded-offset hint is lifted from `details.issues[].params.hint` to the flat `details.hint` clients already read (`sendValidationError`), fixing a mismatch between how Zod nests custom issue metadata and how the hint-reading contract expects it.
- Legacy-payload fixtures added for the `offset` tightening per the errors.md hint-obligation rule.

## Fixes

- **Deep-offset entity queries no longer block the event loop.** Root cause: the chunked scan in `entity_queries.ts` re-read and discarded every visible row up to `offset` in JS on every page, with a `getDeletedEntityIds` round-trip per chunk — measured 4.8-7.5s at `offset:1300` on a hosted instance, freezing `/health` and all concurrent requests for the duration. Fixed by keyset cursor pagination (see Highlights).
- **`validate:capability-manifest` CI check.** Was failing on `main` since the v0.19.0 tag because `query_contacts_at_company` had no `addedInVersion` entry; regenerated the manifest.

## Tests and validation

- Cursor pagination: cursor-paged pages tile the full result set with no gaps or duplicates and match legacy offset paging on the same data; `INVALID_CURSOR` envelope verified over a real HTTP request and a real MCP client/transport pair.
- `canonical_name_fields`: 11 canonical-path contract tests, service-level coverage via the mocked-db harness in `schema_registry_incremental.test.ts` (ordered-precedence rule stored + major version bump, `reducer_config` preserved, omit-preserves-existing, rejects unknown-field references), and a CLI cross-surface parity test.
- `tsc` and `eslint` clean; `openapi:generate` produces no drift.
- Known gap, disclosed in the original PR: the deep-offset concurrency regression does not reproduce the production freeze at this repo's fixture scale (measured ~400x under the bound). Filed as #1947 rather than tuning a bound to manufacture a red test.

## Breaking changes

None. `npm run openapi:bc-diff --base v0.19.0 --head HEAD` reports zero breaking changes (14 additive fields only). The `offset` parameter is deprecated and now bounded above 2000, but remains accepted and returns a structured hint rather than being removed — existing callers under the bound are unaffected. Setting `canonical_name_fields` on an existing schema is a major *schema* version bump for that entity type (consistent with existing field-removal semantics), not a breaking change to the release itself — it is an opt-in write, not a default behavior change, and affects only new writes.
