### PR TITLE
docs(entity_submission): correct inbound webhook claims to match src (#2185)

### DIFF
--- a/docs/subsystems/entity_submission.md
+++ b/docs/subsystems/entity_submission.md
@@ -9,7 +9,7 @@ This document covers:
 - The `submission_config` entity that operators seed to enable a target entity type.
 - `submitEntity` flow (validation, idempotency, conversation threading, guest tokens).
 - Mirror dispatch to GitHub Issues and generic webhooks.
-- Inbound webhook ingest from external mirrors.
+- Inbound webhook ingest from GitHub (the only shipped inbound provider).
 - Defaults seeding for fresh installs.
 
 It does NOT cover:
@@ -45,8 +45,8 @@ Hardcoding those flows per integration would scatter validation, threading, and 
 - `seed_schema.ts` — registers the global `submission_config` schema (canonical_name_field: `config_key`).
 - `seed_submission_defaults.ts` — first-run seeder that installs default `submission_config` rows for `issue` (and any future canonical types) so a fresh install can accept feedback without operator intervention.
 - `ingest/`:
-  - `webhook_ingest.ts` — Express handler for inbound `POST /submissions/webhook/:provider` payloads from external mirrors.
-  - `github_handler.ts` — provider-specific normalization for GitHub issue / comment payloads, delegating to `submitEntity`.
+  - `webhook_ingest.ts` — the `WebhookIngestHandler` interface only. No route, no dispatcher; see [Inbound webhook ingest](#inbound-webhook-ingest).
+  - `github_handler.ts` — signature verification and GitHub issue / comment payload → `store` mapping, consumed by the `POST /github/webhook` route in `src/actions.ts`. Exports `githubWebhookIngestHandler` as a compile-time conformance check against `WebhookIngestHandler`.
 - `mirrors/`:
   - `mirror_interface.ts` — `Mirror` shape (provider id, `dispatch(entity, config)`).
   - `github_mirror.ts` — pushes the new entity into a configured GitHub repo via the issues service.
@@ -99,20 +99,51 @@ After `ops.store` commits, each `external_mirrors[]` entry dispatches in declara
 - `provider: "linear"` — placeholder; current implementation is a no-op stub awaiting the Linear adapter.
 - `provider: "custom_webhook"` — `webhook_mirror.postEntityToWebhookMirror` performs an HMAC-signed POST to `config.url` with the entity payload.
 
-Mirror errors are logged but never block the response. Operators can re-trigger a mirror by issuing a `correct` that touches the entity (which re-emits a substrate event consumed by the mirror dispatcher), or manually via the inbound webhook ingest endpoint.
+Mirror errors are logged but never block the response. Operators can re-trigger a mirror by issuing a `correct` that touches the entity, which re-emits a substrate event consumed by the mirror dispatcher.
 
 ## Inbound webhook ingest
 
-`ingest/webhook_ingest.ts` registers `POST /submissions/webhook/:provider`. The provider key dispatches:
+**GitHub is the only inbound provider that ships.** There is no generic
+`POST /submissions/webhook/:provider` route, and none is planned until a second
+provider justifies one. `ingest/webhook_ingest.ts` declares the
+`WebhookIngestHandler` interface and nothing else — no route registration, no
+provider dispatcher, no runtime registry.
 
-- `github` → `github_handler.handleGithubInboundIssue` / `handleGithubInboundComment`. Both validate the HMAC header, normalize the payload to `SubmitEntityParams`, then call `submitEntity` under a `runWithExternalActor` wrapper that records the originating GitHub user as the external actor. See [`agent_attribution_integration.md`](agent_attribution_integration.md).
-- Other providers can be added by registering a new handler module.
+The shipped path is `POST /github/webhook`, registered in `src/actions.ts`:
 
-The ingest path enforces:
+1. Requires `GITHUB_WEBHOOK_SECRET`; returns `503 WEBHOOK_NOT_CONFIGURED` when unset.
+2. Verifies the `X-Hub-Signature-256` HMAC via `github_handler.verifyGithubSignature`.
+3. Maps the event with `github_handler.mapGithubWebhookEventToStore`, which handles
+   `issues` (`opened`, `edited`, `closed`, `reopened`, `labeled`, `unlabeled`) and
+   `issue_comment` (`created`, `edited`). Unhandled events return `200 {"status":"ignored"}`.
+4. Writes through `storeStructuredForApi` inside `runWithExternalActor`, recording the
+   originating GitHub user as the external actor. See
+   [`agent_attribution_integration.md`](agent_attribution_integration.md).
 
-- HMAC signature verification using the per-mirror secret stored in `submission_config.external_mirrors[*].config.shared_secret`.
-- Idempotency through the same `idempotencyForSubmit` hash so re-delivery from GitHub does not duplicate the entity.
-- Provider-specific dedupe — for GitHub issues, the upstream `issue.number` is folded into the canonical fields so subsequent comments thread into the same Neotoma `conversation`.
+Two properties of this path differ from the `submitEntity` flow described above,
+and matter when reasoning about it:
+
+- **It does not call `submitEntity`.** The route composes a store payload and
+  writes directly. It therefore does not consult `submission_config`, does not
+  apply `assertGuestWriteAllowed`, and does not mint guest read-back tokens.
+  Its trust boundary is the webhook HMAC, not the guest access policy.
+- **It does not use `idempotencyForSubmit`.** `github_handler` builds its own keys
+  (`webhook-issue-<repo>-<number>-<delivery>` and
+  `webhook-comment-<repo>-<number>-<comment>-<delivery>`), so re-delivery with a
+  new delivery id creates a new observation rather than deduplicating. Entity
+  identity still converges: `github_number` resolves the same `issue` entity, and
+  comments thread into the same `conversation`.
+
+### Adding a second provider
+
+`WebhookIngestHandler` is the shape to write against, not a plug-in socket — a
+new provider needs its own route registration in `src/actions.ts` today.
+`githubWebhookIngestHandler` in `github_handler.ts` binds the GitHub functions to
+the interface so the compiler catches divergence; do the same for a new provider.
+Registering a shared `/submissions/webhook/:provider` route becomes worthwhile
+once a second provider exists, and would require the transport-parity work in
+[`change_guardrails_rules.mdc`](../architecture/change_guardrails_rules.mdc)
+(OpenAPI entry, contract mapping, `protected_routes_manifest.json`).
 
 ## Operations
 
@@ -123,9 +154,9 @@ The ingest path enforces:
 
 ## Testing
 
-- Unit: `src/services/entity_submission/__tests__/` (when present); `tests/services/sync_webhook_outbound.test.ts` exercises the mirror dispatch path.
+- Unit: `src/services/entity_submission/submission_service.test.ts` covers `submitEntity` write-integrity and submission-path steering. `tests/services/sync_webhook_outbound.test.ts` exercises the outbound mirror dispatch path.
 - Integration: `tests/integration/cross_instance_issues.test.ts` covers the GitHub mirror loop end-to-end.
-- Contract: `tests/contract/openclaw_plugin.test.ts` and the legacy-payload corpus exercise the inbound webhook handlers.
+- The inbound `POST /github/webhook` route has no dedicated test at present.
 
 ## Related
 
@@ -133,4 +164,4 @@ The ingest path enforces:
 - [`guest_access_policy.md`](guest_access_policy.md) — the policy model that gates guest writes.
 - [`agent_attribution_integration.md`](agent_attribution_integration.md) — external-actor attribution applied to inbound submissions.
 - [`subscriptions.md`](subscriptions.md) — substrate events that trigger downstream mirror re-dispatch.
-- [`docs/plans/observer_wire_feedback_channel.md`](../plans/observer_wire_feedback_channel.md) — design history of the submission pipeline.
+- `observer_wire_feedback_channel` — design history of the submission pipeline; the markdown plan was removed in `3ce1a332c` and its content now lives as a `plan` entity in Neotoma.

--- a/src/services/entity_submission/ingest/github_handler.ts
+++ b/src/services/entity_submission/ingest/github_handler.ts
@@ -6,6 +6,7 @@ import crypto from "node:crypto";
 
 import type { ExternalActor } from "../../../crypto/agent_identity.js";
 import { buildExternalActor } from "../../issues/external_actor_builder.js";
+import type { WebhookIngestHandler } from "./webhook_ingest.js";
 
 export function verifyGithubSignature(
   rawBody: Buffer,
@@ -200,3 +201,25 @@ function mapIssueCommentEvent(
     observation_source: "sensor",
   };
 }
+
+/**
+ * Conformance binding for {@link WebhookIngestHandler}.
+ *
+ * The shipped `POST /github/webhook` route in `src/actions.ts` calls
+ * `verifyGithubSignature` and `mapGithubWebhookEventToStore` directly, so this
+ * object is not on the request path. It exists so the compiler checks the
+ * GitHub handler against the stated interface: if the interface changes, or a
+ * second provider is added and this shape drifts, the build fails here rather
+ * than silently diverging. See `webhook_ingest.ts` for why no generic route
+ * exists.
+ */
+export const githubWebhookIngestHandler: WebhookIngestHandler = {
+  provider: "github",
+  verifySignature(headers, rawBody, secret) {
+    const header = headers["x-hub-signature-256"];
+    const signature = Array.isArray(header) ? header[0] : header;
+    if (!signature) return false;
+    return verifyGithubSignature(rawBody, signature, secret);
+  },
+  mapEventToStore: mapGithubWebhookEventToStore,
+};

--- a/src/services/entity_submission/ingest/webhook_ingest.ts
+++ b/src/services/entity_submission/ingest/webhook_ingest.ts
@@ -1,6 +1,19 @@
 import type { ExternalActor } from "../../../crypto/agent_identity.js";
 
-/** Pluggable inbound webhook → store mapping (GitHub implements this today). */
+/**
+ * Pluggable inbound webhook → store mapping.
+ *
+ * STATUS: contract only. No generic `POST /submissions/webhook/:provider`
+ * route is registered, and none is planned until a second provider exists —
+ * see `docs/subsystems/entity_submission.md` § Inbound webhook ingest.
+ *
+ * The one shipped inbound path is `POST /github/webhook`, registered in
+ * `src/actions.ts`, which calls the functions in `github_handler.ts` directly
+ * and stores via `storeStructuredForApi`. This interface exists so that a
+ * second provider is written against a stated shape rather than by copying
+ * the GitHub handler; `githubWebhookIngestHandler` in `github_handler.ts` is
+ * the reference conformance check.
+ */
 export interface WebhookIngestHandler {
   readonly provider: string;
   verifySignature(


### PR DESCRIPTION
## Problems

`docs/subsystems/entity_submission.md` documented a generic inbound webhook route that does not exist. `grep -rn "submissions/webhook" src/` returned nothing — `ingest/webhook_ingest.ts` is a 22-line interface declaration with no route registration and no handler.

This matters because the interface is the documented extension point for adding external providers. Anyone evaluating Neotoma for a second connector read the doc, believed a pluggable webhook path existed, and found an unwired interface.

Auditing the rest of the section found four further claims the source does not support:

| Doc claimed | Reality |
|---|---|
| `github_handler.ts` delegates to `submitEntity` | It does not. It maps events to a store payload; `POST /github/webhook` writes via `storeStructuredForApi` |
| `handleGithubInboundIssue` / `handleGithubInboundComment` | Neither symbol exists anywhere in the repo |
| HMAC secret from `submission_config.external_mirrors[*].config.shared_secret` | Route reads `process.env.GITHUB_WEBHOOK_SECRET` |
| `idempotencyForSubmit` covers the inbound path | It does not; `github_handler` builds its own delivery-scoped keys |

Testing claims were also wrong: `src/services/entity_submission/__tests__/` does not exist, and `tests/contract/openclaw_plugin.test.ts` was credited with exercising the inbound webhook handlers despite containing no webhook references.

Secondary defect: `WebhookIngestHandler` had no implementors. `github_handler.ts` matched its shape structurally but never declared conformance, so a provider added later could drift from the contract silently.

## Solutions

**Corrected the doc rather than registering the route.** Nothing consumes a generic provider path today, and building one would be speculative infrastructure.

The Inbound webhook ingest section now states plainly that GitHub is the only shipped inbound provider, documents the real `POST /github/webhook` flow step by step, and calls out two properties that bear on its trust boundary:

- It does **not** call `submitEntity`, so it never consults `submission_config`, never applies `assertGuestWriteAllowed`, and never mints guest read-back tokens. Its gate is the webhook HMAC, not the guest access policy.
- It does **not** use `idempotencyForSubmit`. Re-delivery with a new delivery id creates a new observation rather than deduplicating, though entity identity still converges via `github_number`.

Added an "Adding a second provider" subsection recording that a shared route becomes worthwhile once a second provider exists, and what transport-parity work that would require.

**Added `githubWebhookIngestHandler`** in `github_handler.ts` — a compile-time binding of the GitHub functions to `WebhookIngestHandler`. It is off the request path and exists only so `tsc` catches divergence, closing the conformance gap without wiring speculative infrastructure.

Also fixed a dead link to `docs/plans/observer_wire_feedback_channel.md`, removed in `3ce1a332c` when plan content moved into Neotoma.

## Documentation

`docs/subsystems/entity_submission.md` is the change. Every remaining mention of `submissions/webhook` in the repo is now an explicit negation ("No generic … route", "none is planned until a second provider exists"), so the done criterion holds:

```
grep -rn "submissions/webhook" src/ docs/subsystems/
```

## Test plan

Verified on a clean worktree branched off current `main` (`5a50ea965`):

- `npm run type-check` — pass. This is the real check on the new conformance binding; it would fail if the GitHub handler diverged from the interface.
- `npm run lint` — 0 errors
- `npm run format:check` — pass
- `npm run lint:site-copy` — pass
- `npm run validate:doc-deps` — pass
- `npx vitest run entity_submission sync_webhook_outbound` — 4 files, 15 passed

Security gates (classifier reports `sensitive=true`, path-based on `entity_submission/ingest/`; the diff adds no route and no auth logic):

- `npm run security:classify-diff` — 3 files, one path concern
- `npm run security:lint` — 0 errors
- `npm run security:manifest:check` — in sync, 119 routes
- `npm run test:security:auth-matrix` — 18 passed

Full unit suite: **12 files / 22 tests fail identically with and without this commit** in the same worktree (diff of the failing-file lists is empty). These are pre-existing on `main` and unrelated — none touch `entity_submission`.

## Breaking changes

No breaking changes. Documentation plus one non-exported-path type binding; no route added, so no OpenAPI, contract-mapping, or `protected_routes_manifest.json` change is required.

Fixes #2185

🤖 Generated with [Claude Code](https://claude.com/claude-code)
