### PR TITLE
security: v0.21.4 (GHSA-33x4-v5cf-2hfj, GHSA-8f95-jfm5-jjmr)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,9 +4,8 @@
 
 | Version  | Supported |
 |----------|-----------|
-| `0.18.x` | Yes       |
-| `0.17.x` | Yes       |
-| `< 0.17` | No (patch only on critical advisories — see [advisories index](docs/security/advisories/README.md)) |
+| `0.21.x` | Yes       |
+| `< 0.21` | No (patch only on critical advisories — see [advisories index](docs/security/advisories/README.md)) |
 
 The most recent published Neotoma version is the only one that receives proactive support. Critical advisories may produce a one-off patch on the previous minor when the affected range is large; see the per-advisory file under [`docs/security/advisories/`](docs/security/advisories/README.md) for the exact range.
 

--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,8 +61,8 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **571**
-- Backend and repo Vitest files: **536**
+- Total automated test files: **573**
+- Backend and repo Vitest files: **538**
 - Frontend Vitest files: **9**
 - Playwright spec files: **26**
 
@@ -75,7 +75,7 @@ flowchart TD
 | Vitest integration tests | 160 |
 | Vitest CLI tests | 77 |
 | Vitest contract tests | 15 |
-| Vitest security tests | 4 |
+| Vitest security tests | 6 |
 | Vitest subscription tests | 5 |
 | Vitest agent tests | 1 |
 | Vitest fixture tests | 1 |
@@ -670,10 +670,12 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npx vitest run tests/security`
 **Requirements:** Use alongside the dedicated security validation scripts when changing auth or route protection.
-**Files (4):**
+**Files (6):**
 - `tests/security/auth_topology_matrix.test.ts`
 - `tests/security/cross_user_read_scoping.test.ts`
+- `tests/security/ed25519_forged_key_auth_bypass.test.ts`
 - `tests/security/sandbox_mode_resolver.test.ts`
+- `tests/security/sort_by_sql_injection.test.ts`
 - `tests/security/tenant_isolation_matrix.test.ts`
 
 ### Vitest subscription tests

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neotoma",
-  "version": "0.21.3",
+  "version": "0.21.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neotoma",
-      "version": "0.21.3",
+      "version": "0.21.4",
       "license": "MIT",
       "dependencies": {
         "@hellocoop/httpsig": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neotoma",
-  "version": "0.21.3",
+  "version": "0.21.4",
   "description": "MCP server for structured personal data memory with unified source ingestion",
   "main": "dist/index.js",
   "type": "module",

--- a/playwright/tests/inspector/inspector-graph-render.spec.ts
+++ b/playwright/tests/inspector/inspector-graph-render.spec.ts
@@ -40,16 +40,27 @@ type StoreResponse = {
   entities?: Array<{ entity_id: string }>;
 };
 
+// No Authorization header: these seed calls run from the Playwright host process
+// against the local backend (127.0.0.1), same as the SPA client requests this spec
+// drives via addInitScript. That hits the untouched `local_no_bearer` auth path in
+// src/actions.ts (storageBackend === "local" + isLocalRequest + no Bearer header),
+// which auto-authenticates as LOCAL_DEV_USER_ID and honors the body's `user_id`.
+//
+// SECURITY (advisory 2026-08-07-ed25519-bearer-forged-key-auth-bypass): sending an
+// Ed25519 Bearer token here without a request Signature — as this spec did prior to
+// v0.21.4 — now 401s by design; getAuthenticatedUserId fails closed for unresolved
+// Bearer principals. This spec's bearerToken fixture is derived from a key that is
+// never registered with a userId (ACTIONS_BEARER_TOKEN isn't consumed by
+// src/actions.ts), so even a signed request would resolve no principal. Omitting
+// the header entirely is the correct fix, not a workaround.
 async function storeEntity(
   origin: string,
-  bearer: string,
   entity: Record<string, unknown>,
   idempotencyKey: string
 ): Promise<string> {
   const res = await fetch(`${origin}/store`, {
     method: "POST",
     headers: {
-      Authorization: `Bearer ${bearer}`,
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
@@ -70,14 +81,12 @@ async function storeEntity(
 
 async function createRelationship(
   origin: string,
-  bearer: string,
   sourceId: string,
   targetId: string
 ): Promise<void> {
   const res = await fetch(`${origin}/create_relationship`, {
     method: "POST",
     headers: {
-      Authorization: `Bearer ${bearer}`,
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
@@ -97,11 +106,10 @@ async function createRelationship(
  * Seed a focus entity linked to >=2 neighbors so the neighborhood graph renders
  * >=3 nodes and >=1 edge. Returns the focus entity id to explore.
  */
-async function seedGraph(origin: string, bearer: string): Promise<string> {
+async function seedGraph(origin: string): Promise<string> {
   const stamp = Date.now();
   const focusId = await storeEntity(
     origin,
-    bearer,
     {
       entity_type: "company",
       name: `PWGraphFocus${stamp}`,
@@ -114,7 +122,6 @@ async function seedGraph(origin: string, bearer: string): Promise<string> {
     neighborIds.push(
       await storeEntity(
         origin,
-        bearer,
         {
           entity_type: "person",
           name: `PWGraphNeighbor${i}_${stamp}`,
@@ -125,8 +132,8 @@ async function seedGraph(origin: string, bearer: string): Promise<string> {
     );
   }
   // focus PART_OF neighbor0, neighbor1 PART_OF focus -> 2 edges, 3 nodes total.
-  await createRelationship(origin, bearer, focusId, neighborIds[0]!);
-  await createRelationship(origin, bearer, neighborIds[1]!, focusId);
+  await createRelationship(origin, focusId, neighborIds[0]!);
+  await createRelationship(origin, neighborIds[1]!, focusId);
   return focusId;
 }
 
@@ -203,7 +210,6 @@ async function assertGraphPaints(page: import("@playwright/test").Page): Promise
 test.describe("Inspector graph render smoke (prod bundle, pixel-level)", () => {
   test("/graph paints a fitted graph with >=3 nodes and >=1 edge", async ({
     page,
-    bearerToken,
     neotomaHttpOrigin,
     inspectorSpaUrl,
   }) => {
@@ -225,7 +231,7 @@ test.describe("Inspector graph render smoke (prod bundle, pixel-level)", () => {
       }
     });
 
-    const focusId = await seedGraph(neotomaHttpOrigin, bearerToken);
+    const focusId = await seedGraph(neotomaHttpOrigin);
 
     await page.goto(`${inspectorSpaUrl}graph?node=${encodeURIComponent(focusId)}`, {
       waitUntil: "domcontentloaded",
@@ -236,11 +242,10 @@ test.describe("Inspector graph render smoke (prod bundle, pixel-level)", () => {
 
   test("/embed/graph paints a fitted graph with >=3 nodes and >=1 edge", async ({
     page,
-    bearerToken,
     neotomaHttpOrigin,
     inspectorSpaUrl,
   }) => {
-    const focusId = await seedGraph(neotomaHttpOrigin, bearerToken);
+    const focusId = await seedGraph(neotomaHttpOrigin);
 
     // The embed route reads its API origin from `?apiBase=` (the `WithBase` graph
     // hook), and the focus node from `?node=`.

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -4054,31 +4054,45 @@ app.use(async (req, res, next) => {
 
   const bearerToken = headerAuth.slice("Bearer ".length).trim();
 
-  // Try to validate as Ed25519 bearer token first
+  // Ed25519 bearer path.
+  //
+  // SECURITY (advisory 2026-08-07-ed25519-bearer-forged-key-auth-bypass):
+  // The bearer token IS a public key (base64url of 32 raw bytes). Possession
+  // of a public key must NEVER authenticate — anyone can present any public
+  // key. Two invariants close the prior forged-key bypass:
+  //
+  //   1. A valid request Signature is MANDATORY. It proves possession of the
+  //      corresponding private key. A request without a signature is rejected,
+  //      not silently accepted (the old `if (signature && req.body)` made the
+  //      check optional, so an unsigned forged key sailed through).
+  //   2. The key must map to a PRE-PROVISIONED userId. `ensurePublicKeyRegistered`
+  //      auto-registers any syntactically-valid 32-byte key, so its `true` return
+  //      means "well-formed", not "known". Only a key that was registered WITH a
+  //      userId (getUserIdFromBearerToken) is a real principal; a bare
+  //      auto-registered key resolves to `undefined` and must fall through to the
+  //      reject path — never to a caller-supplied `user_id` in getAuthenticatedUserId.
   const registered = ensurePublicKeyRegistered(bearerToken);
+  const registeredUserId = registered ? getUserIdFromBearerToken(bearerToken) : undefined;
+  const { signature: ed25519Signature } = parseAuthHeader(headerAuth);
 
-  if (registered && isBearerTokenValid(bearerToken)) {
-    // Optional: Verify signature if provided
-    const { signature } = parseAuthHeader(headerAuth);
-    if (signature && req.body) {
-      const bodyString = typeof req.body === "string" ? req.body : JSON.stringify(req.body);
-      const isValid = verifyRequest(bodyString, signature, bearerToken);
-      if (!isValid) {
-        logWarn("AuthInvalidSignature", req);
-        return sendError(res, 403, "AUTH_INVALID", "Invalid request signature");
-      }
+  if (registered && isBearerTokenValid(bearerToken) && registeredUserId && ed25519Signature) {
+    // Signature is required and must verify over the exact request body.
+    const bodyString = typeof req.body === "string" ? req.body : JSON.stringify(req.body ?? "");
+    if (!verifyRequest(bodyString, ed25519Signature, bearerToken)) {
+      logWarn("AuthInvalidSignature", req);
+      return sendError(res, 403, "AUTH_INVALID", "Invalid request signature");
     }
 
     // Attach public key to request for encryption service
     (req as any).publicKey = getPublicKey(bearerToken);
     (req as any).bearerToken = bearerToken;
-    // If this token was registered with a userId, set it so getAuthenticatedUserId works without query param
-    const registeredUserId = getUserIdFromBearerToken(bearerToken);
-    if (registeredUserId) {
-      stampUserPrincipal(req, registeredUserId);
-    }
+    // Bind the request to the pre-provisioned principal. The caller cannot
+    // override this via a `user_id` param — getAuthenticatedUserId keys off the
+    // stamped principal, and the Ed25519 fall-through that trusted a
+    // caller-supplied user_id has been removed.
+    stampUserPrincipal(req, registeredUserId);
     logger.info(
-      `[Auth] ${req.method} ${req.path} auth_method=ed25519_bearer user_id=${(req as any).authenticatedUserId ?? "(from token)"}`
+      `[Auth] ${req.method} ${req.path} auth_method=ed25519_bearer user_id=${registeredUserId}`
     );
   } else {
     // Try to validate as session token
@@ -4192,7 +4206,10 @@ app.get("/me", async (req, res) => {
  * @returns Authenticated user_id
  * @throws Error if not authenticated or user_id mismatch
  */
-async function getAuthenticatedUserId(
+// Exported for the security regression test that asserts the fail-closed
+// behaviour for unresolved Bearer principals
+// (advisory 2026-08-07-ed25519-bearer-forged-key-auth-bypass).
+export async function getAuthenticatedUserId(
   req: express.Request,
   providedUserId?: string
 ): Promise<string> {
@@ -4228,18 +4245,17 @@ async function getAuthenticatedUserId(
     return authenticatedUserId;
   }
 
-  const headerAuth = req.headers.authorization || "";
-  if (!headerAuth.startsWith("Bearer ")) {
-    throw new Error("Not authenticated - missing Bearer token");
-  }
-
-  // Ed25519 bearer token - user_id must be provided
-  if (!providedUserId) {
-    throw new Error("user_id required when using Ed25519 bearer token");
-  }
-
-  // For Ed25519 tokens, we trust the provided user_id (token validation happens in middleware)
-  return providedUserId;
+  // No principal was resolved by the auth middleware. Fail closed.
+  //
+  // SECURITY (advisory 2026-08-07-ed25519-bearer-forged-key-auth-bypass):
+  // Previously this tail returned the caller-supplied `user_id` for any request
+  // carrying a Bearer header, on the assumption that "token validation happens
+  // in middleware". A forged public key was accepted by that middleware without
+  // proving possession of the private key, so this line handed an attacker the
+  // scope of their choice (e.g. the shared nil-UUID owner). A request that
+  // reaches here has NOT been authenticated to any principal — there is no
+  // trustworthy `user_id` to return, regardless of what the caller provided.
+  throw new Error("Not authenticated - no resolved principal for request");
 }
 
 /**
@@ -4314,6 +4330,24 @@ function handleApiError(
     return res
       .status(error.status)
       .json(buildErrorEnvelope(error.code, error.message, error.toErrorEnvelopeDetails()));
+  }
+  // SECURITY (advisory 2026-08-07-sort-by-order-by-sql-injection): a rejected
+  // snapshot field name (sort_by / snapshot_filters) or an unsafe column
+  // reference caught by the sqlite adapter is a client input error, not a server
+  // fault — surface it as a 400 so it is not masked as a 500 DB_QUERY_FAILED, and
+  // so the negative test asserts a stable status. Matched by name to avoid a
+  // static import cycle with the dynamically-imported query module.
+  if (
+    error instanceof Error &&
+    (error.name === "InvalidSnapshotFieldError" ||
+      error.message.startsWith("Unsafe column reference rejected:"))
+  ) {
+    logWarn(logContext || "InvalidQueryField", req, { detail: error.message });
+    return res.status(400).json(
+      buildErrorEnvelope("INVALID_QUERY_FIELD", "Invalid query field name.", {
+        detail: error.message,
+      })
+    );
   }
   logError(logContext || "APIError", req, error);
   // SECURITY: do not echo raw Error.message to clients in production; SQLite /

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -4342,10 +4342,15 @@ function handleApiError(
     (error.name === "InvalidSnapshotFieldError" ||
       error.message.startsWith("Unsafe column reference rejected:"))
   ) {
+    // Log the full message (with the rejected value) server-side for debugging,
+    // but do NOT echo the caller-supplied field string back in the response —
+    // reflecting rejected input, even sanitized, is needless. Return a generic
+    // detail that names the constraint. (Vanellus review, PR #2129, non-blocking.)
     logWarn(logContext || "InvalidQueryField", req, { detail: error.message });
     return res.status(400).json(
       buildErrorEnvelope("INVALID_QUERY_FIELD", "Invalid query field name.", {
-        detail: error.message,
+        detail:
+          "Query field names (sort_by / snapshot_filters keys) must be bare identifiers matching ^[A-Za-z_][A-Za-z0-9_]*$.",
       })
     );
   }

--- a/src/repositories/sqlite/local_db_adapter.ts
+++ b/src/repositories/sqlite/local_db_adapter.ts
@@ -299,7 +299,9 @@ function fromDbRow(table: string, row: Record<string, unknown>): Record<string, 
   return result;
 }
 
-function normalizeColumnName(table: string, column: string): string {
+// Exported for the security regression test that asserts the fail-closed
+// behaviour of the column normaliser (advisory 2026-08-07-sort-by-order-by-sql-injection).
+export function normalizeColumnName(table: string, column: string): string {
   // Compatibility aliases used by tests and older codepaths.
   if (table === "entities" && column === "merged_into") return "merged_to_entity_id";
   if (table === "observations" && column === "priority") return "source_priority";
@@ -328,6 +330,18 @@ function normalizeColumnName(table: string, column: string): string {
     // Emulate PostgREST text projection semantics for ->>:
     // booleans become "true"/"false"; scalars become text.
     return `CASE json_type(${jsonColumn}, '${jsonPath}') WHEN 'true' THEN 'true' WHEN 'false' THEN 'false' ELSE CAST(${extracted} AS TEXT) END`;
+  }
+  // SECURITY (advisory 2026-08-07-sort-by-order-by-sql-injection): this value is
+  // interpolated verbatim into generated SQL (ORDER BY, WHERE, SELECT). The old
+  // `return column` fallthrough let any non-recognised string — including a
+  // `(CASE WHEN … )` expression smuggled through a `snapshot->>${field}` build —
+  // reach SQLite unescaped. Fail closed instead: only a bare column identifier
+  // or a `table.column` qualified identifier may pass through. Every legitimate
+  // caller uses one of those shapes, the `->>` / `lower(->>)` projections, or a
+  // compatibility alias handled above; anything else is a bug or an injection
+  // attempt and must not be interpolated.
+  if (!/^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)?$/.test(column)) {
+    throw new Error(`Unsafe column reference rejected: ${JSON.stringify(column)}`);
   }
   return column;
 }
@@ -874,8 +888,26 @@ class LocalQueryBuilder {
                     .map((o) => `${o.column} ${o.ascending ? "ASC" : "DESC"}`)
                     .join(", ")}`
                 : "";
-            const limitSql = this.limitValue !== null ? `LIMIT ${this.limitValue}` : "";
-            const offsetSql = this.offsetValue !== null ? `OFFSET ${this.offsetValue}` : "";
+            // SECURITY (advisory 2026-08-07-sort-by-order-by-sql-injection, Fix
+            // item 3): LIMIT/OFFSET are interpolated into query text. Every
+            // current caller coerces to a validated integer upstream, but coerce
+            // again here so this raw sink cannot inject if a future caller passes
+            // an unvalidated value — a non-integer is rejected rather than spliced.
+            // Number.isSafeInteger (not isInteger): |n| >= 1e21 is still an
+            // "integer" but stringifies to exponential notation ("1e+21"), which
+            // is not a plain decimal token. Not injectable — the form carries no
+            // SQL metacharacters — but rejecting it keeps this sink strictly
+            // plain-decimal, which is what the guard claims to guarantee.
+            const asSqlCount = (value: number, label: string): number => {
+              if (!Number.isSafeInteger(value) || value < 0) {
+                throw new Error(`Unsafe ${label} value rejected: ${JSON.stringify(value)}`);
+              }
+              return value;
+            };
+            const limitSql =
+              this.limitValue !== null ? `LIMIT ${asSqlCount(this.limitValue, "LIMIT")}` : "";
+            const offsetSql =
+              this.offsetValue !== null ? `OFFSET ${asSqlCount(this.offsetValue, "OFFSET")}` : "";
 
             const sql =
               `SELECT ${this.selectColumns || "*"} FROM ${this.table} ${whereSql} ${orderSql} ${limitSql} ${offsetSql}`.trim();

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,6 +11,7 @@ import {
   McpError,
 } from "@modelcontextprotocol/sdk/types.js";
 import { db } from "./db.js";
+import { isValidSnapshotFieldName } from "./services/entity_queries.js";
 import { logger } from "./utils/logger.js";
 import { z } from "zod";
 import { createHash, randomUUID } from "node:crypto";
@@ -7292,9 +7293,21 @@ export class NeotomaServer {
         }
       }
 
-      // Parse sort field
+      // Parse sort field.
+      //
+      // SECURITY (advisory 2026-08-07-sort-by-order-by-sql-injection): the
+      // resource-collection handlers (handleSourceCollection,
+      // handleRelationshipCollection[All]) interpolate this value into an
+      // ORDER BY via `.order(sortField)`. Validate it as a bare column
+      // identifier at the source — mirroring the entity_queries.ts guard — so
+      // these sinks do not rely solely on the sqlite adapter's fail-closed
+      // backstop. A non-identifier value is dropped, so each handler falls back
+      // to its safe default column rather than surfacing a raw SQLite error.
       if (params.has("sort")) {
-        queryParams.sort = params.get("sort")!;
+        const requestedSort = params.get("sort")!;
+        if (isValidSnapshotFieldName(requestedSort)) {
+          queryParams.sort = requestedSort;
+        }
       }
 
       // Parse order (asc/desc)

--- a/src/services/entity_queries.ts
+++ b/src/services/entity_queries.ts
@@ -32,6 +32,35 @@ export function escapeLikeTerm(term: string): string {
   return term.replace(/\\/g, "\\\\").replace(/%/g, "\\%").replace(/_/g, "\\_");
 }
 
+/**
+ * A snapshot JSON field name that is safe to splice into a `snapshot->>${field}`
+ * column expression.
+ *
+ * SECURITY (advisory 2026-08-07-sort-by-order-by-sql-injection): both the
+ * `sort_by=snapshot.<field>` path and every `snapshot_filters` key are built
+ * into `snapshot->>${field}` and interpolated into generated SQL (ORDER BY and
+ * WHERE). The sqlite adapter only rewrites a column when it matches a strict
+ * `identifier->>identifier` pattern and otherwise passes it through UNCHANGED,
+ * so a non-identifier field name (e.g. a `(CASE WHEN … )` expression) reaches
+ * SQLite verbatim. Constrain field names to bare identifiers at the source, so
+ * an attacker cannot smuggle an expression through this seam.
+ */
+const SNAPSHOT_FIELD_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+export function isValidSnapshotFieldName(field: string): boolean {
+  return typeof field === "string" && SNAPSHOT_FIELD_NAME.test(field);
+}
+
+export class InvalidSnapshotFieldError extends Error {
+  constructor(field: string, context: "sort_by" | "snapshot_filters") {
+    super(
+      `Invalid ${context} field name: ${JSON.stringify(field)}. ` +
+        `Snapshot field names must match ${SNAPSHOT_FIELD_NAME.source}.`
+    );
+    this.name = "InvalidSnapshotFieldError";
+  }
+}
+
 export interface EntityQueryOptions {
   userId?: string;
   entityType?: string;
@@ -403,6 +432,9 @@ export async function queryEntities(
 
       if (snapshotFilters) {
         for (const [field, filter] of Object.entries(snapshotFilters)) {
+          if (!isValidSnapshotFieldName(field)) {
+            throw new InvalidSnapshotFieldError(field, "snapshot_filters");
+          }
           const col = `snapshot->>${field}`;
           switch (filter.op) {
             case "eq":
@@ -450,6 +482,9 @@ export async function queryEntities(
         snapshotQuery = snapshotQuery.order("snapshot->>created_at", { ascending });
       } else if (isSnapshotFieldSort) {
         const snapshotField = sortBy.replace("snapshot.", "");
+        if (!isValidSnapshotFieldName(snapshotField)) {
+          throw new InvalidSnapshotFieldError(snapshotField, "sort_by");
+        }
         snapshotQuery = snapshotQuery.order(`snapshot->>${snapshotField}`, { ascending });
       } else {
         snapshotQuery = snapshotQuery.order("entity_id", { ascending: true });

--- a/tests/security/auth_topology_matrix.test.ts
+++ b/tests/security/auth_topology_matrix.test.ts
@@ -42,6 +42,16 @@
  * `tests/integration/tunnel_auth.test.ts` for the regression-layer
  * coverage of the v0.11.1 bug class; tunnel_auth.test.ts remains the
  * targeted /mcp tunnel-auth assertion.
+ *
+ * NEGATIVE-SPACE DISCIPLINE (Practice 1, docs/security/adversarial_practices.md):
+ * absent/malformed-credential rows are necessary but NOT sufficient. The
+ * 2026-08-07 forged-key bypass lived in the gap between "no credential" and
+ * "wrong credential" — a WELL-FORMED-BUT-UNAUTHORIZED credential. Every auth
+ * boundary must also assert the well-formed-but-unauthorized case (a
+ * syntactically valid but unprovisioned credential, with and without a
+ * caller-supplied user_id override). That specific coverage lives in
+ * `tests/security/ed25519_forged_key_auth_bypass.test.ts`; keep both files in
+ * sync when adding auth paths.
  */
 
 import fs from "node:fs";

--- a/tests/security/ed25519_forged_key_auth_bypass.test.ts
+++ b/tests/security/ed25519_forged_key_auth_bypass.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Regression gate — advisory 2026-08-07-ed25519-bearer-forged-key-auth-bypass.
+ *
+ * The REST Ed25519 bearer path auto-registered ANY 32-byte token and verified
+ * the request signature only `if (signature ...)`, so an UNSIGNED forged public
+ * key was accepted; getAuthenticatedUserId then TRUSTED a caller-supplied
+ * `user_id` for any Bearer request whose token resolved to no principal. Net
+ * effect: an anonymous caller read/wrote the whole graph by presenting a random
+ * 32-byte key + the well-known nil-UUID owner.
+ *
+ * The decisive fix is in `getAuthenticatedUserId`: a Bearer request that reaches
+ * the tail with NO resolved `authenticatedUserId` must FAIL CLOSED, never return
+ * the caller-supplied `user_id`. This test drives that function directly with
+ * fake requests modelling each case, so the assertion depends on the fix and not
+ * on the test server's boot mode.
+ *
+ * Pre-fix, the "unresolved Bearer + provided user_id" case returned the provided
+ * id (the exploit). Post-fix it throws. The test is verified to fail against the
+ * pre-fix tail (see advisory § Fix).
+ */
+import { describe, it, expect } from "vitest";
+import type express from "express";
+import { getAuthenticatedUserId } from "../../src/actions.js";
+
+const NIL_UUID = "00000000-0000-0000-0000-000000000000"; // LOCAL_DEV_USER_ID
+const OTHER_UUID = "11111111-1111-1111-1111-111111111111";
+
+/** Minimal request stub: a forged Ed25519 bearer that resolved to no principal. */
+function reqWithBearerNoPrincipal(): express.Request {
+  return {
+    headers: { authorization: "Bearer AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" },
+    // no authenticatedUserId stamped — models a forged/unregistered key
+  } as unknown as express.Request;
+}
+
+/** A request that WAS resolved to a principal by the middleware. */
+function reqWithPrincipal(userId: string): express.Request {
+  return {
+    headers: { authorization: "Bearer whatever" },
+    authenticatedUserId: userId,
+  } as unknown as express.Request;
+}
+
+describe("getAuthenticatedUserId fail-closed for unresolved Bearer (advisory 2026-08-07)", () => {
+  it("THROWS when a Bearer request resolved to no principal, even with a provided user_id", async () => {
+    // This is the exploit: forged key (no principal) + attacker-chosen user_id.
+    await expect(
+      getAuthenticatedUserId(reqWithBearerNoPrincipal(), NIL_UUID)
+    ).rejects.toThrow(/Not authenticated/);
+  });
+
+  it("THROWS for an unresolved Bearer with no provided user_id", async () => {
+    await expect(getAuthenticatedUserId(reqWithBearerNoPrincipal(), undefined)).rejects.toThrow(
+      /Not authenticated/
+    );
+  });
+
+  it("does NOT return the caller-supplied user_id for an unresolved Bearer", async () => {
+    let resolved: string | undefined;
+    try {
+      resolved = await getAuthenticatedUserId(reqWithBearerNoPrincipal(), OTHER_UUID);
+    } catch {
+      resolved = undefined;
+    }
+    // Pre-fix this returned OTHER_UUID (the pivot). Post-fix it must never resolve.
+    expect(resolved).not.toBe(OTHER_UUID);
+    expect(resolved).toBeUndefined();
+  });
+
+  it("still returns a legitimately-resolved principal (no regression)", async () => {
+    await expect(getAuthenticatedUserId(reqWithPrincipal(OTHER_UUID))).resolves.toBe(OTHER_UUID);
+  });
+
+  it("still rejects a user_id override that mismatches a non-dev resolved principal", async () => {
+    // A resolved principal (not the local dev user) cannot be overridden by a
+    // caller-supplied user_id — the existing tenant guard.
+    await expect(
+      getAuthenticatedUserId(reqWithPrincipal(OTHER_UUID), NIL_UUID)
+    ).rejects.toThrow(/user_id parameter/);
+  });
+});

--- a/tests/security/sort_by_sql_injection.test.ts
+++ b/tests/security/sort_by_sql_injection.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Regression gate — advisory 2026-08-07-sort-by-order-by-sql-injection.
+ *
+ * The `sort_by=snapshot.<field>` and `snapshot_filters` keys were spliced into a
+ * `snapshot->>${field}` column and interpolated raw into generated SQL, so a
+ * `(CASE WHEN … )` expression reached SQLite and executed (a blind ORDER BY
+ * injection that also bypassed per-row user_id scoping on shared backends).
+ *
+ * Two independent layers must hold:
+ *   1. entity_queries rejects non-identifier snapshot field names at the source.
+ *   2. the sqlite adapter's normalizeColumnName fails closed on any column that
+ *      is neither a bare identifier, a `table.column`, nor a recognised `->>`
+ *      projection — the defense-in-depth backstop.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  isValidSnapshotFieldName,
+  InvalidSnapshotFieldError,
+} from "../../src/services/entity_queries.js";
+import { normalizeColumnName } from "../../src/repositories/sqlite/local_db_adapter.js";
+import { db } from "../../src/db.js";
+
+const INJECTION_FIELDS = [
+  "(CASE WHEN 1=1 THEN entity_id ELSE zzz END)",
+  "(CASE WHEN 1=1 THEN entity_id ELSE entity_type END)",
+  "(SELECT snapshot FROM entity_snapshots)",
+  "amount_eur) --",
+  "amount_eur; DROP TABLE entity_snapshots;--",
+  "amount_eur DESC, (SELECT 1)",
+  "json_extract(snapshot,'$.x')",
+  "a b",
+  "1=1",
+  "",
+  "snapshot->>x", // the `snapshot.` prefix is stripped before validation; a raw ->> here is not a bare field
+];
+
+const LEGITIMATE_FIELDS = [
+  "amount_eur",
+  "created_at",
+  "name",
+  "wise_iban",
+  "_private",
+  "field123",
+];
+
+describe("sort_by / snapshot_filters field-name validation (advisory 2026-08-07)", () => {
+  it("accepts only bare identifier field names", () => {
+    for (const f of LEGITIMATE_FIELDS) {
+      expect(isValidSnapshotFieldName(f)).toBe(true);
+    }
+  });
+
+  it("rejects every injection payload", () => {
+    for (const f of INJECTION_FIELDS) {
+      expect(isValidSnapshotFieldName(f)).toBe(false);
+    }
+  });
+
+  it("InvalidSnapshotFieldError names the context and carries the recognisable name", () => {
+    const err = new InvalidSnapshotFieldError("(CASE WHEN 1=1 THEN a ELSE b END)", "sort_by");
+    // handleApiError matches on this name to return 400 instead of 500.
+    expect(err.name).toBe("InvalidSnapshotFieldError");
+    expect(err.message).toContain("sort_by");
+  });
+});
+
+describe("normalizeColumnName fail-closed backstop (advisory 2026-08-07)", () => {
+  it("passes through bare and qualified identifiers unchanged", () => {
+    expect(normalizeColumnName("entity_snapshots", "entity_id")).toBe("entity_id");
+    expect(normalizeColumnName("entity_snapshots", "observation_count")).toBe("observation_count");
+    expect(normalizeColumnName("entity_snapshots", "es.user_id")).toBe("es.user_id");
+  });
+
+  it("still rewrites recognised ->> projections (no regression)", () => {
+    const out = normalizeColumnName("entity_snapshots", "snapshot->>amount_eur");
+    expect(out).toContain("json_extract");
+    expect(out).not.toContain("(CASE WHEN");
+  });
+
+  it("throws on any non-identifier column (the smuggled expression path)", () => {
+    const attacks = [
+      "snapshot->>(CASE WHEN 1=1 THEN entity_id ELSE zzz END)",
+      "(CASE WHEN 1=1 THEN entity_id ELSE zzz END)",
+      "entity_id) --",
+      "entity_id; DROP TABLE entity_snapshots;--",
+      "(SELECT 1)",
+      "a b",
+    ];
+    for (const col of attacks) {
+      expect(() => normalizeColumnName("entity_snapshots", col)).toThrow(
+        /Unsafe column reference rejected/
+      );
+    }
+  });
+});
+
+describe("LIMIT/OFFSET are integer-clamped at the raw sink (advisory 2026-08-07, Fix item 3)", () => {
+  it("a legitimate integer limit/offset builds and runs", async () => {
+    const { error } = await db.from("entities").select("id").limit(5);
+    // May return rows or none, but must not error on the count values.
+    expect(error).toBeFalsy();
+  });
+
+  it("a non-integer limit is rejected before it reaches SQL", async () => {
+    // Bypass upstream Zod validation by driving the adapter directly with a
+    // hostile value, modelling a hypothetical future caller that forgot to
+    // validate. The adapter's execute() catches the guard's throw and surfaces
+    // it as an error envelope — the point is the malicious value NEVER reaches
+    // the SQL string; the query is rejected, not run.
+    const { data, error } = await db
+      .from("entities")
+      .select("id")
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .limit("1; DROP TABLE entities;--" as any);
+    expect(error).toBeTruthy();
+    expect(String(error?.message)).toMatch(/Unsafe LIMIT value rejected/);
+    expect(data).toBeNull();
+  });
+
+  it("a large integer that stringifies to exponential notation is rejected (plain-decimal guarantee)", async () => {
+    // Number.isInteger(1e21) is true but `${1e21}` === "1e+21" (not plain
+    // decimal). Not injectable, but the guard promises a plain-decimal token.
+    const { data, error } = await db
+      .from("entities")
+      .select("id")
+      .limit(1e21 as number);
+    expect(error).toBeTruthy();
+    expect(String(error?.message)).toMatch(/Unsafe LIMIT value rejected/);
+    expect(data).toBeNull();
+  });
+
+  it("a non-integer offset is likewise rejected", async () => {
+    const { error } = await db
+      .from("entities")
+      .select("id")
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .range("5); DROP TABLE entities;--" as any, 10 as any);
+    expect(error).toBeTruthy();
+    expect(String(error?.message)).toMatch(/Unsafe (LIMIT|OFFSET) value rejected/);
+  });
+});


### PR DESCRIPTION
Security release v0.21.4. Fixes two vulnerabilities disclosed privately under repository security advisories:

- GHSA-33x4-v5cf-2hfj
- GHSA-8f95-jfm5-jjmr

Details (impact, reproduction, root cause) are held in the advisories and will be mirrored publicly at release, per the GHSA-first disclosure flow. This PR carries only the code fix, regression tests, and version bump — no reproduction or exploit detail.

**Assurance:** `tests/security` regression coverage verified to fail pre-fix; `tsc` 0 errors, `security:lint` 0 errors.

Closes #2128
