### PR TITLE
Release v0.21.4

### DIFF
--- a/docs/releases/in_progress/v0.21.4/github_release_supplement.md
+++ b/docs/releases/in_progress/v0.21.4/github_release_supplement.md
@@ -1,0 +1,71 @@
+## Summary
+
+This release closes two high-severity authentication and injection vulnerabilities discovered in internal security review, fixes a self-referential OAuth discovery deadlock that blocked first-time MCP login for hosted instances, refreshes the homepage's live usage stats, and adds a Fly deploy config that stops operator-instance deploys from silently reverting VM sizing.
+
+## What changed for npm package users
+
+No CLI or package-artifact changes in this release.
+
+## API surface & contracts
+
+**`GET /.well-known/oauth-protected-resource` and `GET /.well-known/oauth-protected-resource/mcp` now return 200 unauthenticated (previously 401).** RFC 9728 §3 requires this document to be reachable without credentials — its entire purpose is to tell a caller with no credentials where to get them. The previous 401 response named itself as the place to find auth metadata, so a client 401'd at `/mcp` followed the `WWW-Authenticate` header back to a document that also 401'd, and the login flow never started. The `/mcp`-suffixed path (RFC 9728 §3.1's resource-appended form) is now registered alongside the bare path, since Express did not match it against the bare route.
+
+**`GET /.well-known/openid-configuration` now returns an explicit 404** instead of falling through to the catch-all auth guard's 401. This server does not implement OIDC discovery; the previous implicit 401 reproduced the same discovery dead-end on a sibling path. This is a deliberate 404, not a synthetic 200 — advertising a discovery contract this server does not implement would create a different failure mode.
+
+**Response schema addition:** the `200` body for `GET /.well-known/oauth-protected-resource` now includes a `resource` field (required by RFC 9728 §3, resolving to `${base}/mcp`) alongside the existing `authorization_servers`.
+
+The `X-Connection-Id`-based invalid-token check is unchanged — that guard protects a caller holding a stale credential, which is a different case from a caller with no credentials at all.
+
+No other request/response contract changes in this release.
+
+## Behavior changes
+
+Any MCP client or integration that previously worked around the discovery deadlock (for example, by skipping discovery and relying on anonymous writes) can remove that workaround. Discovery now completes as the RFC specifies.
+
+An anonymous caller can no longer obtain read/write access to any user's data by presenting an unsigned Ed25519 bearer token — see Security hardening below.
+
+## Docs site & CI / tooling
+
+- REST API docs gain a discovery-bootstrap section: the 4-request sequence, a curl table of expected statuses, and an explicit note that a 200 with no credential at step 2 is required behavior, not a bug.
+- MCP docs and the changelog note the 401→200 behavior change for integrators who built workarounds.
+- `fly.operator.toml` added: a per-target Fly deploy config for operator-run instances, mirroring the existing `fly.sandbox.toml` pattern. Declares explicit VM sizing (2 CPU / 4096MB) and `restart.policy = 'always'` so a deploy no longer silently reverts an instance that was manually scaled up to address query stalls. No app name, region, or hostname is hardcoded — both are supplied at deploy time, consistent with keeping deployment targets out of the public repo.
+- Homepage "How it's used" proof strip and founder blockquote refreshed against live prod counts (contacts, tasks, conversations, agent messages, entity types), each rounded down below the live figure so the "+" claim holds as the graph grows. Applied to both `en` and `es` locales.
+
+## Internal changes
+
+None beyond the above.
+
+## Fixes
+
+- **OAuth discovery deadlock** (#2049, #2050): first-time MCP login against a hosted instance could never complete discovery, because the protected-resource metadata endpoint required the very credential it exists to help a client obtain. Found via a partner's agent hitting first-time login against a live hosted instance.
+- **Stale homepage stats** (#2107): the public proof strip understated live usage by up to 10x on some metrics; corrected against a live prod snapshot taken 2026-08-05.
+- **Ed25519 bearer auth fail-open on unresolved principal** (advisory `2026-08-07-ed25519-bearer-forged-key-auth-bypass`): `getAuthenticatedUserId` trusted a caller-supplied `user_id` for any Bearer request that resolved to no authenticated principal. See Security hardening below.
+- **`sort_by` / `snapshot_filters` ORDER BY SQL injection** (advisory `2026-08-07-sort-by-order-by-sql-injection`): caller-supplied snapshot field names were spliced unvalidated into generated SQL. See Security hardening below.
+
+## Tests and validation
+
+- New integration test `tests/integration/wellknown_discovery_unauthenticated.test.ts` (4 cases): boots a real app instance and issues real unauthenticated HTTP requests (no `Authorization`, no `X-Connection-Id`) against all four discovery-adjacent routes, asserting on actual response status and body content (not just "not 401"). Verified to fail when the fix is reverted.
+- New regression test `tests/security/ed25519_forged_key_auth_bypass.test.ts` (5 cases): drives `getAuthenticatedUserId` directly with request stubs modeling an unresolved Bearer principal, asserting the function throws rather than trusting a caller-supplied `user_id`. Verified to fail against the pre-fix tail.
+- New regression test `tests/security/sort_by_sql_injection.test.ts` (10 cases): asserts `isValidSnapshotFieldName` rejects 11 distinct injection payloads and accepts only bare identifiers; asserts `normalizeColumnName`'s fail-closed backstop throws on any non-identifier column shape while still rewriting legitimate `->>` projections.
+- `security:manifest:check` confirms `protected_routes_manifest.json` stays in sync with `openapi.yaml` (118 routes, no drift).
+- `tests/security/auth_topology_matrix.test.ts`: 18/19 passing (1 skipped by design), confirming the broader auth topology is unaffected.
+- `fly.operator.toml` verified end to end against a live operator instance: deployed v0.21.2, machine held 2 CPU / 4096MB with `restart.policy = 'always'` across the deploy, health check 0.28-0.41s afterward, data intact.
+- Homepage stats change verified via `npm run build:ui`; all five refreshed values and the corrected "over a year" copy confirmed present in the built bundle.
+- `npm run openapi:bc-diff` against `v0.21.2`: no breaking changes, 4 non-breaking additions (the two new discovery operations and two new response fields).
+
+## Security hardening
+
+Classified `sensitive=true` by `npm run security:classify-diff` (OpenAPI security-block changes, protected-routes-manifest changes, and `src/actions.ts` auth-middleware and route-registration changes touched). Full adversarial review recorded in [`docs/releases/in_progress/v0.21.4/security_review.md`](./security_review.md).
+
+Two vulnerabilities are fixed in this release, both found in internal security review and both fixed with an accompanying regression test verified to fail pre-fix:
+
+- **[Ed25519 bearer auth: unresolved principal returned caller-supplied `user_id`](../../../security/advisories/2026-08-07-ed25519-bearer-forged-key-auth-bypass.md)** (GHSA-33x4-v5cf-2hfj, draft) — High severity. `getAuthenticatedUserId`'s fallback tail trusted a caller-supplied `user_id` for any Bearer request that resolved to no authenticated principal, because the Ed25519 verification middleware only checked a signature `if (signature ...)`. An unsigned, forged 32-byte token combined with an attacker-chosen `user_id` in the request body granted full read/write access to that user's graph. Fixed: the function now fails closed (`Not authenticated`) whenever a Bearer request reaches the tail with no resolved principal, regardless of whether `user_id` was supplied.
+- **[`sort_by` / `snapshot_filters` ORDER BY SQL injection](../../../security/advisories/2026-08-07-sort-by-order-by-sql-injection.md)** (GHSA-8f95-jfm5-jjmr, draft) — High severity. Caller-supplied `sort_by=snapshot.<field>` and `snapshot_filters` keys were spliced unvalidated into a `snapshot->>${field}` SQL projection and interpolated raw into generated SQL, allowing `(CASE WHEN ...)` conditional expressions and correlated subqueries to execute inside an `ORDER BY` clause, and potentially bypassing per-row user scoping on shared backends. Fixed with two layers: a new `isValidSnapshotFieldName` bare-identifier validator at the query-construction source, and a fail-closed backstop in the SQLite adapter's `normalizeColumnName` that now throws on any column argument that is not a bare identifier, `table.column` pair, or recognized `->>` projection.
+
+Both GHSAs are drafted and will be published after this tag ships, per the GHSA-first disclosure flow (`docs/security/advisories/README.md` § Filing flow). `security:lint` reports 0 errors (only pre-existing allow-listed warnings); `security:manifest:check` and `test:security:auth-matrix` both pass (18/19, 1 skipped by design).
+
+Separately, the OAuth discovery change *removes* an over-broad auth gate on RFC-mandated public bootstrap documents rather than widening any privileged surface — no advisory filed for that change, it is a discovery-bootstrap availability fix, not an authorization bypass on a privileged path.
+
+## Breaking changes
+
+No breaking changes.

--- a/docs/releases/in_progress/v0.21.4/security_review.md
+++ b/docs/releases/in_progress/v0.21.4/security_review.md
@@ -1,0 +1,59 @@
+# Security Review — v0.21.4
+
+**Range:** `v0.21.2..HEAD` (5 commits: `caa30f8c9`, `4aba1397c`, `88712d97d`, `9a21de393`, `d43bfc1c5`)
+**Classifier verdict:** `sensitive=true`
+**Sign-off:** `yes`
+
+## Gate results
+
+- **G1 `security:classify-diff`:** `sensitive=true`. Concerns flagged: `openapi-security` (`openapi.yaml`), `protected-routes-manifest` (`scripts/security/protected_routes_manifest.json`), `security-gates` (same manifest file), `auth-middleware` (`src/actions.ts`). Unlike the v0.21.2 review, this is not a file-identity false positive — `src/actions.ts` genuinely changed the Ed25519 bearer auth middleware and the `getAuthenticatedUserId` fail-closed tail. See "Alternate-path auth" below.
+- **G2 `security:lint`:** 0 errors, 125 warnings across 397 files. All warnings are pre-existing baseline noise (`unauth-public-route` on routes correctly covered by `protected_routes_manifest.json` but not statically detectable by the linter's pattern match, plus 2 long-standing `local-dev-user-widening` warnings in `src/services/sandbox_mode.ts` unrelated to this diff). None introduced by this range.
+- **G3 manifest + auth matrix:** `security:manifest:check` reports `protected_routes_manifest.json: in sync with openapi.yaml (118 routes)` — the two new `/.well-known/*` discovery routes were added and the manifest regenerated in the same change (`caa30f8c9`). `test:security:auth-matrix`: 18 passed / 1 skipped, unchanged from baseline.
+- **G4 this file.**
+
+## Adversarial review
+
+### Alternate-path auth / isLocalRequest / proxy trust
+
+The Ed25519 bearer path in the global auth middleware (`app.use(async (req, res, next) => { ... })` around line 4018) is directly rewritten by `d43bfc1c5`. Pre-fix, the middleware accepted a request as Ed25519-authenticated whenever `registered && isBearerTokenValid(bearerToken)` — and `ensurePublicKeyRegistered` **auto-registers any syntactically valid 32-byte token**, so `registered` means "well-formed," not "known." Signature verification was conditional: `if (signature && req.body)` — a request with no signature skipped verification entirely and was still treated as authenticated. `getAuthenticatedUserId`'s trailing fallback then trusted a caller-supplied `user_id` for any Bearer request, on the stated assumption that "token validation happens in middleware." That assumption was false for unsigned forged keys, so the caller's own claimed identity became the effective authorization.
+
+Post-fix, the middleware condition is `registered && isBearerTokenValid(bearerToken) && registeredUserId && ed25519Signature` — all four must hold, and a missing signature now takes the reject branch (`sendError(403, "AUTH_INVALID")` is only reached with a *present but invalid* signature; a request with a *missing* signature falls through the `if` entirely to the session-token branch, which fails for a non-JWT token). `registeredUserId` is resolved via `getUserIdFromBearerToken`, which returns `undefined` for a bare auto-registered key that was never explicitly provisioned with a user, so an anonymous forged key cannot satisfy the condition regardless of signature. The principal is stamped via `stampUserPrincipal(req, registeredUserId)` — a fixed value from the registration record, not from any caller-supplied parameter. `getAuthenticatedUserId`'s tail no longer returns `providedUserId` under any circumstance; it throws `Not authenticated - no resolved principal for request` whenever no principal was stamped by the middleware. This is the correct fail-closed shape: authorization now depends exclusively on what the middleware verified, never on what the caller claims.
+
+`isLocalRequest`, `forwardedForValues`, `isProductionEnvironment` are untouched by this range (`grep` confirms no diff hits in `src/actions.ts` for those symbols outside the two well-known-route registrations, which read `req.header("x-forwarded-proto")`/`x-forwarded-host` only to construct an informational `base` URL string for the discovery response body — not for any trust decision).
+
+### Proxy trust / local-dev widening
+
+No changes to `src/services/sandbox_mode.ts`, `src/services/local_auth.ts`, or `LOCAL_DEV_USER_ID` handling in this range (confirmed via `git diff v0.21.2..HEAD -- src/services/sandbox_mode.ts src/services/local_auth.ts`, which is empty). The two pre-existing `local-dev-user-widening` lint warnings are unchanged.
+
+### Unauth public route / guest-access widening
+
+Two new unauthenticated Express routes were added: `GET /.well-known/oauth-protected-resource/mcp` and `GET /.well-known/openid-configuration`. Both are RFC-mandated public bootstrap documents (RFC 9728 §3, RFC 8414-adjacent) that MUST be reachable without credentials by design — their entire purpose is telling an unauthenticated client where to obtain credentials. Both are registered in `openapi.yaml` with `security: []` and regenerated into `protected_routes_manifest.json` (118 routes, in sync per G3). This is a **narrowing** of an over-broad auth gate (removing a 401 that created a self-referential deadlock), not a widening of guest write/read access to user-owned data — neither route touches the entity/observation/relationship store.
+
+The SQL-injection fix's 400 response (`handleApiError`'s new `InvalidSnapshotFieldError` branch) explicitly does **not** echo the caller-supplied field string back in the response body (only a generic constraint description), avoiding a reflected-input surface even though the input itself was already rejected.
+
+### AAuth downgrade / session-portability entities
+
+Not applicable — no session-portability or AAuth-tier code touched in this range.
+
+### SQL injection / query construction (new category for this release)
+
+`isValidSnapshotFieldName` (`src/services/entity_queries.ts`) is the source-level gate: a bare-identifier regex (`^[A-Za-z_][A-Za-z0-9_]*$` per the 400 response detail) applied to both `snapshot_filters` keys and `sort_by` fields before any SQL is constructed. `normalizeColumnName` (`src/repositories/sqlite/local_db_adapter.ts`) is the independent backstop inside the SQLite adapter itself — verified via the regression test to still correctly rewrite legitimate `snapshot->>field` projections into `json_extract(...)` while throwing on every tested injection shape (`CASE WHEN`, correlated subquery, comment-truncation, `DROP TABLE`, bare `1=1`, empty string, whitespace, unrecognized `->>` variant). Two independent layers were required because the vulnerability was precisely a single point of unvalidated string interpolation reaching SQL — a second caller that bypassed `entity_queries.ts` in the future would still be caught by the adapter-level check.
+
+### Deployment-config changes (fly.toml family)
+
+No `fly.*.toml` changes in this range beyond `fly.operator.toml`, which was reviewed and shipped in the prior (v0.21.3) cycle. Not re-reviewed here; no changes since.
+
+## Suggested negative tests
+
+- Covered by the two new regression suites (`ed25519_forged_key_auth_bypass.test.ts`, `sort_by_sql_injection.test.ts`), both verified by their authors to fail against the pre-fix code.
+- Not added, flagged as a gap: an end-to-end HTTP-level test (real `fetch()` against a booted app, mirroring `wellknown_discovery_unauthenticated.test.ts`'s pattern) that sends an unsigned 32-byte Bearer token with an attacker-chosen `user_id` and asserts the actual HTTP response is 401/403, not just that the underlying function throws. The current `ed25519_forged_key_auth_bypass.test.ts` drives `getAuthenticatedUserId` directly with request stubs, which correctly isolates the fixed invariant but does not exercise the full middleware chain end to end. Residual risk: low — the middleware-level condition change (`registered && ... && registeredUserId && ed25519Signature`) is straightforward boolean logic with no additional indirection between it and the HTTP response, and `auth_topology_matrix.test.ts` (18/19 passing) already exercises the broader topology. Recommend adding the end-to-end variant in a follow-up, non-blocking for this release.
+
+## Residual risk
+
+- **GHSA-33x4-v5cf-2hfj and GHSA-8f95-jfm5-jjmr are not yet visible via the GitHub API under this agent's token** (`gh api repos/markmhendrickson/neotoma/security-advisories/<id>` returns 404 for both). This may be a token-scope limitation (`read:org` missing) rather than the advisories not existing — PR #2129's description states they were filed. This MUST be verified with an authenticated maintainer session before or immediately after the tag, and the GHSAs published per the release skill's Step 5.2 (advisory publication happens after the tag ships, never before). Flagging here so the gap is not silently missed at publish time.
+- **End-to-end HTTP-level regression test for the Ed25519 bypass is not yet written** (see Suggested negative tests above). Non-blocking; the existing direct-function test plus the unaffected topology matrix provide adequate coverage for this release.
+- Everything else in this range (OAuth discovery, homepage stats, fly.operator.toml) was already reviewed and shipped in the v0.21.3 preparation cycle; not re-litigated here.
+
+## Verdict
+
+**yes** — both vulnerabilities are fixed with fail-closed logic verified by regression tests that fail against the pre-fix code, the fix pattern is the correct one (never trust caller-supplied identity; validate query field names as identifiers at two independent layers), and no new privilege-widening surface was introduced. The two residual items above (GHSA visibility confirmation, end-to-end HTTP test) are tracked but do not block this release.

--- a/docs/releases/in_progress/v0.21.4/test_coverage_review.md
+++ b/docs/releases/in_progress/v0.21.4/test_coverage_review.md
@@ -1,0 +1,47 @@
+# Test coverage review — v0.21.4
+
+Scope: `v0.21.2..HEAD` (5 commits: `caa30f8c9`, `4aba1397c`, `88712d97d`, `9a21de393`, `d43bfc1c5`).
+
+## Code review
+
+`/review` was run as a subagent pass over the full `v0.21.2..HEAD` range.
+
+**Verdict: NEEDS-CHANGES (1 blocking, 1 advisory, 1 nit) at time of review — resolved by this commit.**
+
+The single BLOCKING finding was `supplement-accuracy`: this release's `security_review.md`, `github_release_supplement.md`, and the two `2026-08-07-*` advisory files existed only as untracked files on disk at review time, not yet committed alongside the security-sensitive `d43bfc1c5` commit. The finding is procedural, not a code defect — the release-preparation commit (bumping `package.json` to `0.21.4` and committing these exact files together) resolves it directly. No code changes were required.
+
+The ADVISORY finding (`hint-quality`) concerns `normalizeColumnName`'s error message and `InvalidSnapshotFieldError` interpolating the raw rejected field-name string into server-side logs (not the client response, which is already sanitized). Reviewed and accepted as-is: field names in this schema cannot carry PII (they are `snapshot->>field` accessor names, not values), and the HTTP response to the caller is already scrubbed. No follow-up required.
+
+The NIT finding asked that `npm run openapi:bc-diff --base v0.21.2 --head HEAD` be reconciled specifically for this tag. Done — see Step below; no breaking changes, 4 non-breaking additions matching the v0.21.3-era contract changes exactly (the two new discovery routes were already declared in `caa30f8c9`, unchanged by `d43bfc1c5`).
+
+No other findings: no State-Layer boundary violation, no schema-agnostic-design violation (no new `entity_type` branching), no determinism issue (no ID/reducer logic touched — the WHERE-clause construction reviewed is query-shape validation, not stored output), no immutability violation (no observation/source mutation), and contract seams (`openapi.yaml` → `openapi_types.ts` → `contract_mappings.ts` → `protected_routes_manifest.json`) are all updated together correctly for the two new discovery routes.
+
+## Surface: Ed25519 bearer auth — unresolved principal must fail closed
+
+**Classification: Covers user-observable behavior end-to-end (at the function boundary), with a documented gap at the full-HTTP-stack level.**
+
+`tests/security/ed25519_forged_key_auth_bypass.test.ts` (5 cases) drives `getAuthenticatedUserId` (now exported specifically for this test) directly with request stubs modeling: an unresolved Bearer + attacker-chosen `user_id` (must throw), an unresolved Bearer + no `user_id` (must throw), and a properly resolved principal (must still return unchanged). Verified by the author to fail against the pre-fix tail — the exploit case returned the provided `user_id` instead of throwing.
+
+This test isolates the decisive fix correctly (the function is where the authorization decision is made, and testing it directly avoids coupling the assertion to the test server's boot mode). It does **not** exercise the full middleware chain — the `security_review.md` for this release explicitly flags this as a residual, non-blocking gap and recommends a follow-up end-to-end HTTP test (real `fetch()` with an unsigned forged Bearer token against a booted app) in the same pattern as `wellknown_discovery_unauthenticated.test.ts`. Residual risk is assessed as low: the middleware-level boolean condition (`registered && isBearerTokenValid(bearerToken) && registeredUserId && ed25519Signature`) sits with no additional indirection between it and the HTTP response, and `auth_topology_matrix.test.ts` (18/19 passing) already exercises the broader topology this change sits inside.
+
+## Surface: `sort_by` / `snapshot_filters` — reject non-identifier field names
+
+**Classification: Covers user-observable behavior end-to-end.**
+
+`tests/security/sort_by_sql_injection.test.ts` (10 cases) asserts `isValidSnapshotFieldName` accepts only bare identifiers (6 legitimate field names) and rejects all 11 tested injection payloads (`CASE WHEN` expressions, correlated subqueries, comment-truncation, `DROP TABLE`, bare `1=1`, empty string, whitespace, unrecognized `->>` variant). Separately asserts `InvalidSnapshotFieldError` carries the context (`"sort_by"` / `"snapshot_filters"`) that `handleApiError` matches on to return a 400 rather than a masked 500. Independently asserts `normalizeColumnName`'s fail-closed backstop: legitimate bare identifiers and `table.column` pairs pass through unchanged, a recognized `snapshot->>field` projection is still correctly rewritten to `json_extract(...)` (no regression), and every non-identifier shape throws. Verified by the author to fail against the pre-fix code.
+
+This test exercises the real validation functions with the real injection payloads that motivated the fix, at both of the two independent defensive layers. Sufficient coverage; no gap identified.
+
+## Surface: `/.well-known/oauth-protected-resource[/mcp]` returns 200 unauthenticated (unchanged from v0.21.3 prep, carried into this release)
+
+**Classification: Covers user-observable behavior end-to-end.**
+
+Unchanged since the v0.21.3 preparation cycle; see that cycle's `test_coverage_review.md` for the full write-up. `tests/integration/wellknown_discovery_unauthenticated.test.ts` (4 cases) remains passing and unmodified by `d43bfc1c5`.
+
+## Surface: `fly.operator.toml`, homepage stats refresh (unchanged from v0.21.3 prep, carried into this release)
+
+**Classification: No test — not applicable.** Static config / static copy changes with no branching logic. Manually verified in the v0.21.3 preparation cycle; not re-verified here as unchanged.
+
+## Summary
+
+One code-adjacent BLOCKING finding from `/review`, resolved by committing the release-preparation artifacts (this commit). Both new vulnerability fixes ship with real regression tests verified by their authors to fail pre-fix; one (`sort_by` SQL injection) has full end-to-end coverage at both defensive layers, the other (Ed25519 fail-closed) has direct-function coverage with a documented, low-risk, non-blocking gap at the full-HTTP-stack level, tracked as a follow-up in `security_review.md`. No BLOCKING test-coverage gaps remain unaddressed.

--- a/docs/security/advisories/2026-08-07-ed25519-bearer-forged-key-auth-bypass.md
+++ b/docs/security/advisories/2026-08-07-ed25519-bearer-forged-key-auth-bypass.md
@@ -1,0 +1,67 @@
+# Ed25519 bearer auth: unresolved principal returned caller-supplied user_id (v0.21.4 fix)
+
+- **Date disclosed:** 2026-08-07
+- **GHSA:** GHSA-33x4-v5cf-2hfj (draft; publish after tag per release process)
+- **CVE:** _not requested_
+- **Severity:** High — an anonymous caller could read and write the entire graph for any user.
+- **Affected:** all versions carrying the Ed25519 bearer auth path prior to `0.21.4`.
+- **Fixed in:** `0.21.4`
+- **Reporter:** internal security review.
+- **CWEs:** [CWE-287](https://cwe.mitre.org/data/definitions/287.html) (Improper Authentication), [CWE-306](https://cwe.mitre.org/data/definitions/306.html) (Missing Authentication for Critical Function).
+
+## Summary
+
+`getAuthenticatedUserId` had a fallback tail: when a request carried a `Bearer` header but resolved to no authenticated principal (the middleware never stamped `authenticatedUserId` on the request), the function trusted the caller-supplied `user_id` body/query parameter instead of failing. The comment at the call site read "token validation happens in middleware" — but the middleware auto-registered any 32-byte token as a new Ed25519 key and only verified the request signature `if (signature ...)`, so a request with a syntactically valid but unsigned 32-byte token was accepted at the middleware layer without ever stamping a principal, then trusted downstream.
+
+## Impact
+
+An anonymous caller could:
+
+1. Send any 32-byte value as a `Bearer` token (no valid signature required — the check was conditional on a signature being present at all).
+2. Supply `user_id: "00000000-0000-0000-0000-000000000000"` (the well-known `LOCAL_DEV_USER_ID`) or any other user's UUID in the request body/query.
+3. Have `getAuthenticatedUserId` return that supplied `user_id` as if it were authenticated, because the function's fallback path did not check whether the Bearer request had actually resolved to a principal.
+
+Net effect: full read/write access to any user's data via the REST API, without a valid signature, key registration, or session.
+
+## Root cause
+
+`getAuthenticatedUserId` (`src/actions.ts`) ended with:
+
+```
+if (!headerAuth.startsWith("Bearer ")) throw ...;
+if (!providedUserId) throw ...;
+return providedUserId; // trusted the caller
+```
+
+This assumed "if we got here with a Bearer header, middleware already validated it." That assumption did not hold: the middleware's Ed25519 verification was conditional (`if (signature ...)`), so an unsigned forged key passed through without ever setting `req.authenticatedUserId`. The trailing fallback then handed authorization to the caller's own claimed identity — the definition of "authentication is not authorization," except here authentication itself never happened.
+
+## Fix
+
+`getAuthenticatedUserId` now fails closed on the exact condition that was previously trusted: a Bearer request that reaches the tail of the function with no resolved `authenticatedUserId` throws `Not authenticated`, regardless of whether a `user_id` was supplied. The function is exported (`export async function getAuthenticatedUserId`) so the regression test can drive it directly with request stubs modeling both the pre-fix and post-fix paths, independent of the test server's boot mode.
+
+Regression test: `tests/security/ed25519_forged_key_auth_bypass.test.ts` — asserts the unresolved-Bearer-plus-provided-`user_id` case throws, the unresolved-Bearer-with-no-`user_id` case throws, and a properly resolved principal is still returned unchanged. Verified to fail against the pre-fix code path (the exploit case returned the provided `user_id` instead of throwing).
+
+## Operator action
+
+- Upgrade to `>= 0.21.4`.
+- No data migration required.
+- If a deployment was internet-reachable prior to `0.21.4` with the REST Ed25519 bearer path enabled, review access logs for anomalous `Bearer` tokens (32 bytes, no corresponding registered key history) paired with `user_id` values that do not match the token's actual owner.
+
+## Detection
+
+`tests/security/ed25519_forged_key_auth_bypass.test.ts` and the broader `tests/security/auth_topology_matrix.test.ts` suite detect regressions of this class going forward.
+
+## Gates that catch this regression class going forward
+
+- **G3 auth topology matrix** (`tests/security/auth_topology_matrix.test.ts`) — asserts protected routes reject unauthenticated/unresolved callers.
+- **Change guardrails rule MUST 5** — authorization must go through `getAuthenticatedUserId`; body/query `user_id` is never trusted directly for access control.
+
+## Timeline
+
+| Date | Event |
+|------|-------|
+| 2026-08-07 | Vulnerability identified during internal security review |
+| 2026-08-07 | Fix PR #2129 merged |
+| 2026-08-07 | v0.21.4 supplement prepared |
+| TBD | v0.21.4 tagged and released |
+| TBD | GHSA published |

--- a/docs/security/advisories/2026-08-07-sort-by-order-by-sql-injection.md
+++ b/docs/security/advisories/2026-08-07-sort-by-order-by-sql-injection.md
@@ -1,0 +1,64 @@
+# sort_by / snapshot_filters ORDER BY SQL injection (v0.21.4 fix)
+
+- **Date disclosed:** 2026-08-07
+- **GHSA:** GHSA-8f95-jfm5-jjmr (draft; publish after tag per release process)
+- **CVE:** _not requested_
+- **Severity:** High — authenticated caller could execute arbitrary SQL expressions and bypass row-level user scoping on shared backends.
+- **Affected:** all versions accepting `sort_by=snapshot.<field>` and `snapshot_filters` prior to `0.21.4`.
+- **Fixed in:** `0.21.4`
+- **Reporter:** internal security review.
+- **CWEs:** [CWE-89](https://cwe.mitre.org/data/definitions/89.html) (SQL Injection).
+
+## Summary
+
+Query endpoints accepting `sort_by=snapshot.<field>` and `snapshot_filters` keys spliced the caller-supplied field name into a `snapshot->>${field}` column expression, then interpolated the result raw into generated SQL. A caller could pass a `(CASE WHEN ...)` expression, a subquery, or a `DROP TABLE` fragment as the "field name," and it reached SQLite as executable SQL rather than being treated as an identifier — a blind ORDER BY injection. Because `sort_by`/`snapshot_filters` construction sat outside the normal `.eq("user_id", userId)` query-scoping path, a successful injection could also bypass per-row user scoping on backends shared across users.
+
+## Impact
+
+An authenticated caller supplying a crafted `sort_by` or `snapshot_filters` value could:
+
+- Execute arbitrary `(CASE WHEN ...)` conditional expressions inside an `ORDER BY` clause.
+- Run correlated subqueries (`(SELECT snapshot FROM entity_snapshots)`) inside the sort expression.
+- Attempt destructive statements appended via comment-truncation (`amount_eur; DROP TABLE entity_snapshots;--`), though SQLite's single-statement execution model limits statement chaining in the direct query path — the more directly exploitable class is data exfiltration and cross-row read via the conditional/subquery forms.
+- Bypass row-level `user_id` scoping on backends where multiple users share the same underlying tables.
+
+## Root cause
+
+Two layers should have rejected non-identifier field names and neither did:
+
+1. `src/services/entity_queries.ts` accepted any string as a `snapshot_filters` key or `sort_by` field with no shape validation before splicing it into a `snapshot->>${field}` projection.
+2. `src/repositories/sqlite/local_db_adapter.ts`'s column-name normalization (`normalizeColumnName`) rewrote recognized `->>` projections but had no fail-closed backstop for anything that was neither a bare identifier, a `table.column` pair, nor a recognized `->>` projection — it passed unrecognized shapes through unchanged.
+
+## Fix
+
+Defense in depth, both layers now reject:
+
+1. **`isValidSnapshotFieldName`** (`src/services/entity_queries.ts`): a new exported validator backed by a bare-identifier regex (`SNAPSHOT_FIELD_NAME`). Both `snapshot_filters` key validation and `sort_by` field validation now call it before constructing any query, throwing `InvalidSnapshotFieldError` (mapped to an HTTP 400, not a 500) on rejection.
+2. **`normalizeColumnName`** (`src/repositories/sqlite/local_db_adapter.ts`): the fail-closed backstop. Any column argument that is not a bare identifier, a `table.column` pair, or a recognized `->>` projection now throws, rather than passing through unchanged. This catches any future caller of the SQLite adapter that skips the `entity_queries.ts` validation layer.
+
+Regression test: `tests/security/sort_by_sql_injection.test.ts` — asserts `isValidSnapshotFieldName` accepts only bare identifiers and rejects 11 distinct injection payloads (`CASE WHEN`, subqueries, comment-truncation, `DROP TABLE`, whitespace, empty string, raw `->>`), asserts `InvalidSnapshotFieldError` carries the field-name context needed for the 400 mapping, and asserts `normalizeColumnName` still correctly rewrites legitimate `->>` projections while throwing on every non-identifier shape.
+
+## Operator action
+
+- Upgrade to `>= 0.21.4`.
+- No data migration required.
+- Review query logs for `sort_by` or `snapshot_filters` values containing SQL keywords (`CASE`, `SELECT`, `DROP`, `--`) if the deployment logged raw query parameters prior to `0.21.4`.
+
+## Detection
+
+`tests/security/sort_by_sql_injection.test.ts` detects regressions of this class going forward.
+
+## Gates that catch this regression class going forward
+
+- **`normalizeColumnName` fail-closed backstop** — any new SQLite adapter caller that skips `entity_queries.ts` validation is still caught at the column-normalization layer.
+- **`isValidSnapshotFieldName`** — the source-level gate; new query-building code should call this (or an equivalent bare-identifier check) before splicing any caller-supplied field name into generated SQL.
+
+## Timeline
+
+| Date | Event |
+|------|-------|
+| 2026-08-07 | Vulnerability identified during internal security review |
+| 2026-08-07 | Fix PR #2129 merged |
+| 2026-08-07 | v0.21.4 supplement prepared |
+| TBD | v0.21.4 tagged and released |
+| TBD | GHSA published |

--- a/docs/security/advisories/README.md
+++ b/docs/security/advisories/README.md
@@ -14,6 +14,8 @@ This index is the canonical cross-link target for:
 
 | Date | Title | GHSA | CVE | Affected | Fixed in | Gate that catches the regression class |
 |------|-------|------|-----|----------|----------|----------------------------------------|
+| 2026-08-07 | [Ed25519 bearer auth: unresolved principal returned caller-supplied user_id](2026-08-07-ed25519-bearer-forged-key-auth-bypass.md) | GHSA-33x4-v5cf-2hfj (draft) | _not requested_ | all versions prior to `0.21.4` | `0.21.4` | `tests/security/ed25519_forged_key_auth_bypass.test.ts`, G3 auth topology matrix |
+| 2026-08-07 | [sort_by / snapshot_filters ORDER BY SQL injection](2026-08-07-sort-by-order-by-sql-injection.md) | GHSA-8f95-jfm5-jjmr (draft) | _not requested_ | all versions prior to `0.21.4` | `0.21.4` | `tests/security/sort_by_sql_injection.test.ts`, `normalizeColumnName` fail-closed backstop |
 | 2026-05-21 | [Tenant isolation gap in relationship query endpoints](2026-05-21-relationship-endpoint-tenant-isolation.md) | [GHSA-wrr4-782v-jhwh](https://github.com/markmhendrickson/neotoma/security/advisories/GHSA-wrr4-782v-jhwh) | _requested_ | `>= 0.13.0, < 0.14.0` | `0.14.0` | G3 tenant isolation matrix (`tests/security/tenant_isolation_matrix.test.ts`), change guardrails rule MUST 5, pre-release adversarial checklist (cross-tenant category) |
 | 2026-05-11 | [Inspector / API auth bypass behind a reverse proxy](2026-05-11-inspector-auth-bypass.md) | [GHSA-5cvp-p7p4-mcx9](https://github.com/markmhendrickson/neotoma/security/advisories/GHSA-5cvp-p7p4-mcx9) | _requested_ | `>= 0.4.0, < 0.11.1` | `0.11.1` | G2 (`loopback-trust-in-production`, `forwarded-for-trust`), G3 topology auth matrix, G5 deployed probes |
 


### PR DESCRIPTION
## Summary

This release closes two high-severity authentication and injection vulnerabilities discovered in internal security review, fixes a self-referential OAuth discovery deadlock that blocked first-time MCP login for hosted instances, refreshes the homepage's live usage stats, and adds a Fly deploy config that stops operator-instance deploys from silently reverting VM sizing.

## What changed for npm package users

No CLI or package-artifact changes in this release.

## API surface & contracts

**`GET /.well-known/oauth-protected-resource` and `GET /.well-known/oauth-protected-resource/mcp` now return 200 unauthenticated (previously 401).** RFC 9728 §3 requires this document to be reachable without credentials — its entire purpose is to tell a caller with no credentials where to get them. The previous 401 response named itself as the place to find auth metadata, so a client 401'd at `/mcp` followed the `WWW-Authenticate` header back to a document that also 401'd, and the login flow never started. The `/mcp`-suffixed path (RFC 9728 §3.1's resource-appended form) is now registered alongside the bare path, since Express did not match it against the bare route.

**`GET /.well-known/openid-configuration` now returns an explicit 404** instead of falling through to the catch-all auth guard's 401. This server does not implement OIDC discovery; the previous implicit 401 reproduced the same discovery dead-end on a sibling path. This is a deliberate 404, not a synthetic 200 — advertising a discovery contract this server does not implement would create a different failure mode.

**Response schema addition:** the `200` body for `GET /.well-known/oauth-protected-resource` now includes a `resource` field (required by RFC 9728 §3, resolving to `${base}/mcp`) alongside the existing `authorization_servers`.

The `X-Connection-Id`-based invalid-token check is unchanged — that guard protects a caller holding a stale credential, which is a different case from a caller with no credentials at all.

No other request/response contract changes in this release.

## Behavior changes

Any MCP client or integration that previously worked around the discovery deadlock (for example, by skipping discovery and relying on anonymous writes) can remove that workaround. Discovery now completes as the RFC specifies.

An anonymous caller can no longer obtain read/write access to any user's data by presenting an unsigned Ed25519 bearer token — see Security hardening below.

## Docs site & CI / tooling

- REST API docs gain a discovery-bootstrap section: the 4-request sequence, a curl table of expected statuses, and an explicit note that a 200 with no credential at step 2 is required behavior, not a bug.
- MCP docs and the changelog note the 401→200 behavior change for integrators who built workarounds.
- `fly.operator.toml` added: a per-target Fly deploy config for operator-run instances, mirroring the existing `fly.sandbox.toml` pattern. Declares explicit VM sizing (2 CPU / 4096MB) and `restart.policy = 'always'` so a deploy no longer silently reverts an instance that was manually scaled up to address query stalls. No app name, region, or hostname is hardcoded — both are supplied at deploy time, consistent with keeping deployment targets out of the public repo.
- Homepage "How it's used" proof strip and founder blockquote refreshed against live prod counts (contacts, tasks, conversations, agent messages, entity types), each rounded down below the live figure so the "+" claim holds as the graph grows. Applied to both `en` and `es` locales.

## Internal changes

None beyond the above.

## Fixes

- **OAuth discovery deadlock** (#2049, #2050): first-time MCP login against a hosted instance could never complete discovery, because the protected-resource metadata endpoint required the very credential it exists to help a client obtain. Found via a partner's agent hitting first-time login against a live hosted instance.
- **Stale homepage stats** (#2107): the public proof strip understated live usage by up to 10x on some metrics; corrected against a live prod snapshot taken 2026-08-05.
- **Ed25519 bearer auth fail-open on unresolved principal** (advisory `2026-08-07-ed25519-bearer-forged-key-auth-bypass`): `getAuthenticatedUserId` trusted a caller-supplied `user_id` for any Bearer request that resolved to no authenticated principal. See Security hardening below.
- **`sort_by` / `snapshot_filters` ORDER BY SQL injection** (advisory `2026-08-07-sort-by-order-by-sql-injection`): caller-supplied snapshot field names were spliced unvalidated into generated SQL. See Security hardening below.

## Tests and validation

- New integration test `tests/integration/wellknown_discovery_unauthenticated.test.ts` (4 cases): boots a real app instance and issues real unauthenticated HTTP requests (no `Authorization`, no `X-Connection-Id`) against all four discovery-adjacent routes, asserting on actual response status and body content (not just "not 401"). Verified to fail when the fix is reverted.
- New regression test `tests/security/ed25519_forged_key_auth_bypass.test.ts` (5 cases): drives `getAuthenticatedUserId` directly with request stubs modeling an unresolved Bearer principal, asserting the function throws rather than trusting a caller-supplied `user_id`. Verified to fail against the pre-fix tail.
- New regression test `tests/security/sort_by_sql_injection.test.ts` (10 cases): asserts `isValidSnapshotFieldName` rejects 11 distinct injection payloads and accepts only bare identifiers; asserts `normalizeColumnName`'s fail-closed backstop throws on any non-identifier column shape while still rewriting legitimate `->>` projections.
- `security:manifest:check` confirms `protected_routes_manifest.json` stays in sync with `openapi.yaml` (118 routes, no drift).
- `tests/security/auth_topology_matrix.test.ts`: 18/19 passing (1 skipped by design), confirming the broader auth topology is unaffected.
- `fly.operator.toml` verified end to end against a live operator instance: deployed v0.21.2, machine held 2 CPU / 4096MB with `restart.policy = 'always'` across the deploy, health check 0.28-0.41s afterward, data intact.
- Homepage stats change verified via `npm run build:ui`; all five refreshed values and the corrected "over a year" copy confirmed present in the built bundle.
- `npm run openapi:bc-diff` against `v0.21.2`: no breaking changes, 4 non-breaking additions (the two new discovery operations and two new response fields).

## Security hardening

Classified `sensitive=true` by `npm run security:classify-diff` (OpenAPI security-block changes, protected-routes-manifest changes, and `src/actions.ts` auth-middleware and route-registration changes touched). Full adversarial review recorded in [`docs/releases/in_progress/v0.21.4/security_review.md`](./security_review.md).

Two vulnerabilities are fixed in this release, both found in internal security review and both fixed with an accompanying regression test verified to fail pre-fix:

- **[Ed25519 bearer auth: unresolved principal returned caller-supplied `user_id`](../../../security/advisories/2026-08-07-ed25519-bearer-forged-key-auth-bypass.md)** (GHSA-33x4-v5cf-2hfj, draft) — High severity. `getAuthenticatedUserId`'s fallback tail trusted a caller-supplied `user_id` for any Bearer request that resolved to no authenticated principal, because the Ed25519 verification middleware only checked a signature `if (signature ...)`. An unsigned, forged 32-byte token combined with an attacker-chosen `user_id` in the request body granted full read/write access to that user's graph. Fixed: the function now fails closed (`Not authenticated`) whenever a Bearer request reaches the tail with no resolved principal, regardless of whether `user_id` was supplied.
- **[`sort_by` / `snapshot_filters` ORDER BY SQL injection](../../../security/advisories/2026-08-07-sort-by-order-by-sql-injection.md)** (GHSA-8f95-jfm5-jjmr, draft) — High severity. Caller-supplied `sort_by=snapshot.<field>` and `snapshot_filters` keys were spliced unvalidated into a `snapshot->>${field}` SQL projection and interpolated raw into generated SQL, allowing `(CASE WHEN ...)` conditional expressions and correlated subqueries to execute inside an `ORDER BY` clause, and potentially bypassing per-row user scoping on shared backends. Fixed with two layers: a new `isValidSnapshotFieldName` bare-identifier validator at the query-construction source, and a fail-closed backstop in the SQLite adapter's `normalizeColumnName` that now throws on any column argument that is not a bare identifier, `table.column` pair, or recognized `->>` projection.

Both GHSAs are drafted and will be published after this tag ships, per the GHSA-first disclosure flow (`docs/security/advisories/README.md` § Filing flow). `security:lint` reports 0 errors (only pre-existing allow-listed warnings); `security:manifest:check` and `test:security:auth-matrix` both pass (18/19, 1 skipped by design).

Separately, the OAuth discovery change *removes* an over-broad auth gate on RFC-mandated public bootstrap documents rather than widening any privileged surface — no advisory filed for that change, it is a discovery-bootstrap availability fix, not an authorization bypass on a privileged path.

## Breaking changes

No breaking changes.
