### PR TITLE
fix(health): split liveness from readiness with a latency budget (#2141)

### DIFF
--- a/.github/workflows/ci_test_lanes.yml
+++ b/.github/workflows/ci_test_lanes.yml
@@ -142,6 +142,14 @@ jobs:
       - name: Run concurrent-backend effect-verified regressions (merge rollback + migration validator)
         run: npx vitest run --no-file-parallelism tests/integration/merge_repoint_relationship_edges.test.ts tests/scripts/validate_libsql_migration.test.ts
 
+      # Readiness-probe regressions (#2141). Same gap as the step above, found
+      # the same way: the suite that pins the latency budget passed locally and
+      # ran in NO PR lane, so a future change could delete the budget and green
+      # every check. That is the #2141 bug itself in a new place — a signal that
+      # reports success while the thing it guards is gone.
+      - name: Run readiness-probe effect-verified regressions (liveness/readiness split)
+        run: npx vitest run --no-file-parallelism tests/integration/readiness_probe.test.ts
+
       # OFFLINE/local-transport parity gate. Curated behaviors that broke on the
       # offline/HTTP path (#1819 at_ingested, #1840 dedup, #1839 null-cleared,
       # #1842 issue-submit auth) are asserted through BOTH the MCP and offline

--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,8 +61,8 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **575**
-- Backend and repo Vitest files: **540**
+- Total automated test files: **576**
+- Backend and repo Vitest files: **541**
 - Frontend Vitest files: **9**
 - Playwright spec files: **26**
 
@@ -72,7 +72,7 @@ flowchart TD
 | Vitest unit tests | 159 |
 | Vitest service tests | 43 |
 | Source-adjacent tests | 65 |
-| Vitest integration tests | 161 |
+| Vitest integration tests | 162 |
 | Vitest CLI tests | 77 |
 | Vitest contract tests | 15 |
 | Vitest security tests | 7 |
@@ -397,7 +397,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm run test:integration` or `npx vitest run tests/integration`
 **Requirements:** Database configured; remote-dependent subsets additionally need `RUN_REMOTE_TESTS=1`.
-**Files (161):**
+**Files (162):**
 - `tests/integration/aauth_attribution_stamping.test.ts`
 - `tests/integration/aauth_mcp_capability_parity.test.ts`
 - `tests/integration/aauth_mcp_initialize_admission.test.ts`
@@ -510,6 +510,7 @@ flowchart TD
 - `tests/integration/plan_body_raw_fragment_backfill.test.ts`
 - `tests/integration/process_issues_skill.test.ts`
 - `tests/integration/public_key_registry.test.ts`
+- `tests/integration/readiness_probe.test.ts`
 - `tests/integration/record_activity_attribution.test.ts`
 - `tests/integration/relationship_agent_attribution_api.test.ts`
 - `tests/integration/relationship_delete_discovery_mcp.test.ts`

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2564,6 +2564,14 @@ paths:
     get:
       summary: Health check
       operationId: healthCheck
+      description: |
+        LIVENESS only. Answers from process state and reads no dependency, so
+        it stays green while the database is slow or unreachable — by design:
+        an operator needs to distinguish "hung" from "dead", and a liveness
+        check that fails on a slow dependency turns latency into a restart.
+
+        Do NOT use this to decide whether the instance can serve requests. It
+        cannot detect degradation; use `/ready` for that.
       security: []
       responses:
         "200":
@@ -2575,6 +2583,62 @@ paths:
                 properties:
                   ok:
                     type: boolean
+
+  /ready:
+    get:
+      summary: Readiness check
+      operationId: readinessCheck
+      description: |
+        LIVENESS **plus** a bounded database probe. Returns 503 when the probe
+        errors, throws, or exceeds `NEOTOMA_READINESS_BUDGET_MS` (default 3000).
+
+        The budget is the point. On 2026-08-10 this instance served `/health`
+        in 0.28s while entity reads took 34-37s — a probe that merely awaited
+        the database would have reported ready 37 seconds later, accurately and
+        uselessly. Sustained degradation is only detectable against a deadline.
+      security: []
+      responses:
+        "200":
+          description: Instance is live and answered a database probe within budget.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  version:
+                    type: string
+                  database:
+                    type: string
+                    enum: [ok]
+                  elapsed_ms:
+                    type: integer
+        "503":
+          description: |
+            Not ready. `database: "error"` means the driver returned an error;
+            `database: "unreachable"` means it threw or exceeded the budget.
+            `error` carries the budget-overrun detail, and in production a
+            generic string for driver faults — the route is unauthenticated, so
+            raw driver messages are logged rather than returned.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  version:
+                    type: string
+                  database:
+                    type: string
+                    enum: [error, unreachable]
+                  elapsed_ms:
+                    type: integer
+                  budget_ms:
+                    type: integer
+                  error:
+                    type: string
 
   /openapi.yaml:
     get:

--- a/scripts/security/protected_routes_manifest.json
+++ b/scripts/security/protected_routes_manifest.json
@@ -9,18 +9,8 @@
       "operation_id": "oauthServerMetadata",
       "requires_auth": false,
       "sandbox_allowed": "hosted_ok",
-      "expected_no_auth_status": [
-        200,
-        400,
-        404,
-        405
-      ],
-      "expected_invalid_auth_status": [
-        200,
-        400,
-        404,
-        405
-      ]
+      "expected_no_auth_status": [200, 400, 404, 405],
+      "expected_invalid_auth_status": [200, 400, 404, 405]
     },
     {
       "path": "/.well-known/oauth-protected-resource",
@@ -28,18 +18,8 @@
       "operation_id": "oauthProtectedResource",
       "requires_auth": false,
       "sandbox_allowed": "hosted_ok",
-      "expected_no_auth_status": [
-        200,
-        400,
-        404,
-        405
-      ],
-      "expected_invalid_auth_status": [
-        200,
-        400,
-        404,
-        405
-      ]
+      "expected_no_auth_status": [200, 400, 404, 405],
+      "expected_invalid_auth_status": [200, 400, 404, 405]
     },
     {
       "path": "/.well-known/oauth-protected-resource/mcp",
@@ -47,18 +27,8 @@
       "operation_id": "oauthProtectedResourceForMcp",
       "requires_auth": false,
       "sandbox_allowed": "hosted_ok",
-      "expected_no_auth_status": [
-        200,
-        400,
-        404,
-        405
-      ],
-      "expected_invalid_auth_status": [
-        200,
-        400,
-        404,
-        405
-      ]
+      "expected_no_auth_status": [200, 400, 404, 405],
+      "expected_invalid_auth_status": [200, 400, 404, 405]
     },
     {
       "path": "/.well-known/openid-configuration",
@@ -66,18 +36,8 @@
       "operation_id": "openidConfigurationNotOffered",
       "requires_auth": false,
       "sandbox_allowed": "hosted_ok",
-      "expected_no_auth_status": [
-        200,
-        400,
-        404,
-        405
-      ],
-      "expected_invalid_auth_status": [
-        200,
-        400,
-        404,
-        405
-      ]
+      "expected_no_auth_status": [200, 400, 404, 405],
+      "expected_invalid_auth_status": [200, 400, 404, 405]
     },
     {
       "path": "/access_policies",
@@ -85,12 +45,8 @@
       "operation_id": "getAccessPolicies",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/admin/compliance/scorecard",
@@ -98,12 +54,8 @@
       "operation_id": "getComplianceScorecard",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/agents",
@@ -111,12 +63,8 @@
       "operation_id": null,
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/agents/grants",
@@ -124,12 +72,8 @@
       "operation_id": "listAgentGrants",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/agents/grants",
@@ -137,12 +81,8 @@
       "operation_id": "createAgentGrant",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/agents/grants/{id}",
@@ -150,12 +90,8 @@
       "operation_id": "getAgentGrant",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/agents/grants/{id}",
@@ -163,12 +99,8 @@
       "operation_id": "updateAgentGrant",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/agents/grants/{id}/restore",
@@ -176,12 +108,8 @@
       "operation_id": "restoreAgentGrant",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/agents/grants/{id}/revoke",
@@ -189,12 +117,8 @@
       "operation_id": "revokeAgentGrant",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/agents/grants/{id}/suspend",
@@ -202,12 +126,8 @@
       "operation_id": "suspendAgentGrant",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/agents/{key}",
@@ -215,12 +135,8 @@
       "operation_id": null,
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/agents/{key}/records",
@@ -228,12 +144,8 @@
       "operation_id": null,
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/analyze_schema_candidates",
@@ -241,12 +153,8 @@
       "operation_id": "analyzeSchemaCandidates",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/audit_undeclared_fragments",
@@ -254,12 +162,8 @@
       "operation_id": "auditUndeclaredFragments",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/auth/dev-signin",
@@ -267,12 +171,8 @@
       "operation_id": "devSignIn",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/conversations/{conversation_id}/turn-index",
@@ -280,12 +180,8 @@
       "operation_id": "getConversationTurnIndex",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/correct",
@@ -293,12 +189,8 @@
       "operation_id": "correct",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/create_relationship",
@@ -306,12 +198,8 @@
       "operation_id": "createRelationship",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/create_relationships",
@@ -319,12 +207,8 @@
       "operation_id": "createRelationships",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/delete_entity",
@@ -332,12 +216,8 @@
       "operation_id": "deleteEntity",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/delete_relationship",
@@ -345,12 +225,8 @@
       "operation_id": "deleteRelationship",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/entities",
@@ -358,12 +234,8 @@
       "operation_id": "listEntities",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/entities/duplicates",
@@ -371,12 +243,8 @@
       "operation_id": "listPotentialDuplicates",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/entities/merge",
@@ -384,12 +252,8 @@
       "operation_id": "mergeEntities",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/entities/query",
@@ -397,12 +261,8 @@
       "operation_id": "queryEntities",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/entities/split",
@@ -410,12 +270,8 @@
       "operation_id": "splitEntity",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/entities/{id}",
@@ -423,12 +279,8 @@
       "operation_id": "getEntityById",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/entities/{id}/observations",
@@ -436,12 +288,8 @@
       "operation_id": "getEntityObservations",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/entities/{id}/relationships",
@@ -449,12 +297,8 @@
       "operation_id": "getEntityRelationships",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/events/stream",
@@ -462,12 +306,8 @@
       "operation_id": "eventsStream",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/get_authenticated_user",
@@ -475,12 +315,8 @@
       "operation_id": "getAuthenticatedUser",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/get_entity_snapshot",
@@ -488,12 +324,8 @@
       "operation_id": "getEntitySnapshot",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/get_field_provenance",
@@ -501,12 +333,8 @@
       "operation_id": "getFieldProvenance",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/get_file_url",
@@ -514,12 +342,8 @@
       "operation_id": "getFileUrl",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/get_schema_recommendations",
@@ -527,12 +351,8 @@
       "operation_id": "getSchemaRecommendations",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/get_subscription_status",
@@ -540,12 +360,8 @@
       "operation_id": "getSubscriptionStatus",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/health",
@@ -553,18 +369,8 @@
       "operation_id": "healthCheck",
       "requires_auth": false,
       "sandbox_allowed": "hosted_ok",
-      "expected_no_auth_status": [
-        200,
-        400,
-        404,
-        405
-      ],
-      "expected_invalid_auth_status": [
-        200,
-        400,
-        404,
-        405
-      ]
+      "expected_no_auth_status": [200, 400, 404, 405],
+      "expected_invalid_auth_status": [200, 400, 404, 405]
     },
     {
       "path": "/health_check_snapshots",
@@ -572,12 +378,8 @@
       "operation_id": "healthCheckSnapshots",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/identify_entity_by_signals",
@@ -585,12 +387,8 @@
       "operation_id": "identifyEntityBySignals",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/interpretations",
@@ -598,12 +396,8 @@
       "operation_id": "listInterpretations",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/interpretations/create",
@@ -611,12 +405,8 @@
       "operation_id": "createInterpretation",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/issues/add_message",
@@ -624,12 +414,8 @@
       "operation_id": "issuesAddMessage",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/issues/bulk_close",
@@ -637,12 +423,8 @@
       "operation_id": "bulkCloseIssues",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/issues/bulk_remove",
@@ -650,12 +432,8 @@
       "operation_id": "bulkRemoveIssues",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/issues/status",
@@ -663,12 +441,8 @@
       "operation_id": "issuesGetStatus",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/issues/submit",
@@ -676,12 +450,8 @@
       "operation_id": "issuesSubmit",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/issues/sync",
@@ -689,12 +459,8 @@
       "operation_id": "issuesSync",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/list_observations",
@@ -702,12 +468,8 @@
       "operation_id": "listObservationsForEntity",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/list_relationships",
@@ -715,12 +477,8 @@
       "operation_id": "listRelationshipsForEntity",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/list_subscriptions",
@@ -728,12 +486,8 @@
       "operation_id": "listSubscriptions",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/mcp/oauth/authorization-details",
@@ -741,12 +495,8 @@
       "operation_id": "mcpOAuthAuthorizationDetails",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/mcp/oauth/authorize",
@@ -754,12 +504,8 @@
       "operation_id": "mcpOAuthAuthorize",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/mcp/oauth/callback",
@@ -767,12 +513,8 @@
       "operation_id": "mcpOAuthCallback",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/mcp/oauth/connections",
@@ -780,12 +522,8 @@
       "operation_id": "mcpOAuthListConnections",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/mcp/oauth/connections/{connection_id}",
@@ -793,12 +531,8 @@
       "operation_id": "mcpOAuthRevokeConnection",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/mcp/oauth/initiate",
@@ -806,12 +540,8 @@
       "operation_id": "mcpOAuthInitiate",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/mcp/oauth/key-auth",
@@ -819,12 +549,8 @@
       "operation_id": "mcpOAuthKeyAuthGet",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/mcp/oauth/key-auth",
@@ -832,12 +558,8 @@
       "operation_id": "mcpOAuthKeyAuthPost",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/mcp/oauth/local-login",
@@ -845,12 +567,8 @@
       "operation_id": "mcpOAuthLocalLogin",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/mcp/oauth/register",
@@ -858,12 +576,8 @@
       "operation_id": "mcpOAuthRegister",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/mcp/oauth/status",
@@ -871,12 +585,8 @@
       "operation_id": "mcpOAuthStatus",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/mcp/oauth/token",
@@ -884,12 +594,8 @@
       "operation_id": "mcpOAuthToken",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/me",
@@ -897,12 +603,8 @@
       "operation_id": "getMe",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/observations",
@@ -910,12 +612,8 @@
       "operation_id": "listObservations",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/observations/create",
@@ -923,12 +621,8 @@
       "operation_id": "createObservation",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/observations/query",
@@ -936,12 +630,8 @@
       "operation_id": "queryObservations",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/openapi.yaml",
@@ -949,18 +639,8 @@
       "operation_id": "getOpenApiSpec",
       "requires_auth": false,
       "sandbox_allowed": "hosted_ok",
-      "expected_no_auth_status": [
-        200,
-        400,
-        404,
-        405
-      ],
-      "expected_invalid_auth_status": [
-        200,
-        400,
-        404,
-        405
-      ]
+      "expected_no_auth_status": [200, 400, 404, 405],
+      "expected_invalid_auth_status": [200, 400, 404, 405]
     },
     {
       "path": "/peers",
@@ -968,12 +648,8 @@
       "operation_id": "listPeers",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/peers",
@@ -981,12 +657,8 @@
       "operation_id": "addPeer",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/peers/resolve_sync_conflict",
@@ -994,12 +666,8 @@
       "operation_id": "resolveSyncConflict",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/peers/{peer_id}",
@@ -1007,12 +675,8 @@
       "operation_id": "getPeerStatus",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/peers/{peer_id}",
@@ -1020,12 +684,8 @@
       "operation_id": "removePeer",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/peers/{peer_id}/sync",
@@ -1033,12 +693,8 @@
       "operation_id": "syncPeer",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/query_contacts_at_company",
@@ -1046,12 +702,18 @@
       "operation_id": "queryContactsAtCompany",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
+    },
+    {
+      "path": "/ready",
+      "method": "GET",
+      "operation_id": "readinessCheck",
+      "requires_auth": false,
+      "sandbox_allowed": "hosted_ok",
+      "expected_no_auth_status": [200, 400, 404, 405, 503],
+      "expected_invalid_auth_status": [200, 400, 404, 405, 503],
+      "override_applied": true
     },
     {
       "path": "/recent_conversations",
@@ -1059,12 +721,8 @@
       "operation_id": "getRecentConversations",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/recent_conversations/{conversation_id}",
@@ -1072,12 +730,8 @@
       "operation_id": "getRecentConversation",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/record_activity",
@@ -1085,12 +739,8 @@
       "operation_id": "getRecordActivity",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/register_schema",
@@ -1098,12 +748,8 @@
       "operation_id": "registerSchema",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/relationships",
@@ -1111,12 +757,8 @@
       "operation_id": "listRelationships",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/relationships/snapshot",
@@ -1124,12 +766,8 @@
       "operation_id": "getRelationshipSnapshot",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/relationships/{id}",
@@ -1137,12 +775,8 @@
       "operation_id": "getRelationshipById",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/rendered-pages/publish",
@@ -1150,12 +784,8 @@
       "operation_id": "publishRenderedPage",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/restore_entity",
@@ -1163,12 +793,8 @@
       "operation_id": "restoreEntity",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/restore_relationship",
@@ -1176,12 +802,8 @@
       "operation_id": "restoreRelationship",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/retrieve_entity_by_identifier",
@@ -1189,12 +811,8 @@
       "operation_id": "retrieveEntityByIdentifier",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/retrieve_graph_neighborhood",
@@ -1202,12 +820,8 @@
       "operation_id": "retrieveGraphNeighborhood",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/retrieve_related_entities",
@@ -1215,12 +829,8 @@
       "operation_id": "retrieveRelatedEntities",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/schemas",
@@ -1228,12 +838,8 @@
       "operation_id": "listSchemas",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/schemas/{entity_type}",
@@ -1241,12 +847,8 @@
       "operation_id": "getSchemaByEntityType",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/server-info",
@@ -1254,12 +856,8 @@
       "operation_id": "getServerInfo",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/session",
@@ -1267,12 +865,8 @@
       "operation_id": "getSessionInfo",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/sources",
@@ -1280,12 +874,8 @@
       "operation_id": "listSources",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/sources/{id}",
@@ -1293,12 +883,8 @@
       "operation_id": "getSourceById",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/sources/{id}/relationships",
@@ -1306,12 +892,8 @@
       "operation_id": "getSourceRelationships",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/stats",
@@ -1319,12 +901,8 @@
       "operation_id": "getStats",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/store",
@@ -1332,12 +910,8 @@
       "operation_id": "store",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/subscribe",
@@ -1345,12 +919,8 @@
       "operation_id": "subscribe",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/sync/entities",
@@ -1358,12 +928,8 @@
       "operation_id": "listSyncEntities",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/sync/webhook",
@@ -1371,12 +937,8 @@
       "operation_id": "applySyncWebhook",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/timeline",
@@ -1384,12 +946,8 @@
       "operation_id": "listTimeline",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/timeline/{id}",
@@ -1397,12 +955,8 @@
       "operation_id": "getTimelineById",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/turn_summary",
@@ -1410,12 +964,8 @@
       "operation_id": "turnSummary",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/unsubscribe",
@@ -1423,12 +973,8 @@
       "operation_id": "unsubscribe",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/update_schema_incremental",
@@ -1436,12 +982,8 @@
       "operation_id": "updateSchemaIncremental",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/usage",
@@ -1449,12 +991,8 @@
       "operation_id": "getUsage",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [
-        401
-      ],
-      "expected_invalid_auth_status": [
-        401
-      ]
+      "expected_no_auth_status": [401],
+      "expected_invalid_auth_status": [401]
     },
     {
       "path": "/",
@@ -1464,22 +1002,8 @@
       "runtime_only": true,
       "reason": "Root landing renders public marketing copy when allowed by env.",
       "sandbox_allowed": "hosted_ok",
-      "expected_no_auth_status": [
-        200,
-        204,
-        400,
-        404,
-        405,
-        429
-      ],
-      "expected_invalid_auth_status": [
-        200,
-        204,
-        400,
-        404,
-        405,
-        429
-      ]
+      "expected_no_auth_status": [200, 204, 400, 404, 405, 429],
+      "expected_invalid_auth_status": [200, 204, 400, 404, 405, 429]
     },
     {
       "path": "/favicon.ico",
@@ -1489,22 +1013,8 @@
       "runtime_only": true,
       "reason": "Static asset.",
       "sandbox_allowed": "hosted_ok",
-      "expected_no_auth_status": [
-        200,
-        204,
-        400,
-        404,
-        405,
-        429
-      ],
-      "expected_invalid_auth_status": [
-        200,
-        204,
-        400,
-        404,
-        405,
-        429
-      ]
+      "expected_no_auth_status": [200, 204, 400, 404, 405, 429],
+      "expected_invalid_auth_status": [200, 204, 400, 404, 405, 429]
     },
     {
       "path": "/docs",
@@ -1514,22 +1024,8 @@
       "runtime_only": true,
       "reason": "Public docs index: read-only render of repo docs/**.md with visibility filtering.",
       "sandbox_allowed": "hosted_ok",
-      "expected_no_auth_status": [
-        200,
-        204,
-        400,
-        404,
-        405,
-        429
-      ],
-      "expected_invalid_auth_status": [
-        200,
-        204,
-        400,
-        404,
-        405,
-        429
-      ]
+      "expected_no_auth_status": [200, 204, 400, 404, 405, 429],
+      "expected_invalid_auth_status": [200, 204, 400, 404, 405, 429]
     },
     {
       "path": "/docs/*",
@@ -1539,22 +1035,8 @@
       "runtime_only": true,
       "reason": "Public docs page: read-only render of a single docs/**.md with visibility filtering and slug sanitization.",
       "sandbox_allowed": "hosted_ok",
-      "expected_no_auth_status": [
-        200,
-        204,
-        400,
-        404,
-        405,
-        429
-      ],
-      "expected_invalid_auth_status": [
-        200,
-        204,
-        400,
-        404,
-        405,
-        429
-      ]
+      "expected_no_auth_status": [200, 204, 400, 404, 405, 429],
+      "expected_invalid_auth_status": [200, 204, 400, 404, 405, 429]
     },
     {
       "path": "/sandbox/session/new",
@@ -1564,22 +1046,8 @@
       "runtime_only": true,
       "reason": "Public sandbox onboarding (rate-limited).",
       "sandbox_allowed": "hosted_ok",
-      "expected_no_auth_status": [
-        200,
-        204,
-        400,
-        404,
-        405,
-        429
-      ],
-      "expected_invalid_auth_status": [
-        200,
-        204,
-        400,
-        404,
-        405,
-        429
-      ]
+      "expected_no_auth_status": [200, 204, 400, 404, 405, 429],
+      "expected_invalid_auth_status": [200, 204, 400, 404, 405, 429]
     },
     {
       "path": "/sandbox/session/redeem",
@@ -1589,22 +1057,8 @@
       "runtime_only": true,
       "reason": "Public sandbox onboarding (rate-limited).",
       "sandbox_allowed": "hosted_ok",
-      "expected_no_auth_status": [
-        200,
-        204,
-        400,
-        404,
-        405,
-        429
-      ],
-      "expected_invalid_auth_status": [
-        200,
-        204,
-        400,
-        404,
-        405,
-        429
-      ]
+      "expected_no_auth_status": [200, 204, 400, 404, 405, 429],
+      "expected_invalid_auth_status": [200, 204, 400, 404, 405, 429]
     },
     {
       "path": "/sandbox/session",
@@ -1614,22 +1068,8 @@
       "runtime_only": true,
       "reason": "Sandbox session probe.",
       "sandbox_allowed": "hosted_ok",
-      "expected_no_auth_status": [
-        200,
-        204,
-        400,
-        404,
-        405,
-        429
-      ],
-      "expected_invalid_auth_status": [
-        200,
-        204,
-        400,
-        404,
-        405,
-        429
-      ]
+      "expected_no_auth_status": [200, 204, 400, 404, 405, 429],
+      "expected_invalid_auth_status": [200, 204, 400, 404, 405, 429]
     },
     {
       "path": "/sandbox/session/reset",
@@ -1639,22 +1079,8 @@
       "runtime_only": true,
       "reason": "Sandbox self-reset.",
       "sandbox_allowed": "hosted_ok",
-      "expected_no_auth_status": [
-        200,
-        204,
-        400,
-        404,
-        405,
-        429
-      ],
-      "expected_invalid_auth_status": [
-        200,
-        204,
-        400,
-        404,
-        405,
-        429
-      ]
+      "expected_no_auth_status": [200, 204, 400, 404, 405, 429],
+      "expected_invalid_auth_status": [200, 204, 400, 404, 405, 429]
     },
     {
       "path": "/sandbox/session",
@@ -1664,23 +1090,19 @@
       "runtime_only": true,
       "reason": "Sandbox self-revoke.",
       "sandbox_allowed": "hosted_ok",
-      "expected_no_auth_status": [
-        200,
-        204,
-        400,
-        404,
-        405,
-        429
-      ],
-      "expected_invalid_auth_status": [
-        200,
-        204,
-        400,
-        404,
-        405,
-        429
-      ]
+      "expected_no_auth_status": [200, 204, 400, 404, 405, 429],
+      "expected_invalid_auth_status": [200, 204, 400, 404, 405, 429]
     }
   ],
-  "overrides": []
+  "overrides": [
+    {
+      "method": "GET",
+      "path": "/ready",
+      "reason": "/ready returns 503 by design when the instance cannot answer a database probe within its latency budget. Without this override the deployed probe treats a genuine degradation as an auth-topology finding — a false positive that fires precisely during the incident the endpoint exists to surface. 503 is a readiness signal here, never an authentication outcome.",
+      "fields": {
+        "expected_no_auth_status": [200, 400, 404, 405, 503],
+        "expected_invalid_auth_status": [200, 400, 404, 405, 503]
+      }
+    }
+  ]
 }

--- a/scripts/security/protected_routes_manifest.json
+++ b/scripts/security/protected_routes_manifest.json
@@ -9,8 +9,18 @@
       "operation_id": "oauthServerMetadata",
       "requires_auth": false,
       "sandbox_allowed": "hosted_ok",
-      "expected_no_auth_status": [200, 400, 404, 405],
-      "expected_invalid_auth_status": [200, 400, 404, 405]
+      "expected_no_auth_status": [
+        200,
+        400,
+        404,
+        405
+      ],
+      "expected_invalid_auth_status": [
+        200,
+        400,
+        404,
+        405
+      ]
     },
     {
       "path": "/.well-known/oauth-protected-resource",
@@ -18,8 +28,18 @@
       "operation_id": "oauthProtectedResource",
       "requires_auth": false,
       "sandbox_allowed": "hosted_ok",
-      "expected_no_auth_status": [200, 400, 404, 405],
-      "expected_invalid_auth_status": [200, 400, 404, 405]
+      "expected_no_auth_status": [
+        200,
+        400,
+        404,
+        405
+      ],
+      "expected_invalid_auth_status": [
+        200,
+        400,
+        404,
+        405
+      ]
     },
     {
       "path": "/.well-known/oauth-protected-resource/mcp",
@@ -27,8 +47,18 @@
       "operation_id": "oauthProtectedResourceForMcp",
       "requires_auth": false,
       "sandbox_allowed": "hosted_ok",
-      "expected_no_auth_status": [200, 400, 404, 405],
-      "expected_invalid_auth_status": [200, 400, 404, 405]
+      "expected_no_auth_status": [
+        200,
+        400,
+        404,
+        405
+      ],
+      "expected_invalid_auth_status": [
+        200,
+        400,
+        404,
+        405
+      ]
     },
     {
       "path": "/.well-known/openid-configuration",
@@ -36,8 +66,18 @@
       "operation_id": "openidConfigurationNotOffered",
       "requires_auth": false,
       "sandbox_allowed": "hosted_ok",
-      "expected_no_auth_status": [200, 400, 404, 405],
-      "expected_invalid_auth_status": [200, 400, 404, 405]
+      "expected_no_auth_status": [
+        200,
+        400,
+        404,
+        405
+      ],
+      "expected_invalid_auth_status": [
+        200,
+        400,
+        404,
+        405
+      ]
     },
     {
       "path": "/access_policies",
@@ -45,8 +85,12 @@
       "operation_id": "getAccessPolicies",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/admin/compliance/scorecard",
@@ -54,8 +98,12 @@
       "operation_id": "getComplianceScorecard",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/agents",
@@ -63,8 +111,12 @@
       "operation_id": null,
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/agents/grants",
@@ -72,8 +124,12 @@
       "operation_id": "listAgentGrants",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/agents/grants",
@@ -81,8 +137,12 @@
       "operation_id": "createAgentGrant",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/agents/grants/{id}",
@@ -90,8 +150,12 @@
       "operation_id": "getAgentGrant",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/agents/grants/{id}",
@@ -99,8 +163,12 @@
       "operation_id": "updateAgentGrant",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/agents/grants/{id}/restore",
@@ -108,8 +176,12 @@
       "operation_id": "restoreAgentGrant",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/agents/grants/{id}/revoke",
@@ -117,8 +189,12 @@
       "operation_id": "revokeAgentGrant",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/agents/grants/{id}/suspend",
@@ -126,8 +202,12 @@
       "operation_id": "suspendAgentGrant",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/agents/{key}",
@@ -135,8 +215,12 @@
       "operation_id": null,
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/agents/{key}/records",
@@ -144,8 +228,12 @@
       "operation_id": null,
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/analyze_schema_candidates",
@@ -153,8 +241,12 @@
       "operation_id": "analyzeSchemaCandidates",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/audit_undeclared_fragments",
@@ -162,8 +254,12 @@
       "operation_id": "auditUndeclaredFragments",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/auth/dev-signin",
@@ -171,8 +267,12 @@
       "operation_id": "devSignIn",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/conversations/{conversation_id}/turn-index",
@@ -180,8 +280,12 @@
       "operation_id": "getConversationTurnIndex",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/correct",
@@ -189,8 +293,12 @@
       "operation_id": "correct",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/create_relationship",
@@ -198,8 +306,12 @@
       "operation_id": "createRelationship",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/create_relationships",
@@ -207,8 +319,12 @@
       "operation_id": "createRelationships",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/delete_entity",
@@ -216,8 +332,12 @@
       "operation_id": "deleteEntity",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/delete_relationship",
@@ -225,8 +345,12 @@
       "operation_id": "deleteRelationship",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/entities",
@@ -234,8 +358,12 @@
       "operation_id": "listEntities",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/entities/duplicates",
@@ -243,8 +371,12 @@
       "operation_id": "listPotentialDuplicates",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/entities/merge",
@@ -252,8 +384,12 @@
       "operation_id": "mergeEntities",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/entities/query",
@@ -261,8 +397,12 @@
       "operation_id": "queryEntities",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/entities/split",
@@ -270,8 +410,12 @@
       "operation_id": "splitEntity",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/entities/{id}",
@@ -279,8 +423,12 @@
       "operation_id": "getEntityById",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/entities/{id}/observations",
@@ -288,8 +436,12 @@
       "operation_id": "getEntityObservations",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/entities/{id}/relationships",
@@ -297,8 +449,12 @@
       "operation_id": "getEntityRelationships",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/events/stream",
@@ -306,8 +462,12 @@
       "operation_id": "eventsStream",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/get_authenticated_user",
@@ -315,8 +475,12 @@
       "operation_id": "getAuthenticatedUser",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/get_entity_snapshot",
@@ -324,8 +488,12 @@
       "operation_id": "getEntitySnapshot",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/get_field_provenance",
@@ -333,8 +501,12 @@
       "operation_id": "getFieldProvenance",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/get_file_url",
@@ -342,8 +514,12 @@
       "operation_id": "getFileUrl",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/get_schema_recommendations",
@@ -351,8 +527,12 @@
       "operation_id": "getSchemaRecommendations",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/get_subscription_status",
@@ -360,8 +540,12 @@
       "operation_id": "getSubscriptionStatus",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/health",
@@ -369,8 +553,18 @@
       "operation_id": "healthCheck",
       "requires_auth": false,
       "sandbox_allowed": "hosted_ok",
-      "expected_no_auth_status": [200, 400, 404, 405],
-      "expected_invalid_auth_status": [200, 400, 404, 405]
+      "expected_no_auth_status": [
+        200,
+        400,
+        404,
+        405
+      ],
+      "expected_invalid_auth_status": [
+        200,
+        400,
+        404,
+        405
+      ]
     },
     {
       "path": "/health_check_snapshots",
@@ -378,8 +572,12 @@
       "operation_id": "healthCheckSnapshots",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/identify_entity_by_signals",
@@ -387,8 +585,12 @@
       "operation_id": "identifyEntityBySignals",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/interpretations",
@@ -396,8 +598,12 @@
       "operation_id": "listInterpretations",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/interpretations/create",
@@ -405,8 +611,12 @@
       "operation_id": "createInterpretation",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/issues/add_message",
@@ -414,8 +624,12 @@
       "operation_id": "issuesAddMessage",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/issues/bulk_close",
@@ -423,8 +637,12 @@
       "operation_id": "bulkCloseIssues",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/issues/bulk_remove",
@@ -432,8 +650,12 @@
       "operation_id": "bulkRemoveIssues",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/issues/status",
@@ -441,8 +663,12 @@
       "operation_id": "issuesGetStatus",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/issues/submit",
@@ -450,8 +676,12 @@
       "operation_id": "issuesSubmit",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/issues/sync",
@@ -459,8 +689,12 @@
       "operation_id": "issuesSync",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/list_observations",
@@ -468,8 +702,12 @@
       "operation_id": "listObservationsForEntity",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/list_relationships",
@@ -477,8 +715,12 @@
       "operation_id": "listRelationshipsForEntity",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/list_subscriptions",
@@ -486,8 +728,12 @@
       "operation_id": "listSubscriptions",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/mcp/oauth/authorization-details",
@@ -495,8 +741,12 @@
       "operation_id": "mcpOAuthAuthorizationDetails",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/mcp/oauth/authorize",
@@ -504,8 +754,12 @@
       "operation_id": "mcpOAuthAuthorize",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/mcp/oauth/callback",
@@ -513,8 +767,12 @@
       "operation_id": "mcpOAuthCallback",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/mcp/oauth/connections",
@@ -522,8 +780,12 @@
       "operation_id": "mcpOAuthListConnections",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/mcp/oauth/connections/{connection_id}",
@@ -531,8 +793,12 @@
       "operation_id": "mcpOAuthRevokeConnection",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/mcp/oauth/initiate",
@@ -540,8 +806,12 @@
       "operation_id": "mcpOAuthInitiate",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/mcp/oauth/key-auth",
@@ -549,8 +819,12 @@
       "operation_id": "mcpOAuthKeyAuthGet",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/mcp/oauth/key-auth",
@@ -558,8 +832,12 @@
       "operation_id": "mcpOAuthKeyAuthPost",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/mcp/oauth/local-login",
@@ -567,8 +845,12 @@
       "operation_id": "mcpOAuthLocalLogin",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/mcp/oauth/register",
@@ -576,8 +858,12 @@
       "operation_id": "mcpOAuthRegister",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/mcp/oauth/status",
@@ -585,8 +871,12 @@
       "operation_id": "mcpOAuthStatus",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/mcp/oauth/token",
@@ -594,8 +884,12 @@
       "operation_id": "mcpOAuthToken",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/me",
@@ -603,8 +897,12 @@
       "operation_id": "getMe",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/observations",
@@ -612,8 +910,12 @@
       "operation_id": "listObservations",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/observations/create",
@@ -621,8 +923,12 @@
       "operation_id": "createObservation",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/observations/query",
@@ -630,8 +936,12 @@
       "operation_id": "queryObservations",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/openapi.yaml",
@@ -639,8 +949,18 @@
       "operation_id": "getOpenApiSpec",
       "requires_auth": false,
       "sandbox_allowed": "hosted_ok",
-      "expected_no_auth_status": [200, 400, 404, 405],
-      "expected_invalid_auth_status": [200, 400, 404, 405]
+      "expected_no_auth_status": [
+        200,
+        400,
+        404,
+        405
+      ],
+      "expected_invalid_auth_status": [
+        200,
+        400,
+        404,
+        405
+      ]
     },
     {
       "path": "/peers",
@@ -648,8 +968,12 @@
       "operation_id": "listPeers",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/peers",
@@ -657,8 +981,12 @@
       "operation_id": "addPeer",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/peers/resolve_sync_conflict",
@@ -666,8 +994,12 @@
       "operation_id": "resolveSyncConflict",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/peers/{peer_id}",
@@ -675,8 +1007,12 @@
       "operation_id": "getPeerStatus",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/peers/{peer_id}",
@@ -684,8 +1020,12 @@
       "operation_id": "removePeer",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/peers/{peer_id}/sync",
@@ -693,8 +1033,12 @@
       "operation_id": "syncPeer",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/query_contacts_at_company",
@@ -702,8 +1046,12 @@
       "operation_id": "queryContactsAtCompany",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/ready",
@@ -711,8 +1059,20 @@
       "operation_id": "readinessCheck",
       "requires_auth": false,
       "sandbox_allowed": "hosted_ok",
-      "expected_no_auth_status": [200, 400, 404, 405, 503],
-      "expected_invalid_auth_status": [200, 400, 404, 405, 503],
+      "expected_no_auth_status": [
+        200,
+        400,
+        404,
+        405,
+        503
+      ],
+      "expected_invalid_auth_status": [
+        200,
+        400,
+        404,
+        405,
+        503
+      ],
       "override_applied": true
     },
     {
@@ -721,8 +1081,12 @@
       "operation_id": "getRecentConversations",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/recent_conversations/{conversation_id}",
@@ -730,8 +1094,12 @@
       "operation_id": "getRecentConversation",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/record_activity",
@@ -739,8 +1107,12 @@
       "operation_id": "getRecordActivity",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/register_schema",
@@ -748,8 +1120,12 @@
       "operation_id": "registerSchema",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/relationships",
@@ -757,8 +1133,12 @@
       "operation_id": "listRelationships",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/relationships/snapshot",
@@ -766,8 +1146,12 @@
       "operation_id": "getRelationshipSnapshot",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/relationships/{id}",
@@ -775,8 +1159,12 @@
       "operation_id": "getRelationshipById",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/rendered-pages/publish",
@@ -784,8 +1172,12 @@
       "operation_id": "publishRenderedPage",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/restore_entity",
@@ -793,8 +1185,12 @@
       "operation_id": "restoreEntity",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/restore_relationship",
@@ -802,8 +1198,12 @@
       "operation_id": "restoreRelationship",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/retrieve_entity_by_identifier",
@@ -811,8 +1211,12 @@
       "operation_id": "retrieveEntityByIdentifier",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/retrieve_graph_neighborhood",
@@ -820,8 +1224,12 @@
       "operation_id": "retrieveGraphNeighborhood",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/retrieve_related_entities",
@@ -829,8 +1237,12 @@
       "operation_id": "retrieveRelatedEntities",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/schemas",
@@ -838,8 +1250,12 @@
       "operation_id": "listSchemas",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/schemas/{entity_type}",
@@ -847,8 +1263,12 @@
       "operation_id": "getSchemaByEntityType",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/server-info",
@@ -856,8 +1276,12 @@
       "operation_id": "getServerInfo",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/session",
@@ -865,8 +1289,12 @@
       "operation_id": "getSessionInfo",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/sources",
@@ -874,8 +1302,12 @@
       "operation_id": "listSources",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/sources/{id}",
@@ -883,8 +1315,12 @@
       "operation_id": "getSourceById",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/sources/{id}/relationships",
@@ -892,8 +1328,12 @@
       "operation_id": "getSourceRelationships",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/stats",
@@ -901,8 +1341,12 @@
       "operation_id": "getStats",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/store",
@@ -910,8 +1354,12 @@
       "operation_id": "store",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/subscribe",
@@ -919,8 +1367,12 @@
       "operation_id": "subscribe",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/sync/entities",
@@ -928,8 +1380,12 @@
       "operation_id": "listSyncEntities",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/sync/webhook",
@@ -937,8 +1393,12 @@
       "operation_id": "applySyncWebhook",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/timeline",
@@ -946,8 +1406,12 @@
       "operation_id": "listTimeline",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/timeline/{id}",
@@ -955,8 +1419,12 @@
       "operation_id": "getTimelineById",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/turn_summary",
@@ -964,8 +1432,12 @@
       "operation_id": "turnSummary",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/unsubscribe",
@@ -973,8 +1445,12 @@
       "operation_id": "unsubscribe",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/update_schema_incremental",
@@ -982,8 +1458,12 @@
       "operation_id": "updateSchemaIncremental",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/usage",
@@ -991,8 +1471,12 @@
       "operation_id": "getUsage",
       "requires_auth": true,
       "sandbox_allowed": "none",
-      "expected_no_auth_status": [401],
-      "expected_invalid_auth_status": [401]
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
     },
     {
       "path": "/",
@@ -1002,8 +1486,22 @@
       "runtime_only": true,
       "reason": "Root landing renders public marketing copy when allowed by env.",
       "sandbox_allowed": "hosted_ok",
-      "expected_no_auth_status": [200, 204, 400, 404, 405, 429],
-      "expected_invalid_auth_status": [200, 204, 400, 404, 405, 429]
+      "expected_no_auth_status": [
+        200,
+        204,
+        400,
+        404,
+        405,
+        429
+      ],
+      "expected_invalid_auth_status": [
+        200,
+        204,
+        400,
+        404,
+        405,
+        429
+      ]
     },
     {
       "path": "/favicon.ico",
@@ -1013,8 +1511,22 @@
       "runtime_only": true,
       "reason": "Static asset.",
       "sandbox_allowed": "hosted_ok",
-      "expected_no_auth_status": [200, 204, 400, 404, 405, 429],
-      "expected_invalid_auth_status": [200, 204, 400, 404, 405, 429]
+      "expected_no_auth_status": [
+        200,
+        204,
+        400,
+        404,
+        405,
+        429
+      ],
+      "expected_invalid_auth_status": [
+        200,
+        204,
+        400,
+        404,
+        405,
+        429
+      ]
     },
     {
       "path": "/docs",
@@ -1024,8 +1536,22 @@
       "runtime_only": true,
       "reason": "Public docs index: read-only render of repo docs/**.md with visibility filtering.",
       "sandbox_allowed": "hosted_ok",
-      "expected_no_auth_status": [200, 204, 400, 404, 405, 429],
-      "expected_invalid_auth_status": [200, 204, 400, 404, 405, 429]
+      "expected_no_auth_status": [
+        200,
+        204,
+        400,
+        404,
+        405,
+        429
+      ],
+      "expected_invalid_auth_status": [
+        200,
+        204,
+        400,
+        404,
+        405,
+        429
+      ]
     },
     {
       "path": "/docs/*",
@@ -1035,8 +1561,22 @@
       "runtime_only": true,
       "reason": "Public docs page: read-only render of a single docs/**.md with visibility filtering and slug sanitization.",
       "sandbox_allowed": "hosted_ok",
-      "expected_no_auth_status": [200, 204, 400, 404, 405, 429],
-      "expected_invalid_auth_status": [200, 204, 400, 404, 405, 429]
+      "expected_no_auth_status": [
+        200,
+        204,
+        400,
+        404,
+        405,
+        429
+      ],
+      "expected_invalid_auth_status": [
+        200,
+        204,
+        400,
+        404,
+        405,
+        429
+      ]
     },
     {
       "path": "/sandbox/session/new",
@@ -1046,8 +1586,22 @@
       "runtime_only": true,
       "reason": "Public sandbox onboarding (rate-limited).",
       "sandbox_allowed": "hosted_ok",
-      "expected_no_auth_status": [200, 204, 400, 404, 405, 429],
-      "expected_invalid_auth_status": [200, 204, 400, 404, 405, 429]
+      "expected_no_auth_status": [
+        200,
+        204,
+        400,
+        404,
+        405,
+        429
+      ],
+      "expected_invalid_auth_status": [
+        200,
+        204,
+        400,
+        404,
+        405,
+        429
+      ]
     },
     {
       "path": "/sandbox/session/redeem",
@@ -1057,8 +1611,22 @@
       "runtime_only": true,
       "reason": "Public sandbox onboarding (rate-limited).",
       "sandbox_allowed": "hosted_ok",
-      "expected_no_auth_status": [200, 204, 400, 404, 405, 429],
-      "expected_invalid_auth_status": [200, 204, 400, 404, 405, 429]
+      "expected_no_auth_status": [
+        200,
+        204,
+        400,
+        404,
+        405,
+        429
+      ],
+      "expected_invalid_auth_status": [
+        200,
+        204,
+        400,
+        404,
+        405,
+        429
+      ]
     },
     {
       "path": "/sandbox/session",
@@ -1068,8 +1636,22 @@
       "runtime_only": true,
       "reason": "Sandbox session probe.",
       "sandbox_allowed": "hosted_ok",
-      "expected_no_auth_status": [200, 204, 400, 404, 405, 429],
-      "expected_invalid_auth_status": [200, 204, 400, 404, 405, 429]
+      "expected_no_auth_status": [
+        200,
+        204,
+        400,
+        404,
+        405,
+        429
+      ],
+      "expected_invalid_auth_status": [
+        200,
+        204,
+        400,
+        404,
+        405,
+        429
+      ]
     },
     {
       "path": "/sandbox/session/reset",
@@ -1079,8 +1661,22 @@
       "runtime_only": true,
       "reason": "Sandbox self-reset.",
       "sandbox_allowed": "hosted_ok",
-      "expected_no_auth_status": [200, 204, 400, 404, 405, 429],
-      "expected_invalid_auth_status": [200, 204, 400, 404, 405, 429]
+      "expected_no_auth_status": [
+        200,
+        204,
+        400,
+        404,
+        405,
+        429
+      ],
+      "expected_invalid_auth_status": [
+        200,
+        204,
+        400,
+        404,
+        405,
+        429
+      ]
     },
     {
       "path": "/sandbox/session",
@@ -1090,8 +1686,22 @@
       "runtime_only": true,
       "reason": "Sandbox self-revoke.",
       "sandbox_allowed": "hosted_ok",
-      "expected_no_auth_status": [200, 204, 400, 404, 405, 429],
-      "expected_invalid_auth_status": [200, 204, 400, 404, 405, 429]
+      "expected_no_auth_status": [
+        200,
+        204,
+        400,
+        404,
+        405,
+        429
+      ],
+      "expected_invalid_auth_status": [
+        200,
+        204,
+        400,
+        404,
+        405,
+        429
+      ]
     }
   ],
   "overrides": [
@@ -1100,8 +1710,20 @@
       "path": "/ready",
       "reason": "/ready returns 503 by design when the instance cannot answer a database probe within its latency budget. Without this override the deployed probe treats a genuine degradation as an auth-topology finding — a false positive that fires precisely during the incident the endpoint exists to surface. 503 is a readiness signal here, never an authentication outcome.",
       "fields": {
-        "expected_no_auth_status": [200, 400, 404, 405, 503],
-        "expected_invalid_auth_status": [200, 400, 404, 405, 503]
+        "expected_no_auth_status": [
+          200,
+          400,
+          404,
+          405,
+          503
+        ],
+        "expected_invalid_auth_status": [
+          200,
+          400,
+          404,
+          405,
+          503
+        ]
       }
     }
   ]

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -2414,6 +2414,32 @@ function readPackageVersionForHealth(): string {
  */
 const READINESS_BUDGET_MS = Number(process.env.NEOTOMA_READINESS_BUDGET_MS || 3000);
 
+/** Marker for the timeout this route raises itself, distinguishable from any
+ *  error the driver produced. Matching on message text would be fragile. */
+const READINESS_BUDGET_ERROR = "NeotomaReadinessBudgetExceeded";
+
+function isBudgetOverrun(err: unknown): boolean {
+  return err instanceof Error && err.name === READINESS_BUDGET_ERROR;
+}
+
+/**
+ * SECURITY: `/ready` is unauthenticated, so a driver error must never reach the
+ * caller verbatim in production — SQLite and filesystem errors routinely carry
+ * absolute paths and schema fragments (security_audit_2026_04_22.md S-5, the
+ * same rule `handleApiError` applies). The detail still reaches the operator
+ * through `logError`; only the wire response is redacted.
+ */
+function readinessDetail(err: unknown, fallback: string): string {
+  const includeDetail =
+    config.environment !== "production" ||
+    process.env.NEOTOMA_VERBOSE_ERRORS === "1" ||
+    process.env.NEOTOMA_VERBOSE_ERRORS === "true";
+  if (!includeDetail) return fallback;
+  if (err instanceof Error) return err.message;
+  const message = (err as { message?: string })?.message;
+  return message || String(err);
+}
+
 // Public health endpoint (no auth) — LIVENESS only.
 //
 // Answers "is this process up?" and deliberately touches nothing else, so it
@@ -2444,23 +2470,23 @@ app.get("/ready", async (_req, res) => {
     // so the probe's own cost never becomes the thing that makes it slow.
     const probe = db.from("entities").select("id").limit(1);
     const timeout = new Promise<never>((_, reject) =>
-      setTimeout(
-        () => reject(new Error(`readiness probe exceeded ${READINESS_BUDGET_MS}ms`)),
-        READINESS_BUDGET_MS
-      )
+      setTimeout(() => {
+        const overrun = new Error(`readiness probe exceeded ${READINESS_BUDGET_MS}ms`);
+        overrun.name = READINESS_BUDGET_ERROR;
+        reject(overrun);
+      }, READINESS_BUDGET_MS)
     );
     const { error } = (await Promise.race([probe, timeout])) as { error?: unknown };
     const elapsed_ms = Date.now() - started;
 
     if (error) {
-      const message = (error as { message?: string })?.message || String(error);
       logError("ReadinessProbeFailed", _req, error, { elapsed_ms });
       return res.status(503).json({
         ok: false,
         version,
         database: "error",
         elapsed_ms,
-        error: message,
+        error: readinessDetail(error, "database probe failed"),
       });
     }
     return res.json({ ok: true, version, database: "ok", elapsed_ms });
@@ -2468,7 +2494,6 @@ app.get("/ready", async (_req, res) => {
     // Budget exceeded, or the driver threw. Both mean the instance cannot
     // serve within a useful time; both are 503.
     const elapsed_ms = Date.now() - started;
-    const message = err instanceof Error ? err.message : String(err);
     logError("ReadinessProbeTimeout", _req, err, { elapsed_ms });
     return res.status(503).json({
       ok: false,
@@ -2476,7 +2501,14 @@ app.get("/ready", async (_req, res) => {
       database: "unreachable",
       elapsed_ms,
       budget_ms: READINESS_BUDGET_MS,
-      error: message,
+      // The budget-overrun message is ours, not the driver's, so it carries no
+      // path or schema detail and is safe to return unconditionally. That
+      // matters: `exceeded 3000ms` is the whole diagnostic value of this
+      // response, and redacting it in production would leave the endpoint
+      // saying only "not ready" during the exact incident it exists for.
+      error: isBudgetOverrun(err)
+        ? (err as Error).message
+        : readinessDetail(err, "database unreachable"),
     });
   }
 });

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -2392,17 +2392,93 @@ function sendValidationError(res: express.Response, issues: unknown): express.Re
   );
 }
 
-// Public health endpoint (no auth)
-app.get("/health", (_req, res) => {
-  let version = "0.0.0";
+/** Read the package version once per request; never throws. */
+function readPackageVersionForHealth(): string {
   try {
     const pkgPath = path.join(config.projectRoot || process.cwd(), "package.json");
     const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf-8")) as { version?: string };
-    version = pkg.version || "0.0.0";
+    return pkg.version || "0.0.0";
   } catch {
-    // fallback
+    return "0.0.0";
   }
-  return res.json({ ok: true, version });
+}
+
+/**
+ * Budget for the readiness DB probe, in ms. Deliberately small: the point is to
+ * fail while the instance is merely SLOW, not to wait until it is dead.
+ *
+ * On 2026-08-10 this instance served `/health` in 0.28s while entity reads took
+ * 34–37s and page renders timed out entirely (#2141). A probe that simply
+ * awaited the database would have returned "ready" 37 seconds later — accurate
+ * and useless. A page that loads in 34s is broken for a human.
+ */
+const READINESS_BUDGET_MS = Number(process.env.NEOTOMA_READINESS_BUDGET_MS || 3000);
+
+// Public health endpoint (no auth) — LIVENESS only.
+//
+// Answers "is this process up?" and deliberately touches nothing else, so it
+// stays cheap and cannot be made to hang by a slow dependency. It is NOT
+// evidence the instance can serve a request: see /ready.
+app.get("/health", (_req, res) => {
+  return res.json({ ok: true, version: readPackageVersionForHealth() });
+});
+
+// Public readiness endpoint (no auth) — LIVENESS **plus** a bounded DB probe.
+//
+// This is what a load balancer or uptime check should target. `/health` cannot
+// distinguish "the server is up" from "the server is up and can answer", and
+// that gap is not theoretical: on 2026-08-10 every dashboard read green while
+// DB-backed requests hung past 40s, because the one signal everybody trusts was
+// the one signal that still worked (#2141).
+//
+// Returns 503 when the probe fails OR exceeds its budget. Sustained degradation
+// is a failure here, not a slow success — a check that waits however long the
+// database takes cannot detect the condition it exists to detect.
+app.get("/ready", async (_req, res) => {
+  const version = readPackageVersionForHealth();
+  const started = Date.now();
+
+  try {
+    // Cheapest possible round trip that proves the driver can actually answer.
+    // `limit(1)` on an indexed table keeps this O(1) regardless of graph size,
+    // so the probe's own cost never becomes the thing that makes it slow.
+    const probe = db.from("entities").select("id").limit(1);
+    const timeout = new Promise<never>((_, reject) =>
+      setTimeout(
+        () => reject(new Error(`readiness probe exceeded ${READINESS_BUDGET_MS}ms`)),
+        READINESS_BUDGET_MS
+      )
+    );
+    const { error } = (await Promise.race([probe, timeout])) as { error?: unknown };
+    const elapsed_ms = Date.now() - started;
+
+    if (error) {
+      const message = (error as { message?: string })?.message || String(error);
+      logError("ReadinessProbeFailed", _req, error, { elapsed_ms });
+      return res.status(503).json({
+        ok: false,
+        version,
+        database: "error",
+        elapsed_ms,
+        error: message,
+      });
+    }
+    return res.json({ ok: true, version, database: "ok", elapsed_ms });
+  } catch (err: unknown) {
+    // Budget exceeded, or the driver threw. Both mean the instance cannot
+    // serve within a useful time; both are 503.
+    const elapsed_ms = Date.now() - started;
+    const message = err instanceof Error ? err.message : String(err);
+    logError("ReadinessProbeTimeout", _req, err, { elapsed_ms });
+    return res.status(503).json({
+      ok: false,
+      version,
+      database: "unreachable",
+      elapsed_ms,
+      budget_ms: READINESS_BUDGET_MS,
+      error: message,
+    });
+  }
 });
 
 // ============================================================================

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -2412,7 +2412,30 @@ function readPackageVersionForHealth(): string {
  * awaited the database would have returned "ready" 37 seconds later — accurate
  * and useless. A page that loads in 34s is broken for a human.
  */
-const READINESS_BUDGET_MS = Number(process.env.NEOTOMA_READINESS_BUDGET_MS || 3000);
+const READINESS_BUDGET_DEFAULT_MS = 3000;
+
+/**
+ * Parse the readiness budget, falling back on anything non-numeric or absurd.
+ *
+ * `Number("not-a-number")` is `NaN`, and `setTimeout(fn, NaN)` fires after ~1ms
+ * — so a typo in this env var would make a healthy database answering in 10ms
+ * return 503 `exceeded NaNms`, with `budget_ms: null` against an OpenAPI schema
+ * that declares an integer. That is #2141 inverted: a monitor reporting failure
+ * while nothing is wrong, which burns operator trust just as fast as one
+ * reporting success while everything is.
+ *
+ * Mirrors `parseMcpSseKeepaliveMs` below. Zero and negatives are rejected too:
+ * a non-positive budget can never be satisfied, so it would 503 unconditionally.
+ */
+export function parseReadinessBudgetMs(raw: string | undefined): number {
+  if (raw === undefined) return READINESS_BUDGET_DEFAULT_MS;
+  const trimmed = raw.trim();
+  if (trimmed === "") return READINESS_BUDGET_DEFAULT_MS;
+  const parsed = Number(trimmed);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : READINESS_BUDGET_DEFAULT_MS;
+}
+
+const READINESS_BUDGET_MS = parseReadinessBudgetMs(process.env.NEOTOMA_READINESS_BUDGET_MS);
 
 /** Marker for the timeout this route raises itself, distinguishable from any
  *  error the driver produced. Matching on message text would be fragile. */
@@ -3973,7 +3996,11 @@ app.use(async (req, res, next) => {
     (req.method === "GET" &&
       (req.path === "/openapi.yaml" ||
         req.path === "/openapi_actions.yaml" ||
-        req.path === "/health")) ||
+        req.path === "/health" ||
+        // Readiness is as public as liveness: a platform probe has no
+        // credential, and the response carries no user data. Listed beside
+        // /health so the pair cannot drift apart.
+        req.path === "/ready")) ||
     (req.method === "POST" && req.path === "/auth/dev-signin")
   ) {
     return next();

--- a/src/services/inspector_mount.ts
+++ b/src/services/inspector_mount.ts
@@ -503,6 +503,7 @@ const API_ONLY_PREFIXES: readonly string[] = [
   "/server-info",
   "/me",
   "/health",
+  "/ready", // liveness's sibling — must stay listed together (see /health)
   "/version",
   "/mcp/", // OAuth + MCP HTTP endpoints serve their own HTML or JSON
   "/oauth/",

--- a/src/shared/contract_mappings.ts
+++ b/src/shared/contract_mappings.ts
@@ -24,7 +24,14 @@ export const OPENAPI_OPERATION_MAPPINGS: OpenApiOperationMapping[] = [
     method: "get",
     path: "/health",
     adapter: "infra",
-    notes: "Health endpoint is infrastructure only.",
+    notes: "Health endpoint is infrastructure only. Liveness only — see /ready.",
+  },
+  {
+    operationId: "readinessCheck",
+    method: "get",
+    path: "/ready",
+    adapter: "infra",
+    notes: "Readiness endpoint is infrastructure only. Liveness plus a budgeted DB probe.",
   },
   {
     operationId: "getOpenApiSpec",

--- a/src/shared/openapi_types.ts
+++ b/src/shared/openapi_types.ts
@@ -31,8 +31,43 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** Health check */
+    /**
+     * Health check
+     * @description LIVENESS only. Answers from process state and reads no dependency, so
+     *     it stays green while the database is slow or unreachable — by design:
+     *     an operator needs to distinguish "hung" from "dead", and a liveness
+     *     check that fails on a slow dependency turns latency into a restart.
+     *
+     *     Do NOT use this to decide whether the instance can serve requests. It
+     *     cannot detect degradation; use `/ready` for that.
+     */
     get: operations["healthCheck"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/ready": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Readiness check
+     * @description LIVENESS **plus** a bounded database probe. Returns 503 when the probe
+     *     errors, throws, or exceeds `NEOTOMA_READINESS_BUDGET_MS` (default 3000).
+     *
+     *     The budget is the point. On 2026-08-10 this instance served `/health`
+     *     in 0.28s while entity reads took 34-37s — a probe that merely awaited
+     *     the database would have reported ready 37 seconds later, accurately and
+     *     uselessly. Sustained degradation is only detectable against a deadline.
+     */
+    get: operations["readinessCheck"];
     put?: never;
     post?: never;
     delete?: never;
@@ -4090,6 +4125,55 @@ export interface operations {
         content: {
           "application/json": {
             ok?: boolean;
+          };
+        };
+      };
+    };
+  };
+  readinessCheck: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Instance is live and answered a database probe within budget. */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            ok?: boolean;
+            version?: string;
+            /** @enum {string} */
+            database?: "ok";
+            elapsed_ms?: number;
+          };
+        };
+      };
+      /**
+       * @description Not ready. `database: "error"` means the driver returned an error;
+       *     `database: "unreachable"` means it threw or exceeded the budget.
+       *     `error` carries the budget-overrun detail, and in production a
+       *     generic string for driver faults — the route is unauthenticated, so
+       *     raw driver messages are logged rather than returned.
+       */
+      503: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            ok?: boolean;
+            version?: string;
+            /** @enum {string} */
+            database?: "error" | "unreachable";
+            elapsed_ms?: number;
+            budget_ms?: number;
+            error?: string;
           };
         };
       };

--- a/tests/integration/readiness_probe.test.ts
+++ b/tests/integration/readiness_probe.test.ts
@@ -229,6 +229,70 @@ describe("readiness probe (#2141)", () => {
     });
   });
 
+  describe("a malformed budget must not fail a healthy instance", () => {
+    // The inverse of #2141. `Number("not-a-number")` is NaN, and
+    // `setTimeout(fn, NaN)` fires after ~1ms — so a typo in the env var would
+    // 503 a database answering in 10ms, reporting `exceeded NaNms` with
+    // `budget_ms: null` against a schema that declares an integer. A monitor
+    // that cries failure while nothing is wrong burns operator trust just as
+    // fast as one that stays silent while everything is.
+    it.each([
+      ["not-a-number", "non-numeric"],
+      ["", "empty"],
+      ["0", "zero"],
+      ["-500", "negative"],
+    ])("falls back to the default for a %s budget (%s)", async (raw) => {
+      process.env.NEOTOMA_READINESS_BUDGET_MS = raw;
+      mockDb(() => new Promise((resolve) => setTimeout(() => resolve({ error: null }), 10)));
+      const app = await freshApp();
+      try {
+        await withHttpServer(app, async (baseUrl) => {
+          const resp = await fetch(`${baseUrl}/ready`);
+          expect(resp.status, `budget "${raw}" must not fail a healthy DB`).toBe(200);
+          const body = (await resp.json()) as Record<string, unknown>;
+          expect(body.database).toBe("ok");
+        });
+      } finally {
+        delete process.env.NEOTOMA_READINESS_BUDGET_MS;
+      }
+    });
+
+    it("still honours a valid budget", async () => {
+      process.env.NEOTOMA_READINESS_BUDGET_MS = "50";
+      mockDb(() => new Promise((resolve) => setTimeout(() => resolve({ error: null }), 5000)));
+      const app = await freshApp();
+      try {
+        await withHttpServer(app, async (baseUrl) => {
+          const resp = await fetch(`${baseUrl}/ready`);
+          expect(resp.status).toBe(503);
+          expect(String(((await resp.json()) as Record<string, unknown>).error)).toMatch(
+            /exceeded 50ms/
+          );
+        });
+      } finally {
+        delete process.env.NEOTOMA_READINESS_BUDGET_MS;
+      }
+    });
+  });
+
+  it("keeps /ready beside /health in the public-route allow-lists", async () => {
+    // Both routes register BEFORE the auth and SPA middlewares today, so this
+    // is latent rather than live. But a later reordering would silently break
+    // public readiness with nothing to catch it — the allow-lists are where the
+    // pair is declared, so that is where the drift must be pinned.
+    const { isApiOnlyPath } = await import("../../src/services/inspector_mount.js");
+    expect(isApiOnlyPath("/health")).toBe(true);
+    expect(isApiOnlyPath("/ready"), "/ready must be API-only, like /health").toBe(true);
+
+    const source = readFileSync(new URL("../../src/actions.ts", import.meta.url), "utf-8");
+    const bypass = source.slice(
+      source.indexOf("Bypass auth only for truly public endpoints"),
+      source.indexOf("Bypass auth only for truly public endpoints") + 900
+    );
+    expect(bypass).toContain('req.path === "/health"');
+    expect(bypass, "/ready must bypass auth alongside /health").toContain('req.path === "/ready"');
+  });
+
   it("declares /ready in the contract, matching what it serves", () => {
     // The route existed and answered before it was declared anywhere
     // (guardrails MUST #17). An undeclared public route is invisible to

--- a/tests/integration/readiness_probe.test.ts
+++ b/tests/integration/readiness_probe.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Readiness must fail while the instance is merely SLOW (#2141).
+ *
+ * `/health` reads package.json and returns `{ok:true}`. It never touches the
+ * database, so it cannot distinguish "the server is up" from "the server is up
+ * and can answer a request". That gap is not theoretical: on 2026-08-10 this
+ * instance served `/health` in 0.28s while entity reads took 34–37s and page
+ * renders timed out past 40s. Every dashboard read green. The one signal
+ * everybody trusts was the one signal that still worked.
+ *
+ * These tests drive the real Express app over a real socket. The important one
+ * is `test_ready_fails_when_the_database_is_slow`: a probe that merely awaits
+ * the database would return "ready" 37 seconds later — accurate and useless.
+ * Detecting sustained degradation requires a LATENCY BUDGET, so that is what is
+ * pinned here.
+ */
+
+import { createServer, type Server } from "node:http";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+async function withHttpServer<T>(
+  app: unknown,
+  callback: (baseUrl: string) => Promise<T>
+): Promise<T> {
+  const server: Server = createServer(app as never);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("test server did not bind to a TCP port");
+  }
+  try {
+    return await callback(`http://127.0.0.1:${address.port}`);
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+/** Replace the db module with a driver that behaves however the test needs. */
+function mockDb(behaviour: () => Promise<unknown>): void {
+  vi.doMock("../../src/db.js", () => ({
+    db: {
+      from: () => ({
+        select: () => ({
+          limit: () => behaviour(),
+        }),
+      }),
+    },
+    getServiceRoleClient: () => ({}),
+    initDatabase: async () => undefined,
+  }));
+}
+
+async function freshApp(): Promise<unknown> {
+  vi.resetModules();
+  const mod = await import("../../src/actions.js");
+  return (mod as { app: unknown }).app;
+}
+
+describe("readiness probe (#2141)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.doUnmock("../../src/db.js");
+    vi.resetModules();
+    vi.useRealTimers();
+  });
+
+  it("reports ready when the database answers promptly", async () => {
+    mockDb(async () => ({ data: [{ id: "e1" }], error: null }));
+    const app = await freshApp();
+
+    await withHttpServer(app, async (baseUrl) => {
+      const resp = await fetch(`${baseUrl}/ready`);
+      expect(resp.status).toBe(200);
+      const body = (await resp.json()) as Record<string, unknown>;
+      expect(body.ok).toBe(true);
+      expect(body.database).toBe("ok");
+      expect(typeof body.elapsed_ms).toBe("number");
+    });
+  });
+
+  it("fails when the database is SLOW, not only when it is down", async () => {
+    // THE test. A probe without a budget would eventually resolve and report
+    // ready — which is exactly the 2026-08-10 condition it must catch.
+    process.env.NEOTOMA_READINESS_BUDGET_MS = "50";
+    mockDb(
+      () => new Promise((resolve) => setTimeout(() => resolve({ data: [], error: null }), 5000))
+    );
+    const app = await freshApp();
+
+    await withHttpServer(app, async (baseUrl) => {
+      const started = Date.now();
+      const resp = await fetch(`${baseUrl}/ready`);
+      const elapsed = Date.now() - started;
+
+      expect(resp.status).toBe(503);
+      const body = (await resp.json()) as Record<string, unknown>;
+      expect(body.ok).toBe(false);
+      expect(body.database).toBe("unreachable");
+      expect(String(body.error)).toMatch(/exceeded/);
+      // It must fail FAST — waiting out the slow query defeats the purpose.
+      expect(elapsed).toBeLessThan(2000);
+    });
+    delete process.env.NEOTOMA_READINESS_BUDGET_MS;
+  });
+
+  it("fails when the driver returns an error", async () => {
+    mockDb(async () => ({ data: null, error: { message: "connection reset" } }));
+    const app = await freshApp();
+
+    await withHttpServer(app, async (baseUrl) => {
+      const resp = await fetch(`${baseUrl}/ready`);
+      expect(resp.status).toBe(503);
+      const body = (await resp.json()) as Record<string, unknown>;
+      expect(body.database).toBe("error");
+      expect(String(body.error)).toContain("connection reset");
+    });
+  });
+
+  it("fails when the driver throws", async () => {
+    mockDb(async () => {
+      throw new Error("driver exploded");
+    });
+    const app = await freshApp();
+
+    await withHttpServer(app, async (baseUrl) => {
+      const resp = await fetch(`${baseUrl}/ready`);
+      expect(resp.status).toBe(503);
+    });
+  });
+
+  it("keeps /health cheap and independent of the database", async () => {
+    // Liveness must NOT be made to fail by a slow dependency — that is the
+    // division of labour. A hung database should fail /ready and leave /health
+    // answering, so an operator can still tell the process is alive.
+    process.env.NEOTOMA_READINESS_BUDGET_MS = "50";
+    mockDb(() => new Promise(() => {})); // never resolves
+    const app = await freshApp();
+
+    await withHttpServer(app, async (baseUrl) => {
+      const started = Date.now();
+      const resp = await fetch(`${baseUrl}/health`);
+      expect(resp.status).toBe(200);
+      expect(Date.now() - started).toBeLessThan(1000);
+      const body = (await resp.json()) as Record<string, unknown>;
+      expect(body.ok).toBe(true);
+    });
+    delete process.env.NEOTOMA_READINESS_BUDGET_MS;
+  });
+});

--- a/tests/integration/readiness_probe.test.ts
+++ b/tests/integration/readiness_probe.test.ts
@@ -16,8 +16,13 @@
  */
 
 import { createServer, type Server } from "node:http";
+import { readFileSync } from "node:fs";
 
+import { load } from "js-yaml";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { OPENAPI_OPERATION_MAPPINGS } from "../../src/shared/contract_mappings.js";
+import { resolveOpenApiPath } from "../../src/shared/openapi_file.js";
 
 async function withHttpServer<T>(
   app: unknown,
@@ -110,6 +115,10 @@ describe("readiness probe (#2141)", () => {
   });
 
   it("fails when the driver returns an error", async () => {
+    // Detail IS returned here because the test env is not production. That is
+    // the intended behaviour and also exactly why the production leak below
+    // went unnoticed on the first pass — asserting only this case proves
+    // nothing about what an unauthenticated caller sees in production.
     mockDb(async () => ({ data: null, error: { message: "connection reset" } }));
     const app = await freshApp();
 
@@ -132,6 +141,107 @@ describe("readiness probe (#2141)", () => {
       const resp = await fetch(`${baseUrl}/ready`);
       expect(resp.status).toBe(503);
     });
+  });
+
+  describe("production does not leak driver detail to unauthenticated callers", () => {
+    // `/ready` has `security: []` — anyone on the internet can call it. SQLite
+    // and filesystem errors routinely carry absolute paths and schema
+    // fragments, so returning `Error.message` verbatim hands those out on
+    // request. Same rule `handleApiError` already applies
+    // (security_audit_2026_04_22.md S-5); this route bypassed it.
+    const withProdEnv = async (
+      behaviour: () => Promise<unknown>,
+      assertion: (body: Record<string, unknown>) => void
+    ) => {
+      process.env.NEOTOMA_ENV = "production";
+      delete process.env.NEOTOMA_VERBOSE_ERRORS;
+      mockDb(behaviour);
+      const app = await freshApp();
+      try {
+        await withHttpServer(app, async (baseUrl) => {
+          const resp = await fetch(`${baseUrl}/ready`);
+          expect(resp.status).toBe(503);
+          assertion((await resp.json()) as Record<string, unknown>);
+        });
+      } finally {
+        delete process.env.NEOTOMA_ENV;
+      }
+    };
+
+    it("redacts a driver error message", async () => {
+      await withProdEnv(
+        async () => ({
+          data: null,
+          error: { message: "SQLITE_CANTOPEN: unable to open /var/lib/neotoma/prod.db" },
+        }),
+        (body) => {
+          const detail = String(body.error);
+          expect(detail).not.toContain("/var/lib/neotoma");
+          expect(detail).not.toContain("SQLITE_CANTOPEN");
+          expect(body.database).toBe("error");
+        }
+      );
+    });
+
+    it("redacts a thrown driver error", async () => {
+      await withProdEnv(
+        async () => {
+          throw new Error("connect ENOENT /Users/someone/secret/path/neotoma.db");
+        },
+        (body) => {
+          const detail = String(body.error);
+          expect(detail).not.toContain("/Users/someone");
+          expect(detail).not.toContain("ENOENT");
+        }
+      );
+    });
+
+    it("still returns the budget overrun, which is ours and carries no paths", async () => {
+      // Redacting this one would gut the endpoint: "exceeded 3000ms" is the
+      // entire diagnostic value of the response during the incident it exists
+      // to catch. The string is constructed here, not by the driver.
+      process.env.NEOTOMA_READINESS_BUDGET_MS = "50";
+      await withProdEnv(
+        () => new Promise((resolve) => setTimeout(() => resolve({ error: null }), 5000)),
+        (body) => {
+          expect(body.database).toBe("unreachable");
+          expect(String(body.error)).toMatch(/exceeded 50ms/);
+          expect(body.budget_ms).toBe(50);
+        }
+      );
+      delete process.env.NEOTOMA_READINESS_BUDGET_MS;
+    });
+
+    it("returns detail again when NEOTOMA_VERBOSE_ERRORS is set", async () => {
+      process.env.NEOTOMA_ENV = "production";
+      process.env.NEOTOMA_VERBOSE_ERRORS = "1";
+      mockDb(async () => ({ data: null, error: { message: "SQLITE_BUSY on /tmp/x.db" } }));
+      const app = await freshApp();
+      try {
+        await withHttpServer(app, async (baseUrl) => {
+          const body = (await (await fetch(`${baseUrl}/ready`)).json()) as Record<string, unknown>;
+          expect(String(body.error)).toContain("SQLITE_BUSY");
+        });
+      } finally {
+        delete process.env.NEOTOMA_ENV;
+        delete process.env.NEOTOMA_VERBOSE_ERRORS;
+      }
+    });
+  });
+
+  it("declares /ready in the contract, matching what it serves", () => {
+    // The route existed and answered before it was declared anywhere
+    // (guardrails MUST #17). An undeclared public route is invisible to
+    // generated clients and to the security manifest.
+    const spec = load(readFileSync(resolveOpenApiPath(), "utf-8")) as {
+      paths?: Record<string, { get?: { operationId?: string } }>;
+    };
+    expect(spec.paths?.["/ready"]?.get?.operationId).toBe("readinessCheck");
+
+    const mapping = OPENAPI_OPERATION_MAPPINGS.find((m) => m.path === "/ready");
+    expect(mapping, "/ready must have a contract mapping row").toBeTruthy();
+    expect(mapping?.operationId).toBe("readinessCheck");
+    expect(mapping?.adapter).toBe("infra");
   });
 
   it("keeps /health cheap and independent of the database", async () => {


### PR DESCRIPTION
Closes #2141.

## The failure

On 2026-08-10 the instance served `/health` in **0.28s** while entity reads took **34–37s** and page renders timed out past 40s. Every dashboard read green through a 100× degradation.

The cause is that `/health` only read `package.json`. It could tell you the process was alive; it could never tell you the process could answer a request. `src/actions.ts:1040` already carried a comment naming this exact hazard — the check stays green because the process is alive.

## The change

**`/health` is unchanged** — liveness, cheap, no dependencies. This matters: it must keep answering while the database is hung, so an operator can still distinguish *slow* from *dead*.

**`/ready` is new** — runs `db.from("entities").select("id").limit(1)` against a latency budget (`NEOTOMA_READINESS_BUDGET_MS`, default `3000`) and returns `503` when the probe errors, throws, or overruns.

## Why a budget, not just an await

This is the load-bearing decision. A probe that merely awaits the database would have returned `ready` 37 seconds later — accurate, and useless for detecting the exact condition it exists to detect. Sustained degradation is only visible against a deadline.

The test `fails when the database is SLOW, not only when it is down` pins it. Verified by removing the budget from `src/actions.ts` and re-running: that test fails, taking **5,035ms** to answer a query it should have abandoned at 50ms.

## Tests

Five integration tests driving the real Express app over a real socket:

- ready when the database answers promptly
- **fails when the database is SLOW** (budget overrun → 503, and fails *fast*)
- fails when the driver returns an error
- fails when the driver throws
- `/health` stays cheap and answers while the database never resolves

## Follow-up (not in this PR)

Nothing yet points a platform health check at `/ready`. Cutting that over changes restart behaviour under load and deserves its own review — a readiness probe wired to a `restart: always` policy can turn a slow database into a restart loop. Filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)