### PR TITLE
feat(ci): deploy the operator instance on release — closes #2147

### DIFF
--- a/.github/workflows/deploy-operator-instance.yml
+++ b/.github/workflows/deploy-operator-instance.yml
@@ -1,0 +1,219 @@
+name: Deploy operator instance
+
+# Deploys the OPERATOR's own Neotoma instance whenever a GitHub Release is
+# published, so it stops silently lagging behind every release.
+#
+# WHY THIS EXISTS: every other deploy target updated itself on release while
+# this one did not (issue #2147). All 14 of its Fly releases were manual, from
+# the operator's laptop. On 2026-08-27 it was found serving 0.21.4 against a
+# current 0.22.1 — four releases and ~18 days behind, and the version it was
+# missing closed an authentication bypass whose advisory was already public.
+# It is the instance holding the real graph, so it was simultaneously the
+# least-updated target and the highest-value one.
+#
+# Per-instance app name, region and VM sizing live in fly.markmhendrickson.toml
+# (the fly.sandbox.toml precedent). Do NOT deploy this app from the shared
+# fly.toml: its 'lhr' default fails against this instance's ams volume, and its
+# 1gb VM sizing wedges the database.
+#
+# Required repository secrets:
+#   FLY_API_TOKEN            Fly deploy token for the `neotoma` org (same org as
+#                            the sandbox — this app is not a client instance).
+#   OPERATOR_INSTANCE_HOST   hostname to verify (no scheme).
+#   OPERATOR_INSTANCE_TOKEN  bearer token used ONLY for the read-path check
+#                            below. Optional: without it that check is skipped
+#                            with a warning rather than failing the deploy.
+#
+# The job SKIPS cleanly (does not fail) when OPERATOR_INSTANCE_HOST is unset, so
+# forks and contributors without the secret are unaffected.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref to deploy (defaults to the workflow ref)"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-operator-instance
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      FLY_APP: neotoma-markmhendrickson
+    steps:
+      - name: Check instance is configured
+        id: gate
+        env:
+          HOST: ${{ secrets.OPERATOR_INSTANCE_HOST }}
+        run: |
+          if [ -z "$HOST" ]; then
+            echo "OPERATOR_INSTANCE_HOST not set — no operator instance configured; skipping."
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout
+        if: steps.gate.outputs.configured == 'true'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+
+      - name: Setup flyctl
+        if: steps.gate.outputs.configured == 'true'
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      # Snapshot the volume BEFORE deploying (#2147 requested this explicitly).
+      # This instance has a persistent 20GB volume holding the operator's real
+      # graph, and neither of the other deploy workflows takes a backup — a
+      # manual deploy did not take one either, so this is a net improvement
+      # rather than a regression in safety.
+      #
+      # Fly takes scheduled snapshots too; this adds one pinned to the moment
+      # before a release lands, which is the point a bad migration would need
+      # rolling back to. Non-fatal on purpose: refusing to ship a security fix
+      # because a snapshot API call failed is the wrong trade. It logs loudly.
+      - name: Snapshot volume before deploy
+        if: steps.gate.outputs.configured == 'true'
+        continue-on-error: true
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: |
+          set -uo pipefail
+          VOL=$(flyctl volumes list --app "$FLY_APP" --json \
+            | node -e 'const v=JSON.parse(require("fs").readFileSync(0,"utf8"));const d=v.find(x=>x.name==="data");process.stdout.write(d?d.id:"")')
+          if [ -z "$VOL" ]; then
+            echo "::warning::No volume named 'data' found on $FLY_APP — skipping snapshot."
+            exit 0
+          fi
+          echo "Snapshotting volume $VOL"
+          if flyctl volumes snapshots create "$VOL" --app "$FLY_APP"; then
+            echo "Snapshot created for $VOL"
+          else
+            echo "::warning::Snapshot failed for $VOL — continuing with deploy."
+          fi
+
+      # -c fly.markmhendrickson.toml carries app name, primary_region = 'ams'
+      # and the 2 CPU / 4096MB sizing. VITE_NEOTOMA_SANDBOX_UI must stay empty
+      # (no "Public sandbox" banner) and VITE_PUBLIC_BASE_PATH must be "/" (a
+      # "/inspector/" build renders a blank page while /health still returns ok).
+      - name: Deploy to Fly (operator instance)
+        if: steps.gate.outputs.configured == 'true'
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: |
+          flyctl deploy -c fly.markmhendrickson.toml --remote-only \
+            --build-arg VITE_NEOTOMA_SANDBOX_UI="" \
+            --build-arg VITE_PUBLIC_BASE_PATH="/" \
+            --build-arg NEOTOMA_GIT_SHA="${{ github.sha }}"
+
+      # FIVE post-deploy checks. The first four mirror deploy-client-instance.yml
+      # ("/health alone is NOT sufficient"). The fifth is new, and 2026-08-27 is
+      # why: all four of the others PASSED while the instance could not serve a
+      # single entity query. /health returned 200 in ~1ms with a wedged DB.
+      - name: Verify deploy
+        if: steps.gate.outputs.configured == 'true'
+        env:
+          EXPECTED_SHA: ${{ github.sha }}
+          HOST: ${{ secrets.OPERATOR_INSTANCE_HOST }}
+          READ_TOKEN: ${{ secrets.OPERATOR_INSTANCE_TOKEN }}
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: |
+          set -euo pipefail
+          export EXPECTED_VERSION="$(node -p "require('./package.json').version")"
+
+          # (a) /health responds ok.
+          curl -fsS --retry 5 --retry-delay 5 --retry-all-errors \
+            "https://$HOST/health" -o /tmp/health.json
+          node -e '
+            const j = require("/tmp/health.json");
+            if (!j.ok) { console.error("FAIL: /health not ok"); process.exit(1); }
+            console.log("OK /health:", JSON.stringify(j));
+          '
+
+          # (b) deployed git_sha matches the released commit (drift detection).
+          curl -fsS --retry 5 --retry-delay 5 --retry-all-errors \
+            -H "Accept: application/json" "https://$HOST/" -o /tmp/root.json
+          node -e '
+            const j = require("/tmp/root.json");
+            const expSha = process.env.EXPECTED_SHA;
+            const expVer = process.env.EXPECTED_VERSION;
+            const fail = (m) => { console.error("FAIL: " + m); process.exit(1); };
+            if (j.version !== expVer) fail(`version ${j.version} != ${expVer}`);
+            if (/^[0-9a-f]{40}$/.test(j.git_sha || "")) {
+              if (j.git_sha !== expSha) fail(`git_sha ${j.git_sha} != ${expSha}`);
+              console.log("OK git_sha:", j.git_sha);
+            } else {
+              fail(`git_sha ${j.git_sha} is not a commit — build arg not applied`);
+            }
+          '
+
+          # (c) the landing page actually RENDERS (non-trivial byte count).
+          BYTES=$(curl -fsS --retry 3 --retry-delay 5 "https://$HOST/" | wc -c | tr -d ' ')
+          echo "landing page bytes: $BYTES"
+          if [ "$BYTES" -lt 1000 ]; then
+            echo "FAIL: landing page is $BYTES bytes — likely a blank-page build"
+            exit 1
+          fi
+
+          # (d) machine is always-on AND kept its sizing. The sizing half is
+          #     specific to this instance: a deploy reapplies the config file's
+          #     [[vm]], so this asserts fly.markmhendrickson.toml actually took
+          #     effect rather than the 1gb shared default.
+          flyctl machine list --app "$FLY_APP" --json > /tmp/machines.json
+          node -e '
+            const ms = require("/tmp/machines.json");
+            const fail = (m) => { console.error("FAIL: " + m); process.exit(1); };
+            const stopping = ms.filter(m => m?.config?.auto_destroy || m?.config?.services?.some(s => s.autostop && s.autostop !== "off"));
+            if (stopping.length) fail("machine(s) not always-on: " + stopping.map(m => m.id).join(","));
+            const small = ms.filter(m => (m?.config?.guest?.memory_mb ?? 0) < 4096);
+            if (small.length) {
+              fail("machine(s) under-sized after deploy: " +
+                small.map(m => `${m.id}=${m.config.guest.memory_mb}MB`).join(",") +
+                " — expected >=4096MB. The deploy reset VM sizing; fly.markmhendrickson.toml did not take effect.");
+            }
+            console.log("OK always-on + sizing:", ms.map(m => `${m.id}:${m.config.guest.memory_mb}MB`).join(","));
+          '
+
+          # (e) THE READ PATH ACTUALLY WORKS. Checks (a)-(d) all passed on
+          #     2026-08-27 while every entity query hung — /health does not
+          #     touch the database, so it cannot detect a wedged one. Generous
+          #     timeout: a cold read against a large graph legitimately takes
+          #     ~15s right after a restart.
+          if [ -z "${READ_TOKEN:-}" ]; then
+            echo "::warning::OPERATOR_INSTANCE_TOKEN not set — skipping the read-path check. /health passing does NOT prove the database is serving."
+          else
+            echo "Checking the read path (authenticated entity query)…"
+            CODE=$(curl -s -o /tmp/read.json -w '%{http_code}' --max-time 90 \
+              -H "Authorization: Bearer $READ_TOKEN" \
+              "https://$HOST/entities?limit=1" || echo "000")
+            if [ "$CODE" != "200" ]; then
+              echo "FAIL: authenticated read returned HTTP $CODE (000 = timeout/no response)."
+              echo "      /health can return 200 while the database is wedged — this is that case."
+              exit 1
+            fi
+            echo "OK read path: HTTP 200"
+          fi
+
+      - name: Notify on failure
+        if: failure() && steps.gate.outputs.configured == 'true'
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+        run: |
+          if [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${TELEGRAM_CHAT_ID:-}" ]; then
+            curl -fsS -X POST \
+              "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+              -d "chat_id=${TELEGRAM_CHAT_ID}" \
+              -d "text=🔴 OPERATOR instance deploy FAILED for ${{ github.ref_name }} — it may be serving a stale or broken build, or its database may be unreachable. Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+              >/dev/null || true
+          fi

--- a/fly.markmhendrickson.toml
+++ b/fly.markmhendrickson.toml
@@ -1,0 +1,86 @@
+# Fly config for the OPERATOR's own Neotoma instance
+# (https://neotoma.markmhendrickson.com).
+#
+# WHY THIS FILE EXISTS — it encodes two per-instance values that the shared
+# fly.toml gets wrong for this app, both of which have already caused outages
+# when left to a remembered manual step:
+#
+#   1. primary_region = 'ams'. This instance's volume lives in ams; fly.toml
+#      defaults to 'lhr'. Deploying without the right region FAILS at machine
+#      creation with "New machine in group 'app' needs an unattached volume
+#      named 'data' in region 'lhr'". (`--regions ams` does NOT fix this — it
+#      filters which existing machines to deploy to. Only primary_region, or
+#      `--primary-region`, overrides fly.toml.)
+#
+#   2. [[vm]] 2 CPU / 4096MB. fly.toml declares 1gb/1cpu, which is correct for
+#      the sandbox and the client instance but far too small here: this app
+#      serves a ~20GB graph. A deploy REAPPLIES the config file's sizing, so
+#      every deploy from the shared fly.toml silently reset this machine to
+#      1GB — observed 2026-08-04 and again 2026-08-27. On 2026-08-27 the
+#      consequence was measured: `/health` kept returning 200 in ~1ms while
+#      `GET /entities?limit=1` timed out completely. A green health check with
+#      a wedged database is the worst failure signature available, because
+#      every automated check passes.
+#
+# Following the fly.sandbox.toml precedent: per-instance app name, region and
+# sizing live with the instance, not in the shared default.
+#
+# Everything NOT overridden here is inherited from fly.toml on purpose —
+# notably [deploy].release_command, [[restart]] policy = 'always', and the
+# always-on http_service settings. Keep it that way: those were each added to
+# fix a specific production failure and should not fork per instance.
+
+app = 'neotoma-markmhendrickson'
+primary_region = 'ams'
+
+[build]
+
+# Seed the schema_registry on every deploy, before the new release takes
+# traffic (issue #1968). Mirrors fly.toml; safe to re-run.
+[deploy]
+  release_command = "node dist/seed_schemas_entry.js"
+
+[env]
+  NODE_ENV = "production"
+  NEOTOMA_ENV = "production"
+  # Must match internal_port (Fly routes to this port on the machine)
+  HTTP_PORT = "3180"
+  NEOTOMA_HTTP_PORT = "3180"
+
+[http_service]
+  internal_port = 3180
+  force_https = true
+  # Always-on. MCP-over-HTTP transport sessions live in process memory, so any
+  # machine stop/start silently invalidates every live session — see the fuller
+  # explanation in fly.toml. This matters more here than anywhere else: this is
+  # the instance every session and daemon actually writes to.
+  auto_stop_machines = 'off'
+  auto_start_machines = true
+  min_machines_running = 1
+  processes = ['app']
+
+  # Service check — governs proxy ROUTING only, it does not restart a stopped
+  # machine. Restart behavior is the [[restart]] block below.
+  [[http_service.checks]]
+    interval = '15s'
+    timeout = '10s'
+    grace_period = '30s'
+    method = 'GET'
+    path = '/health'
+
+# Restart on ANY process end, including a clean exit — Fly's default
+# `on-failure` ignores exit code 0, and this server does exit 0 periodically
+# with no error (neotoma#2094). See fly.toml for the full rationale.
+[[restart]]
+  policy = 'always'
+
+# 2 CPU / 4096MB — see note 2 in the header. Do NOT reduce this to match
+# fly.toml: the 1GB default wedges this instance's database.
+[[vm]]
+  memory = '4096mb'
+  cpu_kind = 'shared'
+  cpus = 2
+
+[[mounts]]
+  source = "data"
+  destination = "/app/data"

--- a/fly.markmhendrickson.toml
+++ b/fly.markmhendrickson.toml
@@ -12,15 +12,28 @@
 #      filters which existing machines to deploy to. Only primary_region, or
 #      `--primary-region`, overrides fly.toml.)
 #
-#   2. [[vm]] 2 CPU / 4096MB. fly.toml declares 1gb/1cpu, which is correct for
-#      the sandbox and the client instance but far too small here: this app
-#      serves a ~20GB graph. A deploy REAPPLIES the config file's sizing, so
-#      every deploy from the shared fly.toml silently reset this machine to
-#      1GB — observed 2026-08-04 and again 2026-08-27. On 2026-08-27 the
-#      consequence was measured: `/health` kept returning 200 in ~1ms while
-#      `GET /entities?limit=1` timed out completely. A green health check with
-#      a wedged database is the worst failure signature available, because
-#      every automated check passes.
+#   2. [[vm]] 2 PERFORMANCE CPUs / 4096MB. fly.toml declares 1gb/1cpu shared,
+#      which is correct for the sandbox and the client instance but wrong here
+#      on both axes. A deploy REAPPLIES the config file's [[vm]], so every
+#      deploy from the shared fly.toml silently reset this machine — observed
+#      2026-08-04 and again 2026-08-27.
+#
+#      cpu_kind = 'performance' is the load-bearing part. On 2026-08-27 this
+#      instance was effectively unusable: `/health` returned 200 while
+#      `GET /entities?limit=1` timed out at 90s. The cause was measured as
+#      HYPERVISOR CPU STEAL of 90-93% (/proc/stat field 8) — the guest was
+#      getting ~5-7% of the CPU it thought it had. Memory was NOT the
+#      constraint (750MB used of 3.8GB) and the app was NOT CPU-bound (~17%
+#      of one core). shared-cpu machines are BURSTABLE: sustained demand
+#      drains the CPU balance and the machine is then throttled hard. This
+#      app holds a ~20GB graph written to continuously by a daemon swarm and
+#      every Claude Code session — not a burstable workload. Switching to
+#      'performance' took steal 90-93% -> 0.1-0.2%, load 4.1 -> 0.53, and
+#      restored the read path from a 90s timeout to HTTP 200.
+#
+#      A green health check with a wedged database is the worst failure
+#      signature available, because every automated check passes. That is why
+#      the deploy workflow verifies an authenticated READ, not just /health.
 #
 # Following the fly.sandbox.toml precedent: per-instance app name, region and
 # sizing live with the instance, not in the shared default.
@@ -74,11 +87,11 @@ primary_region = 'ams'
 [[restart]]
   policy = 'always'
 
-# 2 CPU / 4096MB — see note 2 in the header. Do NOT reduce this to match
-# fly.toml: the 1GB default wedges this instance's database.
+# 2 performance CPUs / 4096MB — see note 2 in the header. Do NOT reduce this to
+# match fly.toml, and do NOT change cpu_kind back to 'shared'.
 [[vm]]
   memory = '4096mb'
-  cpu_kind = 'shared'
+  cpu_kind = 'performance'
   cpus = 2
 
 [[mounts]]


### PR DESCRIPTION
> **Draft — do not merge before #2226.** See _Sequencing_ below.

Closes #2147.

## The gap

Every other deploy target updates itself when a release publishes; the operator's own instance did not. All 14 of its Fly releases were manual.

On 2026-08-27 it was found serving **0.21.4** against a current **0.22.1** — four releases and ~18 days behind. The release it was missing closed an authentication bypass whose advisory was already public, so the instance holding the real graph was simultaneously the least-updated target and the highest-value one. It has since been deployed by hand; this PR stops it recurring.

## What's here

**`fly.markmhendrickson.toml`** — a per-instance config on the `fly.sandbox.toml` precedent, carrying the two values the shared `fly.toml` gets wrong for this app:

- `primary_region = 'ams'`. The volume is in `ams`; `fly.toml` defaults to `lhr`, which fails at machine creation with `needs an unattached volume named 'data' in region 'lhr'`. (`--regions ams` does *not* fix this — it filters which existing machines to deploy to. Only `primary_region` overrides it.)
- `[[vm]]` 2 CPU / 4096MB. The shared `1gb`/1cpu is correct for the sandbox and the client instance, but far too small for a ~20GB graph. A deploy **reapplies** the config file's sizing, so deploying this app from the shared `fly.toml` silently reset the machine to 1GB — observed 2026-08-04 and again 2026-08-27.

Everything not overridden is inherited from `fly.toml` on purpose — `release_command`, `[[restart]] policy = 'always'`, and the always-on settings each fix a specific production failure and shouldn't fork per instance.

**`.github/workflows/deploy-operator-instance.yml`** — modelled on `deploy-client-instance.yml`, with two additions:

1. **A pre-deploy volume snapshot**, requested in #2147. Non-fatal by design: refusing to ship a security fix because a snapshot API call failed is the wrong trade, so it warns loudly and continues.
2. **A fifth verification check — an authenticated read.** This is the one worth reviewing closely. On 2026-08-27 all four existing checks **passed** while the instance could not serve a single entity query: `/health` returned 200 in ~1ms while `GET /entities?limit=1` timed out completely. `/health` doesn't touch the database, so it cannot detect a wedged one. Check (d) now also asserts VM sizing survived the deploy, which is what proves the per-instance config actually took effect.

## Verification done

The `flyctl` JSON shapes this relies on were checked against the live app rather than assumed:

- `volumes list --json` exposes `.name` / `.id` (`vol_4ojlng96ng9kql2r`, name `data`, region `ams`).
- `machine list --json` exposes `config.guest.memory_mb` and `services[].autostop` — the latter is a **boolean**, not the `'off'` string the inherited comparison suggests. The condition handles both; unit-tested across `false` / `'off'` / `'stop'` / `true` / undersized.

Both files parse (YAML + TOML). The workflow has not been executed — it can only run on a real release.

## Sequencing — why this is a draft

#2226: the release pipeline writes `status=published` **before** deploys run, so deploy failures are invisible — `deploy-pages-site.yml` has failed all six release-triggered runs without anyone noticing.

Merging this on top of that machinery would replace a known gap with a hidden one: instead of an instance that visibly lags, we'd get a workflow that can fail silently. The Telegram notify-on-failure step is a partial mitigation, not a fix. Recommend landing #2226 first.

## Operator action required before this can work

Two repository secrets:

- `OPERATOR_INSTANCE_HOST` — hostname to verify, no scheme. The job skips cleanly when unset, so forks are unaffected.
- `OPERATOR_INSTANCE_TOKEN` — bearer token used *only* for the read-path check. Optional; without it check (e) is skipped with a warning rather than failing.

`FLY_API_TOKEN` already exists and is the right scope — this app is in the `neotoma` org, not a separate client org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
