### PR TITLE
security(v0.21.5): hardening per GHSA-qp63-9r52-4q25

### DIFF
--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -72,10 +72,10 @@ flowchart TD
 | Vitest unit tests | 159 |
 | Vitest service tests | 43 |
 | Source-adjacent tests | 65 |
-| Vitest integration tests | 161 |
+| Vitest integration tests | 160 |
 | Vitest CLI tests | 77 |
 | Vitest contract tests | 15 |
-| Vitest security tests | 6 |
+| Vitest security tests | 7 |
 | Vitest subscription tests | 5 |
 | Vitest agent tests | 1 |
 | Vitest fixture tests | 1 |
@@ -397,7 +397,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm run test:integration` or `npx vitest run tests/integration`
 **Requirements:** Database configured; remote-dependent subsets additionally need `RUN_REMOTE_TESTS=1`.
-**Files (161):**
+**Files (160):**
 - `tests/integration/aauth_attribution_stamping.test.ts`
 - `tests/integration/aauth_mcp_capability_parity.test.ts`
 - `tests/integration/aauth_mcp_initialize_admission.test.ts`
@@ -529,7 +529,6 @@ flowchart TD
 - `tests/integration/seed_then_works_at_e2e.test.ts`
 - `tests/integration/session_introspection.test.ts`
 - `tests/integration/snapshot_ingestion_cutoff.test.ts`
-- `tests/integration/standing_rules_initialize_effect.test.ts`
 - `tests/integration/store_builtin_identity_opt_out_schemas.test.ts`
 - `tests/integration/store_canonical_name_recompute.test.ts`
 - `tests/integration/store_conversation_message_count.test.ts`
@@ -671,10 +670,11 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npx vitest run tests/security`
 **Requirements:** Use alongside the dedicated security validation scripts when changing auth or route protection.
-**Files (6):**
+**Files (7):**
 - `tests/security/auth_topology_matrix.test.ts`
 - `tests/security/cross_user_read_scoping.test.ts`
 - `tests/security/ed25519_forged_key_auth_bypass.test.ts`
+- `tests/security/rendered_page_csp.test.ts`
 - `tests/security/sandbox_mode_resolver.test.ts`
 - `tests/security/sort_by_sql_injection.test.ts`
 - `tests/security/tenant_isolation_matrix.test.ts`

--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,8 +61,8 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **574**
-- Backend and repo Vitest files: **539**
+- Total automated test files: **575**
+- Backend and repo Vitest files: **540**
 - Frontend Vitest files: **9**
 - Playwright spec files: **26**
 
@@ -72,7 +72,7 @@ flowchart TD
 | Vitest unit tests | 159 |
 | Vitest service tests | 43 |
 | Source-adjacent tests | 65 |
-| Vitest integration tests | 160 |
+| Vitest integration tests | 161 |
 | Vitest CLI tests | 77 |
 | Vitest contract tests | 15 |
 | Vitest security tests | 7 |
@@ -397,7 +397,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm run test:integration` or `npx vitest run tests/integration`
 **Requirements:** Database configured; remote-dependent subsets additionally need `RUN_REMOTE_TESTS=1`.
-**Files (160):**
+**Files (161):**
 - `tests/integration/aauth_attribution_stamping.test.ts`
 - `tests/integration/aauth_mcp_capability_parity.test.ts`
 - `tests/integration/aauth_mcp_initialize_admission.test.ts`
@@ -529,6 +529,7 @@ flowchart TD
 - `tests/integration/seed_then_works_at_e2e.test.ts`
 - `tests/integration/session_introspection.test.ts`
 - `tests/integration/snapshot_ingestion_cutoff.test.ts`
+- `tests/integration/standing_rules_initialize_effect.test.ts`
 - `tests/integration/store_builtin_identity_opt_out_schemas.test.ts`
 - `tests/integration/store_canonical_name_recompute.test.ts`
 - `tests/integration/store_conversation_message_count.test.ts`

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -4710,6 +4710,30 @@ app.get("/entities/:id/html", async (req, res) => {
       : undefined;
     if (etag) res.setHeader("ETag", etag);
     res.setHeader("Content-Type", "text/html; charset=utf-8");
+    // SECURITY (Phase 2, stored XSS in publish_rendered_page): html_body is
+    // author-supplied and served verbatim, and the GLOBAL CSP allows
+    // 'unsafe-inline' scripts — so an injected <script> in a rendered page would
+    // execute in this origin (a page minted with a guest access_token is viewable
+    // unauthenticated). Rendered pages are static CONTENT, never applications:
+    // they never need to run script. Override the global policy for THIS response
+    // with a strict, self-contained CSP that blocks all script execution (inline
+    // and external) and sandboxes the document, neutralizing stored XSS regardless
+    // of html_body contents. Inline <style> from the template is still allowed.
+    res.setHeader(
+      "Content-Security-Policy",
+      [
+        "default-src 'none'",
+        "script-src 'none'",
+        "style-src 'unsafe-inline'",
+        "img-src 'self' data:",
+        "font-src 'self' data:",
+        "base-uri 'none'",
+        "form-action 'none'",
+        "frame-ancestors 'self'",
+        "sandbox allow-same-origin",
+      ].join("; ")
+    );
+    res.setHeader("X-Content-Type-Options", "nosniff");
     return res.send(html);
   } catch (error) {
     if (error instanceof Error && error.message.includes("Not authenticated")) {

--- a/src/crypto/crypto.test.ts
+++ b/src/crypto/crypto.test.ts
@@ -83,6 +83,12 @@ describe("Envelope Encryption", () => {
 
     expect(envelope.ciphertext).toBeInstanceOf(Uint8Array);
     expect(envelope.encryptedKey).toBeInstanceOf(Uint8Array);
+    // SECURITY (Phase 2): no wrapped key is transmitted — both parties derive
+    // the AES content key via HKDF from the shared secret. `encryptedKey` is
+    // retained only for wire-shape compat and must always be empty; a
+    // reintroduced wrapped-key path would fail this assertion even though it
+    // would still satisfy the looser `toBeInstanceOf(Uint8Array)` check above.
+    expect(envelope.encryptedKey.byteLength).toBe(0);
     expect(envelope.ephemeralPublicKey).toBeInstanceOf(Uint8Array);
     expect(envelope.nonce).toBeInstanceOf(Uint8Array);
     expect(envelope.signature).toBeInstanceOf(Uint8Array);

--- a/src/crypto/envelope.ts
+++ b/src/crypto/envelope.ts
@@ -31,8 +31,17 @@ export async function encryptEnvelope(
   // Derive shared secret using X25519
   const sharedSecret = x25519.getSharedSecret(ephemeralPrivateKey, recipientPublicKey);
 
-  // Generate ephemeral AES-GCM key from shared secret (HKDF-like)
-  const aesKey = await deriveAESKey(sharedSecret);
+  // Derive the AES-GCM content key from the X25519 shared secret via HKDF.
+  //
+  // SECURITY (Phase 2): the AES key is NOT transmitted. Both parties derive it
+  // deterministically from the same ECDH shared secret + HKDF, so there is no key
+  // to wrap. The previous implementation redundantly XOR-wrapped the AES key with
+  // the raw shared secret ("simple XOR for now") and shipped it in `encryptedKey`
+  // — homemade, unauthenticated key-wrap that added attack surface without adding
+  // security (the recipient can already derive the key). Removing the wrap
+  // eliminates that surface entirely; `deriveAESKey` uses HKDF-SHA256 with a
+  // per-envelope salt bound to the ephemeral public key (see deriveAESKey).
+  const aesKey = await deriveAESKey(sharedSecret, ephemeralPublicKey);
 
   // Generate nonce
   const nonce = randomBytes(AES_GCM_NONCE_LENGTH);
@@ -40,13 +49,11 @@ export async function encryptEnvelope(
   // Encrypt plaintext with AES-GCM
   const ciphertext = await encryptAESGCM(plaintext, aesKey, nonce);
 
-  // Encrypt the AES key with X25519 (using shared secret)
-  const encryptedKey = await encryptAESKey(aesKey, sharedSecret);
-
-  // Create envelope
+  // Create envelope (no wrapped key — the recipient re-derives it from the
+  // shared secret + ephemeralPublicKey).
   const envelope: Omit<EncryptedEnvelope, "signature" | "signerPublicKey"> = {
     ciphertext,
-    encryptedKey,
+    encryptedKey: new Uint8Array(0), // retained for wire-shape compat; no longer carries a key
     ephemeralPublicKey,
     nonce,
   };
@@ -84,8 +91,9 @@ export async function decryptEnvelope(
   // Derive shared secret using X25519
   const sharedSecret = x25519.getSharedSecret(recipientPrivateKey, envelope.ephemeralPublicKey);
 
-  // Decrypt the AES key
-  const aesKey = await decryptAESKey(envelope.encryptedKey, sharedSecret);
+  // Re-derive the AES-GCM content key from the shared secret + ephemeral public
+  // key (same HKDF the sender used). No wrapped key is transmitted.
+  const aesKey = await deriveAESKey(sharedSecret, envelope.ephemeralPublicKey);
 
   // Decrypt plaintext with AES-GCM
   const plaintext = await decryptAESGCM(envelope.ciphertext, aesKey, envelope.nonce);
@@ -96,9 +104,15 @@ export async function decryptEnvelope(
 /**
  * Derive AES key from shared secret (simplified HKDF)
  */
-async function deriveAESKey(sharedSecret: Uint8Array): Promise<CryptoKey> {
-  // Use Web Crypto API to derive key
-  // Convert to standard Uint8Array for Web Crypto API compatibility
+async function deriveAESKey(
+  sharedSecret: Uint8Array,
+  salt: Uint8Array
+): Promise<CryptoKey> {
+  // HKDF-SHA256 over the ECDH shared secret. The salt is the per-envelope
+  // ephemeral X25519 public key (SECURITY, Phase 2: the prior implementation
+  // used an empty salt; binding the salt to the ephemeral key domain-separates
+  // each envelope's derived key). The key is not extractable — it never leaves
+  // the crypto layer, since the wrapped-key path that required export is gone.
   const secretBuffer = new Uint8Array(sharedSecret).buffer;
   const keyMaterial = await crypto.subtle.importKey("raw", secretBuffer, { name: "HKDF" }, false, [
     "deriveKey",
@@ -107,13 +121,13 @@ async function deriveAESKey(sharedSecret: Uint8Array): Promise<CryptoKey> {
   return crypto.subtle.deriveKey(
     {
       name: "HKDF",
-      salt: new Uint8Array(0), // No salt for simplicity
+      salt: new Uint8Array(salt),
       info: new Uint8Array([0x6e, 0x65, 0x6f, 0x74, 0x6f, 0x6d, 0x61]), // "neotoma"
       hash: "SHA-256",
     },
     keyMaterial,
     { name: "AES-GCM", length: AES_GCM_KEY_LENGTH * 8 },
-    true, // extractable: true - needed to export key for encryption
+    false, // non-extractable: the key is used in-place, never exported
     ["encrypt", "decrypt"]
   );
 }
@@ -152,42 +166,6 @@ async function decryptAESGCM(
     ciphertextBuffer as ArrayBuffer
   );
   return new Uint8Array(plaintext);
-}
-
-/**
- * Encrypt AES key with shared secret (simple XOR for now, could use proper encryption)
- */
-async function encryptAESKey(aesKey: CryptoKey, sharedSecret: Uint8Array): Promise<Uint8Array> {
-  const keyBytes = await crypto.subtle.exportKey("raw", aesKey);
-  const keyArray = new Uint8Array(keyBytes);
-
-  // Simple XOR with shared secret (in production, use proper encryption)
-  const encrypted = new Uint8Array(keyArray.length);
-  for (let i = 0; i < keyArray.length; i++) {
-    encrypted[i] = keyArray[i] ^ sharedSecret[i % sharedSecret.length];
-  }
-  return encrypted;
-}
-
-/**
- * Decrypt AES key
- */
-async function decryptAESKey(
-  encryptedKey: Uint8Array,
-  sharedSecret: Uint8Array
-): Promise<CryptoKey> {
-  const decrypted = new Uint8Array(encryptedKey.length);
-  for (let i = 0; i < encryptedKey.length; i++) {
-    decrypted[i] = encryptedKey[i] ^ sharedSecret[i % sharedSecret.length];
-  }
-
-  return crypto.subtle.importKey(
-    "raw",
-    decrypted,
-    { name: "AES-GCM", length: AES_GCM_KEY_LENGTH * 8 },
-    false,
-    ["encrypt", "decrypt"]
-  );
 }
 
 /**

--- a/src/crypto/envelope.ts
+++ b/src/crypto/envelope.ts
@@ -104,10 +104,7 @@ export async function decryptEnvelope(
 /**
  * Derive AES key from shared secret (simplified HKDF)
  */
-async function deriveAESKey(
-  sharedSecret: Uint8Array,
-  salt: Uint8Array
-): Promise<CryptoKey> {
+async function deriveAESKey(sharedSecret: Uint8Array, salt: Uint8Array): Promise<CryptoKey> {
   // HKDF-SHA256 over the ECDH shared secret. The salt is the per-envelope
   // ephemeral X25519 public key (SECURITY, Phase 2: the prior implementation
   // used an empty salt; binding the salt to the ephemeral key domain-separates

--- a/tests/security/rendered_page_csp.test.ts
+++ b/tests/security/rendered_page_csp.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Regression gate — Phase 2 stored XSS in publish_rendered_page.
+ *
+ * html_body is author-supplied and served verbatim by GET /entities/:id/html,
+ * and the GLOBAL CSP allows 'unsafe-inline' scripts — so an injected <script>
+ * in a rendered page (viewable unauthenticated via a guest access_token) would
+ * execute in-origin. The fix serves this route with a strict per-route CSP
+ * (script-src 'none' + sandbox), neutralizing script execution regardless of
+ * html_body contents. This test locks that the route response carries the
+ * strict policy.
+ */
+import { AddressInfo } from "node:net";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+describe("rendered_page /html strict CSP (Phase 2 stored-XSS mitigation)", () => {
+  let server: ReturnType<import("express").Application["listen"]>;
+  let baseUrl: string;
+  let entityId: string | null = null;
+
+  beforeAll(async () => {
+    const { app } = await import("../../src/actions.js");
+    server = app.listen(0);
+    const addr = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${addr.port}`;
+
+    // Seed a rendered_page containing a script payload.
+    const res = await fetch(`${baseUrl}/store`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        idempotency_key: "csp-xss-test-seed",
+        entities: [
+          {
+            entity_type: "rendered_page",
+            canonical_name: "rendered_page:csp-xss-test",
+            title: "CSP XSS Test",
+            html_body: "<h1>content</h1><script>document.title='PWNED'</script>",
+          },
+        ],
+      }),
+    });
+    if (res.ok) {
+      const body = (await res.json()) as { entities?: Array<{ entity_id: string }> };
+      entityId = body.entities?.[0]?.entity_id ?? null;
+    }
+  });
+
+  afterAll(() => {
+    server?.close();
+  });
+
+  it("serves the rendered page with a strict script-blocking CSP", async () => {
+    if (!entityId) {
+      // Seeding depends on local-dev auth mode; if it did not seed, skip rather
+      // than false-fail. The header assertion below is the security-relevant one.
+      return;
+    }
+    const res = await fetch(`${baseUrl}/entities/${entityId}/html`);
+    expect(res.status).toBe(200);
+    const csp = res.headers.get("content-security-policy") ?? "";
+    // The strict route policy must block ALL script execution (inline + external).
+    expect(csp).toContain("script-src 'none'");
+    expect(csp).toContain("default-src 'none'");
+    expect(csp).toContain("sandbox");
+    // The global 'unsafe-inline' script policy must NOT apply to this route.
+    expect(csp).not.toContain("'unsafe-inline' https://cdn.jsdelivr.net");
+    // The page still renders its content (the script is served inert, not stripped).
+    const html = await res.text();
+    expect(html).toContain("<h1>content</h1>");
+  });
+});

--- a/tests/security/rendered_page_csp.test.ts
+++ b/tests/security/rendered_page_csp.test.ts
@@ -50,11 +50,10 @@ describe("rendered_page /html strict CSP (Phase 2 stored-XSS mitigation)", () =>
   });
 
   it("serves the rendered page with a strict script-blocking CSP", async () => {
-    if (!entityId) {
-      // Seeding depends on local-dev auth mode; if it did not seed, skip rather
-      // than false-fail. The header assertion below is the security-relevant one.
-      return;
-    }
+    // Seeding depends on local-dev auth mode. Fail loudly rather than
+    // early-returning with zero assertions — a broken seed must not
+    // silently greenwash this GHSA regression gate.
+    expect(entityId, "seed /store call failed — see beforeAll for details").toBeTruthy();
     const res = await fetch(`${baseUrl}/entities/${entityId}/html`);
     expect(res.status).toBe(200);
     const csp = res.headers.get("content-security-policy") ?? "";
@@ -64,6 +63,8 @@ describe("rendered_page /html strict CSP (Phase 2 stored-XSS mitigation)", () =>
     expect(csp).toContain("sandbox");
     // The global 'unsafe-inline' script policy must NOT apply to this route.
     expect(csp).not.toContain("'unsafe-inline' https://cdn.jsdelivr.net");
+    // MIME-sniffing hardening pairs with the strict CSP on this route.
+    expect(res.headers.get("x-content-type-options")).toBe("nosniff");
     // The page still renders its content (the script is served inert, not stripped).
     const html = await res.text();
     expect(html).toContain("<h1>content</h1>");


### PR DESCRIPTION
Security hardening release v0.21.5 (follow-on to v0.21.4).

Addresses findings from internal security review. Full details are held in the repository security advisory; not restated here per the GHSA-first disclosure flow.

- Rendered-page HTML route response hardening — GHSA-qp63-9r52-4q25.
- Response-encryption envelope: content key now derived via HKDF rather than transmitting a wrapped key (an unreachable-in-production cleanup; no advisory).
- Regression coverage added; test catalog regenerated.

**Surface scope:** Both hardening changes are single-surface — no cross-surface parity testing applies.
- CSP/`nosniff` hardening touches only `GET /entities/:id/html` (HTTP route response headers). No MCP tool, CLI command, or SDK method exposes this behavior separately.
- Envelope HKDF key-derivation change is internal to `src/crypto/envelope.ts` (`encryptEnvelope`/`decryptEnvelope`), consumed as a library function. It has no independent MCP/REST/CLI surface of its own.

**Assurance:** `tsc` 0 errors; `tests/security` + crypto suites green. Fixes already deployed to operator-run instances ahead of this release.

Closes #2140
