### PR TITLE
fix(mcp): honor source_entity_id/target_entity_id in list_relationships

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -3391,6 +3391,58 @@ export class NeotomaServer {
 
     const relationships: any[] = [];
 
+    // `source_entity_id` / `target_entity_id` are explicit endpoint filters and
+    // take precedence over the legacy `entity_id` + `direction` pattern, exactly
+    // as HTTP `POST /list_relationships` resolves them (src/actions.ts).
+    //
+    // Before #2205/#1973 this handler queried `parsed.entity_id` alone, so a
+    // call filtered only by `source_entity_id` ran `.eq("source_entity_id",
+    // undefined)` and matched nothing — the read path silently disagreed with
+    // the write path, and callers routed around it via
+    // `GET /entities/<id>/relationships` or `retrieve_graph_neighborhood`.
+    if (parsed.source_entity_id || parsed.target_entity_id) {
+      let query = db.from("relationship_snapshots").select("*").eq("user_id", userId);
+
+      if (!parsed.include_deleted) {
+        query = query.eq("is_live", 1);
+      }
+      if (parsed.relationship_type) {
+        query = query.eq("relationship_type", parsed.relationship_type);
+      }
+      if (parsed.source_entity_id) {
+        query = query.eq("source_entity_id", parsed.source_entity_id);
+      }
+      if (parsed.target_entity_id) {
+        query = query.eq("target_entity_id", parsed.target_entity_id);
+      }
+
+      const { data, error } = await query;
+
+      if (!error && data) {
+        relationships.push(
+          ...data.map(
+            (r: {
+              relationship_key: string;
+              source_entity_id: string;
+              snapshot?: unknown;
+              last_observation_at?: string;
+            }) => ({
+              ...r,
+              id: r.relationship_key,
+              // With an explicit endpoint filter there is no traversal origin to
+              // orient against, so direction reports the row's own role relative
+              // to the filtered source when one was given.
+              direction: parsed.source_entity_id ? "outbound" : "inbound",
+              metadata: r.snapshot,
+              created_at: r.last_observation_at,
+            })
+          )
+        );
+      }
+
+      return this.finalizeRelationshipList(relationships, parsed);
+    }
+
     // Query relationship_snapshots instead of relationships table
     if (normalizedDirection === "outbound" || normalizedDirection === "both") {
       let outboundQuery = db
@@ -3472,14 +3524,28 @@ export class NeotomaServer {
       }
     }
 
-    // Sort by last_observation_at DESC, tiebroken by relationship_key ASC
-    // (#1571). last_observation_at is mutable and ties for rows upserted in the
-    // same millisecond (batch ingestion); without a stable tiebreaker, tied
-    // rows can move between pages across successive calls, so pagination over
-    // this order can drop or duplicate rows. relationship_key is the snapshot
-    // primary key — a stable, unique tiebreaker that fully determines order.
-    // This matches the HTTP /list_relationships ordering (actions.ts) and the
-    // determinism invariant (docs/architecture/determinism.md). See issue #368.
+    return this.finalizeRelationshipList(relationships, parsed);
+  }
+
+  /**
+   * Shared ordering + pagination tail for `list_relationships`, applied
+   * identically to the endpoint-filter path (`source_entity_id` /
+   * `target_entity_id`) and the legacy `entity_id` + `direction` path so the
+   * two cannot drift (#2205).
+   *
+   * Sort by last_observation_at DESC, tiebroken by relationship_key ASC
+   * (#1571). last_observation_at is mutable and ties for rows upserted in the
+   * same millisecond (batch ingestion); without a stable tiebreaker, tied
+   * rows can move between pages across successive calls, so pagination over
+   * this order can drop or duplicate rows. relationship_key is the snapshot
+   * primary key — a stable, unique tiebreaker that fully determines order.
+   * This matches the HTTP /list_relationships ordering (actions.ts) and the
+   * determinism invariant (docs/architecture/determinism.md). See issue #368.
+   */
+  private finalizeRelationshipList(
+    relationships: any[],
+    parsed: { offset: number; limit: number }
+  ): { content: Array<{ type: string; text: string }> } {
     relationships.sort((a, b) => {
       const aTime = new Date(a.last_observation_at || a.computed_at || 0).getTime();
       const bTime = new Date(b.last_observation_at || b.computed_at || 0).getTime();
@@ -3490,9 +3556,9 @@ export class NeotomaServer {
     });
 
     // Soft-deleted edges were already excluded at the DB via the `is_live`
-    // predicate on each direction's query (#1570), so `relationships` holds
-    // only live edges on the default path (all edges when include_deleted).
-    // `total` therefore reflects the correct post-filter count.
+    // predicate on each query (#1570), so `relationships` holds only live edges
+    // on the default path (all edges when include_deleted). `total` therefore
+    // reflects the correct post-filter count.
     const paginated = relationships.slice(parsed.offset, parsed.offset + parsed.limit);
 
     return this.buildTextResponse({

--- a/tests/integration/mcp_list_relationships_source_target_filters.test.ts
+++ b/tests/integration/mcp_list_relationships_source_target_filters.test.ts
@@ -1,0 +1,148 @@
+/**
+ * MCP `list_relationships` source/target filters (neotoma#2205, #1973).
+ *
+ * `ListRelationshipsRequestSchema` accepts `source_entity_id` and
+ * `target_entity_id`, and the HTTP handler (`POST /list_relationships`,
+ * src/actions.ts) branches on both. The MCP handler
+ * (`NeotomaServer.listRelationships`, src/server.ts) does not: it queries
+ * `parsed.entity_id` only, so a call filtered solely by `source_entity_id`
+ * runs `.eq("source_entity_id", undefined)` and matches nothing.
+ *
+ * The result is a read path that disagrees with the write path — the defect
+ * reported five times (#2205, #1973, #2156, #369, #277) and worked around, for
+ * months, with `GET /entities/<id>/relationships` or
+ * `retrieve_graph_neighborhood`.
+ *
+ * Harness mirrors tests/integration/mcp_handler_cross_user_scoping.test.ts:
+ * construct a server, set `authenticatedUserId`, call the private handler via
+ * a cast, seed rows directly through `db`.
+ */
+
+import { randomUUID } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { db } from "../../src/db.js";
+import { NeotomaServer } from "../../src/server.js";
+
+const PFX = "mcp_lr_filters";
+
+describe("MCP list_relationships source/target filters (#2205, #1973)", () => {
+  let server: NeotomaServer;
+  const userId = randomUUID();
+
+  const sourceId = `${PFX}_src_${randomUUID().slice(0, 8)}`;
+  const targetId = `${PFX}_tgt_${randomUUID().slice(0, 8)}`;
+  const otherTargetId = `${PFX}_tgt2_${randomUUID().slice(0, 8)}`;
+
+  const relType = "PART_OF";
+  const relKey = `${relType}:${sourceId}:${targetId}`;
+  const otherRelKey = `${relType}:${sourceId}:${otherTargetId}`;
+  const relKeys = [relKey, otherRelKey];
+  const entityIds = [sourceId, targetId, otherTargetId];
+
+  async function seedEntity(id: string): Promise<void> {
+    await db.from("entities").insert({
+      id,
+      user_id: userId,
+      entity_type: "test",
+      canonical_name: id,
+    });
+  }
+
+  async function seedEdge(key: string, src: string, tgt: string): Promise<void> {
+    const ts = new Date().toISOString();
+    await db.from("relationship_snapshots").insert({
+      relationship_key: key,
+      relationship_type: relType,
+      source_entity_id: src,
+      target_entity_id: tgt,
+      schema_version: "1.0",
+      snapshot: {},
+      computed_at: ts,
+      observation_count: 1,
+      last_observation_at: ts,
+      provenance: {},
+      user_id: userId,
+      is_live: 1,
+    });
+  }
+
+  /** Call the private MCP handler and parse its JSON text payload. */
+  async function listRelationships(args: Record<string, unknown>) {
+    const res = await (server as any).listRelationships(args);
+    return JSON.parse(res.content[0].text) as {
+      relationships: Array<{
+        source_entity_id: string;
+        target_entity_id: string;
+        relationship_type: string;
+      }>;
+      total?: number;
+    };
+  }
+
+  beforeAll(async () => {
+    server = new NeotomaServer();
+    (server as any).authenticatedUserId = userId;
+
+    for (const id of entityIds) await seedEntity(id);
+    await seedEdge(relKey, sourceId, targetId);
+    await seedEdge(otherRelKey, sourceId, otherTargetId);
+  });
+
+  afterAll(async () => {
+    await db.from("relationship_snapshots").delete().in("relationship_key", relKeys);
+    await db.from("entities").delete().in("id", entityIds);
+  });
+
+  it("baseline: the legacy entity_id + direction filter finds the live edges", async () => {
+    const out = await listRelationships({ entity_id: sourceId, direction: "outgoing" });
+    expect(out.relationships).toHaveLength(2);
+  });
+
+  it("source_entity_id alone returns the live out-edges", async () => {
+    const out = await listRelationships({ source_entity_id: sourceId });
+    expect(out.relationships.length).toBeGreaterThan(0);
+    for (const r of out.relationships) {
+      expect(r.source_entity_id).toBe(sourceId);
+    }
+    expect(out.relationships).toHaveLength(2);
+  });
+
+  it("target_entity_id alone returns the live in-edges", async () => {
+    const out = await listRelationships({ target_entity_id: targetId });
+    expect(out.relationships).toHaveLength(1);
+    expect(out.relationships[0]!.target_entity_id).toBe(targetId);
+  });
+
+  it("source_entity_id + target_entity_id resolves one edge (documented pre-delete type discovery)", async () => {
+    const out = await listRelationships({
+      source_entity_id: sourceId,
+      target_entity_id: targetId,
+    });
+    expect(out.relationships).toHaveLength(1);
+    expect(out.relationships[0]!.relationship_type).toBe(relType);
+  });
+
+  it("source_entity_id + relationship_type traverses typed out-edges", async () => {
+    const out = await listRelationships({
+      source_entity_id: sourceId,
+      relationship_type: relType,
+    });
+    expect(out.relationships).toHaveLength(2);
+
+    const none = await listRelationships({
+      source_entity_id: sourceId,
+      relationship_type: "REFERS_TO",
+    });
+    expect(none.relationships).toHaveLength(0);
+  });
+
+  it("does not leak edges belonging to another user", async () => {
+    (server as any).authenticatedUserId = randomUUID();
+    try {
+      const out = await listRelationships({ source_entity_id: sourceId });
+      expect(out.relationships).toHaveLength(0);
+    } finally {
+      (server as any).authenticatedUserId = userId;
+    }
+  });
+});


### PR DESCRIPTION
Fixes #2205. Also fixes #1973.

## Root cause

`ListRelationshipsRequestSchema` accepts `source_entity_id` and `target_entity_id`, and its `.refine()` explicitly permits a call carrying only those. HTTP `POST /list_relationships` branches on both (`src/actions.ts`). The MCP handler did not — it queried `parsed.entity_id` alone:

```ts
.eq("source_entity_id", parsed.entity_id)   // undefined when only source_entity_id was passed
```

So a call filtered solely by `source_entity_id` ran `.eq("source_entity_id", undefined)` and matched nothing. The write path and the read path disagreed: `create_relationship` reported `is_live: 1` for an edge that `list_relationships` then said did not exist.

Two documented flows were broken outright:

- **Pre-delete type discovery.** The tool description tells callers to pass both endpoint ids to learn an edge's type before `delete_relationship`. That call returned empty for a live edge.
- **Typed out-edge traversal.** `source_entity_id` + `relationship_type` — "all `works_at` out of node N" — returned empty.

## Why this took five reports to fix

Filed as #2205, #1973, #2156, #369, and #277 over several months. Every symptom is a **silent empty result, never an error**, and a working fallback was always one call away: `entity_id` + `direction`, `GET /entities/<id>/relationships`, or `retrieve_graph_neighborhood`. Each reporter routed around it and kept moving, so the workaround propagated as institutional knowledge while the defect stayed put.

An empty list is indistinguishable from "no edges" without a second, differently-shaped call to contradict it — which is precisely why this survived five reports and why the fix ships with a legacy-path baseline test asserting the two views agree.

## The fix

Endpoint filters take precedence over the legacy `entity_id` + `direction` pattern, matching the HTTP handler's resolution order. The ordering and pagination tail is extracted into `finalizeRelationshipList` so the two paths cannot drift apart again.

## Tests

`tests/integration/mcp_list_relationships_source_target_filters.test.ts` — **4 of 6 fail on origin/main**, all 6 pass here:

- legacy `entity_id` + `direction` baseline (passes on main — proves the edges exist and the test harness is sound)
- `source_entity_id` alone, `target_entity_id` alone
- `source_entity_id` + `target_entity_id` (pre-delete discovery)
- `source_entity_id` + `relationship_type`, with a negative case
- tenant isolation: the new query path stays scoped to the authenticated user

## Downstream

Agent code carrying the `GET /entities/<id>/relationships` / `retrieve_graph_neighborhood` workaround can move back to `list_relationships` once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
