### PR TITLE
Flaky: issues_message CLI test times out at 60s in the 'no DB' unit lane (needs a live server, sets no timeout)

### DIFF
--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,8 +61,8 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **563**
-- Backend and repo Vitest files: **528**
+- Total automated test files: **564**
+- Backend and repo Vitest files: **529**
 - Frontend Vitest files: **9**
 - Playwright spec files: **26**
 
@@ -73,7 +73,7 @@ flowchart TD
 | Vitest service tests | 42 |
 | Source-adjacent tests | 65 |
 | Vitest integration tests | 159 |
-| Vitest CLI tests | 72 |
+| Vitest CLI tests | 73 |
 | Vitest contract tests | 15 |
 | Vitest security tests | 4 |
 | Vitest subscription tests | 5 |
@@ -561,7 +561,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/cli`
 **Requirements:** Basic `.env`; some tests provision temp config homes automatically.
-**Files (72):**
+**Files (73):**
 - `tests/cli/api_client_offline_fallback.test.ts`
 - `tests/cli/backup_verify.test.ts`
 - `tests/cli/cli_access_commands.test.ts`
@@ -621,6 +621,7 @@ flowchart TD
 - `tests/cli/instance_skills.test.ts`
 - `tests/cli/issues_import.test.ts`
 - `tests/cli/issues_message.test.ts`
+- `tests/cli/live_api_probe.test.ts`
 - `tests/cli/onboarding_import_transcripts.test.ts`
 - `tests/cli/peers.test.ts`
 - `tests/cli/processes_command.test.ts`

--- a/docs/testing/testing_standard.md
+++ b/docs/testing/testing_standard.md
@@ -1,30 +1,39 @@
 # Neotoma Testing Standard
-*(Test Types, Coverage Requirements, and Testing Strategy)*
+
+_(Test Types, Coverage Requirements, and Testing Strategy)_
+
 ## Test Types
+
 ### Unit Tests
+
 **Scope:** Pure functions, deterministic logic
 **Examples:**
+
 - `extractFieldsForFinancialRecord(text)`
 - `generateEntityId(type, name)`
 - `calculateScore(record, query)`
-**Requirements:**
+  **Requirements:**
 - Fast (<10ms per test)
 - No external dependencies
 - Deterministic (100 runs → 100 same results)
+
 ```typescript
-test('entity ID generation is deterministic', () => {
-  const id1 = generateEntityId('company', 'Acme Corp');
-  const id2 = generateEntityId('company', 'Acme Corp');
+test("entity ID generation is deterministic", () => {
+  const id1 = generateEntityId("company", "Acme Corp");
+  const id2 = generateEntityId("company", "Acme Corp");
   expect(id1).toBe(id2);
 });
 ```
+
 ### Integration Tests
+
 **Scope:** Service interactions, database operations
 **Examples:**
+
 - Ingestion pipeline with test DB
 - Search service with fixtures
 - Graph insertion with transactions
-**Requirements:**
+  **Requirements:**
 - Use test database (real operations, not mocked)
 - Clean up after each test
 - Deterministic ordering
@@ -37,87 +46,109 @@ test('entity ID generation is deterministic', () => {
 **Markdown run reports (opt-in):** set `WRITE_TEST_RUN_REPORT=1` or use `npm run test:integration:report` / `npm run test:remote:critical:report` to emit `.vitest/reports/*.md` summaries. See [`integration_run_reports.md`](./integration_run_reports.md).
 
 ```typescript
-test('record insert creates entities', async () => {
+test("record insert creates entities", async () => {
   const record = await insertRecord({
-    type: 'FinancialRecord',
-    properties: { vendor_name: 'Acme Corp' },
+    type: "FinancialRecord",
+    properties: { vendor_name: "Acme Corp" },
   });
 
   const entities = await getRecordEntities(record.id);
   expect(entities).toHaveLength(1);
-  expect(entities[0].canonical_name).toBe('acme corp');
+  expect(entities[0].canonical_name).toBe("acme corp");
 
   // Verify database state
   const stored = await db.queryOne("entities", { id: entities[0].id });
   expect(stored).toBeDefined();
 });
 ```
+
 ### E2E Tests (Playwright)
+
 **Scope:** Full user flows, browser automation
 **Examples:**
+
 - Upload file → see record details
 - Search records → click result → view detail
 - Timeline view → filter by date
 - **Inspector** (`/inspector/` on the Neotoma HTTP server): seed via `POST /store`, open `…/inspector/entities/:id` (note detail), `…/inspector/issues` and `…/inspector/issues/:id` (issues list + issue detail), assert headings and snapshot fields (`playwright/tests/inspector/`). Run `npm run test:e2e:inspector` (runs `build:inspector` first) or build once then `npm run test:e2e`. Specs skip when `dist/inspector/index.html` is missing. In `playwright.config.ts`, `inspector/**` is ignored for the `mobile-webkit` project so a second worker does not hit a torn-down Neotoma port (`ECONNREFUSED`); Inspector is exercised under **chromium** only.
-**Requirements:**
+  **Requirements:**
 - Use test fixtures
 - Deterministic test data
 - Clean DB state per test
+
 ```typescript
-test('upload invoice flow', async ({ page }) => {
-  await page.goto('/upload');
-  await page.setInputFiles('input[type="file"]', 'fixtures/invoice.pdf');
+test("upload invoice flow", async ({ page }) => {
+  await page.goto("/upload");
+  await page.setInputFiles('input[type="file"]', "fixtures/invoice.pdf");
   await page.click('button:has-text("Upload")');
 
-  await page.waitForSelector('text=Invoice #INV-001');
-  expect(await page.textContent('h1')).toContain('FinancialRecord');
+  await page.waitForSelector("text=Invoice #INV-001");
+  expect(await page.textContent("h1")).toContain("FinancialRecord");
 });
 ```
+
 ### Property-Based Tests
+
 **Scope:** Invariant verification
 **Example:**
+
 ```typescript
-import fc from 'fast-check';
-test('entity ID is always same length', () => {
+import fc from "fast-check";
+test("entity ID is always same length", () => {
   fc.assert(
     fc.property(fc.string(), fc.string(), (type, name) => {
       const id = generateEntityId(type, name);
-      return id.startsWith('ent_') && id.length === 28;
+      return id.startsWith("ent_") && id.length === 28;
     })
   );
 });
 ```
+
 ## Coverage Requirements
-| Code Type | Lines | Branches | Critical Paths |
-|-----------|-------|----------|----------------|
-| Domain Logic | >85% | >85% | 100% |
-| Application Layer | >80% | >80% | 100% |
-| UI Components | >75% | >75% | N/A |
-| Infrastructure | >70% | >70% | N/A |
+
+| Code Type         | Lines | Branches | Critical Paths |
+| ----------------- | ----- | -------- | -------------- |
+| Domain Logic      | >85%  | >85%     | 100%           |
+| Application Layer | >80%  | >80%     | 100%           |
+| UI Components     | >75%  | >75%     | N/A            |
+| Infrastructure    | >70%  | >70%     | N/A            |
+
 **Critical Paths:**
+
 - Ingestion pipeline
 - Entity resolution
 - Graph insertion
 - Search ranking
+
 ## Testing by Subsystem
+
 ### Ingestion
+
 - Unit: Field extraction, schema detection
 - Integration: Full pipeline with test DB
 - E2E: Upload file via UI
+
 ### Search
+
 - Unit: Ranking algorithm, query parsing
 - Integration: Search with fixtures
 - E2E: Search via UI
+
 ### Entity Resolution
+
 - Unit: Entity ID generation, normalization
 - Property: Determinism, collision resistance
+
 ## Test Fixtures
+
 See `docs/testing/fixtures_standard.md`.
 
 ## Automated test catalog
+
 See `docs/testing/automated_test_catalog.md` for the canonical repo-wide inventory of automated tests and primary suite commands.
 
 ### Catalog maintenance
+
 - The catalog is generated by `npm run generate:test-catalog`.
 - When automated test files are added, removed, moved, or renamed, regenerate the catalog in the same change.
 - When test commands, CI lanes, or default-vs-optional execution modes change, update both the catalog and this policy doc in the same change.
@@ -125,7 +156,7 @@ See `docs/testing/automated_test_catalog.md` for the canonical repo-wide invento
 
 ## High-risk surface classes (mandatory coverage)
 
-Some change classes routinely ship with named-but-shallow tests that exercise an internal helper while leaving the user-observable behavior unverified. These classes MUST have a test that proves the *user-visible* behavior works, not just that an internal function returns the expected value.
+Some change classes routinely ship with named-but-shallow tests that exercise an internal helper while leaving the user-observable behavior unverified. These classes MUST have a test that proves the _user-visible_ behavior works, not just that an internal function returns the expected value.
 
 ### Destructive or data-mutating operations
 
@@ -166,6 +197,10 @@ Examples: `keepAliveTimeout`, `headersTimeout`, `Connection` header policy, requ
 
 **Required test**: assert the **runtime** behavior, not the source string. For timeouts, read the `Keep-Alive: timeout=N` response header against the actually-running server. For size limits, send a request at the boundary and assert the response code. Constants declared in code with no runtime assertion regress silently when an unrelated change moves the assignment or overrides it via env var.
 
+### CLI tests and live HTTP (unit / `no DB` lane)
+
+The CI step **Run unit Vitest suite (no DB)** (`npm run test:unit`) must not silently depend on a live HTTP server. Live-API CLI cases belong in `npm run test:integration`, or must use `tests/cli/support/live_api_probe.ts` (`probeLiveApi`, default 800ms) so absence fails or skips in ≤1s instead of hanging to Vitest’s global `testTimeout: 60000`. See [`tests/cli/README.md`](../../tests/cli/README.md). Sibling sweep search term: `resolveTestApiBaseUrl`.
+
 ### New CLI commands or flags
 
 Every new top-level command (or new flag on an existing command) MUST have:
@@ -178,6 +213,7 @@ Every new top-level command (or new flag on an existing command) MUST have:
 **See `foundation/conventions/testing_conventions.md` for generic principles.**
 
 **See `docs/testing/integration_test_quality_rules.mdc` for Neotoma-specific applications:**
+
 - Applying foundation principles to database layer
 - Testing Neotoma's default UUID and null handling
 - Testing Neotoma-specific tables (raw_fragments, auto_enhancement_queue, etc.)
@@ -185,14 +221,16 @@ Every new top-level command (or new flag on an existing command) MUST have:
 - Examples from actual Neotoma bugs
 
 ## Agent Instructions
+
 Load when writing tests or planning test strategy for Feature Units.
 Required co-loaded:
+
 - `foundation/conventions/testing_conventions.md` (generic testing principles)
 - `docs/architecture/determinism.md` (deterministic test requirements)
 - `docs/testing/fixtures_standard.md` (fixture guidelines)
 - `docs/testing/integration_test_quality_rules.mdc` (Neotoma-specific quality standards)
 - `docs/testing/test_quality_enforcement_rules.mdc` (enforceable patterns from actual bugs)
-Constraints:
+  Constraints:
 - All tests MUST be deterministic
 - Unit tests MUST be fast (<10ms)
 - Integration tests MUST follow foundation conventions (see `foundation/conventions/testing_conventions.md`)

--- a/tests/cli/README.md
+++ b/tests/cli/README.md
@@ -18,7 +18,7 @@ issues message --entity-id … --body … --json exercises POST /issues/add_mess
 ### Example probe-failure message
 
 ```text
-[COPY: Live API not listening] on 127.0.0.1:18080 (NEOTOMA_SESSION_DEV_PORT / NEOTOMA_HTTP_PORT). [COPY: Start the local server, or run this test in the integration lane.]
+Live API not listening on 127.0.0.1:18080 (NEOTOMA_SESSION_DEV_PORT / NEOTOMA_HTTP_PORT). Start the local server, or run this test in the integration lane.
 ```
 
 Set `NEOTOMA_SESSION_DEV_PORT` or `NEOTOMA_HTTP_PORT` to a running local server, or run the case in the integration lane.

--- a/tests/cli/README.md
+++ b/tests/cli/README.md
@@ -1,0 +1,24 @@
+# CLI tests (`tests/cli/`)
+
+## Lane contract: unit / `no DB` vs live HTTP
+
+The CI step labelled **Run unit Vitest suite (no DB)** (`npm run test:unit`) must **not** depend on a live HTTP server. Cases that call a real API on `NEOTOMA_SESSION_DEV_PORT` / `NEOTOMA_HTTP_PORT` belong in the **integration** lane (`npm run test:integration`), **or** must use the shared fail-fast helper:
+
+- `tests/cli/support/live_api_probe.ts` — `resolveTestApiBaseUrl`, `probeLiveApi`, `formatLiveApiUnavailableMessage`
+- Probe timeout defaults to **800ms** (≪ Vitest’s global `testTimeout: 60000`)
+
+Sibling sweep search term: `resolveTestApiBaseUrl` under `tests/cli/`.
+
+### Example test title (live-server cue)
+
+```text
+issues message --entity-id … --body … --json exercises POST /issues/add_message (requires live API on NEOTOMA_*_PORT)
+```
+
+### Example probe-failure message
+
+```text
+[COPY: Live API not listening] on 127.0.0.1:18080 (NEOTOMA_SESSION_DEV_PORT / NEOTOMA_HTTP_PORT). [COPY: Start the local server, or run this test in the integration lane.]
+```
+
+Set `NEOTOMA_SESSION_DEV_PORT` or `NEOTOMA_HTTP_PORT` to a running local server, or run the case in the integration lane.

--- a/tests/cli/issues_message.test.ts
+++ b/tests/cli/issues_message.test.ts
@@ -2,27 +2,27 @@ import { describe, expect, it, vi } from "vitest";
 import { randomUUID } from "node:crypto";
 
 import { runCli } from "../../src/cli/index.ts";
-
-function resolveTestApiBaseUrl(): string {
-  const port = process.env.NEOTOMA_SESSION_DEV_PORT || process.env.NEOTOMA_HTTP_PORT || "18080";
-  return `http://127.0.0.1:${port}`;
-}
+import {
+  formatLiveApiUnavailableMessage,
+  probeLiveApi,
+  resolveTestApiBaseUrl,
+} from "./support/live_api_probe.ts";
 
 async function runNeotomaCli(
   argvSuffix: string[],
-  env: Record<string, string | undefined>,
+  env: Record<string, string | undefined>
 ): Promise<{ exitCode: number; stdout: string; stderr: string; error?: unknown }> {
   const stdoutParts: string[] = [];
   const stderrParts: string[] = [];
   const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
     stdoutParts.push(
-      typeof chunk === "string" ? chunk : Buffer.from(chunk as Uint8Array).toString("utf8"),
+      typeof chunk === "string" ? chunk : Buffer.from(chunk as Uint8Array).toString("utf8")
     );
     return true;
   });
   const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation((chunk: unknown) => {
     stderrParts.push(
-      typeof chunk === "string" ? chunk : Buffer.from(chunk as Uint8Array).toString("utf8"),
+      typeof chunk === "string" ? chunk : Buffer.from(chunk as Uint8Array).toString("utf8")
     );
     return true;
   });
@@ -78,8 +78,18 @@ describe("CLI issues message (smoke)", () => {
   /** Blank target avoids inherited operator URL pushing thread rows to remote during smoke tests. */
   const issuesEnv = { NEOTOMA_ISSUES_TARGET_URL: "" };
 
-  it("issues message --entity-id … --body … --json exercises POST /issues/add_message", async () => {
-    const title = `cli-smoke-issues-message ${Date.now()}`;
+  it("issues message --entity-id … --body … --json exercises POST /issues/add_message (requires live API on NEOTOMA_*_PORT)", async (ctx) => {
+    const probe = await probeLiveApi(baseUrl);
+    if (!probe.reachable) {
+      const message = formatLiveApiUnavailableMessage(baseUrl, probe.reason);
+      // eslint-disable-next-line no-console -- actionable skip reason for CI/local triage
+      console.error(message);
+      ctx.skip(message);
+      return;
+    }
+
+    // Unique title/body per run — no product idempotency_key on create/message; uniqueness is the substitute.
+    const title = `cli-smoke-issues-message ${Date.now()}-${randomUUID()}`;
     const create = await runNeotomaCli(
       [
         "--json",
@@ -97,7 +107,7 @@ describe("CLI issues message (smoke)", () => {
         "--reporter-git-sha",
         "cli-smoke-test",
       ],
-      issuesEnv,
+      issuesEnv
     );
     expect(create.exitCode, create.stderr + create.stdout).toBe(0);
     const created = JSON.parse(create.stdout) as { entity_id?: string };
@@ -119,7 +129,7 @@ describe("CLI issues message (smoke)", () => {
         "--reporter-git-sha",
         "cli-smoke-test",
       ],
-      issuesEnv,
+      issuesEnv
     );
     if (msg.exitCode !== 0) {
       expect(msg.stderr + msg.stdout).toMatch(/ISSUE_MESSAGE_FAILED|stored locally for follow-up/i);
@@ -128,12 +138,13 @@ describe("CLI issues message (smoke)", () => {
 
     const out = JSON.parse(msg.stdout) as { submitted_to_neotoma?: boolean };
     expect(out.submitted_to_neotoma === true || out.submitted_to_neotoma === false).toBe(true);
-  });
+  }, // Far below vitest.config.ts testTimeout (60000); generous for create+message under CI load.
+  15000);
 
   it("issues message --body only (--json) errors when entity_id and issue number are missing", async () => {
     const res = await runNeotomaCli(
       ["--json", "--api-only", "--base-url", baseUrl, "issues", "message", "--body", "orphan body"],
-      issuesEnv,
+      issuesEnv
     );
     expect(res.exitCode).toBe(1);
     expect(res.stderr).toMatch(/provide.*GitHub issue number|entity-id/i);

--- a/tests/cli/live_api_probe.test.ts
+++ b/tests/cli/live_api_probe.test.ts
@@ -1,0 +1,91 @@
+import http from "node:http";
+import net from "node:net";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { formatLiveApiUnavailableMessage, probeLiveApi } from "./support/live_api_probe.ts";
+
+/**
+ * Effect test for issue #2052: when no live API is listening, the probe path
+ * completes in well under Vitest's global 60000ms testTimeout and emits the
+ * UX-specified message shape (port + env names + next action) — proving the
+ * hang→fast-clear-failure effect, not merely that probeLiveApi returns a value.
+ */
+describe("live_api_probe (effect: no hang to suite testTimeout)", () => {
+  let server: http.Server | undefined;
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise<void>((resolve, reject) => {
+        server!.close((err) => (err ? reject(err) : resolve()));
+      });
+      server = undefined;
+    }
+  });
+
+  it("closed-port probe finishes in ≪60s and message matches UX shape (no secrets)", async () => {
+    // Bind-and-close to obtain a port that is guaranteed free (connection refused).
+    const binder = net.createServer();
+    const freePort: number = await new Promise((resolve, reject) => {
+      binder.once("error", reject);
+      binder.listen(0, "127.0.0.1", () => {
+        const address = binder.address();
+        resolve(typeof address === "object" && address ? address.port : 0);
+      });
+    });
+    await new Promise<void>((resolve) => binder.close(() => resolve()));
+
+    const baseUrl = `http://127.0.0.1:${freePort}`;
+    const start = Date.now();
+    const result = await probeLiveApi(baseUrl);
+    const elapsedMs = Date.now() - start;
+
+    expect(result.reachable).toBe(false);
+    if (result.reachable) {
+      throw new Error("unreachable");
+    }
+    expect(elapsedMs).toBeLessThan(2000);
+
+    const message = formatLiveApiUnavailableMessage(baseUrl, result.reason);
+    expect(message).toContain(String(freePort));
+    expect(message).toContain("NEOTOMA_SESSION_DEV_PORT");
+    expect(message).toContain("NEOTOMA_HTTP_PORT");
+    expect(message).toMatch(/integration lane|Start the local server/i);
+    expect(message).not.toMatch(/authorization|bearer|aauth|guest_access_token|token=/i);
+  }, 5000);
+
+  it("reachable when a loopback /health responds", async () => {
+    server = http.createServer((_req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true }));
+    });
+    const port: number = await new Promise((resolve, reject) => {
+      server!.once("error", reject);
+      server!.listen(0, "127.0.0.1", () => {
+        const address = server!.address();
+        resolve(typeof address === "object" && address ? address.port : 0);
+      });
+    });
+
+    const result = await probeLiveApi(`http://127.0.0.1:${port}`);
+    expect(result).toEqual({ reachable: true });
+  }, 5000);
+
+  it("rejects bare localhost and non-loopback without issuing a network call", async () => {
+    await expect(probeLiveApi("http://localhost:18080")).resolves.toEqual({
+      reachable: false,
+      reason: "invalid_url",
+    });
+    await expect(probeLiveApi("http://example.com:80")).resolves.toEqual({
+      reachable: false,
+      reason: "invalid_url",
+    });
+  });
+
+  it("timeout reason gets a distinct message token from unreachable", () => {
+    const timedOut = formatLiveApiUnavailableMessage("http://127.0.0.1:18080", "timeout");
+    const unreachable = formatLiveApiUnavailableMessage("http://127.0.0.1:18080", "unreachable");
+    expect(timedOut).toMatch(/live API probe timed out/i);
+    expect(unreachable).toMatch(/Live API not listening/i);
+    expect(timedOut).not.toEqual(unreachable);
+  });
+});

--- a/tests/cli/live_api_probe.test.ts
+++ b/tests/cli/live_api_probe.test.ts
@@ -50,6 +50,7 @@ describe("live_api_probe (effect: no hang to suite testTimeout)", () => {
     expect(message).toContain("NEOTOMA_SESSION_DEV_PORT");
     expect(message).toContain("NEOTOMA_HTTP_PORT");
     expect(message).toMatch(/integration lane|Start the local server/i);
+    expect(message).not.toMatch(/\[COPY:/);
     expect(message).not.toMatch(/authorization|bearer|aauth|guest_access_token|token=/i);
   }, 5000);
 
@@ -87,5 +88,7 @@ describe("live_api_probe (effect: no hang to suite testTimeout)", () => {
     expect(timedOut).toMatch(/live API probe timed out/i);
     expect(unreachable).toMatch(/Live API not listening/i);
     expect(timedOut).not.toEqual(unreachable);
+    expect(timedOut).not.toMatch(/\[COPY:/);
+    expect(unreachable).not.toMatch(/\[COPY:/);
   });
 });

--- a/tests/cli/schemas_describe.test.ts
+++ b/tests/cli/schemas_describe.test.ts
@@ -1,27 +1,27 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { runCli } from "../../src/cli/index.ts";
-
-function resolveTestApiBaseUrl(): string {
-  const port = process.env.NEOTOMA_SESSION_DEV_PORT || process.env.NEOTOMA_HTTP_PORT || "18080";
-  return `http://127.0.0.1:${port}`;
-}
+import {
+  formatLiveApiUnavailableMessage,
+  probeLiveApi,
+  resolveTestApiBaseUrl,
+} from "./support/live_api_probe.ts";
 
 async function runNeotomaCli(
   argvSuffix: string[],
-  env: Record<string, string | undefined>,
+  env: Record<string, string | undefined>
 ): Promise<{ exitCode: number; stdout: string; stderr: string; error?: unknown }> {
   const stdoutParts: string[] = [];
   const stderrParts: string[] = [];
   const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
     stdoutParts.push(
-      typeof chunk === "string" ? chunk : Buffer.from(chunk as Uint8Array).toString("utf8"),
+      typeof chunk === "string" ? chunk : Buffer.from(chunk as Uint8Array).toString("utf8")
     );
     return true;
   });
   const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation((chunk: unknown) => {
     stderrParts.push(
-      typeof chunk === "string" ? chunk : Buffer.from(chunk as Uint8Array).toString("utf8"),
+      typeof chunk === "string" ? chunk : Buffer.from(chunk as Uint8Array).toString("utf8")
     );
     return true;
   });
@@ -75,10 +75,19 @@ async function runNeotomaCli(
 describe("CLI schemas describe (smoke)", () => {
   const baseUrl = resolveTestApiBaseUrl();
 
-  it("schemas describe <type> --json exercises GET /schemas/{entity_type}", async () => {
+  it("schemas describe <type> --json against live HTTP exercises GET /schemas/{entity_type} (requires live API on NEOTOMA_*_PORT)", async (ctx) => {
+    const probe = await probeLiveApi(baseUrl);
+    if (!probe.reachable) {
+      const message = formatLiveApiUnavailableMessage(baseUrl, probe.reason);
+      // eslint-disable-next-line no-console -- actionable skip reason for CI/local triage
+      console.error(message);
+      ctx.skip(message);
+      return;
+    }
+
     const res = await runNeotomaCli(
       ["--json", "--api-only", "--base-url", baseUrl, "schemas", "describe", "company"],
-      {},
+      {}
     );
     expect(res.exitCode, res.stderr + res.stdout).toBe(0);
     const parsed = JSON.parse(res.stdout) as {
@@ -89,5 +98,6 @@ describe("CLI schemas describe (smoke)", () => {
     expect(parsed.entity_type).toBe("company");
     expect(parsed.fields !== undefined).toBe(true);
     expect(Array.isArray(parsed.notes)).toBe(true);
-  });
+  }, // Far below vitest.config.ts testTimeout (60000); generous for live round-trip under CI load.
+  15000);
 });

--- a/tests/cli/support/live_api_probe.ts
+++ b/tests/cli/support/live_api_probe.ts
@@ -100,13 +100,13 @@ export function formatLiveApiUnavailableMessage(
   }
 
   const envNames = "NEOTOMA_SESSION_DEV_PORT / NEOTOMA_HTTP_PORT";
-  const nextAction = "[COPY: Start the local server, or run this test in the integration lane.]";
+  const nextAction = "Start the local server, or run this test in the integration lane.";
 
   if (reason === "timeout") {
-    return `[COPY: live API probe timed out] on ${hostPort} (${envNames}). ${nextAction}`;
+    return `Live API probe timed out on ${hostPort} (${envNames}). ${nextAction}`;
   }
   if (reason === "invalid_url") {
-    return `[COPY: Live API not listening] on ${hostPort} (${envNames}) — base URL must be literal loopback (127.0.0.1 or ::1). ${nextAction}`;
+    return `Live API not listening on ${hostPort} (${envNames}) — base URL must be literal loopback (127.0.0.1 or ::1). ${nextAction}`;
   }
-  return `[COPY: Live API not listening] on ${hostPort} (${envNames}). ${nextAction}`;
+  return `Live API not listening on ${hostPort} (${envNames}). ${nextAction}`;
 }

--- a/tests/cli/support/live_api_probe.ts
+++ b/tests/cli/support/live_api_probe.ts
@@ -1,0 +1,112 @@
+/**
+ * Shared fail-fast probe for CLI tests that hit a live loopback HTTP API.
+ *
+ * Unit / `no DB` lane contract: do not hang to Vitest's global `testTimeout`
+ * (60000ms in vitest.config.ts) when the server is absent. Prefer moving
+ * live-HTTP cases into the integration lane; if a case must stay runnable
+ * outside that lane, call `probeLiveApi` first and skip/fail with
+ * `formatLiveApiUnavailableMessage`.
+ *
+ * Search term for siblings: `resolveTestApiBaseUrl` under `tests/cli/`.
+ */
+
+export const LIVE_API_PROBE_DEFAULT_TIMEOUT_MS = 800;
+
+export type LiveApiProbeReason = "unreachable" | "timeout" | "invalid_url";
+
+export type LiveApiProbeResult =
+  | { reachable: true }
+  | { reachable: false; reason: LiveApiProbeReason };
+
+/**
+ * Resolves the base URL for CLI tests that exercise a live HTTP server,
+ * honoring the same env vars the CLI reads for its session/dev port.
+ */
+export function resolveTestApiBaseUrl(): string {
+  const port = process.env.NEOTOMA_SESSION_DEV_PORT || process.env.NEOTOMA_HTTP_PORT || "18080";
+  return `http://127.0.0.1:${port}`;
+}
+
+function isLiteralLoopbackHostname(hostname: string): boolean {
+  // Arch constraint: reject bare `localhost` string match — require literal loopback IP.
+  return hostname === "127.0.0.1" || hostname === "::1" || hostname === "[::1]";
+}
+
+/**
+ * Minimal reachability check against a loopback API. Never attaches credentials.
+ * Uses `redirect: "error"` so a probe cannot follow an off-loopback Location.
+ */
+export async function probeLiveApi(
+  baseUrl: string,
+  opts?: { timeoutMs?: number }
+): Promise<LiveApiProbeResult> {
+  let parsed: URL;
+  try {
+    parsed = new URL(baseUrl);
+  } catch {
+    return { reachable: false, reason: "invalid_url" };
+  }
+
+  if (!isLiteralLoopbackHostname(parsed.hostname)) {
+    return { reachable: false, reason: "invalid_url" };
+  }
+
+  const timeoutMs = opts?.timeoutMs ?? LIVE_API_PROBE_DEFAULT_TIMEOUT_MS;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  // Prefer the lightweight /health path used elsewhere in the suite; fall back to root.
+  const probeUrl = new URL("/health", parsed).toString();
+
+  try {
+    await fetch(probeUrl, {
+      method: "GET",
+      signal: controller.signal,
+      redirect: "error",
+      credentials: "omit",
+      // Reachability only — never attach Authorization / Bearer / AAuth material.
+      headers: { Accept: "application/json" },
+    });
+    return { reachable: true };
+  } catch (err) {
+    const name = err instanceof Error ? err.name : "";
+    const message = err instanceof Error ? err.message : String(err);
+    if (name === "AbortError" || /aborted|timeout/i.test(message)) {
+      return { reachable: false, reason: "timeout" };
+    }
+    // redirect: "error" surfaces as a TypeError / fetch failed when Location leaves
+    // the origin, or as an opaque redirect error — treat as unreachable for messaging.
+    return { reachable: false, reason: "unreachable" };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * UX-shaped skip/fail text: resolved port + env var *names* + next action.
+ * Never interpolates env values, headers, or token-shaped material.
+ */
+export function formatLiveApiUnavailableMessage(
+  baseUrl: string,
+  reason: LiveApiProbeReason
+): string {
+  let hostPort = baseUrl;
+  try {
+    const parsed = new URL(baseUrl);
+    const port = parsed.port || (parsed.protocol === "https:" ? "443" : "80");
+    hostPort = `${parsed.hostname}:${port}`;
+  } catch {
+    /* keep raw baseUrl */
+  }
+
+  const envNames = "NEOTOMA_SESSION_DEV_PORT / NEOTOMA_HTTP_PORT";
+  const nextAction = "[COPY: Start the local server, or run this test in the integration lane.]";
+
+  if (reason === "timeout") {
+    return `[COPY: live API probe timed out] on ${hostPort} (${envNames}). ${nextAction}`;
+  }
+  if (reason === "invalid_url") {
+    return `[COPY: Live API not listening] on ${hostPort} (${envNames}) — base URL must be literal loopback (127.0.0.1 or ::1). ${nextAction}`;
+  }
+  return `[COPY: Live API not listening] on ${hostPort} (${envNames}). ${nextAction}`;
+}


### PR DESCRIPTION
## Summary

Closes #2052.

Fail-fast loopback probe for CLI live-HTTP smoke tests so an absent/unready server skips in ≤1s with an actionable message instead of hanging to Vitest’s global `testTimeout: 60000`.

- New shared helper `tests/cli/support/live_api_probe.ts` (`resolveTestApiBaseUrl`, `probeLiveApi` @ 800ms, `formatLiveApiUnavailableMessage`)
- Migrated `issues_message.test.ts` and `schemas_describe.test.ts`: live-server titles, probe→skip, explicit per-test timeout (15s ≪ 60s)
- Effect test `tests/cli/live_api_probe.test.ts` proves closed-port path finishes ≪60s and message shape (port + env **names** + next action; no token-shaped substrings)
- Docs: `tests/cli/README.md` + note in `docs/testing/testing_standard.md`
- Regenerated `docs/testing/automated_test_catalog.md` (`validate:test-catalog` green)

### Lane placement decision

**Probe-in-place** (kept both files in `tests/cli/` / unit/`no DB` lane).

Rationale: `issues_message.test.ts` mixes a true unit case (orphan `--body` validation) with a live-HTTP case, so a whole-file move is not clean. Sibling `schemas_describe.test.ts` is pure live-HTTP but shares the same helper contract; Arch allows fail-fast probe when a case must remain runnable outside integration. Preferring probe keeps local feedback without spinning the integration lane.

### Sibling sweep (`resolveTestApiBaseUrl` under `tests/cli/`)

| Caller | Disposition |
|---|---|
| `tests/cli/issues_message.test.ts` | **probed** (shared helper + skip + title + timeout) |
| `tests/cli/schemas_describe.test.ts` | **probed** (same) |
| Other callers | **N/A** — search returned only these two |

### Idempotency / uniqueness

Product create/message path has no `idempotency_key` in this harness; tests use **unique title/body per run** (`Date.now()` + `randomUUID()`). Effect test performs **no** mutating call.

### Self-review

Author-side review: APPROVE after catalog regen fix. Non-blocking: pure-live `schemas_describe` could move to integration later.

## Test plan

- [x] `npx vitest run tests/cli/live_api_probe.test.ts tests/cli/issues_message.test.ts tests/cli/schemas_describe.test.ts` — pass
- [x] `npm run generate:test-catalog` + `npm run validate:test-catalog` — green
- [x] Prettier + type-check + lint (warnings-only baseline) on commit
- [ ] CI baseline / `test:unit` (no DB) — confirm no 60s hang when live server absent; probe skip message visible
- [ ] With live server up — live HTTP cases still pass; graceful `ISSUE_MESSAGE_FAILED|stored locally for follow-up` path remains distinct from probe skip

---
**🤖 Cicada — Ateles swarm, implementation build**
**SIGNED_OFF**

Impl gate ready for Vanellus after CI.

📎 Neotoma: [neotoma#2052](https://neotoma.markmhendrickson.com/entities/ent_9a1cbb32441a4ab5ae596280)

Made with [Cursor](https://cursor.com)