### PR TITLE
fix(ci): deploy the operator instance from its own Fly config

### DIFF
--- a/.github/workflows/deploy-operator-instance.yml
+++ b/.github/workflows/deploy-operator-instance.yml
@@ -197,13 +197,29 @@ jobs:
         if: steps.gate.outputs.configured == 'true'
         uses: superfly/flyctl-actions/setup-flyctl@master
 
-      # --app is passed EXPLICITLY: the repo's fly.toml declares the SANDBOX
-      # app, so a bare `flyctl deploy` here would redeploy the sandbox.
-      # --primary-region is REQUIRED: fly.toml declares primary_region='lhr'
-      # while this instance's volume is in ams. Without it the deploy builds and
-      # then fails at machine creation with "needs an unattached volume named
-      # 'data' in region 'lhr'". `--regions` does NOT substitute — it filters
-      # existing machines and produces the identical error.
+      # -c fly.operator.toml is LOAD-BEARING, not tidiness. `flyctl deploy`
+      # defaults to fly.toml, and it REAPPLIES the config's [[vm]] block over
+      # the running machine — it does not merge, and it prints no warning when
+      # it shrinks one. fly.toml declares the small shared default; the operator
+      # instance runs performance / 2 CPU / 8GB, set by hand after repeated
+      # exit-134 (V8 heap OOM) aborts. Deploying without -c would silently
+      # downgrade it by 8x on memory and drop it from `performance` to `shared`.
+      #
+      # That is not hypothetical: on 2026-09-01 a deploy from a stale checkout
+      # reapplied a 1GB/shared-cpu-1x guest over this instance and took it from
+      # slow to unreachable for ~30 minutes, while `flyctl status` reported
+      # `started` throughout. The memory half announces itself with an OOM
+      # abort; the CPU half is quieter and just makes every read slower.
+      #
+      # fly.operator.toml also carries the [[mounts]] source = "data" and the
+      # /ready health check. Deploying from fly.toml would take those settings
+      # from a file that is not describing this instance.
+      #
+      # --app is passed EXPLICITLY because no config in this repo names an app
+      # (this repo is public). --primary-region is REQUIRED: without it machine
+      # creation fails with "needs an unattached volume named 'data' in region
+      # '<region>'". `--regions` does NOT substitute — it filters existing
+      # machines and produces the identical error.
       # VITE_NEOTOMA_SANDBOX_UI must stay empty (no "Public sandbox" banner) and
       # VITE_PUBLIC_BASE_PATH must be "/" (a "/inspector/" build renders a blank
       # page while /health still returns ok).
@@ -215,7 +231,8 @@ jobs:
           REGION: ${{ vars.OPERATOR_INSTANCE_REGION || 'ams' }}
           SHA: ${{ steps.resolve.outputs.ref }}
         run: |
-          flyctl deploy --app "$APP" --primary-region "$REGION" --remote-only \
+          flyctl deploy -c fly.operator.toml \
+            --app "$APP" --primary-region "$REGION" --remote-only \
             --build-arg VITE_NEOTOMA_SANDBOX_UI="" \
             --build-arg VITE_PUBLIC_BASE_PATH="/" \
             --build-arg NEOTOMA_GIT_SHA="$SHA"

--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,8 +61,8 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **587**
-- Backend and repo Vitest files: **552**
+- Total automated test files: **588**
+- Backend and repo Vitest files: **553**
 - Frontend Vitest files: **9**
 - Playwright spec files: **26**
 
@@ -74,7 +74,7 @@ flowchart TD
 | Source-adjacent tests | 66 |
 | Vitest integration tests | 166 |
 | Vitest CLI tests | 77 |
-| Vitest contract tests | 16 |
+| Vitest contract tests | 17 |
 | Vitest security tests | 7 |
 | Vitest subscription tests | 5 |
 | Vitest agent tests | 1 |
@@ -659,10 +659,11 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/contract`
 **Requirements:** Generated contract artifacts present when the suite expects them.
-**Files (16):**
+**Files (17):**
 - `tests/contract/cli_handler_dist_smoke.test.ts`
 - `tests/contract/contract_mapping.test.ts`
 - `tests/contract/contract_mcp_cli_parity.test.ts`
+- `tests/contract/deploy_workflow_config.test.ts`
 - `tests/contract/fly_deploy_config.test.ts`
 - `tests/contract/get_entities_alias.test.ts`
 - `tests/contract/ironclaw_integration.test.ts`

--- a/tests/contract/deploy_workflow_config.test.ts
+++ b/tests/contract/deploy_workflow_config.test.ts
@@ -1,0 +1,102 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * Contract test over the operator deploy WORKFLOW's flyctl invocation.
+ *
+ * `tests/contract/fly_deploy_config.test.ts` asserts that the committed Fly
+ * configs declare the right machine. This file asserts the complementary half:
+ * that the workflow actually DEPLOYS FROM the right one.
+ *
+ * Both halves are needed, and neither implies the other. `flyctl deploy`
+ * defaults to `fly.toml` when no `-c` is passed, and it REAPPLIES the selected
+ * config's `[[vm]]` block over the running machine — it does not merge, and it
+ * prints no warning when it shrinks one. So a workflow that omits `-c` deploys
+ * the small shared default over the operator instance no matter how correct
+ * fly.operator.toml is.
+ *
+ * That is the 2026-09-01 outage in one flag: a deploy reapplied a
+ * 1GB/shared-cpu-1x guest over a machine running performance/2 CPU/8GB and took
+ * it from slow to unreachable for ~30 minutes, while `flyctl status` reported
+ * `started` throughout.
+ *
+ * This is asserted as a test rather than left to the comment above the step
+ * because the failure is silent: a deploy missing `-c` still exits 0, still
+ * reports success, and only shows up later as "the database is degraded".
+ */
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "..", "..");
+const WORKFLOW = ".github/workflows/deploy-operator-instance.yml";
+
+function readWorkflow(): string {
+  return fs.readFileSync(path.join(repoRoot, WORKFLOW), "utf8");
+}
+
+/** The `flyctl deploy ...` invocation, rejoined across YAML line continuations. */
+function deployCommand(source: string): string {
+  const flattened = source.replace(/\\\r?\n\s*/g, " ");
+  const line = flattened.split("\n").find((l) => /^\s*flyctl\s+deploy\b/.test(l));
+  if (!line) throw new Error(`no 'flyctl deploy' invocation found in ${WORKFLOW}`);
+  return line.trim();
+}
+
+/**
+ * The real `[[vm]]` table, excluding comments.
+ *
+ * These configs discuss `[[vm]]` and past bad sizes at length in prose, so a
+ * naive indexOf("[[vm]]") lands in a comment and asserts against the very
+ * values the comment is warning about. Strip comment lines first, then take
+ * the table.
+ */
+function vmBlockOf(config: string): string {
+  const lines = config.split("\n").filter((l) => !/^\s*#/.test(l));
+  const start = lines.findIndex((l) => /^\s*\[\[vm\]\]/.test(l));
+  if (start === -1) throw new Error("no [[vm]] table found");
+  const rest = lines.slice(start + 1);
+  const end = rest.findIndex((l) => /^\s*\[/.test(l));
+  return rest.slice(0, end === -1 ? undefined : end).join("\n");
+}
+
+describe("deploy_workflow_config", () => {
+  it("deploys the operator instance from fly.operator.toml, not the default fly.toml", () => {
+    // -c is what stops `flyctl deploy` falling back to fly.toml. Accept the
+    // long form too, so a later rewrite to --config is not a false failure.
+    expect(deployCommand(readWorkflow())).toMatch(/(?:-c|--config)\s+fly\.operator\.toml\b/);
+  });
+
+  it("selects a config that declares the operator machine's real size", () => {
+    // The flag is only worth having if the file it selects is right, so follow
+    // it to the config rather than trusting the name. These are the verified
+    // running values of the largest operator instance, read from the live
+    // machine on 2026-09-01: performance / 2 CPU / 8GB. It was scaled up by
+    // hand after repeated exit-134 (V8 heap OOM) aborts.
+    const configName = deployCommand(readWorkflow()).match(/(?:-c|--config)\s+(\S+)/)?.[1];
+    expect(configName).toBe("fly.operator.toml");
+
+    const vmBlock = vmBlockOf(fs.readFileSync(path.join(repoRoot, configName!), "utf8"));
+    expect(vmBlock).toMatch(/memory\s*=\s*['"]8gb['"]/);
+    expect(vmBlock).toMatch(/cpu_kind\s*=\s*['"]performance['"]/);
+    expect(vmBlock).toMatch(/cpus\s*=\s*2\b/);
+  });
+
+  it("keeps the volume mount the database lives on", () => {
+    // A fresh machine must mount the EXISTING volume. The mount is declared by
+    // source name ("data"), and Fly attaches an available volume of that name
+    // in the target region. Losing this block is how a redeploy comes back
+    // serving an empty database on ephemeral storage.
+    const config = fs.readFileSync(path.join(repoRoot, "fly.operator.toml"), "utf8");
+    expect(config).toMatch(/\[\[mounts\]\]/);
+    expect(config).toMatch(/source\s*=\s*["']data["']/);
+  });
+
+  it("passes --primary-region, without which machine creation fails on the volume", () => {
+    // The volume is region-pinned. Without --primary-region the deploy builds
+    // and then fails at machine creation with "needs an unattached volume named
+    // 'data' in region '<region>'". `--regions` does NOT substitute.
+    expect(deployCommand(readWorkflow())).toMatch(/--primary-region\s/);
+  });
+});


### PR DESCRIPTION
## The bug

The operator deploy workflow merged in #2278 passes no `-c` flag, so `flyctl deploy` falls back to `fly.toml`.

`flyctl` **reapplies** the selected config's `[[vm]]` block over the running machine. It does not merge, and it prints no warning when it shrinks one. `fly.toml` declares the small shared default; the operator instance runs `performance` / 2 CPU / 8GB, set by hand after repeated exit-134 (V8 heap OOM) aborts.

So the workflow as merged would downgrade the instance **8x on memory and from `performance` to `shared`** on its first run — the same failure mode #2284 was written to prevent, reintroduced through the deploy path rather than the config file.

This is not hypothetical. It is the 2026-09-01 outage in one missing flag: a deploy reapplied a small guest over that machine and took it from slow to unreachable for ~30 minutes, while `flyctl status` reported `started` throughout.

## The fix

Pass `-c fly.operator.toml`. That file also carries the `[[mounts]]` block the database volume attaches through and the `/ready` check that exercises a real read, so deploying from `fly.toml` would have taken those from a file that is not describing this instance either.

## Why a test and not just a comment

A deploy missing `-c` still exits 0 and still reports success. The damage only shows up later as "the database is degraded", which is why it survived review the first time.

`tests/contract/deploy_workflow_config.test.ts` follows the flag **to the config it selects** and asserts the guest values there, rather than trusting the filename — so the workflow and the file it deploys from cannot drift apart silently. It also pins the `[[mounts]]` block and `--primary-region`, both of which the volume attach depends on.

This complements `tests/contract/fly_deploy_config.test.ts` from #2284: that suite asserts the configs declare the right machine, this one asserts the workflow deploys from the right config. Neither implies the other.

Note the parser reads the real `[[vm]]` table with comment lines stripped — these configs discuss past bad sizes at length in prose, and a naive scan lands in a comment and asserts against the very values the comment warns about.

## Verification

- `deploy_workflow_config` + `fly_deploy_config`: 26 tests pass against current `main`.
- Confirmed the assertions fail against the pre-#2284 config (4GB/shared) rather than passing vacuously.
- Confirmed `scripts/check_fly_config_drift.sh` flags both downgrade halves for that config and exits 0 for the reconciled one.

## Operational note

A deploy run triggered by the #2284 merge was **cancelled before it reached the deploy step**, since it would have run the unfixed command against the instance. No machine was created and the volume is untouched. The instance is intentionally at zero machines pending the operator's go-ahead, so nothing is currently serving from the wrong size — but **this should land before the instance is brought back**, because the push-to-main trigger means the next merge would otherwise deploy the shrinking command.

Also worth knowing for the restore: with zero machines `check_fly_config_drift.sh` exits **2** ("could not determine"), not 0. That is by design and must not be read as approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)