### PR TITLE
ci(pages): deploy the marketing site from the published release, not push-to-main

### DIFF
--- a/.github/workflows/deploy-pages-site.yml
+++ b/.github/workflows/deploy-pages-site.yml
@@ -1,21 +1,27 @@
-# Deploy marketing site to GitHub Pages from the main branch. Configure custom domain
-# neotoma.io in repo Settings → Pages → Custom domain so the site is served at https://neotoma.io.
-# Push to main only triggers deploy when site content changes (paths below); workflow_dispatch always runs.
+# Deploy marketing site to GitHub Pages from the latest PUBLISHED RELEASE. Configure custom
+# domain neotoma.io in repo Settings → Pages → Custom domain so the site is served at
+# https://neotoma.io.
+#
+# Release-gated (not push-to-main) so the public site ships on the same human-gated boundary as
+# every other consequential deploy in this repo (client instance, sandbox, npm all trigger on
+# `release: published` / release tags). A merge to main is reversible; publishing to the public
+# marketing domain is the step that warrants a deliberate act. `workflow_dispatch` remains as the
+# escape hatch for an urgent copy/docs fix between releases.
+#
+# Note: because this now builds from the release tag, site content edited after the last release
+# does NOT appear on neotoma.io until the next release is published (or a manual dispatch).
+# dev.neotoma.io continues to track the `dev` branch continuously for preview.
 name: Deploy site (GitHub Pages)
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - "frontend/**"
-      - "public/**"
-      - "scripts/build_github_pages_site.tsx"
-      - "scripts/validate_site_route_parity.ts"
-      - "scripts/validate_site_export.ts"
-      - "package.json"
-      - "package-lock.json"
+  release:
+    types: [published]
   workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref to deploy (defaults to the triggering release tag / workflow ref)"
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -33,8 +39,13 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
+      # Explicit ref so the deployed tree is unambiguous: a manual dispatch may name a ref;
+      # otherwise use the triggering release's tag. Without this, checkout takes the event's
+      # implicit default, which is easy to misread when debugging what is actually live.
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.event.release.tag_name || github.ref }}
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/docs/infrastructure/deployment.md
+++ b/docs/infrastructure/deployment.md
@@ -21,18 +21,22 @@ This document covers:
 
 The static marketing site is built with `npm run build:site:pages` (output: `site_pages/`) and deployed to **GitHub Pages** (`.github/workflows/deploy-pages-site.yml`).
 
-- **Prod:** Push to **main** (or run the workflow manually). Served at **https://neotoma.io** (root).
-- **Dev preview:** Push to **dev** and deploy to a **separate repository** via `.github/workflows/deploy-pages-dev-site.yml`. Served at **https://dev.neotoma.io**.
+- **Prod:** Publishing a **release** deploys the site from that release's tag (or run the workflow
+  manually, optionally naming a `ref`). Served at **https://neotoma.io** (root). Release-gated so the
+  public site ships on the same human-gated boundary as the client instance, sandbox, and npm
+  publish. Note: site content merged to `main` after the last release does **not** appear on
+  neotoma.io until the next release is published — use the manual dispatch for an urgent fix.
+- **Dev preview:** Push to **dev** and deploy to a **separate repository** via `.github/workflows/deploy-pages-dev-site.yml`. Served at **https://dev.neotoma.io**. This tier tracks `dev` continuously.
 
 ### One-time: Enable GitHub Pages from Actions
 
 1. In the repo on GitHub: **Settings → Pages** (under "Code and automation").
 2. Under **Build and deployment**, set **Source** to **GitHub Actions** (not "Deploy from a branch"). Save.
-3. The prod workflow runs on push to **main** or when run manually (Actions → "Deploy site (GitHub Pages)" → Run workflow).
+3. The prod workflow runs when a **release is published**, or when run manually (Actions → "Deploy site (GitHub Pages)" → Run workflow).
 
 ### Deploy
 
-No extra secrets: the prod workflow uses the repo’s GitHub Pages environment. Push to **main** (or run the workflow manually from the Actions tab) to build and deploy production at **https://neotoma.io**.
+No extra secrets: the prod workflow uses the repo’s GitHub Pages environment. **Publish a release** to build and deploy production at **https://neotoma.io** from that release's tag. To ship a site change between releases, run the workflow manually from the Actions tab (optionally passing a `ref`).
 
 ### Dev preview site (dev.neotoma.io, isolated from prod)
 


### PR DESCRIPTION
Closes #2048.

## Problem

`neotoma.io` (the public marketing site) was the **only** path in this repo where merged code reached the public without a deliberate human step.

Every other consequential deploy is release-gated:
- `deploy-client-instance.yml` → `release: [published]`
- `deploy-sandbox.yml` → `release: [published]`
- `npm-publish.yml` → `push: tags: v*`

But `deploy-pages-site.yml` fired on **any push to `main`** touching `frontend/**`, `public/**`, or the site build scripts.

## Why now

That asymmetry becomes load-bearing as PR merges become more autonomous. A merge to `main` is reversible; publishing to the public marketing domain is not the kind of step that should happen as a side effect of a merge. This aligns the site with the same human-gated boundary as everything else consequential.

## Change

- **Trigger:** `push: main` → `release: [published]`.
- **`workflow_dispatch` retained**, now accepting an optional `ref` — the escape hatch for an urgent copy/docs fix between releases, so continuous publishing is still possible, just deliberate.
- **Checkout ref made explicit** (`inputs.ref || github.event.release.tag_name || github.ref`) so the deployed tree is unambiguous rather than relying on the event's implicit default.
- **Docs updated** (`docs/infrastructure/deployment.md`) in all three places describing the old behaviour.

## Trade-off (stated, not hidden)

Site content merged to `main` after the last release does **not** appear on `neotoma.io` until the next release is published — or until someone runs the manual dispatch. That's the intended trade: deliberate publishing over automatic. `dev.neotoma.io` continues to track the `dev` branch continuously, so there's still a live preview tier.

## Verification

- YAML parses; triggers resolve to exactly `release: [published]` + `workflow_dispatch`.
- `validate:doc-deps` green; prettier clean on both changed files.
- No behaviour change to the dev-site workflow.