### PR TITLE
fix(db): default servers to the non-blocking DB backend (#2280)

### DIFF
--- a/docs/operations/configuration.md
+++ b/docs/operations/configuration.md
@@ -29,22 +29,46 @@ Resolution order for the data directory and variables: a project-local `.env`, t
 | `NEOTOMA_ENV` | `development` or `production` | `development` |
 | `NEOTOMA_DATA_DIR` | Root data directory | local `data/` |
 | `NEOTOMA_SQLITE_PATH` | Explicit database file path | `{dataDir}/neotoma.db` (dev) |
-| `NEOTOMA_DB_BACKEND` | DB driver: `sqlite` (synchronous, zero-config) or `libsql` (concurrent — statements run off the event loop via worker-hosted driver for local files, or @libsql/client for remote sqld/Turso, so slow queries can't freeze the server; recommended for hosted/agent-heavy/shared instances) | `sqlite` |
+| `NEOTOMA_DB_BACKEND` | DB driver: `sqlite` (synchronous, zero-config) or `libsql` (concurrent — statements run off the event loop via worker-hosted driver for local files, or @libsql/client for remote sqld/Turso, so slow queries can't freeze the server) | `libsql` for servers, `sqlite` for CLI |
 | `NEOTOMA_DB_URL` | libsql connection URL (`file:` for embedded local, `http(s)://`/`libsql://` for remote sqld/Turso) | `file:{NEOTOMA_SQLITE_PATH}` |
 | `NEOTOMA_DB_AUTH_TOKEN` | Auth token for remote libsql connections | unset |
 | `NEOTOMA_DB_READER_WORKERS` | Read-only worker connections for the local `libsql` backend (WAL lets them run concurrently with the writer) | `2` |
+| `NEOTOMA_DB_MAX_QUEUED_STATEMENTS` | Max statements queued per worker connection before new ones are rejected with `WorkerDbOverloadError`; bounds memory under saturation. `0` disables the bound (not recommended for servers) | `512` |
 | `NEOTOMA_RAW_STORAGE_DIR` | Content-addressed source files | `{dataDir}/sources` |
 | `NEOTOMA_LOGS_DIR` / `NEOTOMA_EVENT_LOG_PATH` | Log directory and event log file | under `{dataDir}/logs` |
 | `NEOTOMA_HOST_URL` / `NEOTOMA_PUBLIC_BASE_URL` | Public URL of this instance | auto-discovered or unset |
 
-### When to opt into `NEOTOMA_DB_BACKEND=libsql`
+### How the backend is chosen
 
-Stay on the default `sqlite` backend until you have a concrete reason to switch. Switch to `libsql` when **either** of these is true:
+`NEOTOMA_DB_BACKEND` wins whenever it is set. When it is unset, the default depends on what kind of process is running:
 
-- You operate a **hosted, multi-user, or agent-heavy instance** where a single slow query (e.g. a deep-offset paginated query) has been observed to block health checks or other callers — this was the production symptom that motivated the concurrent backend (see `docs/infrastructure/deployment.md` § SQLite concurrency and the multi-writer model).
-- You are moving a database file to a **remote sqld/Turso URL** (`NEOTOMA_DB_URL=libsql://...` or `http(s)://...`), which requires the `libsql` backend regardless of load.
+| Process | Default | Why |
+| --- | --- | --- |
+| **Server** (`dist/actions.js`, MCP stdio server) | `libsql` | Many callers share one event loop. Under the synchronous driver a single slow query blocks *every* concurrent request for its full duration — including `GET /health`, which touches no database. |
+| **CLI** (`neotoma …`, scripts) | `sqlite` | One-shot process, nothing else waiting on the loop. Spawning worker threads would be pure overhead. |
 
-Before flipping the variable on an existing database, run `npx tsx scripts/validate_libsql_migration.ts <path-to-db>` — it proves the file adopts safely under libsql (integrity check, per-table row-count parity, snapshot hydration spot check) without mutating the original file.
+A process declares itself a server by importing `src/process_role.js`; see the note in that file. The role is deliberately **not** read from the environment — an inherited or `.env`-sourced value would flip the backend for every CLI invocation and every test worker.
+
+This default changed in response to neotoma#2280. The worker-hosted backend had existed since #1944, but it was opt-in via an env var that no Dockerfile, fly config, or start script set — so every server deployment silently kept the blocking driver. A hosted instance served the DB-free `/health` endpoint in 9.4s measured from inside its own VM, with 6GB free and ~42% idle CPU. An opt-in fix that nothing opts into is not a fix.
+
+Measured on the same slow query (a self-join over 6k rows), sync backend vs worker pool:
+
+| Backend | Slow query | Max event-loop lag | Concurrent health check |
+| --- | --- | --- | --- |
+| `sqlite` (synchronous) | 1100ms | **1091ms** | blocked until the slow query finished |
+| `libsql` (worker pool) | 1112ms | **2ms** | answered in 15ms, before the slow query |
+
+The slow query itself is no faster — SQLite does the same work. What changes is that it no longer holds the event loop while doing it.
+
+### Overriding the default
+
+Set `NEOTOMA_DB_BACKEND=sqlite` on a server to force the synchronous driver (e.g. to isolate a suspected backend-specific bug). Set `NEOTOMA_DB_BACKEND=libsql` on a CLI process when pointing it at a **remote sqld/Turso URL** (`NEOTOMA_DB_URL=libsql://...` or `http(s)://...`), which requires the `libsql` backend regardless of load.
+
+Before adopting an existing database file under libsql, run `npx tsx scripts/validate_libsql_migration.ts <path-to-db>` — it proves the file adopts safely (integrity check, per-table row-count parity, snapshot hydration spot check) without mutating the original file.
+
+### Backpressure
+
+Moving statements off the event loop does not make the database faster. If arrivals outpace what SQLite can retire, the backlog has to go somewhere — and unbounded, it grows the heap until the process OOMs, which is worse than being slow because it loses every queued request instead of delaying them. Each worker connection therefore bounds its in-flight queue at `NEOTOMA_DB_MAX_QUEUED_STATEMENTS` (default 512) and rejects overflow with a retryable `WorkerDbOverloadError` naming the limit.
 
 ## Server and ports
 

--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,15 +61,15 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **587**
-- Backend and repo Vitest files: **552**
+- Total automated test files: **590**
+- Backend and repo Vitest files: **555**
 - Frontend Vitest files: **9**
 - Playwright spec files: **26**
 
 ### Suite counts
 | Suite | Files |
 |---|---:|
-| Vitest unit tests | 163 |
+| Vitest unit tests | 166 |
 | Vitest service tests | 43 |
 | Source-adjacent tests | 66 |
 | Vitest integration tests | 166 |
@@ -109,7 +109,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/unit`
 **Requirements:** Basic `.env` if required by the module under test.
-**Files (163):**
+**Files (166):**
 - `tests/unit/aauth_admission.test.ts`
 - `tests/unit/aauth_attestation_apple_se.test.ts`
 - `tests/unit/aauth_attestation_revocation.test.ts`
@@ -158,12 +158,15 @@ flowchart TD
 - `tests/unit/cursor_hooks_context.test.ts`
 - `tests/unit/cursor_hooks_external_data.test.ts`
 - `tests/unit/cursor_hooks_small_model.test.ts`
+- `tests/unit/db_backend_server_default.test.ts`
 - `tests/unit/db_driver_contract.test.ts`
 - `tests/unit/db_idempotency_concurrency.test.ts`
 - `tests/unit/db_libsql_nonblocking.test.ts`
 - `tests/unit/db_libsql_remote_class.test.ts`
 - `tests/unit/db_url_misconfig_guard.test.ts`
+- `tests/unit/db_worker_backpressure.test.ts`
 - `tests/unit/db_worker_file_database.test.ts`
+- `tests/unit/db_worker_transaction_integrity.test.ts`
 - `tests/unit/docs_sidebar_nav.test.ts`
 - `tests/unit/docs/index_builder_deprecation.test.ts`
 - `tests/unit/drift_comparison.test.ts`

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1,3 +1,7 @@
+// MUST be first: declares this process a long-lived server so config.ts picks
+// the non-blocking DB backend. Imports are evaluated in source order, so any
+// import above this one that reaches config.js would lock in the CLI default.
+import "./process_role.js";
 import express from "express";
 import cookieParser from "cookie-parser";
 import cors from "cors";

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,5 @@
 import dotenv from "dotenv";
+import { isServerProcess } from "./process_role_state.js";
 import { fileURLToPath } from "url";
 import { dirname, join } from "path";
 import { existsSync, readFileSync } from "fs";
@@ -154,31 +155,80 @@ function discoverTunnelUrl(httpPort: number, allowAutoDiscovery: boolean): strin
 }
 
 /**
- * DB backend selection (concurrent-backend plan). `sqlite` (default) keeps the
- * zero-config synchronous better-sqlite3/node:sqlite path. `libsql` opts into
- * the concurrent backend — statements run off the Node event loop, so slow
- * queries cannot freeze the whole server. For local `file:` URLs that is
- * delivered by worker threads hosting the synchronous libSQL driver (a writer
- * plus a read-only reader pool under WAL — every local Node binding is
+ * DB backend selection (concurrent-backend plan), and which backend a process
+ * gets when NEOTOMA_DB_BACKEND is unset.
+ *
+ * `sqlite` keeps the zero-config synchronous better-sqlite3/node:sqlite path.
+ * `libsql` opts into the concurrent backend: statements run off the Node event
+ * loop, so slow queries cannot freeze the whole server. For local `file:` URLs
+ * that is delivered by worker threads hosting the synchronous libSQL driver (a
+ * writer plus a read-only reader pool under WAL — every local Node binding is
  * synchronous on the calling thread, so "async" local libSQL alone would not
  * fix blocking); remote URLs (sqld/Turso) use the genuinely-async
- * @libsql/client. The trigger for opting in is genuine multi-writer/hosted
- * contention (agent-heavy or shared instances), not data size. Same file
- * format and SQL dialect; a `file:` URL derived from sqlitePath is used
- * unless NEOTOMA_DB_URL points at a remote instance.
+ * @libsql/client. Same file format and SQL dialect; a `file:` URL derived from
+ * sqlitePath is used unless NEOTOMA_DB_URL points at a remote instance.
+ *
+ * The `sqlite` backend executes every statement synchronously on the calling
+ * thread. In a one-shot CLI process that is the right trade: no worker spawn,
+ * no extra file handles, and nothing else is waiting on the event loop anyway.
+ *
+ * In a long-lived HTTP server it is a defect. Every request shares one event
+ * loop, so a single slow query freezes *every* concurrent caller for its full
+ * duration — including `GET /health`, which touches no database at all. That
+ * is neotoma#2280: a hosted instance served the DB-free health endpoint in
+ * 9.4s measured from inside its own VM, with 6GB free and ~42% idle CPU.
+ *
+ * The worker-hosted backend that fixes this landed in #1944 and has been
+ * available ever since — but nothing ever selected it. It was opt-in via an
+ * env var that no Dockerfile, fly config, or start script sets, so every
+ * server deployment silently kept the blocking driver. An opt-in fix that no
+ * deployment opts into is not a fix, so servers now default to `libsql`.
+ *
+ * `NEOTOMA_DB_BACKEND` still wins when set explicitly, in either direction.
+ * A process declares itself a server by importing `./process_role.js` (see
+ * src/actions.ts); everything else is treated as CLI.
  */
-const dbBackend = (process.env.NEOTOMA_DB_BACKEND || "sqlite").toLowerCase();
-if (dbBackend !== "sqlite" && dbBackend !== "libsql") {
+export function defaultDbBackend(isServer: boolean): "sqlite" | "libsql" {
+  return isServer ? "libsql" : "sqlite";
+}
+
+/**
+ * Validate an explicit NEOTOMA_DB_BACKEND at module load, as before — a bad
+ * value is a startup error, not a lazy surprise at first query.
+ */
+const explicitDbBackend = (process.env.NEOTOMA_DB_BACKEND || "").toLowerCase();
+if (explicitDbBackend && explicitDbBackend !== "sqlite" && explicitDbBackend !== "libsql") {
   throw new Error(
     `Invalid NEOTOMA_DB_BACKEND "${process.env.NEOTOMA_DB_BACKEND}": expected "sqlite" or "libsql"`
   );
+}
+
+/**
+ * Resolve the backend for this process. Read lazily (see the `dbBackend` getter
+ * on `config`) rather than captured at module load, so an entrypoint that
+ * imports config transitively before declaring itself a server still gets the
+ * server default. Both call sites live in openDb(), which runs at first DB use
+ * — long after entrypoint imports settle.
+ */
+function resolveDbBackend(): "sqlite" | "libsql" {
+  if (explicitDbBackend === "sqlite" || explicitDbBackend === "libsql") {
+    return explicitDbBackend;
+  }
+  return defaultDbBackend(isServerProcess());
 }
 
 export const config = {
   projectRoot,
   storageBackend,
   dataDir,
-  dbBackend: dbBackend as "sqlite" | "libsql",
+  /**
+   * DB driver for this process. A getter, not a captured value — see
+   * resolveDbBackend(). NEOTOMA_DB_BACKEND wins when set; otherwise servers
+   * get the non-blocking backend and CLI processes the synchronous one.
+   */
+  get dbBackend(): "sqlite" | "libsql" {
+    return resolveDbBackend();
+  },
   /** Connection URL for non-file backends (e.g. libsql://…, http(s)://… for sqld/Turso). */
   dbUrl: process.env.NEOTOMA_DB_URL || "",
   /** Auth token for remote libSQL (sqld/Turso) connections. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,10 @@
 // Disable HTTP server autostart for MCP mode
 process.env.NEOTOMA_ACTIONS_DISABLE_AUTOSTART = "1";
 
+// Long-lived MCP stdio server: same event-loop exposure as the HTTP server, so
+// it takes the non-blocking DB backend too. Must precede any import reaching
+// config.js (see src/process_role.ts).
+import "./process_role.js";
 import { initDatabase } from "./db.js";
 import { NeotomaServer } from "./server.js";
 import { initServerKeys } from "./services/encryption_service.js";

--- a/src/process_role.ts
+++ b/src/process_role.ts
@@ -1,0 +1,29 @@
+/**
+ * Side-effect import that declares this process a long-lived server, so
+ * `src/config.ts` picks a DB backend appropriate to it:
+ *
+ *     import "./process_role.js";
+ *
+ * Servers get the worker-hosted backend (statements off the event loop);
+ * one-shot CLI processes keep the synchronous driver, where the worker spawn
+ * would be pure overhead. See `defaultDbBackend()` in src/config.ts.
+ *
+ * Ordering is NOT load-bearing: config resolves the backend lazily, at first
+ * DB use, so importing this after config still takes effect. Entrypoints
+ * nonetheless import it first, so the declaration is visible at the top of the
+ * file rather than buried.
+ *
+ * Why an entrypoint import rather than an env var in the Dockerfile or fly
+ * config: the same server code runs from `npm run start:server`, the Docker
+ * CMD, launchd, and the dev watcher. Marking the entrypoint covers all of them
+ * at once and cannot drift the way a value duplicated across five deployment
+ * files does. neotoma#2280 is precisely that drift — the non-blocking backend
+ * existed for a month behind an env var that no deployment ever set.
+ *
+ * The flag itself lives in process_role_state.ts (see the note there on why it
+ * is not an env var).
+ */
+
+import { markServerProcess } from "./process_role_state.js";
+
+markServerProcess();

--- a/src/process_role_state.ts
+++ b/src/process_role_state.ts
@@ -1,0 +1,30 @@
+/**
+ * Process-role state, split from `process_role.ts` so that module can stay a
+ * pure side-effect import (`import "./process_role.js"`) while `config.ts`
+ * reads the flag without triggering that side effect.
+ *
+ * Why a module-scoped flag rather than an env var: env vars are inherited by
+ * child processes and leak in from the shell and .env files, so an ambient
+ * `NEOTOMA_PROCESS_ROLE=server` would silently flip the DB backend for every
+ * CLI invocation and every test worker. That is not hypothetical — the value
+ * was already present in this repo's environment and changed the default under
+ * vitest during development of neotoma#2280. A module flag is process-local and
+ * set only by an entrypoint that actually imports `process_role.js`.
+ */
+
+let serverProcess = false;
+
+/** Called by long-lived server entrypoints. */
+export function markServerProcess(): void {
+  serverProcess = true;
+}
+
+/** True once a server entrypoint has declared itself. */
+export function isServerProcess(): boolean {
+  return serverProcess;
+}
+
+/** Test-only: restore the default (CLI) role. */
+export function resetProcessRoleForTests(): void {
+  serverProcess = false;
+}

--- a/src/repositories/worker/worker_file_database.ts
+++ b/src/repositories/worker/worker_file_database.ts
@@ -161,6 +161,46 @@ export class WorkerDbCrashError extends Error {
   }
 }
 
+/**
+ * Thrown when a worker's in-flight queue is full. Moving statements off the
+ * event loop stops a slow query from freezing the process, but it does not make
+ * the database faster: if arrivals outpace what SQLite can retire, the backlog
+ * has to go somewhere. Unbounded, it goes into heap — the stall is traded for
+ * unbounded memory growth and an eventual OOM, which is strictly worse than
+ * being slow because it takes the process down and loses every queued request
+ * rather than just delaying them.
+ *
+ * So the queue is bounded and overflow is rejected fast. A caller gets a clear,
+ * retryable error naming the limit and the env var that raises it, while
+ * requests already accepted still complete. Shedding load at a known boundary
+ * is a decision; growing the heap until the kernel decides is not.
+ */
+export class WorkerDbOverloadError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "WorkerDbOverloadError";
+  }
+}
+
+/**
+ * Maximum statements queued to a single worker before new ones are rejected.
+ * Per-connection, so the writer and each reader carry their own budget.
+ *
+ * 512 is chosen to sit far above any legitimate burst — a single request fans
+ * out to a few dozen statements at worst, so this absorbs a deep queue across
+ * many concurrent callers — while still bounding worst-case retained memory to
+ * something trivial next to the heap. Raise via NEOTOMA_DB_MAX_QUEUED_STATEMENTS
+ * if a workload genuinely needs a deeper queue; set 0 to disable the bound
+ * (restoring the pre-bound unbounded behavior, not recommended for servers).
+ */
+export const DEFAULT_MAX_QUEUED_STATEMENTS = 512;
+
+function resolveMaxQueued(): number {
+  const raw = Number.parseInt(process.env.NEOTOMA_DB_MAX_QUEUED_STATEMENTS || "", 10);
+  if (!Number.isFinite(raw) || raw < 0) return DEFAULT_MAX_QUEUED_STATEMENTS;
+  return raw;
+}
+
 class WorkerConnection {
   private worker: Worker | null = null;
   private nextId = 1;
@@ -169,6 +209,7 @@ class WorkerConnection {
     { resolve: (v: unknown) => void; reject: (e: Error) => void }
   >();
   private closed = false;
+  private readonly maxQueued = resolveMaxQueued();
 
   constructor(
     private readonly options: {
@@ -239,6 +280,19 @@ class WorkerConnection {
   ): Promise<unknown> {
     if (this.closed) {
       return Promise.reject(new WorkerDbCrashError("DB connection is closed"));
+    }
+    // Bound the backlog (see WorkerDbOverloadError). Checked before spawning or
+    // messaging the worker so an overloaded connection sheds load cheaply.
+    if (this.maxQueued > 0 && this.pending.size >= this.maxQueued) {
+      return Promise.reject(
+        new WorkerDbOverloadError(
+          `DB ${this.options.readonly ? "reader" : "writer"} queue is full ` +
+            `(${this.pending.size} statements in flight, limit ${this.maxQueued}). ` +
+            `The database is saturated; retry shortly. Raise the limit with ` +
+            `NEOTOMA_DB_MAX_QUEUED_STATEMENTS, or add reader workers with ` +
+            `NEOTOMA_DB_READER_WORKERS, if this is sustained rather than a burst.`
+        )
+      );
     }
     const worker = this.ensureWorker();
     const id = this.nextId++;

--- a/tests/unit/db_backend_server_default.test.ts
+++ b/tests/unit/db_backend_server_default.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Server processes must default to the non-blocking DB backend (neotoma#2280).
+ *
+ * The worker-hosted backend that keeps SQLite statements off the Node event
+ * loop landed in #1944, but it was opt-in via NEOTOMA_DB_BACKEND and no
+ * Dockerfile, fly config, or start script ever set it. So every server
+ * deployment silently kept the synchronous driver, where one slow query blocks
+ * every concurrent request — a hosted instance served the DB-free /health
+ * endpoint in 9.4s from inside its own VM.
+ *
+ * These tests pin the selection rule so the fix cannot silently regress to
+ * opt-in again: servers get `libsql`, one-shot CLI processes keep `sqlite`,
+ * and an explicit NEOTOMA_DB_BACKEND still wins in either direction.
+ */
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { defaultDbBackend } from "../../src/config.ts";
+
+async function makeProjectRoot(prefix: string): Promise<{ homeDir: string; projectRoot: string }> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  const homeDir = path.join(root, "home");
+  const projectRoot = path.join(root, "project");
+  await fs.mkdir(homeDir, { recursive: true });
+  await fs.mkdir(projectRoot, { recursive: true });
+  await fs.writeFile(
+    path.join(projectRoot, "package.json"),
+    JSON.stringify({ name: "neotoma", version: "0.0.0-test" }, null, 2)
+  );
+  return { homeDir, projectRoot };
+}
+
+async function stubBaseEnv(prefix: string) {
+  const { homeDir, projectRoot } = await makeProjectRoot(prefix);
+  vi.stubEnv("HOME", homeDir);
+  vi.stubEnv("USERPROFILE", homeDir);
+  vi.stubEnv("NEOTOMA_ENV", "development");
+  vi.stubEnv("NEOTOMA_PROJECT_ROOT", projectRoot);
+  vi.stubEnv("NEOTOMA_DATA_DIR", path.join(projectRoot, "data"));
+}
+
+/** Import config fresh, optionally declaring the process a server first. */
+async function importConfig({ asServer }: { asServer: boolean }) {
+  vi.resetModules();
+  const state = await import("../../src/process_role_state.ts");
+  state.resetProcessRoleForTests();
+  if (asServer) state.markServerProcess();
+  return import("../../src/config.ts");
+}
+
+describe("DB backend default by process role (#2280)", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it("selects the non-blocking backend for servers", () => {
+    expect(defaultDbBackend(true)).toBe("libsql");
+  });
+
+  it("keeps the synchronous backend for one-shot CLI processes", () => {
+    expect(defaultDbBackend(false)).toBe("sqlite");
+  });
+
+  it("a server process resolves to libsql when NEOTOMA_DB_BACKEND is unset", async () => {
+    await stubBaseEnv("neotoma-role-server-");
+    vi.stubEnv("NEOTOMA_DB_BACKEND", "");
+
+    const { config } = await importConfig({ asServer: true });
+    expect(config.dbBackend).toBe("libsql");
+  });
+
+  it("a CLI process resolves to sqlite when NEOTOMA_DB_BACKEND is unset", async () => {
+    await stubBaseEnv("neotoma-role-cli-");
+    vi.stubEnv("NEOTOMA_DB_BACKEND", "");
+
+    const { config } = await importConfig({ asServer: false });
+    expect(config.dbBackend).toBe("sqlite");
+  });
+
+  it("an explicit NEOTOMA_DB_BACKEND overrides the server default", async () => {
+    await stubBaseEnv("neotoma-role-explicit-sqlite-");
+    vi.stubEnv("NEOTOMA_DB_BACKEND", "sqlite");
+
+    const { config } = await importConfig({ asServer: true });
+    expect(config.dbBackend).toBe("sqlite");
+  });
+
+  it("an explicit NEOTOMA_DB_BACKEND overrides the CLI default", async () => {
+    await stubBaseEnv("neotoma-role-explicit-libsql-");
+    vi.stubEnv("NEOTOMA_DB_BACKEND", "libsql");
+
+    const { config } = await importConfig({ asServer: false });
+    expect(config.dbBackend).toBe("libsql");
+  });
+
+  it("importing process_role.js marks the process a server", async () => {
+    await stubBaseEnv("neotoma-role-import-");
+    vi.stubEnv("NEOTOMA_DB_BACKEND", "");
+
+    vi.resetModules();
+    const state = await import("../../src/process_role_state.ts");
+    state.resetProcessRoleForTests();
+    expect(state.isServerProcess()).toBe(false);
+
+    await import("../../src/process_role.ts");
+    expect(state.isServerProcess()).toBe(true);
+  });
+
+  /**
+   * The role must NOT be readable from the environment. An inherited or
+   * .env-sourced value would flip the backend for every CLI invocation and
+   * every test worker — which is exactly what an earlier env-var-based version
+   * of this fix did.
+   */
+  it("ignores an ambient NEOTOMA_PROCESS_ROLE env var", async () => {
+    await stubBaseEnv("neotoma-role-ambient-");
+    vi.stubEnv("NEOTOMA_DB_BACKEND", "");
+    vi.stubEnv("NEOTOMA_PROCESS_ROLE", "server");
+
+    const { config } = await importConfig({ asServer: false });
+    expect(config.dbBackend).toBe("sqlite");
+  });
+});

--- a/tests/unit/db_worker_backpressure.test.ts
+++ b/tests/unit/db_worker_backpressure.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Bounded worker queue (neotoma#2280 follow-through).
+ *
+ * Moving statements off the event loop stops a slow query from freezing the
+ * process, but it does not make the database faster. If arrivals outpace what
+ * SQLite can retire, the backlog has to go somewhere — and unbounded, it goes
+ * into the heap, trading an event-loop stall for unbounded memory growth and an
+ * eventual OOM. That is strictly worse than being slow: it takes the process
+ * down and loses every queued request rather than just delaying them.
+ *
+ * So the per-connection queue is bounded and overflow is rejected fast, with an
+ * error naming the limit and how to raise it. These tests pin both halves: a
+ * realistic burst is never shed, and genuine saturation sheds rather than grows.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_MAX_QUEUED_STATEMENTS,
+  WorkerFileDatabase,
+  WorkerDbOverloadError,
+} from "../../src/repositories/worker/worker_file_database.js";
+
+const workDir = mkdtempSync(path.join(tmpdir(), "neotoma-backpressure-"));
+
+afterAll(() => {
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+describe("worker queue backpressure", () => {
+  it("does not shed a realistic concurrent burst under the default limit", async () => {
+    const db = new WorkerFileDatabase(path.join(workDir, "burst.db"));
+    try {
+      await db.exec("CREATE TABLE t (v INTEGER)");
+      const results = await Promise.allSettled(
+        Array.from({ length: 300 }, () => db.prepare("SELECT 1 AS ok").get())
+      );
+      expect(results.filter((r) => r.status === "rejected")).toHaveLength(0);
+    } finally {
+      await db.close();
+    }
+  }, 60_000);
+
+  it("rejects overflow with an actionable error instead of growing the queue", async () => {
+    const previous = process.env.NEOTOMA_DB_MAX_QUEUED_STATEMENTS;
+    process.env.NEOTOMA_DB_MAX_QUEUED_STATEMENTS = "10";
+    const db = new WorkerFileDatabase(path.join(workDir, "overflow.db"));
+    try {
+      await db.exec("CREATE TABLE t (v INTEGER)");
+      const results = await Promise.allSettled(
+        Array.from({ length: 200 }, () => db.prepare("SELECT 1 AS ok").get())
+      );
+      const rejected = results.filter(
+        (r): r is PromiseRejectedResult => r.status === "rejected"
+      );
+
+      // Some are shed — the queue is bounded, not elastic.
+      expect(rejected.length).toBeGreaterThan(0);
+      // Accepted work still completes; shedding does not fail the whole batch.
+      expect(results.length - rejected.length).toBeGreaterThan(0);
+
+      const reason = rejected[0].reason as Error;
+      expect(reason).toBeInstanceOf(WorkerDbOverloadError);
+      // The message must tell an operator what to do about it.
+      expect(reason.message).toMatch(/queue is full/i);
+      expect(reason.message).toMatch(/NEOTOMA_DB_MAX_QUEUED_STATEMENTS/);
+    } finally {
+      await db.close();
+      if (previous === undefined) delete process.env.NEOTOMA_DB_MAX_QUEUED_STATEMENTS;
+      else process.env.NEOTOMA_DB_MAX_QUEUED_STATEMENTS = previous;
+    }
+  }, 60_000);
+
+  it("keeps a default bound well above any legitimate burst", () => {
+    expect(DEFAULT_MAX_QUEUED_STATEMENTS).toBeGreaterThanOrEqual(256);
+  });
+});

--- a/tests/unit/db_worker_transaction_integrity.test.ts
+++ b/tests/unit/db_worker_transaction_integrity.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Transaction integrity on the worker-hosted backend under concurrency
+ * (neotoma#2280).
+ *
+ * Making servers default to the worker pool is only safe if transactions stay
+ * atomic across it. A pool that handed successive statements of one transaction
+ * to different connections would break transactions *silently* — a correctness
+ * regression far worse than the latency it fixes, because slow is visible and
+ * wrong is not. This is a hot path: every session and daemon reads through it.
+ *
+ * The invariants pinned here:
+ *   - writes serialize (SQLite has one writer), so no lost updates;
+ *   - a transaction's statements all land on the writer connection, so
+ *     read-modify-write across an `await` is safe;
+ *   - a failed transaction rolls back completely;
+ *   - statements outside a transaction cannot resolve inside its window;
+ *   - statements inside a transaction see its own uncommitted writes.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+
+import { WorkerFileDatabase } from "../../src/repositories/worker/worker_file_database.js";
+
+const workDir = mkdtempSync(path.join(tmpdir(), "neotoma-tx-integrity-"));
+
+afterAll(() => {
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+describe("worker backend transaction integrity", () => {
+  it("serializes concurrent transactions with no lost updates", async () => {
+    const db = new WorkerFileDatabase(path.join(workDir, "transfers.db"));
+    try {
+      await db.exec("CREATE TABLE acct (id INTEGER PRIMARY KEY, bal INTEGER)");
+      await db.exec("INSERT INTO acct (id, bal) VALUES (1, 0), (2, 0)");
+
+      const TRANSFERS = 40;
+      await Promise.all(
+        Array.from({ length: TRANSFERS }, () =>
+          db.transaction(async (tx) => {
+            const row = (await tx.prepare("SELECT bal FROM acct WHERE id = 1").get()) as {
+              bal: number;
+            };
+            // Read-modify-write spanning an await: correct only if the
+            // transaction holds the writer exclusively for its whole body.
+            await new Promise((resolve) => setImmediate(resolve));
+            await tx.prepare("UPDATE acct SET bal = ? WHERE id = 1").run(row.bal + 1);
+            await tx.prepare("UPDATE acct SET bal = bal - 1 WHERE id = 2").run();
+          })
+        )
+      );
+
+      const a = (await db.prepare("SELECT bal FROM acct WHERE id = 1").get()) as { bal: number };
+      const b = (await db.prepare("SELECT bal FROM acct WHERE id = 2").get()) as { bal: number };
+      expect(a.bal).toBe(TRANSFERS);
+      // Double-entry invariant: every debit has its credit.
+      expect(a.bal + b.bal).toBe(0);
+    } finally {
+      await db.close();
+    }
+  }, 60_000);
+
+  it("rolls a failed transaction back completely", async () => {
+    const db = new WorkerFileDatabase(path.join(workDir, "rollback.db"));
+    try {
+      await db.exec("CREATE TABLE t (v INTEGER)");
+      await expect(
+        db.transaction(async (tx) => {
+          await tx.prepare("INSERT INTO t (v) VALUES (1)").run();
+          await tx.prepare("INSERT INTO t (v) VALUES (2)").run();
+          throw new Error("boom");
+        })
+      ).rejects.toThrow("boom");
+
+      const row = (await db.prepare("SELECT COUNT(*) AS n FROM t").get()) as { n: number };
+      expect(row.n).toBe(0);
+    } finally {
+      await db.close();
+    }
+  }, 60_000);
+
+  it("holds outside statements out of an open transaction's window", async () => {
+    const db = new WorkerFileDatabase(path.join(workDir, "isolation.db"));
+    try {
+      await db.exec("CREATE TABLE t (v INTEGER)");
+
+      let txOpen = true;
+      let resolvedWhileOpen = false;
+
+      const txDone = db
+        .transaction(async (tx) => {
+          await tx.prepare("INSERT INTO t (v) VALUES (99)").run();
+          await new Promise((resolve) => setTimeout(resolve, 120));
+        })
+        .then(() => {
+          txOpen = false;
+        });
+
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      const outsideRead = db
+        .prepare("SELECT COUNT(*) AS n FROM t WHERE v = 99")
+        .get()
+        .then((row) => {
+          if (txOpen) resolvedWhileOpen = true;
+          return row;
+        });
+
+      await txDone;
+      const row = (await outsideRead) as { n: number };
+
+      // Asserting on the value alone would not be a valid isolation test: by
+      // the time the awaited read resolves the commit has landed, so a correct
+      // implementation legitimately returns the committed row. What matters is
+      // that it could not resolve *during* the transaction.
+      expect(resolvedWhileOpen).toBe(false);
+      expect(row.n).toBe(1);
+    } finally {
+      await db.close();
+    }
+  }, 60_000);
+
+  it("lets statements inside a transaction see its own uncommitted writes", async () => {
+    const db = new WorkerFileDatabase(path.join(workDir, "self_visible.db"));
+    try {
+      await db.exec("CREATE TABLE t (v INTEGER)");
+      let seen = -1;
+      await db.transaction(async (tx) => {
+        await tx.prepare("INSERT INTO t (v) VALUES (1234)").run();
+        const row = (await tx.prepare("SELECT COUNT(*) AS n FROM t WHERE v = 1234").get()) as {
+          n: number;
+        };
+        seen = row.n;
+      });
+      expect(seen).toBe(1);
+    } finally {
+      await db.close();
+    }
+  }, 60_000);
+});


### PR DESCRIPTION
Closes #2280.

## The issue's diagnosis is right; its conclusion about the code is not

#2280 localises the fault precisely, and the measurement holds up:

```
external GET /health              200 in 18.79s
internal GET /health              200 in  9.41s   <- from inside the VM
POST /entities/query {"limit":1}  200 in  9.33s
```

`/health` reads `package.json` and touches no database. A DB-free handler taking 9.4s inside the machine, with 6GB free and ~42% idle CPU, can only mean the event loop is unavailable. `limit=1` costing the same proves the time is not query cost — every request pays the same stall.

I re-measured the live instance before changing anything, and it reproduces: **6.3s, 9.6s, 14.2s** for `GET /health`.

Where the issue goes wrong is the next step. It concludes "there is no worker pool in this build" and asks for one to be built. **The worker pool already exists on `main`.** It landed in #1944 on 2026-07-29 — `src/repositories/worker/worker_file_database.ts`, a writer worker plus a read-only reader pool under WAL, behind the existing async `DbDatabase` contract. It is complete, tested, and correct.

Two things hid it:

1. **The deployed build predates it.** `/health` reports `version: 0.17.0`; the pool shipped in 0.22.x. The issue was read against that build, where the observation was accurate.
2. **Even on current `main`, nothing selects it.** The pool is opt-in via `NEOTOMA_DB_BACKEND=libsql`, and no Dockerfile, `fly.toml`, `fly.sandbox.toml`, start script, or launchd plist sets it. `config.ts` defaults to `sqlite` — the synchronous, main-thread driver.

So the fix that was written a month ago has never run in a server process anywhere. An opt-in fix that nothing opts into is not a fix.

(This also resolves the "dead config" finding in #2282 from the other direction. That instance really does have `NEOTOMA_DB_BACKEND=libsql` set — the variable was correct all along; it was the *build* that was too old to read it.)

## What this PR does

**Servers default to the worker-hosted backend. CLI processes keep the synchronous one.**

| Process | Default | Why |
|---|---|---|
| Server (`dist/actions.js`, MCP stdio) | `libsql` | Many callers share one event loop; one slow query blocks all of them |
| CLI (`neotoma …`, scripts) | `sqlite` | One-shot, nothing else waiting; worker spawn is pure overhead |

`NEOTOMA_DB_BACKEND` still wins when set, in either direction.

A process declares itself a server by importing `src/process_role.js` — one line at the top of each server entrypoint. **The role is deliberately not read from the environment.** My first attempt used `NEOTOMA_PROCESS_ROLE`, and it was wrong: env vars are inherited by child processes and leak in from `.env` files, and an ambient value silently flipped the backend for every CLI invocation and every vitest worker. That is the same class of bug as the one being fixed — configuration that appears to say one thing while the process does another. There is a regression test pinning that an ambient env var is ignored.

Marking the entrypoint rather than the deployment also means the setting cannot drift across the five places a server gets started. That drift *is* #2280.

### Why not a new pool, `node:sqlite` async, or something else

The task framing offered these as open options. They are settled by what is already in the tree:

- **Build a new worker pool** — it exists and is good. Writing a second one would be duplicate machinery to maintain, and would discard #1944's already-reviewed transaction semantics.
- **`node:sqlite`'s async API** — the deployment runs Node 20, where `node:sqlite` is not available at all (it falls back to `better-sqlite3`, matching the issue's observation). More fundamentally, #1944 verified empirically that *every* Node binding for local SQLite/libSQL files blocks the calling thread, including `libsql/promise` and `@libsql/client`'s file protocol — their promises resolve only after the statement has already blocked the loop. Worker threads are the only local mechanism that actually yields.
- **Something else** — the smallest correct change is to select the working code. That is what this does.

### Backpressure (new)

The pool's pending map was unbounded. Moving statements off the event loop does not make the database faster — if arrivals outpace what SQLite can retire, the backlog has to go somewhere, and unbounded it goes into heap. That trades an event-loop stall for unbounded memory growth and an eventual OOM, which is **worse** than being slow: it takes the process down and loses every queued request instead of delaying them.

Each worker connection now caps in-flight statements at `NEOTOMA_DB_MAX_QUEUED_STATEMENTS` (default 512, per-connection) and sheds overflow with a retryable `WorkerDbOverloadError` naming the limit and how to raise it.

## The design questions, answered

**Write serialization.** SQLite permits one writer, and the pool has exactly one writer worker. All mutating statements, `exec`, `pragma`, and every statement inside a transaction route to it (`routeWrite` / `routeRead`). Reader workers open the file `readonly`, so a read that turns out to write is rejected by SQLite with `SQLITE_READONLY` and retried on the writer — no SQL-parsing heuristics. Concurrent writes cannot happen; they queue in the writer's message order.

**Transaction integrity.** This was the risk worth taking seriously — a pool that handed successive statements of one transaction to different connections would break transactions *silently*, which is far worse than the latency it fixes. It does not: `transaction()` runs under a `TransactionGate` that serializes transactions and holds unrelated statements out of the open window, and `AsyncLocalStorage` routes statements issued inside the callback to the writer connection. I added `tests/unit/db_worker_transaction_integrity.test.ts` to pin it under concurrency:

- 40 concurrent transactions each doing a read-modify-write **across an `await`** → no lost updates (`bal == 40`), double-entry invariant `sum == 0`;
- a throwing transaction rolls back completely (0 rows);
- a statement issued outside a transaction cannot *resolve* inside its window;
- statements inside a transaction see its own uncommitted writes.

One note on that third test, because it caught me out. My first version asserted that an outside read returns the pre-transaction *value*, and it "failed". It was the test that was wrong: by the time an awaited read resolves, the commit has landed, so a correct implementation legitimately returns the committed row. The real invariant is that the read cannot resolve while the transaction is open — instrumented ordering confirms the gate holds it (`tx:insert → outside:read-start → tx:commit-return → outside:read-done`). The test now asserts that, with a comment explaining why the obvious assertion is invalid.

**Large responses — residual, not fixed.** JSON-serialising a multi-MB response still happens on the main thread; this PR does not change that. Measured: **1.62MB serialises in 3ms**, with 1ms max event-loop lag. Real, but ~360x smaller than the 1091ms query stall that was previously hiding it. Worth a separate issue for streaming/pagination; not a co-cause of #2280.

**Hot path.** Eighteen daemons and every session read through this. That is why the change is "select the existing, tested backend" rather than new query machinery, and why the transaction tests above exist. Slow is visible; wrong is not.

## Measurements

Same slow query throughout (self-join over 6k rows). Not a synthetic microbenchmark of the driver — an **actual express server**, with `/health` mirroring `src/actions.ts` (no DB access), probed continuously while one slow request is in flight:

| Backend | `/slow` | `/health` probes completed during it | median | worst |
|---|---|---|---|---|
| `sqlite` (synchronous) | 1089ms | **1** | 1089ms | 1089ms |
| `libsql` (worker pool) | 1149ms | **11,694** | **0ms** | **2ms** |

Under the sync driver, exactly one health check completed in the entire window, and it took as long as the slow query — the server was frozen. Under the pool, ~11.7k completed with a 0ms median.

Event-loop lag under the same query, measured directly:

| Backend | slow query | max event-loop lag | concurrent health check |
|---|---|---|---|
| `sqlite` | 1100ms | **1091ms** | blocked until the slow query finished |
| `libsql` | 1112ms | **2ms** | answered in 15ms, *before* the slow query |

**The slow query is not faster** — SQLite does the same work. What changes is that it no longer holds the event loop while doing it. That is the actual success criterion from the issue: a slow query no longer stalls unrelated fast ones.

Backpressure, measured: a 300-request concurrent burst is not shed at all under the default limit; with the limit forced to 10, overflow is rejected with `WorkerDbOverloadError` while accepted work still completes.

## Tests

- **New:** `db_backend_server_default.test.ts` (8), `db_worker_transaction_integrity.test.ts` (4), `db_worker_backpressure.test.ts` (3) — 15 new tests, all passing.
- **Existing DB suite:** 43/43 passing, including the `db_libsql_nonblocking` regression test that already existed for this exact symptom.
- `tsc --noEmit` clean; eslint clean on all changed files (the 4 remaining warnings in `config.ts` are pre-existing `any`s on lines this PR does not touch).
- Full-suite comparison against clean `origin/main` is in a comment below, so any delta is attributable rather than asserted. Note for anyone re-running: a fresh worktree needs `npm run build:server` first — without `dist/`, ~200 CLI tests fail on `Cannot find module dist/cli/index.js`, which has nothing to do with this change.

## Deployment

**Rebased onto current `main` (post-#2284).** The sequencing hold in the original version of this description is now resolved and no longer applies:

- **#2284 merged**, so `fly.operator.toml` declares `performance` / 2 CPU / `8gb` — matching what production actually ran. The downscale hazard I flagged (a deploy from this repo silently shrinking prod ~8x) is fixed at the source, and there is now a config-drift check plus an operator deploy workflow with the right `-c` flag.
- This branch touches **no** Fly config file. #2284's sizing corrections are untouched; nothing here reintroduces the values it fixed.

The two changes compose in a way worth calling out. #2284 repointed the Fly health check from `/health` to `/ready`, which performs a **real database read** — precisely so a green check can no longer coexist with a total read outage. Under the synchronous driver that probe would have been subject to the same event-loop stall this PR removes: the check would have been measuring something real and then failing to answer it. Together, the check now measures something real *and* can actually respond while the database is busy.

**Still: do not merge and do not deploy from this PR.** The operator is sequencing the production restore himself.

Context for that restore, since it bears on why this matters now: the production instance was taken down deliberately — it was running the June v0.17.0 build, outside the supported version window, with four security advisories against it including an auth bypass. It is to be restored on **v0.22.1**.

**v0.22.1 alone ships the worker pool but does not select it.** That is the finding at the centre of this PR: without this change, a straight upgrade restores a current, still-blocking instance — the same cascade, on a newer build. The one mitigating detail is that the operator instance already has `NEOTOMA_DB_BACKEND=libsql` set, so it would pick up the non-blocking backend from its own env even without this PR. This PR is what makes that true for **every** deployment, structurally, rather than depending on one instance's secret happening to be right.
