### PR TITLE
fix(auth): reject the nil UUID in the shared-graph binding (#2130)

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -2885,7 +2885,17 @@ app.get("/mcp/oauth/google/callback", async (req, res) => {
     // their isolated per-email one — so the whole allowlisted team, plus the
     // bearer/MCP identity that owns the data, share one populated graph. Unset
     // → isolated per-email behavior (unchanged). See getSharedGraphUserId.
-    const resolvedUserId = getSharedGraphUserId() ?? perEmailUser.id;
+    const sharedGraphUserId = getSharedGraphUserId();
+    // A configured-but-rejected value means NEOTOMA_SHARED_GRAPH_USER_ID is set
+    // to something unusable (malformed, or the nil UUID). The signer silently
+    // falls back to their isolated per-email graph, which looks like an empty
+    // team graph rather than an error — so say so once per sign-in.
+    if (!sharedGraphUserId && (process.env.NEOTOMA_SHARED_GRAPH_USER_ID || "").trim()) {
+      logWarn("SharedGraphUserIdRejected", req, {
+        reason: "not a usable UUID (malformed or nil); falling back to isolated per-email graph",
+      });
+    }
+    const resolvedUserId = sharedGraphUserId ?? perEmailUser.id;
 
     // Mark this browser session as Google-verified and bound to the resolved
     // user_id, exactly the same OAuth key-session cookie the private-key/

--- a/src/services/google_oidc.ts
+++ b/src/services/google_oidc.ts
@@ -147,6 +147,7 @@ export function isGoogleSigninEnabled(): boolean {
 }
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const NIL_UUID = "00000000-0000-0000-0000-000000000000";
 
 /**
  * Shared-graph opt-in (a bounded, explicit slice of "Model B").
@@ -165,12 +166,26 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
  * for emails that already pass the `NEOTOMA_APPROVED_EMAILS` allowlist, so a
  * non-approved Google account can never be mapped onto the shared graph.
  *
- * Returns null when unset or malformed (fail-safe to isolated behavior).
+ * Returns null when unset, malformed, or the nil UUID (fail-safe to isolated
+ * behavior).
+ *
+ * The nil UUID is rejected deliberately. It is syntactically a valid UUID, so
+ * it would otherwise pass and bind every approved signer to
+ * `00000000-0000-0000-0000-000000000000` — the conventional "no user"
+ * sentinel, and the same value an unauthenticated session reports. The
+ * observable effect is that a person who signs in correctly is told they are
+ * anonymous, and every per-user mechanism (notably `standing_rule` injection)
+ * silently resolves to the nil principal. Binding a real team to the "no user"
+ * value is never intentional, so it is treated as a misconfiguration rather
+ * than honored.
  */
 export function getSharedGraphUserId(): string | null {
   const raw = (process.env.NEOTOMA_SHARED_GRAPH_USER_ID || "").trim();
   if (!raw) return null;
-  return UUID_RE.test(raw) ? raw.toLowerCase() : null;
+  if (!UUID_RE.test(raw)) return null;
+  const normalized = raw.toLowerCase();
+  if (normalized === NIL_UUID) return null;
+  return normalized;
 }
 
 function getJwks(): ReturnType<typeof createRemoteJWKSet> {

--- a/tests/unit/google_oidc.test.ts
+++ b/tests/unit/google_oidc.test.ts
@@ -135,7 +135,10 @@ describe("google_oidc", () => {
   });
 
   describe("getSharedGraphUserId", () => {
-    const UUID = "00000000-0000-0000-0000-000000000000";
+    // Deliberately NOT the nil UUID: getSharedGraphUserId rejects that as a
+    // misconfiguration, and using it as the "valid" fixture is how a nil
+    // binding slips into a real deployment unnoticed.
+    const UUID = "3f2a91c4-7b5e-4d18-9c60-2ae8b4471d3f";
 
     it("returns null when unset (default: isolated per-email graphs)", async () => {
       withEnv({ NEOTOMA_SHARED_GRAPH_USER_ID: undefined });
@@ -165,6 +168,29 @@ describe("google_oidc", () => {
       withEnv({ NEOTOMA_SHARED_GRAPH_USER_ID: "not-a-uuid" });
       const mod = await loadModule();
       expect(mod.getSharedGraphUserId()).toBeNull();
+    });
+
+    // The nil UUID is syntactically valid, so without an explicit check it
+    // would bind every approved signer to the conventional "no user" sentinel
+    // — the same value an unauthenticated session reports. A person who signed
+    // in correctly would then be told they are anonymous, and every per-user
+    // mechanism would resolve to the nil principal.
+    it("rejects the nil UUID rather than binding a team to the no-user sentinel", async () => {
+      withEnv({ NEOTOMA_SHARED_GRAPH_USER_ID: "00000000-0000-0000-0000-000000000000" });
+      const mod = await loadModule();
+      expect(mod.getSharedGraphUserId()).toBeNull();
+    });
+
+    it("rejects the nil UUID regardless of case or surrounding whitespace", async () => {
+      withEnv({ NEOTOMA_SHARED_GRAPH_USER_ID: "  00000000-0000-0000-0000-000000000000  " });
+      const mod = await loadModule();
+      expect(mod.getSharedGraphUserId()).toBeNull();
+    });
+
+    it("still accepts a UUID that merely contains zero groups", async () => {
+      withEnv({ NEOTOMA_SHARED_GRAPH_USER_ID: "00000000-0000-0000-0000-000000000001" });
+      const mod = await loadModule();
+      expect(mod.getSharedGraphUserId()).toBe("00000000-0000-0000-0000-000000000001");
     });
   });
 


### PR DESCRIPTION
Closes #2130.

## What was broken

`NEOTOMA_SHARED_GRAPH_USER_ID` accepted any syntactically valid UUID, and the nil UUID is syntactically valid. An instance configured with it bound **every approved signer** to `00000000-0000-0000-0000-000000000000` — the conventional "no user" sentinel, and the same value an unauthenticated session reports.

The observable effect: someone who completed Google sign-in correctly was told by their agent that they were anonymous, and every per-user mechanism (notably `standing_rule` injection) silently resolved to the nil principal. From the client side this is indistinguishable from a failed sign-in, so it was diagnosed as an auth failure rather than a misconfiguration.

## The change

Treat the nil UUID as unusable and fail-safe to isolated per-email behaviour, exactly as a malformed value already does. Binding a real team to the "no user" value is never intentional.

Also log once per sign-in when the variable is set but rejected, since the fallback otherwise presents as an empty team graph rather than an error.

## Testing note worth reading

The existing `"returns the UUID when set to a valid UUID"` test used the **nil UUID as its valid fixture** — which is plausibly how a nil binding reached a deployment unnoticed in the first place. Replaced with a real UUID, and added coverage for nil rejection (bare, and with case/whitespace), plus a regression guard that a UUID merely *containing* zero groups is still accepted.

27 tests passing; `tsc --noEmit` clean.

## Deployment ordering — this matters

This fix must **not** reach an instance whose data is still attributed to the nil UUID. Applying it there sends every signer to an isolated per-email graph and the existing graph appears to vanish.

The affected client instance was migrated first: 158,163 rows across 12 tables moved onto a real identity in a single locked transaction, the binding was repointed to match, and a signed-in session was verified to resolve to that identity with the full graph visible. Only then is this safe to deploy.

Any other instance running a nil binding needs the same treatment before this lands.

## Scope

This does not deliver per-person attribution — it removes a false signal. Distinguishing people within a shared graph is workspace membership (#2085).

🤖 Generated with [Claude Code](https://claude.com/claude-code)