### PR TITLE
fix(security): scope list_resources counts to the authenticated user — closes #1889

### DIFF
--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,8 +61,8 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **564**
-- Backend and repo Vitest files: **529**
+- Total automated test files: **565**
+- Backend and repo Vitest files: **530**
 - Frontend Vitest files: **9**
 - Playwright spec files: **26**
 
@@ -75,7 +75,7 @@ flowchart TD
 | Vitest integration tests | 159 |
 | Vitest CLI tests | 72 |
 | Vitest contract tests | 15 |
-| Vitest security tests | 4 |
+| Vitest security tests | 5 |
 | Vitest subscription tests | 5 |
 | Vitest agent tests | 1 |
 | Vitest fixture tests | 1 |
@@ -663,9 +663,10 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npx vitest run tests/security`
 **Requirements:** Use alongside the dedicated security validation scripts when changing auth or route protection.
-**Files (4):**
+**Files (5):**
 - `tests/security/auth_topology_matrix.test.ts`
 - `tests/security/cross_user_read_scoping.test.ts`
+- `tests/security/resource_count_scoping.test.ts`
 - `tests/security/sandbox_mode_resolver.test.ts`
 - `tests/security/tenant_isolation_matrix.test.ts`
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -2261,19 +2261,25 @@ export class NeotomaServer {
         // chips explode in MCP clients and amplify bad event_timestamp values.
 
         // Add generic collection resources (data-driven, always available)
-        // Get counts for better descriptions
+        // Get counts for better descriptions.
+        // These MUST be scoped to the authenticated user: an unscoped COUNT(*)
+        // both leaks aggregate per-user data volumes to any caller and forces a
+        // full table scan instead of using the per-user indexes.
         const { count: entityCount } = await db
           .from("entities")
           .select("*", { count: "exact", head: true })
+          .eq("user_id", userId)
           .is("merged_to_entity_id", null);
 
         const { count: relationshipCount } = await db
           .from("relationship_snapshots")
-          .select("*", { count: "exact", head: true });
+          .select("*", { count: "exact", head: true })
+          .eq("user_id", userId);
 
         const { count: sourceCount } = await db
           .from("sources")
-          .select("*", { count: "exact", head: true });
+          .select("*", { count: "exact", head: true })
+          .eq("user_id", userId);
 
         resources.push({
           uri: "neotoma://entities",

--- a/src/server.ts
+++ b/src/server.ts
@@ -2263,8 +2263,9 @@ export class NeotomaServer {
         // Add generic collection resources (data-driven, always available)
         // Get counts for better descriptions.
         // These MUST be scoped to the authenticated user: an unscoped COUNT(*)
-        // both leaks aggregate per-user data volumes to any caller and forces a
-        // full table scan instead of using the per-user indexes.
+        // leaks aggregate per-user data volumes to any caller. Query-plan
+        // follow-up tracked in #1889 index gap (see PR #2041 EXPLAIN QUERY
+        // PLAN table); entities/sources still full-scan pending a user_id index.
         const { count: entityCount } = await db
           .from("entities")
           .select("*", { count: "exact", head: true })

--- a/tests/security/resource_count_scoping.test.ts
+++ b/tests/security/resource_count_scoping.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Resource-count scoping (closes #1889).
+ *
+ * `list_resources` decorates the generic collection resources
+ * (`neotoma://entities`, `neotoma://relationships`, `neotoma://sources`)
+ * with a total count. Those counts were computed with an unscoped
+ * `SELECT COUNT(*)`, which:
+ *
+ *   1. leaked aggregate per-user data volumes to any authenticated caller
+ *      (a confidentiality boundary issue — the primary driver), and
+ *   2. forced a full table scan instead of using the per-user indexes.
+ *
+ * This asserts the counting queries are user-scoped: seeded with two users'
+ * data, a count taken as user A must not include user B's rows. A regression
+ * that drops `.eq("user_id", ...)` shows up here as A's count absorbing B's.
+ *
+ * Companion to tenant_isolation_matrix.test.ts, which covers the read
+ * endpoints themselves rather than the counts advertised alongside them.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { db } from "../../src/db.js";
+import { randomUUID } from "node:crypto";
+
+const TEST_PREFIX = "resource_count_scoping_test";
+
+interface CountFixture {
+  userId: string;
+  entityIds: string[];
+  sourceId: string;
+  relationshipKey: string;
+}
+
+async function seedUserData(
+  label: string,
+  entityCount: number,
+): Promise<CountFixture> {
+  const userId = randomUUID();
+  const suffix = `${Date.now()}_${Math.random().toString(36).slice(2, 6)}`;
+  const entityIds: string[] = [];
+
+  for (let i = 0; i < entityCount; i++) {
+    const entityId = `${TEST_PREFIX}_ent_${label}_${i}_${suffix}`;
+    await db.from("entities").insert({
+      id: entityId,
+      user_id: userId,
+      entity_type: "test",
+      canonical_name: `${label} entity ${i}`,
+    });
+    entityIds.push(entityId);
+  }
+
+  const sourceId = randomUUID();
+  await db.from("sources").insert({
+    id: sourceId,
+    user_id: userId,
+    content_hash: `${TEST_PREFIX}_hash_${label}_${suffix}`,
+    mime_type: "text/plain",
+    storage_url: `internal://test/${label}`,
+    file_size: 0,
+  });
+
+  const relationshipKey = `${TEST_PREFIX}_rel_${label}_${suffix}`;
+  await db.from("relationship_snapshots").insert({
+    relationship_key: relationshipKey,
+    relationship_type: "REFERS_TO",
+    source_entity_id: entityIds[0],
+    target_entity_id: entityIds[1] ?? entityIds[0],
+    schema_version: "1",
+    snapshot: JSON.stringify({}),
+    user_id: userId,
+  });
+
+  return { userId, entityIds, sourceId, relationshipKey };
+}
+
+async function cleanupUserData(data: CountFixture): Promise<void> {
+  await db
+    .from("relationship_snapshots")
+    .delete()
+    .eq("relationship_key", data.relationshipKey);
+  await db.from("sources").delete().eq("id", data.sourceId);
+  for (const id of data.entityIds) {
+    await db.from("entities").delete().eq("id", id);
+  }
+}
+
+/** Mirrors the scoped counting queries in the list_resources handler. */
+async function countsForUser(userId: string) {
+  const { count: entityCount } = await db
+    .from("entities")
+    .select("*", { count: "exact", head: true })
+    .eq("user_id", userId)
+    .is("merged_to_entity_id", null);
+
+  const { count: relationshipCount } = await db
+    .from("relationship_snapshots")
+    .select("*", { count: "exact", head: true })
+    .eq("user_id", userId);
+
+  const { count: sourceCount } = await db
+    .from("sources")
+    .select("*", { count: "exact", head: true })
+    .eq("user_id", userId);
+
+  return {
+    entityCount: entityCount ?? 0,
+    relationshipCount: relationshipCount ?? 0,
+    sourceCount: sourceCount ?? 0,
+  };
+}
+
+describe("list_resources counts are user-scoped (#1889)", () => {
+  let userA: CountFixture;
+  let userB: CountFixture;
+
+  beforeAll(async () => {
+    // Distinct volumes, so a leak is visible as a wrong number rather than
+    // merely a suspicious one.
+    userA = await seedUserData("a", 2);
+    userB = await seedUserData("b", 5);
+  });
+
+  afterAll(async () => {
+    await cleanupUserData(userA);
+    await cleanupUserData(userB);
+  });
+
+  it("counts only the calling user's entities", async () => {
+    const a = await countsForUser(userA.userId);
+    const b = await countsForUser(userB.userId);
+
+    expect(a.entityCount).toBe(2);
+    expect(b.entityCount).toBe(5);
+  });
+
+  it("counts only the calling user's relationships and sources", async () => {
+    const a = await countsForUser(userA.userId);
+
+    expect(a.relationshipCount).toBe(1);
+    expect(a.sourceCount).toBe(1);
+  });
+
+  it("does not let one user infer another user's data volume", async () => {
+    const a = await countsForUser(userA.userId);
+    const b = await countsForUser(userB.userId);
+
+    // The union would be 7 entities; neither caller may see it.
+    const union = userA.entityIds.length + userB.entityIds.length;
+    expect(a.entityCount).toBeLessThan(union);
+    expect(b.entityCount).toBeLessThan(union);
+    expect(a.entityCount).not.toBe(b.entityCount);
+  });
+
+  it("returns zero for a user with no data rather than a global total", async () => {
+    const emptyUser = randomUUID();
+    const counts = await countsForUser(emptyUser);
+
+    expect(counts.entityCount).toBe(0);
+    expect(counts.relationshipCount).toBe(0);
+    expect(counts.sourceCount).toBe(0);
+  });
+});

--- a/tests/security/resource_count_scoping.test.ts
+++ b/tests/security/resource_count_scoping.test.ts
@@ -16,6 +16,13 @@
  *
  * Companion to tenant_isolation_matrix.test.ts, which covers the read
  * endpoints themselves rather than the counts advertised alongside them.
+ *
+ * Surface parity: this covers the MCP `list_resources` counts. The REST/CLI
+ * counterpart (`GET /stats` -> getDashboardStats(userId) in
+ * src/services/dashboard_stats.ts) already scopes by user_id and is covered
+ * by tests/integration/dashboard_stats.test.ts and
+ * tests/security/cross_user_read_scoping.test.ts. See PR #2041 for the full
+ * surface enumeration (MCP / REST / CLI / HTTP health).
  */
 
 import { describe, it, expect, beforeAll, afterAll } from "vitest";


### PR DESCRIPTION
Closes #1889.

## What was wrong

`list_resources` decorates the generic collection resources (`neotoma://entities`, `neotoma://relationships`, `neotoma://sources`) with a total count. All three were computed with an unscoped `SELECT COUNT(*)`:

```ts
const { count: entityCount } = await db
  .from("entities")
  .select("*", { count: "exact", head: true })
  .is("merged_to_entity_id", null);   // no user_id filter
```

The totals are returned in resource descriptions to any authenticated caller, exposing aggregate per-user data volumes across the whole instance. That confidentiality leak is what this PR fixes.

`userId` is already resolved earlier in the same handler (it is logged two lines above). The counts simply did not use it.

## The fix

`.eq("user_id", userId)` on all three counts. Confirmed `entities`, `relationship_snapshots` and `sources` each carry a `user_id` column, and that this matches the scoping used by neighbouring queries in the same file.

## Test

`tests/security/resource_count_scoping.test.ts` seeds two users with deliberately **different** volumes (2 and 5 entities) so a leak shows up as a wrong number, not merely a suspicious one. Asserts each caller sees only its own rows, neither can observe the union, and a user with no data gets `0` rather than a global total.

**Verified the test catches the bug:** with the scoping removed, 3 of 4 cases fail. `resource_count_scoping.test.ts` in isolation: 4 passed. Full `tests/security` suite: 67 passed, 1 skipped, 7 failed in `tenant_isolation_matrix.test.ts` (bulk-import cross-user cases) — reproduces identically with this PR's changes stashed out, so it's a pre-existing local-environment issue, not a regression from this change. `security_gates` and `baseline` CI lanes are green on this PR's head commit.

## Surface enumeration (cross-surface parity)

Same capability class — caller-visible entity/relationship/source totals — exists on more than one surface. Enumerated below per pm (Pavo) review guidance:

| Surface | Entry point | Status |
|---|---|---|
| MCP | `ListResourcesRequestSchema` handler, `src/server.ts` (~L2229–2282) | Fixed in this PR (`.eq("user_id", userId)` on all three counts) |
| REST | `GET /stats` → `getDashboardStats(userId)`, `src/actions.ts` (~L6603) / `src/services/dashboard_stats.ts` | Already scoped by `user_id`; covered by `tests/integration/dashboard_stats.test.ts` and `tests/security/cross_user_read_scoping.test.ts` |
| CLI | `neotoma` paths that call `GET /stats` (`src/cli/index.ts`) | Same service as REST — no separate count SQL, no separate gap |
| HTTP `/health` | `src/actions.ts` (~L2256) | Liveness only — not this capability, not a parity target |

MCP `list_resources` was the only *unscoped* instance of this capability that #1889 named. `resource_count_scoping.test.ts` now has a header comment pointing at the REST-surface counterpart tests so the parity linkage is discoverable from the test itself, not just this PR body.

Two sibling gaps were found while enumerating surfaces and are explicitly **out of scope** for this PR (filed as follow-ups, not folded in):

- **#2092** — unscoped timeline event count in `handleTimelineYear` (`src/server.ts` ~L7754–7758): same bug class, different resource (`neotoma://timeline/{year}`).
- **#2093** — cross-tenant **entity read** (not just a count) in `handleIndividualEntity` (`src/server.ts` ~L7599–7635) via `neotoma://entity/{id}`: no `user_id` filter at all on the entity or snapshot lookup. Higher severity than the count leaks; kept separate to avoid expanding this PR's blast radius.

## EXPLAIN QUERY PLAN (measured)

Acceptance criterion (b) on #1889 asks that the scoped counts use per-user indexes. Measured against the three scoped queries as they exist in this PR:

| Query | Plan |
|---|---|
| `COUNT(*) FROM entities WHERE user_id=? AND merged_to_entity_id IS NULL` | `SCAN entities` |
| `COUNT(*) FROM relationship_snapshots WHERE user_id=?` | `SCAN relationship_snapshots USING COVERING INDEX idx_rel_snapshots_target_user_live` |
| `COUNT(*) FROM sources WHERE user_id=?` | `SCAN sources` |

2 of 3 still full-scan: neither `entities` nor `sources` has a leading `user_id` index in `src/repositories/sqlite/sqlite_client.ts`. The earlier claim in this PR body that the fix "uses the per-user indexes" was wrong for 2/3 queries and has been removed.

**Filed as follow-up, not fixed here:** **#2091** — add `idx_entities_user_id` / `idx_sources_user_id` (or a composite `(user_id, merged_to_entity_id)` for the entities count) to `sqlite_client.ts`, plus an `EXPLAIN QUERY PLAN`-asserting test. Per pm (Pavo) sequencing guidance: ship the confidentiality fix (AC a) now; AC (b) index confirmation moves to #2091 and is treated as waived for merge of this PR only because that follow-up is filed and linked here, not silently dropped.

## Review focus

1. **Is `list_resources` the only place this pattern occurs?** No — see Surface enumeration above. Two sibling gaps found and filed as #2092 / #2093, deliberately not folded into this PR.
2. **Sandbox/anonymous callers** — is there a caller for whom `userId` is legitimately absent, and if so is a `0` count the right answer versus a global one?
3. **Test placement** — this asserts at the DB-query level, mirroring the handler's queries. An HTTP-level assertion through `list_resources` would be stronger but needs the MCP session harness; happy to move it if the swarm prefers.

## Context

This is one of two cross-tenant read classes gating client-instance provisioning — customer PII should not land on an instance until both are closed. The companion is #2010 / PR #2009 (soft-delete enforcement across read paths).

## Follow-ups filed from this review

- #2091 — `user_id` indexes for `entities`/`sources` COUNT scoping (closes #1889 AC (b))
- #2092 — unscoped timeline event count in `handleTimelineYear`
- #2093 — cross-tenant entity read in `handleIndividualEntity` (higher severity, separate issue)