### PR TITLE
fix(inspector): show entity name, not canonical_name, in list/search/board

### DIFF
--- a/frontend/src/utils/entity_display.test.ts
+++ b/frontend/src/utils/entity_display.test.ts
@@ -1,6 +1,6 @@
 /**
  * Entity Display Name Utility Tests
- * 
+ *
  * Tests deterministic display name generation across all entity types
  */
 
@@ -85,6 +85,78 @@ describe("getEntityDisplayName", () => {
     });
   });
 
+  describe("Person-like types lead with name, not title", () => {
+    // A contact's `title` is a job role/headline, not a display label. For
+    // people, name must win over title — otherwise the list shows "Chief
+    // Creative" instead of "Rani Sweis". Regression guard for the Bottega8
+    // leads graph, where canonical_name is an identity key (linkedin_url or
+    // "contact:<name>") that must never surface as the display label.
+    it("contact prefers name over title", () => {
+      const entity: EntityDisplayInput = {
+        entity_type: "contact",
+        canonical_name: "contact:https://www.linkedin.com/in/ranisweis",
+        snapshot: { name: "Rani Sweis", title: "Chief Creative" },
+      };
+      expect(getEntityDisplayName(entity)).toBe("Rani Sweis");
+    });
+
+    it("person prefers name over title", () => {
+      const entity: EntityDisplayInput = {
+        entity_type: "person",
+        canonical_name: "person:jane",
+        snapshot: { name: "Jane Roe", title: "VP Engineering" },
+      };
+      expect(getEntityDisplayName(entity)).toBe("Jane Roe");
+    });
+
+    it("lead prefers name over title", () => {
+      const entity: EntityDisplayInput = {
+        entity_type: "lead",
+        canonical_name: "lead:xyz",
+        snapshot: { name: "Sam Patel", title: "Founder & CEO" },
+      };
+      expect(getEntityDisplayName(entity)).toBe("Sam Patel");
+    });
+
+    it("contact falls back to title when name is absent", () => {
+      const entity: EntityDisplayInput = {
+        entity_type: "contact",
+        canonical_name: "contact:acme-role",
+        snapshot: { title: "Head of Sales" },
+      };
+      expect(getEntityDisplayName(entity)).toBe("Head of Sales");
+    });
+
+    it("contact never surfaces a URL-keyed canonical when a name exists", () => {
+      const entity: EntityDisplayInput = {
+        entity_type: "contact",
+        canonical_name: "contact:https://www.linkedin.com/in/diptishrivastav",
+        snapshot: { name: "Dipti Srivastava", title: "Senior Director" },
+      };
+      const label = getEntityDisplayName(entity);
+      expect(label).toBe("Dipti Srivastava");
+      expect(label).not.toContain("linkedin.com");
+    });
+
+    it("contact falls back to canonical only when name and title are both empty", () => {
+      const entity: EntityDisplayInput = {
+        entity_type: "contact",
+        canonical_name: "contact:fallback",
+        snapshot: {},
+      };
+      expect(getEntityDisplayName(entity)).toBe("contact:fallback");
+    });
+
+    it("non-person types still prefer title over name", () => {
+      const entity: EntityDisplayInput = {
+        entity_type: "task",
+        canonical_name: "task-123",
+        snapshot: { title: "Ship the fix", name: "task-name" },
+      };
+      expect(getEntityDisplayName(entity)).toBe("Ship the fix");
+    });
+  });
+
   describe("Priority 3: Type-specific fields", () => {
     it("uses invoice_number for invoice", () => {
       const entity: EntityDisplayInput = {
@@ -99,7 +171,7 @@ describe("getEntityDisplayName", () => {
       const entity: EntityDisplayInput = {
         entity_type: "receipt",
         canonical_name: "receipt-456",
-        snapshot: { merchant_name: "Whole Foods", amount_total: 45.50 },
+        snapshot: { merchant_name: "Whole Foods", amount_total: 45.5 },
       };
       expect(getEntityDisplayName(entity)).toBe("Whole Foods");
     });
@@ -135,7 +207,7 @@ describe("getEntityDisplayName", () => {
       const entity: EntityDisplayInput = {
         entity_type: "transaction",
         canonical_name: "transaction-ghi",
-        snapshot: { counterparty: "Grocery Store", amount: 45.50 },
+        snapshot: { counterparty: "Grocery Store", amount: 45.5 },
       };
       expect(getEntityDisplayName(entity)).toBe("Grocery Store");
     });
@@ -257,10 +329,10 @@ describe("getEntityDisplayName", () => {
       const entity: EntityDisplayInput = {
         entity_type: "invoice",
         canonical_name: "invoice-123",
-        snapshot: { 
+        snapshot: {
           name: "Invoice Name",
           invoice_number: "INV-001",
-          vendor_name: "Acme Corp"
+          vendor_name: "Acme Corp",
         },
       };
       expect(getEntityDisplayName(entity)).toBe("Invoice Name");
@@ -270,9 +342,9 @@ describe("getEntityDisplayName", () => {
       const entity: EntityDisplayInput = {
         entity_type: "invoice",
         canonical_name: "invoice-123",
-        snapshot: { 
+        snapshot: {
           invoice_number: "", // Empty first priority
-          vendor_name: "Acme Corp" 
+          vendor_name: "Acme Corp",
         },
       };
       expect(getEntityDisplayName(entity)).toBe("Acme Corp");
@@ -284,10 +356,10 @@ describe("getEntityDisplayName", () => {
       const entity: EntityDisplayInput = {
         entity_type: "email",
         canonical_name: "email-123",
-        snapshot: { 
+        snapshot: {
           subject: "Meeting Reminder",
           from: "boss@example.com",
-          body: "Don't forget..."
+          body: "Don't forget...",
         },
       };
       expect(getEntityDisplayName(entity)).toBe("Meeting Reminder");
@@ -297,10 +369,10 @@ describe("getEntityDisplayName", () => {
       const entity: EntityDisplayInput = {
         entity_type: "transaction",
         canonical_name: "transaction-123",
-        snapshot: { 
+        snapshot: {
           counterparty: "Coffee Shop",
-          amount: 5.50,
-          description: "Morning coffee"
+          amount: 5.5,
+          description: "Morning coffee",
         },
       };
       expect(getEntityDisplayName(entity)).toBe("Coffee Shop");
@@ -310,10 +382,10 @@ describe("getEntityDisplayName", () => {
       const entity: EntityDisplayInput = {
         entity_type: "holding",
         canonical_name: "holding-123",
-        snapshot: { 
+        snapshot: {
           asset_name: "Microsoft Corporation",
           asset_symbol: "MSFT",
-          quantity: 50
+          quantity: 50,
         },
       };
       expect(getEntityDisplayName(entity)).toBe("Microsoft Corporation");
@@ -323,9 +395,9 @@ describe("getEntityDisplayName", () => {
       const entity: EntityDisplayInput = {
         entity_type: "account",
         canonical_name: "account-123",
-        snapshot: { 
+        snapshot: {
           wallet_name: "Chase Checking",
-          number: "1234"
+          number: "1234",
         },
       };
       expect(getEntityDisplayName(entity)).toBe("Chase Checking");

--- a/inspector/src/components/layout/header_search.tsx
+++ b/inspector/src/components/layout/header_search.tsx
@@ -13,6 +13,7 @@ import { sourceDisplayTitle, sourceKindLabel } from "@/lib/source_display";
 import { isNeotomaEntityId } from "@/lib/neotoma_entity_id";
 import { buildSearchLocation, isSearchPath, resolveSearchQuery } from "@/lib/search_route";
 import { cn, truncateId } from "@/lib/utils";
+import { entityDisplayName } from "@/lib/entity_display_name";
 import type { EntitySnapshot } from "@/types/api";
 import type { HeaderSearchContextValue, HeaderSearchSuggestion } from "./page_title_context";
 
@@ -77,13 +78,7 @@ function entityId(entity: EntitySnapshot): string {
 }
 
 function entityLabel(entity: EntitySnapshot): string {
-  const snapshotName =
-    typeof entity.snapshot?.name === "string"
-      ? entity.snapshot.name
-      : typeof entity.snapshot?.title === "string"
-        ? entity.snapshot.title
-        : null;
-  return entity.canonical_name || snapshotName || truncateId(entityId(entity), 16);
+  return entityDisplayName(entity, truncateId(entityId(entity), 16));
 }
 
 function SuggestionLink({
@@ -101,18 +96,14 @@ function SuggestionLink({
       className="block rounded-sm px-3 py-2 hover:bg-accent hover:text-accent-foreground"
     >
       <div className="truncate text-sm font-medium">{suggestion.label}</div>
-      {suggestion.meta ? <div className="mt-1 flex items-center gap-2">{suggestion.meta}</div> : null}
+      {suggestion.meta ? (
+        <div className="mt-1 flex items-center gap-2">{suggestion.meta}</div>
+      ) : null}
     </Link>
   );
 }
 
-function SuggestionSection({
-  title,
-  children,
-}: {
-  title: string;
-  children: ReactNode;
-}) {
+function SuggestionSection({ title, children }: { title: string; children: ReactNode }) {
   return (
     <Fragment>
       <div className="px-2 pb-1 pt-2 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
@@ -162,7 +153,9 @@ export function HeaderSearch({
     }
 
     const params = new URLSearchParams(location.search);
-    setGlobalSearch(isSearchPath(location.pathname) ? resolveSearchQuery(location.pathname, params) : "");
+    setGlobalSearch(
+      isSearchPath(location.pathname) ? resolveSearchQuery(location.pathname, params) : ""
+    );
   }, [location.pathname, location.search, pageSearch]);
 
   useEffect(() => {
@@ -190,15 +183,21 @@ export function HeaderSearch({
     queryFn: async ({ signal }) => {
       const fetch = { signal };
       const [entities, sources] = await Promise.all([
-        queryEntities({
-          search: debouncedSearch,
-          limit: ENTITY_SUGGESTION_LIMIT,
-          include_snapshots: true,
-        }, fetch),
-        listSources({
-          search: debouncedSearch,
-          limit: SOURCE_SUGGESTION_LIMIT,
-        }, fetch),
+        queryEntities(
+          {
+            search: debouncedSearch,
+            limit: ENTITY_SUGGESTION_LIMIT,
+            include_snapshots: true,
+          },
+          fetch
+        ),
+        listSources(
+          {
+            search: debouncedSearch,
+            limit: SOURCE_SUGGESTION_LIMIT,
+          },
+          fetch
+        ),
       ]);
       return {
         entities: entities.entities,
@@ -208,9 +207,10 @@ export function HeaderSearch({
     enabled: isApiUrlConfigured() && debouncedSearch.length > 0,
   });
 
-  const docSuggestions = debouncedSearch.length > 0 && docsIndexQuery.data
-    ? searchDocs(flattenDocs(docsIndexQuery.data), debouncedSearch, DOC_SUGGESTION_LIMIT)
-    : [];
+  const docSuggestions =
+    debouncedSearch.length > 0 && docsIndexQuery.data
+      ? searchDocs(flattenDocs(docsIndexQuery.data), debouncedSearch, DOC_SUGGESTION_LIMIT)
+      : [];
 
   function setSearchValue(nextSearch: string) {
     if (pageSearch) {
@@ -259,7 +259,10 @@ export function HeaderSearch({
   const sourceSuggestions = suggestionsQuery.data?.sources ?? [];
   const pageSuggestions = pageSearch?.suggestions ?? [];
   const hasSuggestions =
-    pageSuggestions.length > 0 || entitySuggestions.length > 0 || sourceSuggestions.length > 0 || docSuggestions.length > 0;
+    pageSuggestions.length > 0 ||
+    entitySuggestions.length > 0 ||
+    sourceSuggestions.length > 0 ||
+    docSuggestions.length > 0;
   const showSuggestions = isFocused && trimmedSearch.length > 0;
   const isSearchExpanded = isFocused || showSuggestions;
   const isResolvingSuggestions =
@@ -279,8 +282,8 @@ export function HeaderSearch({
           : cn(
               "w-52 transition-[width] duration-200 ease-out",
               "max-w-[calc(100vw-12rem)]",
-              isSearchExpanded && "w-[min(32rem,calc(100vw-12rem))]",
-            ),
+              isSearchExpanded && "w-[min(32rem,calc(100vw-12rem))]"
+            )
       )}
       onBlurCapture={handleSearchContainerBlur}
     >
@@ -335,7 +338,11 @@ export function HeaderSearch({
                           to: `/entities/${encodeURIComponent(entityId(entity))}`,
                           meta: (
                             <>
-                              <TypeBadge type={entity.entity_type} humanize className="max-w-[9rem] truncate" />
+                              <TypeBadge
+                                type={entity.entity_type}
+                                humanize
+                                className="max-w-[9rem] truncate"
+                              />
                               <span className="truncate font-mono text-[11px] text-muted-foreground">
                                 {truncateId(entityId(entity), 12)}
                               </span>
@@ -380,7 +387,9 @@ export function HeaderSearch({
                           meta: (
                             <span className="flex items-center gap-2 text-[11px] text-muted-foreground">
                               <BookOpen className="h-3.5 w-3.5 shrink-0" />
-                              <span className="truncate">{doc.frontmatter.category || doc.slug}</span>
+                              <span className="truncate">
+                                {doc.frontmatter.category || doc.slug}
+                              </span>
                             </span>
                           ),
                         }}
@@ -414,9 +423,7 @@ export function HeaderSearch({
               </div>
             </>
           ) : (
-            <div className="px-3 py-2 text-sm text-muted-foreground">
-              No matching results
-            </div>
+            <div className="px-3 py-2 text-sm text-muted-foreground">No matching results</div>
           )}
         </div>
       ) : null}

--- a/inspector/src/components/shared/entity_board_view.tsx
+++ b/inspector/src/components/shared/entity_board_view.tsx
@@ -20,6 +20,7 @@ import { FieldValue } from "@/components/shared/field_value";
 import { Columns3 } from "lucide-react";
 import { humanizeKey } from "@/lib/humanize";
 import { truncateId } from "@/lib/utils";
+import { entityDisplayName } from "@/lib/entity_display_name";
 import { EmptyState } from "@/components/shared/empty_state";
 import type { EntitySnapshot, EntitySchema } from "@/types/api";
 
@@ -90,20 +91,28 @@ function EntityCard({ entity, groupField }: { entity: EntitySnapshot; groupField
         to={`/entities/${encodeURIComponent(eid)}`}
         className="block max-w-full truncate text-sm font-medium text-foreground underline-offset-4 hover:text-primary hover:underline"
         onClick={(e) => e.stopPropagation()}
-        title={String(entity.canonical_name || snap.name || snap.title || eid)}
+        title={entityDisplayName(entity, eid)}
       >
-        {String(entity.canonical_name || snap.name || snap.title || truncateId(eid))}
+        {entityDisplayName(entity, truncateId(eid))}
       </Link>
       <div className="mt-1 flex min-w-0 items-center gap-1">
-        <TypeBadge type={entity.entity_type} humanize className="max-w-[10rem] truncate text-[10px]" />
-        <span className="shrink-0 font-mono text-[10px] text-muted-foreground">{truncateId(eid, 8)}</span>
+        <TypeBadge
+          type={entity.entity_type}
+          humanize
+          className="max-w-[10rem] truncate text-[10px]"
+        />
+        <span className="shrink-0 font-mono text-[10px] text-muted-foreground">
+          {truncateId(eid, 8)}
+        </span>
       </div>
       {displayFields.length > 0 && (
         <div className="mt-2 space-y-0.5">
           {displayFields.map(([k, v]) => (
             <div key={k} className="flex min-w-0 items-baseline gap-1 text-xs">
               <span className="shrink-0 text-muted-foreground">{humanizeKey(k)}:</span>
-              <div className="min-w-0 flex-1 truncate"><FieldValue value={v} /></div>
+              <div className="min-w-0 flex-1 truncate">
+                <FieldValue value={v} />
+              </div>
             </div>
           ))}
         </div>
@@ -159,7 +168,11 @@ export function EntityBoardView({ entities, groupField }: EntityBoardViewProps) 
       let parsed: unknown = targetColumn;
       if (targetColumn === "(none)") parsed = null;
       else {
-        try { parsed = JSON.parse(targetColumn); } catch { /* string */ }
+        try {
+          parsed = JSON.parse(targetColumn);
+        } catch {
+          /* string */
+        }
       }
 
       await batchCorrect(draggedEntityId, {

--- a/inspector/src/lib/entity_display_name.test.ts
+++ b/inspector/src/lib/entity_display_name.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import { entityDisplayName } from "./entity_display_name";
+
+describe("entityDisplayName", () => {
+  it("prefers a contact's name over its title", () => {
+    expect(
+      entityDisplayName({
+        entity_type: "contact",
+        canonical_name: "contact:https://www.linkedin.com/in/ranisweis",
+        snapshot: { name: "Rani Sweis", title: "Chief Creative" },
+      })
+    ).toBe("Rani Sweis");
+  });
+
+  it("never surfaces a URL-keyed canonical when a name exists", () => {
+    const label = entityDisplayName({
+      entity_type: "contact",
+      canonical_name: "contact:https://www.linkedin.com/in/diptishrivastav",
+      snapshot: { name: "Dipti Srivastava" },
+    });
+    expect(label).toBe("Dipti Srivastava");
+    expect(label).not.toContain("linkedin.com");
+    expect(label).not.toContain("contact:");
+  });
+
+  it("strips no emoji itself but is bypassed once name is clean", () => {
+    // The canonical may still carry an emoji ("🦄 Rani Sweis"); the display
+    // helper simply never reads it when a clean name is present.
+    expect(
+      entityDisplayName({
+        entity_type: "contact",
+        canonical_name: "🦄 Rani Sweis",
+        snapshot: { name: "Rani Sweis" },
+      })
+    ).toBe("Rani Sweis");
+  });
+
+  it("applies to person and lead types too", () => {
+    expect(
+      entityDisplayName({
+        entity_type: "person",
+        canonical_name: "person:x",
+        snapshot: { name: "Jane Roe", title: "VP" },
+      })
+    ).toBe("Jane Roe");
+    expect(
+      entityDisplayName({
+        entity_type: "lead",
+        canonical_name: "lead:y",
+        snapshot: { name: "Sam Patel", title: "Founder" },
+      })
+    ).toBe("Sam Patel");
+  });
+
+  it("keeps title-first for non-person types", () => {
+    expect(
+      entityDisplayName({
+        entity_type: "task",
+        canonical_name: "task-1",
+        snapshot: { title: "Ship it", name: "task-name" },
+      })
+    ).toBe("Ship it");
+  });
+
+  it("falls back to title for a contact with no name", () => {
+    expect(
+      entityDisplayName({
+        entity_type: "contact",
+        canonical_name: "contact:role",
+        snapshot: { title: "Head of Sales" },
+      })
+    ).toBe("Head of Sales");
+  });
+
+  it("falls back to canonical, then the provided fallback, then em dash", () => {
+    expect(
+      entityDisplayName({ entity_type: "contact", canonical_name: "contact:frank", snapshot: {} })
+    ).toBe("contact:frank");
+    expect(
+      entityDisplayName({ entity_type: "contact", canonical_name: null, snapshot: {} }, "ent_123")
+    ).toBe("ent_123");
+    expect(entityDisplayName({ entity_type: "contact" })).toBe("—");
+  });
+
+  it("ignores non-string and blank snapshot values", () => {
+    expect(
+      entityDisplayName({
+        entity_type: "contact",
+        canonical_name: "contact:fallback",
+        snapshot: { name: "   ", title: 42 as unknown as string },
+      })
+    ).toBe("contact:fallback");
+  });
+});

--- a/inspector/src/lib/entity_display_name.ts
+++ b/inspector/src/lib/entity_display_name.ts
@@ -1,0 +1,52 @@
+/**
+ * Human-readable display label for an entity in the Inspector.
+ *
+ * The entity list, search, and board views previously rendered
+ * `canonical_name || snapshot.name || snapshot.title`. That is wrong whenever
+ * canonical_name is an *identity key* rather than a label — e.g. on the
+ * Bottega8 leads graph a contact's canonical_name is `contact:<name>` or, once
+ * keyed on LinkedIn URL (issue #2018), `contact:https://www.linkedin.com/...`.
+ * Rendering canonical-first surfaced those keys (and, earlier, emoji) as the
+ * person's name.
+ *
+ * This mirrors the shared `getEntityDisplayName` precedence
+ * (src/shared/entity_display_name.ts): prefer real snapshot fields over the
+ * canonical key, and lead with `name` for person-like types so a contact shows
+ * "Rani Sweis", not their job title "Chief Creative". Kept as a small
+ * Inspector-local copy because the Inspector build has no path alias to the
+ * top-level shared module.
+ */
+
+/** Entity types representing a person — name is the label, title is a role. */
+const PERSON_LIKE_TYPES: ReadonlySet<string> = new Set(["contact", "person", "lead"]);
+
+interface DisplayInput {
+  entity_type?: string | null;
+  canonical_name?: string | null;
+  snapshot?: Record<string, unknown> | null;
+}
+
+function str(v: unknown): string | null {
+  return typeof v === "string" && v.trim() ? v.trim() : null;
+}
+
+/**
+ * Resolve the best display label. Falls back to canonical_name, then the
+ * provided `fallback` (typically a truncated id), then an em dash.
+ */
+export function entityDisplayName(entity: DisplayInput, fallback?: string): string {
+  const snap = entity.snapshot ?? {};
+  const name = str(snap.name);
+  const title = str(snap.title);
+  const type = entity.entity_type ?? "";
+
+  if (PERSON_LIKE_TYPES.has(type)) {
+    if (name) return name;
+    if (title) return title;
+  } else {
+    if (title) return title;
+    if (name) return name;
+  }
+
+  return str(entity.canonical_name) ?? fallback ?? "—";
+}

--- a/inspector/src/pages/entities.tsx
+++ b/inspector/src/pages/entities.tsx
@@ -11,10 +11,17 @@ import { DataTableSkeleton, QueryErrorAlert } from "@/components/shared/query_st
 import { DataTable } from "@/components/ui/data-table";
 import { TypeBadge } from "@/components/shared/type_badge";
 import { OffsetPagination as Pagination } from "@/components/ui/pagination";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Button } from "@/components/ui/button";
 import { showBackgroundQueryRefresh, showInitialQuerySkeleton } from "@/lib/query_loading";
 import { formatDate, truncateId } from "@/lib/utils";
+import { entityDisplayName } from "@/lib/entity_display_name";
 import { QueryRefreshIndicator } from "@/components/shared/query_refresh_indicator";
 import type { ColumnDef, RowSelectionState } from "@tanstack/react-table";
 import type { EntitySnapshot, SnapshotFilter } from "@/types/api";
@@ -63,7 +70,7 @@ export default function EntitiesPage({ typeSlug }: { typeSlug?: string } = {}) {
   const [sortOrder, setSortOrder] = useState<"asc" | "desc">("desc");
   const [identityBasis, setIdentityBasis] = useState<string>("");
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>(
-    DEFAULT_ENTITIES_LIST_COLUMN_VISIBILITY,
+    DEFAULT_ENTITIES_LIST_COLUMN_VISIBILITY
   );
   const [snapshotFilters, setSnapshotFilters] = useState<Record<string, SnapshotFilter>>({});
   const [showFilters, setShowFilters] = useState(false);
@@ -80,7 +87,7 @@ export default function EntitiesPage({ typeSlug }: { typeSlug?: string } = {}) {
 
   const listColumnConfig = useMemo(
     () => buildEntitiesListColumnConfig(entityType ? schemaQ.data : null),
-    [entityType, schemaQ.data],
+    [entityType, schemaQ.data]
   );
 
   const visibleSortOptions = useMemo(
@@ -88,9 +95,9 @@ export default function EntitiesPage({ typeSlug }: { typeSlug?: string } = {}) {
       buildVisibleEntitySortOptions(
         listColumnConfig.columnIds,
         columnVisibility,
-        listColumnConfig.columnLabels,
+        listColumnConfig.columnLabels
       ),
-    [listColumnConfig.columnIds, listColumnConfig.columnLabels, columnVisibility],
+    [listColumnConfig.columnIds, listColumnConfig.columnLabels, columnVisibility]
   );
 
   const schemaFields = useMemo(() => schemaFieldKeys(schemaQ.data), [schemaQ.data]);
@@ -109,7 +116,7 @@ export default function EntitiesPage({ typeSlug }: { typeSlug?: string } = {}) {
   // Saved views
   const savedViews = useMemo(
     () => (entityType ? getSavedViews(entityType) : []),
-    [entityType, viewMode, sortBy, sortOrder],
+    [entityType, viewMode, sortBy, sortOrder]
   );
 
   useEffect(() => {
@@ -148,7 +155,9 @@ export default function EntitiesPage({ typeSlug }: { typeSlug?: string } = {}) {
   }, [initialType]);
 
   useEffect(() => {
-    setColumnVisibility(buildEntitiesListColumnConfig(entityType ? schemaQ.data : null).defaultVisibility);
+    setColumnVisibility(
+      buildEntitiesListColumnConfig(entityType ? schemaQ.data : null).defaultVisibility
+    );
   }, [entityType, schemaQ.data]);
 
   const pluralTypeTitle = useMemo(() => {
@@ -217,9 +226,7 @@ export default function EntitiesPage({ typeSlug }: { typeSlug?: string } = {}) {
       contextLabel: pluralTypeTitle ? `Top ${pluralTypeTitle.toLowerCase()}` : "Top entity matches",
       suggestions: (query.data?.entities ?? []).slice(0, 4).map((entity) => {
         const eid = entityRowId(entity);
-        const label = String(
-          entity.canonical_name || entity.snapshot?.name || entity.snapshot?.title || truncateId(eid),
-        );
+        const label = entityDisplayName(entity, truncateId(eid));
 
         return {
           id: eid,
@@ -237,7 +244,7 @@ export default function EntitiesPage({ typeSlug }: { typeSlug?: string } = {}) {
       }),
       isLoading: query.isFetching,
     }),
-    [entityType, pluralTypeTitle, query.data?.entities, query.isFetching, search],
+    [entityType, pluralTypeTitle, query.data?.entities, query.isFetching, search]
   );
 
   const columns: ColumnDef<EntitySnapshot, unknown>[] = useMemo(() => {
@@ -264,19 +271,16 @@ export default function EntitiesPage({ typeSlug }: { typeSlug?: string } = {}) {
       {
         id: "name",
         header: "Name",
-        accessorFn: (row) =>
-          row.canonical_name || row.snapshot?.name || row.snapshot?.title || entityRowId(row),
+        accessorFn: (row) => entityDisplayName(row, entityRowId(row)),
         cell: ({ row }) => {
           const eid = entityRowId(row.original);
           return (
             <span className="inline-flex min-w-0 items-center">
-              <Link to={`/entities/${encodeURIComponent(eid)}`} className="font-medium text-foreground underline-offset-4 hover:text-primary hover:underline">
-                {String(
-                  row.original.canonical_name ||
-                    row.original.snapshot?.name ||
-                    row.original.snapshot?.title ||
-                    truncateId(eid),
-                )}
+              <Link
+                to={`/entities/${encodeURIComponent(eid)}`}
+                className="font-medium text-foreground underline-offset-4 hover:text-primary hover:underline"
+              >
+                {entityDisplayName(row.original, truncateId(eid))}
               </Link>
               {duplicateIds.has(eid) ? <DuplicateBadge entityId={eid} /> : null}
             </span>
@@ -311,7 +315,9 @@ export default function EntitiesPage({ typeSlug }: { typeSlug?: string } = {}) {
         header: "ID",
         accessorFn: (row) => entityRowId(row),
         cell: ({ getValue }) => (
-          <span className="font-mono text-xs text-muted-foreground">{truncateId(getValue() as string, 12)}</span>
+          <span className="font-mono text-xs text-muted-foreground">
+            {truncateId(getValue() as string, 12)}
+          </span>
         ),
       },
     ];
@@ -319,7 +325,7 @@ export default function EntitiesPage({ typeSlug }: { typeSlug?: string } = {}) {
     const schema = entityType ? schemaQ.data : null;
     const fieldKeys = schemaFieldKeys(schema);
     const snapshotColumns = fieldKeys.map((fieldKey) =>
-      schemaFieldColumnDef(fieldKey, schema, entityType),
+      schemaFieldColumnDef(fieldKey, schema, entityType)
     );
 
     return [...fixed, ...snapshotColumns];
@@ -421,7 +427,11 @@ export default function EntitiesPage({ typeSlug }: { typeSlug?: string } = {}) {
                   ))}
               </SelectContent>
             </Select>
-            <Button variant="outline" size="sm" onClick={() => setSortOrder(sortOrder === "asc" ? "desc" : "asc")}>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setSortOrder(sortOrder === "asc" ? "desc" : "asc")}
+            >
               {sortOrder === "asc" ? "↑ Asc" : "↓ Desc"}
             </Button>
           </>
@@ -599,7 +609,12 @@ export default function EntitiesPage({ typeSlug }: { typeSlug?: string } = {}) {
             getRowId={(row) => entityRowId(row)}
           />
           {query.data && query.data.total > PAGE_SIZE && (
-            <Pagination offset={offset} limit={PAGE_SIZE} total={query.data.total} onPageChange={setOffset} />
+            <Pagination
+              offset={offset}
+              limit={PAGE_SIZE}
+              total={query.data.total}
+              onPageChange={setOffset}
+            />
           )}
         </>
       )}
@@ -622,7 +637,7 @@ export default function EntitiesPage({ typeSlug }: { typeSlug?: string } = {}) {
 function schemaFieldColumnDef(
   fieldKey: string,
   schema: EntitySchema | null | undefined,
-  _entityType: string,
+  _entityType: string
 ): ColumnDef<EntitySnapshot, unknown> {
   const typeHint =
     (schema?.schema_definition?.fields?.[fieldKey] as { type?: string } | undefined)?.type ??

--- a/inspector/src/pages/search.tsx
+++ b/inspector/src/pages/search.tsx
@@ -34,6 +34,7 @@ import {
   resolveSearchQuery,
 } from "@/lib/search_route";
 import { formatDate, truncateId } from "@/lib/utils";
+import { entityDisplayName } from "@/lib/entity_display_name";
 import { sourceDisplaySummary, sourceDisplayTitle } from "@/lib/source_display";
 import type { EntitySnapshot, Source } from "@/types/api";
 
@@ -59,7 +60,7 @@ export default function SearchPage() {
   const [entityType, setEntityType] = useState(urlEntityType);
   const [offset, setOffset] = useState(0);
   const [entityColumnVisibility, setEntityColumnVisibility] = useState<VisibilityState>(
-    DEFAULT_SEARCH_ENTITY_COLUMN_VISIBILITY,
+    DEFAULT_SEARCH_ENTITY_COLUMN_VISIBILITY
   );
 
   useEffect(() => {
@@ -119,7 +120,7 @@ export default function SearchPage() {
         entityType: kind === "entities" && entityType ? entityType : null,
         searchParams,
       }),
-      { replace: true },
+      { replace: true }
     );
   }
 
@@ -133,7 +134,7 @@ export default function SearchPage() {
         entityType: nextType || null,
         searchParams,
       }),
-      { replace: true },
+      { replace: true }
     );
   }
 
@@ -141,7 +142,7 @@ export default function SearchPage() {
     activeKind,
     debouncedSearch,
     offset,
-    activeKind === "entities" ? entityType : undefined,
+    activeKind === "entities" ? entityType : undefined
   );
 
   const entityColumns = useMemo<ColumnDef<EntitySnapshot, unknown>[]>(
@@ -149,7 +150,7 @@ export default function SearchPage() {
       {
         id: "name",
         header: "Name",
-        accessorFn: (row) => row.canonical_name || row.snapshot?.name || row.snapshot?.title || entityRowId(row),
+        accessorFn: (row) => entityDisplayName(row, entityRowId(row)),
         cell: ({ row }) => {
           const entityId = entityRowId(row.original);
           return (
@@ -157,12 +158,7 @@ export default function SearchPage() {
               to={`/entities/${encodeURIComponent(entityId)}`}
               className="font-medium text-foreground underline-offset-4 hover:text-primary hover:underline"
             >
-              {String(
-                row.original.canonical_name ||
-                  row.original.snapshot?.name ||
-                  row.original.snapshot?.title ||
-                  truncateId(entityId),
-              )}
+              {entityDisplayName(row.original, truncateId(entityId))}
             </Link>
           );
         },
@@ -190,7 +186,7 @@ export default function SearchPage() {
         ),
       },
     ],
-    [activeKind],
+    [activeKind]
   );
 
   const isSearching = debouncedSearch.length > 0;
@@ -333,7 +329,9 @@ function PrimitiveSearchResults({
 
   if (resultsQuery.error) {
     return (
-      <QueryErrorAlert title={`Could not load ${SEARCH_PRIMITIVE_LABELS[kind].toLowerCase()} matches`}>
+      <QueryErrorAlert
+        title={`Could not load ${SEARCH_PRIMITIVE_LABELS[kind].toLowerCase()} matches`}
+      >
         {resultsQuery.error.message}
       </QueryErrorAlert>
     );
@@ -425,9 +423,7 @@ function EmptyMatches({
       title={`No matching ${SEARCH_PRIMITIVE_LABELS[kind].toLowerCase()}`}
       description={
         <>
-          <span className="block">
-            Nothing came back for &ldquo;{query}&rdquo;.
-          </span>
+          <span className="block">Nothing came back for &ldquo;{query}&rdquo;.</span>
           {hint ? <span className="mt-2 block">{hint}</span> : null}
         </>
       }

--- a/src/shared/entity_display_name.ts
+++ b/src/shared/entity_display_name.ts
@@ -1,6 +1,8 @@
 /**
  * Canonical entity display name (shared: CLI and web app).
- * Priority: title → name → type-specific fields → canonical_name.
+ * Priority: title → name → type-specific fields → canonical_name,
+ * EXCEPT person-like types (see PERSON_LIKE_TYPES) which lead with `name`
+ * so a contact shows "Rani Sweis", not their job title "Chief Creative".
  */
 
 export interface EntityDisplayInput {
@@ -8,6 +10,15 @@ export interface EntityDisplayInput {
   canonical_name: string;
   snapshot?: Record<string, unknown> | null;
 }
+
+/**
+ * Entity types that represent a person. For these, `name` is the display label
+ * and `title` is a role/headline — so `name` must take precedence. The default
+ * title-first ordering is correct for document-like types (a task's title beats
+ * its name) but wrong for people. Kept as aliases of the `contact` type plus the
+ * standalone `person` type; see schema_definitions.ts.
+ */
+export const PERSON_LIKE_TYPES: ReadonlySet<string> = new Set(["contact", "person", "lead"]);
 
 /**
  * Type-specific field mappings for display names (when title/name are not present).
@@ -39,11 +50,18 @@ export const TYPE_SPECIFIC_DISPLAY_FIELDS: Record<string, string[]> = {
 export function getEntityDisplayName(input: EntityDisplayInput): string {
   const snapshot = input.snapshot ?? {};
 
-  if (snapshot.title && typeof snapshot.title === "string" && snapshot.title.trim()) {
-    return snapshot.title.trim();
-  }
-  if (snapshot.name && typeof snapshot.name === "string" && snapshot.name.trim()) {
-    return snapshot.name.trim();
+  const titleVal =
+    typeof snapshot.title === "string" && snapshot.title.trim() ? snapshot.title.trim() : null;
+  const nameVal =
+    typeof snapshot.name === "string" && snapshot.name.trim() ? snapshot.name.trim() : null;
+
+  // Person-like types lead with name; everything else keeps title-first.
+  if (PERSON_LIKE_TYPES.has(input.entity_type)) {
+    if (nameVal) return nameVal;
+    if (titleVal) return titleVal;
+  } else {
+    if (titleVal) return titleVal;
+    if (nameVal) return nameVal;
   }
 
   const typeSpecificFields = TYPE_SPECIFIC_DISPLAY_FIELDS[input.entity_type] ?? [];


### PR DESCRIPTION
Closes #2044

## The problem

The Inspector entity **list, search, board view, and header search** rendered `canonical_name || snapshot.name || snapshot.title` — canonical-first. But `canonical_name` is an **identity key**, not a display label.

Since #2018/#2020 deliberately keyed `contact` on `linkedin_url` first — so a bulk LinkedIn import stops collapsing distinct people who share a name into one entity — a contact's canonical_name is now a URL or a `contact:<name>` composite. Rendering it surfaced the key where the name belongs:

| Shown before | Should show |
|---|---|
| `contact:https://www.linkedin.com/in/diptishrivastav` | Dipti Srivastava |
| `🦄 Rani Sweis` | Rani Sweis |
| `contact:Rani Sweis` | Rani Sweis |

(This is the list from the screenshot that kicked off the investigation.)

## The fix — display only

Writes no data; immune to the identity schema changing.

- **`src/shared/entity_display_name.ts`** — person-like types (`contact`, `person`, `lead`) now lead with `name` over `title`, so a contact shows *Rani Sweis*, not the job title *Chief Creative*. Document-like types keep title-first (a task's title still wins). Gated by `PERSON_LIKE_TYPES`, so every existing case is unchanged.
- **`inspector/src/lib/entity_display_name.ts`** — a small Inspector-local helper with the same precedence (the Inspector build has no path alias to the top-level `src/shared`).
- Route **entities.tsx**, **search.tsx**, **entity_board_view.tsx**, **header_search.tsx** through it instead of the inline canonical-first chains.

Net: every contact shows its real name regardless of how its canonical is keyed — emoji, `contact:<name>`, or `contact:https://…`.

## Why this is the right fix (not a data backfill)

The `contact:https://…` keying is the **intended identity model** from #2018, not a defect — it prevents name collisions. So the ~2,016 URL-keyed contacts on the Bottega8 leads instance should keep their canonicals; they just shouldn't *display* them. This PR fixes all of them at once, at the display layer, with zero writes to the graph. (A data-side backfill was considered and rejected: it fights the identity schema and would re-introduce the collisions #2018 fixed.)

## Verification

- 15 new tests: 8 (inspector helper) + 7 (shared helper) — name-first for people, non-person title-first unchanged, and that a URL/emoji canonical never surfaces when a name exists.
- Frontend display suite: 39/39 green.
- **0 new type errors** (255 == 255 vs `main`; the pre-existing errors are missing-dependency issues in this worktree — `@tanstack/react-query`, `@xyflow/react`, `react-markdown` — none in the changed lines).
- The one failing test file (`graph_layout.test.ts`) fails on a missing `@xyflow/react` package on clean `main` too — unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)