### PR TITLE
fix(proxy): reject downstream responses that do not correlate to the request

### DIFF
--- a/src/proxy/mcp_stdio_proxy.test.ts
+++ b/src/proxy/mcp_stdio_proxy.test.ts
@@ -4,6 +4,7 @@ import {
   backoffMs,
   createLoopState,
   dispatchCore,
+  isJsonRpcResponse,
   isRecoverableMcpSessionLostError,
   withTimeout,
   type DispatchDeps,
@@ -303,5 +304,179 @@ describe("dispatchCore", () => {
     expect(calls).toBe(1); // no retry/replay for initialize itself
     expect(emitted).toHaveLength(1);
     expect((emitted[0] as { error?: unknown }).error).toBeDefined();
+  });
+});
+
+/**
+ * Regression coverage for neotoma#2272 — a `store` call receiving another
+ * caller's response payload.
+ *
+ * The proxy forwarded whatever JSON-RPC envelope came back from downstream
+ * without ever checking that its `id` matched the request's. A response
+ * belonging to a different in-flight call therefore reached the client as the
+ * answer to this one — and an agent that stores the returned `entity_id` would
+ * attach subsequent work to the wrong parent.
+ */
+describe("dispatchCore response/request correlation (neotoma#2272)", () => {
+  it("never emits a response whose JSON-RPC id differs from the request's", async () => {
+    const loop = createLoopState();
+    loop.session.sessionId = "sess-1";
+    loop.lastInitializeBody = JSON.stringify({ jsonrpc: "2.0", id: 0, method: "initialize" });
+
+    // Downstream returns a well-formed JSON-RPC response that belongs to a
+    // DIFFERENT in-flight request (id 41) than the one being dispatched (42) —
+    // exactly the mis-routed payload observed in #2272.
+    const { deps, emitted } = makeDeps(
+      scriptedSend([
+        () =>
+          jsonResponse({
+            jsonrpc: "2.0",
+            id: 41,
+            result: {
+              content: [{ type: "text", text: '{"entity_id":"ent_other_callers_write"}' }],
+            },
+          }),
+      ])
+    );
+
+    await dispatchCore(deps, loop, baseConfig, {
+      jsonrpc: "2.0",
+      id: 42,
+      method: "tools/call",
+      params: { name: "store", arguments: { entities: [{ entity_type: "project" }] } },
+    });
+
+    expect(emitted).toHaveLength(1);
+    const payload = emitted[0] as { id?: unknown; error?: { message?: string } };
+
+    // A response for id 41 must never be delivered as the answer to id 42, and
+    // the caller must never see the other write's entity id.
+    expect(payload.id).toBe(42);
+    expect(JSON.stringify(payload)).not.toContain("ent_other_callers_write");
+    expect(payload.error).toBeDefined();
+  });
+
+  it("passes through a correctly correlated response untouched", async () => {
+    const loop = createLoopState();
+    loop.session.sessionId = "sess-1";
+
+    const { deps, emitted } = makeDeps(
+      scriptedSend([
+        () =>
+          jsonResponse({
+            jsonrpc: "2.0",
+            id: 42,
+            result: { content: [{ type: "text", text: '{"entity_id":"ent_mine"}' }] },
+          }),
+      ])
+    );
+
+    await dispatchCore(deps, loop, baseConfig, {
+      jsonrpc: "2.0",
+      id: 42,
+      method: "tools/call",
+      params: { name: "store", arguments: {} },
+    });
+
+    expect(emitted).toHaveLength(1);
+    expect(JSON.stringify(emitted[0])).toContain("ent_mine");
+  });
+
+  it("forwards server-initiated messages that carry no id (notifications/requests)", async () => {
+    const loop = createLoopState();
+    loop.session.sessionId = "sess-1";
+
+    // A notification has no id of its own and must not be judged against the
+    // request's id — dropping these would break server-initiated traffic.
+    const { deps, emitted } = makeDeps(
+      scriptedSend([
+        () => jsonResponse({ jsonrpc: "2.0", method: "notifications/message", params: {} }),
+      ])
+    );
+
+    await dispatchCore(deps, loop, baseConfig, {
+      jsonrpc: "2.0",
+      id: 7,
+      method: "tools/call",
+      params: { name: "store", arguments: {} },
+    });
+
+    // The notification is forwarded verbatim — it carries no id and is not a
+    // response, so it is never judged against the request's id.
+    expect((emitted[0] as { method?: string }).method).toBe("notifications/message");
+
+    // It is also not an answer to the pending call, so the request is still
+    // owed a response rather than left hanging.
+    const answer = emitted.find((m) => isJsonRpcResponse(m)) as { id?: unknown } | undefined;
+    expect(answer?.id).toBe(7);
+  });
+
+  it("forwards a batched response array only when every id matches", async () => {
+    const loop = createLoopState();
+    loop.session.sessionId = "sess-1";
+
+    const { deps, emitted } = makeDeps(
+      scriptedSend([() => jsonResponse([{ jsonrpc: "2.0", id: 99, result: { ok: true } }])])
+    );
+
+    await dispatchCore(deps, loop, baseConfig, {
+      jsonrpc: "2.0",
+      id: 5,
+      method: "tools/call",
+      params: { name: "store", arguments: {} },
+    });
+
+    expect(emitted).toHaveLength(1);
+    const payload = emitted[0] as { id?: unknown; error?: unknown };
+    expect(payload.id).toBe(5);
+    expect(payload.error).toBeDefined();
+  });
+
+  it("does not emit a late response from a request it already abandoned to a timeout", async () => {
+    const loop = createLoopState();
+    loop.session.sessionId = "sess-1";
+    loop.lastInitializeBody = JSON.stringify({ jsonrpc: "2.0", id: 0, method: "initialize" });
+
+    let releaseSlowCall: (r: Response) => void = () => {};
+    let callCount = 0;
+
+    const { deps, emitted } = makeDeps(
+      async () => {
+        callCount += 1;
+        if (callCount === 1) {
+          // First attempt hangs past the deadline, then completes AFTER the
+          // proxy has given up and retried.
+          return await new Promise<Response>((resolve) => {
+            releaseSlowCall = resolve;
+          });
+        }
+        return jsonResponse({
+          jsonrpc: "2.0",
+          id: 42,
+          result: { content: [{ type: "text", text: '{"entity_id":"ent_retry"}' }] },
+        });
+      },
+      { timeoutMs: 10, maxAttempts: 2 }
+    );
+
+    await dispatchCore(deps, loop, baseConfig, {
+      jsonrpc: "2.0",
+      id: 42,
+      method: "tools/call",
+      params: { name: "store", arguments: { entities: [{ entity_type: "project" }] } },
+    });
+
+    // The abandoned first attempt now settles. Its body must not reach stdout.
+    releaseSlowCall(
+      jsonResponse({
+        jsonrpc: "2.0",
+        id: 42,
+        result: { content: [{ type: "text", text: '{"entity_id":"ent_first_attempt"}' }] },
+      })
+    );
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(emitted).toHaveLength(1);
+    expect(JSON.stringify(emitted[0])).not.toContain("ent_first_attempt");
   });
 });

--- a/src/proxy/mcp_stdio_proxy.ts
+++ b/src/proxy/mcp_stdio_proxy.ts
@@ -222,18 +222,76 @@ function emitErrorResponse(
   });
 }
 
-async function forwardJsonResponse(response: Response, emit: EmitFn = emitJson): Promise<void> {
+/**
+ * True when `payload` is a JSON-RPC *response* (it carries `result` or
+ * `error`). Server-initiated requests and notifications are not responses and
+ * are never correlated against the pending request's id.
+ */
+export function isJsonRpcResponse(payload: unknown): payload is { id?: unknown } {
+  if (typeof payload !== "object" || payload === null || Array.isArray(payload)) return false;
+  const rec = payload as Record<string, unknown>;
+  return "result" in rec || "error" in rec;
+}
+
+/**
+ * Guard against neotoma#2272: a response describing a DIFFERENT caller's write.
+ *
+ * The proxy used to forward whatever envelope downstream returned, so a payload
+ * belonging to another in-flight call could be delivered as the answer to this
+ * one. That is strictly worse than a failed write: the entire discipline for an
+ * append-only store under load is "don't trust a success code, re-read the
+ * entity", and that assumes the response at least says WHICH write it
+ * describes. An agent that stores the returned `entity_id` would attach
+ * subsequent work to the wrong parent, and no idempotency key can detect it —
+ * the mismatch is downstream of the write.
+ *
+ * A response whose id does not match the request is therefore dropped and
+ * replaced with an explicit error, so the caller retries or verifies rather
+ * than silently adopting another caller's entity id. Notifications and
+ * server-initiated requests (no id, no result/error) pass through untouched.
+ *
+ * Returns the payload to emit, or null to drop it.
+ */
+export function correlateResponse(payload: unknown, requestId: unknown): unknown | null {
+  // A batch is forwarded only when every response in it matches.
+  if (Array.isArray(payload)) {
+    const mismatch = payload.some((el) => isJsonRpcResponse(el) && el.id !== requestId);
+    return mismatch ? null : payload;
+  }
+  if (!isJsonRpcResponse(payload)) return payload;
+  // A response with a null id is the spec's shape for "could not determine the
+  // request" (e.g. a parse error), so it is passed through as this call's error.
+  if (payload.id === null || payload.id === undefined) return payload;
+  return payload.id === requestId ? payload : null;
+}
+
+async function forwardJsonResponse(
+  response: Response,
+  emit: EmitFn = emitJson,
+  requestId?: unknown
+): Promise<void> {
   const body = await response.text();
   if (!body) return;
   try {
     const payload = JSON.parse(body);
-    emit(payload);
+    const correlated = correlateResponse(payload, requestId);
+    if (correlated === null) {
+      log(
+        `Dropped mis-correlated downstream response (neotoma#2272): expected id=${JSON.stringify(requestId)}`
+      );
+      return;
+    }
+    emit(correlated);
   } catch (err) {
     log(`Failed to decode JSON response: ${String(err)}`);
   }
 }
 
-async function forwardSseResponse(response: Response, emit: EmitFn = emitJson): Promise<void> {
+async function forwardSseResponse(
+  response: Response,
+  emit: EmitFn = emitJson,
+  requestId?: unknown
+): Promise<void> {
   const reader = response.body?.getReader();
   if (!reader) return;
   const decoder = new TextDecoder();
@@ -263,7 +321,14 @@ async function forwardSseResponse(response: Response, emit: EmitFn = emitJson): 
           if (currentEvent !== "message") continue;
           try {
             const payload = JSON.parse(data);
-            emit(payload);
+            const correlated = correlateResponse(payload, requestId);
+            if (correlated === null) {
+              log(
+                `Dropped mis-correlated downstream SSE response (neotoma#2272): expected id=${JSON.stringify(requestId)}`
+              );
+              continue;
+            }
+            emit(correlated);
           } catch {
             log(`SSE data frame is not JSON: ${data.slice(0, 200)}`);
           }
@@ -275,13 +340,32 @@ async function forwardSseResponse(response: Response, emit: EmitFn = emitJson): 
   }
 }
 
-async function forwardResponse(response: Response, emit: EmitFn): Promise<void> {
+/**
+ * Forward a downstream response to stdout, dropping any envelope that does not
+ * correlate to `requestId` (neotoma#2272).
+ *
+ * Returns true when a response for `requestId` was emitted. A false return
+ * means every response frame was mis-correlated and dropped, so the caller is
+ * still owed an answer — `dispatchCore` turns that into an explicit error
+ * rather than leaving the client waiting forever.
+ */
+async function forwardResponse(
+  response: Response,
+  emit: EmitFn,
+  requestId?: unknown
+): Promise<boolean> {
+  let answered = requestId === undefined;
+  const trackingEmit: EmitFn = (payload) => {
+    if (isJsonRpcResponse(payload) || Array.isArray(payload)) answered = true;
+    emit(payload);
+  };
   const contentType = response.headers.get("content-type") ?? "";
   if (contentType.includes("text/event-stream")) {
-    await forwardSseResponse(response, emit);
+    await forwardSseResponse(response, trackingEmit, requestId);
   } else {
-    await forwardJsonResponse(response, emit);
+    await forwardJsonResponse(response, trackingEmit, requestId);
   }
+  return answered;
 }
 
 /** Default per-request downstream timeout (ms) — below typical harness MCP timeouts so a hang retries rather than surfacing as "unavailable". */
@@ -413,7 +497,18 @@ export async function dispatchCore(
       loopState.session.capture(resp.headers);
 
       if (resp.status < 400) {
-        await forwardResponse(resp, deps.emit);
+        const answered = await forwardResponse(resp, deps.emit, message.id);
+        if (!answered) {
+          // Every frame downstream sent belonged to a different request
+          // (neotoma#2272). The caller must never adopt another write's
+          // payload, and must not be left hanging either.
+          emitErrorResponse(
+            message,
+            502,
+            "downstream response did not correlate to this request (neotoma#2272); it was dropped rather than delivered as your result — re-read the entity to confirm whether the write landed",
+            deps.emit
+          );
+        }
         return;
       }
 


### PR DESCRIPTION
Fixes #2272.

## Root cause

The stdio proxy forwarded whatever JSON-RPC envelope downstream returned **without ever checking that its `id` matched the request in flight**. Both emit paths did this: `forwardJsonResponse`, and each SSE `data:` frame in `forwardSseResponse`.

```ts
const payload = JSON.parse(body);
emit(payload);              // no correlation check
```

A response belonging to a different call therefore reached the client as the answer to this one — the reported symptom, where a `store` creating a project received a `correct` result for an unrelated `task` entity being written concurrently. Both writes landed; only the response was mis-routed.

## Why this is worse than a failed write

The discipline for an append-only store under load is *don't trust a success code, re-read the entity*. That assumes the response at least tells you **which** write it describes. An agent that stores the returned `entity_id` and links subsequent work to it would attach that work to the **wrong parent**, and no idempotency key can catch it — the mismatch is downstream of the write. A confidently wrong success payload fails in the one direction that does not prompt verification.

## The fix

A mis-correlated response is dropped and replaced with an explicit error naming the defect, so the caller re-reads instead of silently adopting another caller's entity id.

Deliberately narrow, to avoid breaking traffic that legitimately carries no matching id:

- notifications and server-initiated requests (no `result`/`error`) pass through untouched;
- a **null-id** response — the spec's shape for "could not determine the request" — is still delivered as this call's error;
- a **batch** is forwarded only when every response in it matches.

When every frame is dropped the request is still answered, so the guard itself can never leave a client hanging.

## Tests

**3 of the 5 new tests fail against the pristine origin/main implementation and pass here. The other 2 are controls that pass on both** — so the suite is not vacuously green (cf. ateles#602, a suite 31/31 green over a feature that had never worked).

| test | on main |
|---|---|
| never emits a response whose id differs from the request's | ❌ fails |
| forwards server-initiated messages carrying no id | ❌ fails |
| forwards a batched array only when every id matches | ❌ fails |
| passes through a correctly correlated response untouched | ✅ control |
| does not emit a late response from an abandoned timeout | ✅ control |

That last control is worth calling out: I expected `withTimeout`'s abandoned-fetch path ("a late success is harmless") to be a second leak, and **it is not** — the abandoned response never reaches stdout. The mis-routing is purely the missing correlation check.

## Scope

This is the **proxy half**. It stops a mis-routed payload from being delivered as your result; it does not address whatever upstream condition produces one. Worth pursuing separately — see the correlation question raised against #2217.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
