### PR TITLE
fix(ops): restart on a clean exit — the service check never could

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -44,19 +44,36 @@ primary_region = 'lhr'
   min_machines_running = 1
   processes = ['app']
 
-  # Restart the machine when the app stops answering, regardless of how it
-  # stopped. `min_machines_running` alone does NOT cover a process that exits
-  # with code 0: the platform reads a clean exit as "the job finished" and
-  # declines to restart, so a silent exit becomes an open-ended outage rather
-  # than a blip. Observed in production 2026-08-04 — the server exited code 0
-  # roughly every 12 minutes with no error and stayed down (neotoma#2094).
-  # This check is a safety net, not a fix for that bug.
+  # Health check for LOAD-BALANCER ROUTING ONLY. A check declared under
+  # [http_service] is a *service* check: it decides whether the Fly proxy sends
+  # traffic to a machine. It does NOT restart one. An earlier version of this
+  # comment claimed it restarted the machine "regardless of how it stopped" —
+  # that was wrong, and it made the deployment look self-healing when it was
+  # not. Restart behavior is the [restart] block below.
   [[http_service.checks]]
     interval = '15s'
     timeout = '10s'
     grace_period = '30s'
     method = 'GET'
     path = '/health'
+
+# Restart the machine whenever the process ends, INCLUDING a clean exit.
+#
+# Fly's default policy is `on-failure`, which by definition ignores exit code 0:
+# the platform reads a clean exit as "the job finished" and declines to restart.
+# The server does exit 0 periodically with no error (neotoma#2094, root cause
+# still unknown), and under `on-failure` the machine then stays stopped until an
+# inbound request happens to wake it. That cold start is what users experience —
+# measured at 33-45s, with intermittent 503s, against a normal 0.2s.
+#
+# `always` is the only policy that covers a code-0 exit. Verified on a hosted
+# instance 2026-08-05: no exits in ~40 minutes where they had been occurring
+# every ~16, and worst-case latency dropped from 45s to ~2.3s.
+#
+# This is a safety net, NOT a fix for #2094 — the process should not be exiting
+# in the first place.
+[[restart]]
+  policy = 'always'
 
 [[vm]]
   memory = '1gb'


### PR DESCRIPTION
## What

Adds `[[restart]] policy = 'always'` to `fly.toml`, and corrects a comment that described restart behavior the config never implemented.

Refs #2094.

## Why

`[[http_service.checks]]` is a **service** check — it decides whether the Fly proxy *routes traffic* to a machine. It does not restart one. Confirmed both in [Fly's config reference](https://fly.io/docs/reference/configuration/) and on a live machine, where `--display-config` reports top-level `checks: null` with the check nested under `services[].checks`.

The comment added with that check claimed otherwise:

> Restart the machine when the app stops answering, regardless of how it stopped.

That made the deployment read as self-healing when it wasn't.

The actual gate is the restart policy, which defaults to `on-failure`:

```
restart policy: {"policy": "on-failure", "max_retries": 10}
```

`on-failure` ignores exit code 0 by definition — and the server exits 0 periodically with no error (#2094). The machine then stays stopped until an inbound request wakes it. The event log shows the restart source is `proxy` (a request), one second *before* `flyd`:

```
started  │ start │ flyd   │ 10:01:16 │
starting │ start │ proxy  │ 10:01:13 │
stopped  │ exit  │ flyd   │ 10:01:12 │ exit_code=0,oom_killed=false,requested_stop=false
```

That cold start is the user-visible symptom: **33–45s stalls and intermittent 503s** against a normal 0.2s.

## Verification

Applied at the platform level first (`flyctl machine update --restart always`) to confirm the hypothesis before changing shared config:

| | before | after |
|---|---|---|
| exits | every ~16 min | none in ~40 min |
| worst-case latency | 33–45s + 503s | ~2.3s |
| typical latency | 0.2s | 0.18–0.24s |

`flyctl config validate` passes against **neotoma-sandbox**, **bottega8-neotoma**, and the operator instance. `always` is strictly safer than `on-failure` — it covers every case the default did, plus clean exits.

Note: `[[restart]]` must be an array-of-tables; `[restart]` fails validation with `cannot unmarshal object into Go struct field Config.restart`.

## Scope

This is a **safety net, not a fix** — the process should not be exiting at all, and #2094 stays open for that.

One further datum for whoever picks it up: the `beforeExit` + `getActiveResourcesInfo` diagnostic from #2095 **never fires** — zero occurrences across all retained logs and multiple observed exits, though the handler is present in `src/actions.ts`. Since `beforeExit` only fires when the loop drains *naturally*, its silence suggests the process is being terminated abruptly rather than running out of work. "The event loop drains" is likely the wrong hypothesis; `process.on('exit')`, signal handlers, and `uncaughtException`/`unhandledRejection` would be the more promising instrumentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)