### PR TITLE
fix(auth): reject unverified-JWT bearer fallback in validateSessionToken

### DIFF
--- a/src/services/__tests__/mcp_oauth.test.ts
+++ b/src/services/__tests__/mcp_oauth.test.ts
@@ -335,6 +335,77 @@ describe("MCP OAuth Service", () => {
       rmSync(tempDir, { recursive: true, force: true });
     });
 
+    it("rejects a forged unsigned JWT bearer instead of trusting its claims (auth bypass regression)", async () => {
+      // Regression for the unverified-JWT authentication bypass: validateSessionToken
+      // must NOT fall back to decoding the bearer and trusting its own sub/email when
+      // no live connection row matches. A fully attacker-controlled `alg:none` token
+      // that names an arbitrary user_id must be rejected, not admitted.
+      const tempDir = path.join(process.cwd(), "tmp", `neotoma-oauth-forged-jwt-${Date.now()}`);
+      const localAuth = await loadLocalAuthModule(tempDir);
+      const mcpAuth = await loadLocalMcpAuthModule(tempDir);
+      await loadDbConnection(tempDir);
+
+      // A real user exists in this instance; the attacker targets their id.
+      await localAuth.createLocalAuthUser("victim@example.com", "password123");
+      const victim = await localAuth.getLocalAuthUserByEmail("victim@example.com");
+      if (!victim) {
+        throw new Error("Local auth user not found in test");
+      }
+
+      const b64url = (obj: unknown) =>
+        Buffer.from(JSON.stringify(obj)).toString("base64url").replace(/=+$/, "");
+      const forge = (sub: string, email?: string) =>
+        `${b64url({ alg: "none", typ: "JWT" })}.${b64url({ sub, ...(email ? { email } : {}) })}.x`;
+
+      // Forged token naming the victim's real user_id — must be rejected.
+      await expect(
+        mcpAuth.validateSessionToken(forge(victim.id, "attacker@example.com"))
+      ).rejects.toThrow("Invalid session token");
+
+      // Forged token naming an arbitrary user_id that never signed in — must be rejected.
+      await expect(
+        mcpAuth.validateSessionToken(forge("deadbeef-0000-4000-8000-000000000001"))
+      ).rejects.toThrow("Invalid session token");
+
+      // A non-JWT random bearer that matches no connection — must be rejected.
+      await expect(mcpAuth.validateSessionToken("not-a-real-token")).rejects.toThrow(
+        "Invalid session token"
+      );
+
+      rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    it("still accepts a valid, live connection access token after the fail-closed fix", async () => {
+      // Guards against over-correction: the legitimate OAuth-issued token must
+      // continue to authenticate as its bound user with the right email.
+      const tempDir = path.join(process.cwd(), "tmp", `neotoma-oauth-valid-token-${Date.now()}`);
+      const oauth = await loadLocalOAuthModule(tempDir);
+      const localAuth = await loadLocalAuthModule(tempDir);
+      const mcpAuth = await loadLocalMcpAuthModule(tempDir);
+      await loadDbConnection(tempDir);
+      await localAuth.createLocalAuthUser("valid@example.com", "password123");
+      const user = await localAuth.getLocalAuthUserByEmail("valid@example.com");
+      if (!user) {
+        throw new Error("Local auth user not found in test");
+      }
+
+      const connectionId = "cursor-local-valid-token";
+      const request = await oauth.createLocalAuthorizationRequest({
+        connectionId,
+        redirectUri: "cursor://oauth",
+        clientState: "client-state",
+        codeChallenge: "test-challenge",
+      });
+      await oauth.completeLocalAuthorization(request.state, user.id);
+      const tokenResponse = await oauth.getTokenResponseForConnection(connectionId);
+
+      const validated = await mcpAuth.validateSessionToken(tokenResponse.access_token);
+      expect(validated.userId).toBe(user.id);
+      expect(validated.email).toBe("valid@example.com");
+
+      rmSync(tempDir, { recursive: true, force: true });
+    });
+
     it("exchanges a refresh token for a new local access token", async () => {
       const tempDir = path.join(process.cwd(), "tmp", `neotoma-oauth-refresh-${Date.now()}`);
       const oauth = await loadLocalOAuthModule(tempDir);

--- a/src/services/mcp_auth.ts
+++ b/src/services/mcp_auth.ts
@@ -4,7 +4,6 @@
  * Validates session tokens for MCP server authentication
  */
 
-import { logger } from "../utils/logger.js";
 import { getDb } from "../repositories/db/connection.js";
 import { getLocalAuthUserById } from "./local_auth.js";
 
@@ -14,34 +13,27 @@ export interface ValidatedUser {
 }
 
 /**
- * Decode JWT token header and payload without verification
- * Extracts algorithm, user_id, and other claims for diagnostics
- */
-function decodeJWTUnverified(token: string): {
-  header?: { alg?: string; kid?: string; typ?: string };
-  payload?: { sub?: string; email?: string; exp?: number };
-} | null {
-  try {
-    const parts = token.split(".");
-    if (parts.length !== 3) {
-      return null;
-    }
-    // Decode header (first part)
-    const header = JSON.parse(Buffer.from(parts[0], "base64url").toString("utf-8"));
-    // Decode payload (second part)
-    const payload = JSON.parse(Buffer.from(parts[1], "base64url").toString("utf-8"));
-    return { header, payload };
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Validate a session token (JWT) and extract user information
+ * Validate a session token and extract user information.
  *
- * @param token - access_token (JWT)
+ * A session token is valid only if it maps to a live (non-revoked, unexpired)
+ * row in `mcp_oauth_connections`. A token that matches no such row is rejected
+ * — claims decoded from the token itself are never trusted.
+ *
+ * SECURITY: a previous revision fell back to decoding the bearer as an
+ * UNVERIFIED JWT and trusting its `sub`/`email` claims when no connection row
+ * matched. That is an authentication bypass: the token is fully
+ * attacker-controlled, so `Bearer <base64url({alg:none})>.<base64url({sub:<any
+ * user_id>})>.x` authenticated the caller as any user over the public internet
+ * (there was no local-only gate despite the "local-only" comment; the claimed
+ * `user_id` is derivable as sha256(email)). The fix enforces the same
+ * fail-closed invariant the Ed25519 bearer path adopted after advisory
+ * 2026-08-07-ed25519-bearer-forged-key-auth-bypass: a bearer that does not
+ * resolve to a pre-provisioned principal must be rejected, never mapped to a
+ * caller-supplied identity.
+ *
+ * @param token - access_token issued by the OAuth flow
  * @returns User information including user_id
- * @throws Error if token is invalid or expired
+ * @throws Error if the token is unknown, revoked, or expired
  */
 export async function validateSessionToken(token: string): Promise<ValidatedUser> {
   const db = await getDb();
@@ -52,15 +44,10 @@ export async function validateSessionToken(token: string): Promise<ValidatedUser
     .get(token)) as { user_id?: string; access_token_expires_at?: string } | undefined;
 
   if (!connection?.user_id) {
-    const decoded = decodeJWTUnverified(token);
-    if (!decoded?.payload?.sub) {
-      throw new Error("Invalid local session token");
-    }
-    logger.warn("[MCP Auth] Falling back to unverified JWT payload for local-only compatibility");
-    return {
-      userId: decoded.payload.sub,
-      email: decoded.payload.email,
-    };
+    // Fail closed: a bearer that matches no live connection is not a valid
+    // session. Never decode and trust the token's own claims (see SECURITY
+    // note above).
+    throw new Error("Invalid session token");
   }
 
   if (

--- a/src/shared/capability_manifest.json
+++ b/src/shared/capability_manifest.json
@@ -41,6 +41,9 @@
     "describe_entity_type": {
       "addedInVersion": "v0.16.0"
     },
+    "describe_instance_policy": {
+      "addedInVersion": "v0.22.0"
+    },
     "get_authenticated_user": {
       "addedInVersion": "v0.4.3"
     },

--- a/tests/services/mcp_auth.test.ts
+++ b/tests/services/mcp_auth.test.ts
@@ -10,22 +10,33 @@ import { validateSessionToken } from "../../src/services/mcp_auth.js";
 
 describe("MCP Authentication Service", () => {
   describe("validateSessionToken", () => {
+    // A bearer that resolves to no live mcp_oauth_connections row is rejected
+    // (fail closed). The error message is "Invalid session token" — the prior
+    // "Invalid local session token" wording accompanied an unverified-JWT
+    // fallback that has been removed (auth-bypass fix). The regex stays tolerant
+    // of either wording so the assertion is about the reject, not the phrasing.
+    const rejects = /Token validation failed|Invalid( local)? session token/;
+
     it("should throw error for invalid token format", async () => {
-      await expect(validateSessionToken("invalid-token")).rejects.toThrow(
-        /Token validation failed|Invalid local session token/
-      );
+      await expect(validateSessionToken("invalid-token")).rejects.toThrow(rejects);
     });
 
     it("should throw error for empty token", async () => {
-      await expect(validateSessionToken("")).rejects.toThrow(
-        /Token validation failed|Invalid local session token/
-      );
+      await expect(validateSessionToken("")).rejects.toThrow(rejects);
     });
 
     it("should throw error for malformed JWT", async () => {
-      await expect(validateSessionToken("not.a.valid.jwt")).rejects.toThrow(
-        /Token validation failed|Invalid local session token/
-      );
+      await expect(validateSessionToken("not.a.valid.jwt")).rejects.toThrow(rejects);
+    });
+
+    it("should throw error for a forged unsigned JWT rather than trusting its claims", async () => {
+      // Regression: the removed fallback decoded this and returned its `sub` as
+      // an authenticated user_id. It must now be rejected like any other
+      // unknown token.
+      const b64 = (o: unknown) =>
+        Buffer.from(JSON.stringify(o)).toString("base64url").replace(/=+$/, "");
+      const forged = `${b64({ alg: "none" })}.${b64({ sub: "attacker-user-id" })}.x`;
+      await expect(validateSessionToken(forged)).rejects.toThrow(rejects);
     });
 
     // Note: Testing valid tokens requires integration test with real auth instance


### PR DESCRIPTION
## Summary

Security hardening of `validateSessionToken` (`src/services/mcp_auth.ts`): a bearer token that matches no live `mcp_oauth_connections` row is now **rejected (fail closed)** rather than falling back to trusting claims decoded from the token itself.

This enforces the same fail-closed invariant the Ed25519 bearer path adopted after advisory `2026-08-07-ed25519-bearer-forged-key-auth-bypass`: a bearer that does not resolve to a pre-provisioned principal must never be mapped to a caller-supplied identity.

## Changes

- Remove the unverified-token fallback in `validateSessionToken`; reject unknown/revoked/expired session tokens.
- Remove the now-unused decode helper.
- Regression tests: forged/unknown bearers are rejected; a valid live connection token still authenticates with the correct user and email.

## Verification

- New tests fail against the pre-fix code and pass with the fix.
- Verified end-to-end against a production-configured local instance: the previously-accepted forged bearer now returns 401 from `/me` and `/entities`; a legitimate session token is unaffected.
- Typecheck clean on the edited files.

## Disclosure

Full technical detail and reproduction are in a private security advisory rather than here, since affected instances upgrade on this fix. Operators should rotate `NEOTOMA_BEARER_TOKEN` and revoke outstanding session tokens after upgrading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
