### PR TITLE
fix(fly): use dedicated CPUs for operator instances (89% steal caused a 40-min outage)

### DIFF
--- a/fly.operator.toml
+++ b/fly.operator.toml
@@ -29,7 +29,7 @@
 # rather than intermittent.
 #
 # WHAT DIFFERS FROM fly.toml
-#   - [[vm]]      2 CPU / 4096MB, not the sandbox's 1 CPU / 1GB
+#   - [[vm]]      2 DEDICATED CPU / 4096MB, not the sandbox's 1 shared CPU / 1GB
 #   - [[restart]] policy = 'always' (see below)
 #   - no VITE_NEOTOMA_SANDBOX_UI, and VITE_PUBLIC_BASE_PATH = "/"
 #   - primary_region is NOT set — pass --primary-region, since the volume's
@@ -97,7 +97,34 @@
 [[restart]]
   policy = 'always'
 
+# DEDICATED CPUs, not shared. This costs roughly 2.9x more and is deliberate.
+#
+# On 2026-08-09 this instance spent ~40 minutes at 89% CPU STEAL — the
+# hypervisor was withholding ~90% of the CPU the machine was nominally
+# allocated, because a neighbour on the same shared host was busy. Measured
+# from inside the guest via /proc/stat deltas:
+#
+#   during:  steal 89.6% / 89.1%   busy 6.3%   loadavg 5.11
+#   after:   steal  0.0%           busy 0.4%   loadavg 0.15
+#
+# Every database-backed path failed while the app itself was healthy: a
+# limit=1 query on a 7-row entity type took 73s, larger types never completed,
+# the MCP transport went 5x slower, and rendered pages timed out — so anyone
+# holding a share link got nothing. It resolved on its own when the neighbour
+# left. Nothing in Neotoma was at fault, and nothing in Neotoma could fix it.
+#
+# `shared` offers no warning and no recourse for this: the guest cannot detect
+# it in advance, /health keeps returning 200 in 0.25s throughout (answering
+# from process state needs almost no CPU), and Fly's service check therefore
+# stays green — so `[[restart]] policy = 'always'` below can never fire for it.
+# See neotoma#2141 for that monitoring gap and neotoma#2144 for the incident.
+#
+# An operator instance is the durable store several agents and sessions depend
+# on. Losing it for 40 minutes on a neighbour's schedule is the failure this
+# preset exists to prevent. Do NOT revert to `shared` to save cost without
+# accounting for that — the sandbox and client instances are the right place
+# to economise, and Bottega8 stayed healthy on shared throughout this incident.
 [[vm]]
   memory = '4gb'
-  cpu_kind = 'shared'
+  cpu_kind = 'performance'
   cpus = 2


### PR DESCRIPTION
## What

Sets `cpu_kind = 'performance'` for operator instances in `fly.operator.toml`. Sandbox and client instances are unchanged.

**Already applied to the live machine** (`flyctl machine update`, one restart, back healthy). This PR makes it survive the next deploy — without it, the machine config reverts to `shared` silently, which is the exact class of bug this file was created to prevent (its header documents a 4GB instance reverting to 1GB on redeploy).

## Why

On 2026-08-09 the personal hosted instance spent ~40 minutes at **89% CPU steal**. Steal is the hypervisor withholding CPU from the guest — a neighbour on the same shared host was busy, so the machine received roughly a tenth of the CPU it was nominally allocated.

Measured from inside the guest via `/proc/stat` deltas:

```
during:  steal 89.6% / 89.1%   busy 6.3%   loadavg 5.11
after:   steal  0.0%           busy 0.4%   loadavg 0.15
```

Every database-backed path failed while the application itself was fine:

```
/entities?entity_type=lifecycle_stage&limit=1   (7 rows)   73.2s   ->  0.99s
/entities?entity_type=task&limit=1                         >75s    ->  1.53s
/entities?entity_type=task&limit=5                         >90s    ->  1.47s
POST /mcp initialize                                       6.19s   ->  0.29s
GET /entities/<id>/html                                    >60s    ->  0.62s
/health                                                    0.25s   ->  0.51s   (never varied)
```

Rendered pages timing out is user-visible: anyone holding a share link got nothing for 40 minutes.

It resolved on its own when the neighbour left. **Nothing in Neotoma was at fault, and nothing in Neotoma could have fixed it.**

## Why `shared` is the wrong preset for an operator instance

Three properties make this failure mode unmanageable rather than merely unlucky:

1. **No warning.** The guest cannot detect an incoming noisy neighbour.
2. **No recourse.** No application change mitigates being descheduled.
3. **Invisible to every health signal.** `/health` answers from process state, which needs almost no CPU, so it returned 200 in 0.25s throughout. Fly's service check uses that endpoint and stayed green — meaning `[[restart]] policy = 'always'` **can never fire for this failure mode**. See #2141.

An operator instance is the durable store several agents and sessions depend on. Losing it for 40 minutes on a neighbour's schedule is the failure this preset exists to prevent.

## Cost

| Preset | Hourly | Monthly (ams) |
|---|---|---|
| `shared-cpu-2x` 4GB (before) | $0.0309 | $22.22 |
| `performance-2x` 4GB (after) | $0.0894 | $64.39 |

**+$42.17/month**, ~2.9×. Same 2 CPUs and 4GB — the only change is dedicated cores. Documented inline so the tradeoff is visible to anyone tempted to revert it for cost.

## Scope

Deliberately narrow:

- `fly.operator.toml` — **changed** (operator instances)
- `fly.toml` — unchanged (sandbox, 1 CPU / 1GB shared)
- client instances — unchanged; **Bottega8 stayed healthy on shared throughout this incident**, so there is no evidence they need this

## Verification

- `flyctl config validate -c fly.operator.toml` → valid
- No `app` or `primary_region` key introduced (public-repo hygiene preserved — see the header note re #2001)
- Live machine confirmed `CPU Kind = performance`, `vCPUs = 2`, `Memory = 4096`
- Post-change steal measured over a 30s window: **0.27%**
- All previously-failing paths verified healthy (table above), `v0.21.4` serving

## Related

- #2141 — `/health` does not exercise the database, so it cannot detect this class of stall
- #2144 — the incident; note it was **originally filed misattributing the latency to Neotoma's auth path**, corrected in-thread once steal was measured. It is now scoped to a genuine, hosting-independent defect: timed-out writes commit but report failure (a `create_relationships` batch of 10 returned 502 with 4 actually created).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
