### PR TITLE
fix(ops): compare restart policy against the running machine

### DIFF
--- a/fly.sandbox.toml
+++ b/fly.sandbox.toml
@@ -85,6 +85,20 @@ primary_region = 'lhr'
     method = 'GET'
     path = '/ready'
 
+# The sandbox had no [[restart]] block, so it inherited Fly's `on-failure`
+# default — which ignores exit code 0 by definition, and this server exits 0 on
+# a cadence (neotoma#2094). A clean exit under `on-failure` leaves the machine
+# stopped until an inbound request wakes it, which users experience as a 33-45s
+# cold start against a normal 0.2s.
+#
+# The running sandbox machine was confirmed on `on-failure` on 2026-09-01, the
+# same divergence found on the operator instance during that incident.
+#
+# Double brackets are required: `[restart]` fails flyctl validation with
+# "cannot unmarshal object into Go struct field Config.restart".
+[[restart]]
+  policy = 'always'
+
 [[mounts]]
   source = "persistent_sandbox"
   destination = "/data"

--- a/scripts/check_fly_config_drift.sh
+++ b/scripts/check_fly_config_drift.sh
@@ -9,14 +9,20 @@
 # performance/2 CPU/8GB and dropped its health check, taking it from slow to
 # unreachable for ~30 minutes. `flyctl status` reported `started` throughout.
 #
+# Four attributes were found diverged in that one incident: memory, CPU kind,
+# health checks, and restart policy. All four are compared here.
+#
 # Run this BEFORE deploying anything you care about:
 #
 #   scripts/check_fly_config_drift.sh --app <app> [--config fly.operator.toml]
 #
-# Exit 0 = the deploy will not resize the machine or drop its checks.
-# Exit 1 = drift; the deploy WOULD change the running machine's shape.
-# Exit 2 = could not determine (no flyctl, no jq, app unreachable). Deliberately
-#          distinct from 1: "I could not check" must never read as "it is fine".
+# Exit 0 = the deploy will not resize the machine, drop its checks, and the
+#          machine's restart policy is no weaker than the config declares.
+# Exit 1 = drift; the deploy WOULD change the running machine's shape, or the
+#          machine already runs a weaker restart policy than the config.
+# Exit 2 = could not determine (no flyctl, no jq, app unreachable, or an
+#          attribute that could not be read). Deliberately distinct from 1:
+#          "I could not check" must never read as "it is fine".
 #
 # This is intentionally NOT wired into CI. CI has no Fly credentials, and a
 # check that silently degrades to exit 2 on every run is one nobody reads. The
@@ -58,6 +64,28 @@ want_cpus="$(grep -oE 'cpus *= *[0-9]+' <<<"$vm_block" | grep -oE '[0-9]+' | hea
 want_kind="$(grep -oE "cpu_kind *= *'[^']*'|cpu_kind *= *\"[^\"]*\"" <<<"$vm_block" | head -1 | sed -E "s/.*[=] *['\"]([^'\"]*)['\"].*/\1/" || true)"
 want_checks="$(grep -c '^\s*\[\[http_service\.checks\]\]' "$CONFIG" || true)"
 
+# Same treatment for [[restart]]: read only that block, so a `policy` key under
+# some other table cannot be mistaken for the restart policy. Note the double
+# brackets — `[restart]` fails flyctl validation ("cannot unmarshal object into
+# Go struct field Config.restart").
+restart_block="$(awk '/^\[\[restart\]\]/{f=1;next} /^\[/{f=0} f' "$CONFIG")"
+want_restart="$(grep -oE "policy *= *'[^']*'|policy *= *\"[^\"]*\"" <<<"$restart_block" | head -1 | sed -E "s/.*[=] *['\"]([^'\"]*)['\"].*/\1/" || true)"
+
+# How much of a clean exit each policy covers. `always` is the only one that
+# restarts on exit code 0, which is the exit this server actually produces
+# (neotoma#2094) — `on-failure` reads code 0 as "the job finished" and declines,
+# and `no` never restarts at all. Ranking them lets the comparison below report
+# only a genuine DOWNGRADE, so a machine running something stronger than the
+# file declares is not flagged as drift.
+restart_rank() {
+  case "${1:-}" in
+    always) echo 3 ;;
+    on-failure|on_failure) echo 2 ;;
+    no|never|off) echo 1 ;;
+    *) echo -1 ;;  # unknown / unreadable — never silently treated as adequate
+  esac
+}
+
 # Normalize '8gb' / '8192' to megabytes so the comparison is apples to apples.
 to_mb() {
   local raw="${1:-}" n
@@ -79,8 +107,9 @@ if [[ "$count" == "0" ]]; then
 fi
 
 drift=0
-while read -r id got_mb got_cpus got_kind got_checks; do
-  echo "machine $id: ${got_mb}MB / ${got_cpus} x ${got_kind} / ${got_checks} check(s)"
+undetermined=0
+while read -r id got_mb got_cpus got_kind got_checks got_restart; do
+  echo "machine $id: ${got_mb}MB / ${got_cpus} x ${got_kind} / ${got_checks} check(s) / restart=${got_restart}"
 
   if [[ "$want_mb" != "0" && "$got_mb" -gt "$want_mb" ]]; then
     echo "  DRIFT: deploying $CONFIG would SHRINK memory ${got_mb}MB -> ${want_mb}MB" >&2
@@ -109,22 +138,63 @@ while read -r id got_mb got_cpus got_kind got_checks; do
   if [[ "$got_checks" -eq 0 ]]; then
     echo "  WARNING: this machine currently has NO health checks" >&2
   fi
+
+  # The fourth attribute found diverged during the 2026-09-01 investigation:
+  # the machine ran `on-failure` while both fly.toml and fly.operator.toml
+  # declared `always`. It did NOT cause that outage — the machine's event log
+  # shows it restarted and was serving when an operator destroy ended it — but
+  # `on-failure` ignores exit code 0 by definition, and this server does exit 0
+  # on a cadence (neotoma#2094). Nothing compared this attribute, so the
+  # divergence survived undetected until someone read the machine by hand.
+  want_rank="$(restart_rank "$want_restart")"
+  got_rank="$(restart_rank "$got_restart")"
+
+  if [[ -z "$want_restart" ]]; then
+    # A config with no [[restart]] block inherits Fly's default, which is
+    # `on-failure` — the policy that does not cover a code-0 exit. That is a
+    # gap in the file, not drift against the machine, so it is reported here
+    # rather than compared.
+    echo "  WARNING: $CONFIG declares no [[restart]] policy; Fly defaults to on-failure," >&2
+    echo "           which does not restart on a clean exit (neotoma#2094)" >&2
+  elif [[ "$got_rank" -lt 0 ]]; then
+    # Deliberately exit 2, not 0: an unreadable live policy is "I could not
+    # check", and must never be reported as agreement.
+    echo "  UNDETERMINED: could not read this machine's restart policy (got '${got_restart}')" >&2
+    undetermined=1
+  elif [[ "$want_rank" -lt 0 ]]; then
+    echo "  UNDETERMINED: $CONFIG declares an unrecognized restart policy '${want_restart}'" >&2
+    undetermined=1
+  elif [[ "$got_rank" -lt "$want_rank" ]]; then
+    echo "  DRIFT: machine runs restart policy '${got_restart}', weaker than the '${want_restart}' $CONFIG declares" >&2
+    [[ "$got_restart" != "always" && "$want_restart" == "always" ]] &&
+      echo "         '${got_restart}' does not restart on exit code 0; this server exits 0 (neotoma#2094)" >&2
+    drift=1
+  fi
 done < <(jq -r '.[] | [
     .id,
     (.config.guest.memory_mb // 0),
     (.config.guest.cpus // 0),
     (.config.guest.cpu_kind // "unknown"),
-    ((.config.checks // {}) | length)
+    ((.config.checks // {}) | length),
+    (.config.restart.policy // "unknown")
   ] | @tsv' <<<"$machines")
 
 if [[ "$drift" -ne 0 ]]; then
   cat >&2 <<EOF
 
-Deploying $CONFIG to $APP would change the running machine's shape.
+Deploying $CONFIG to $APP would change the running machine's shape, or the
+machine is already running a weaker restart policy than $CONFIG declares.
 Either update $CONFIG to match what the machine should run, or deploy from the
 config that describes this instance. Do not deploy over this.
 EOF
   exit 1
+fi
+
+# Checked last, and only when nothing drifted: a real drift is the more
+# actionable finding, and exit 1 already means "do not deploy over this".
+if [[ "$undetermined" -ne 0 ]]; then
+  echo >&2 "could not determine every attribute for $APP; treat this as unchecked, not as OK"
+  exit 2
 fi
 
 echo "OK: $CONFIG matches the running shape of $APP"

--- a/tests/contract/fly_deploy_config.test.ts
+++ b/tests/contract/fly_deploy_config.test.ts
@@ -246,6 +246,36 @@ describe("fly_deploy_config.all_configs", () => {
     }
   });
 
+  it.each(listFlyConfigs())("%s restarts on a clean exit", (fileName) => {
+    // Asserted across EVERY config, not just fly.toml. Fly's default when no
+    // [[restart]] block is present is `on-failure`, which ignores exit code 0
+    // by definition — and this server exits 0 on a cadence (neotoma#2094), so
+    // an omitted block leaves the machine stopped until a request wakes it.
+    //
+    // Omission is the failure mode that matters here: on 2026-09-01 a running
+    // machine was found on `on-failure` while the configs declared `always`,
+    // and nothing in the repo or the tooling compared the two. The live half
+    // of that comparison needs Fly credentials and lives in
+    // scripts/check_fly_config_drift.sh; this half needs none and runs on
+    // every PR.
+    //
+    // Note the double brackets: `[restart]` fails flyctl validation with
+    // "cannot unmarshal object into Go struct field Config.restart".
+    const restarts = (readFlyConfig(fileName).restart as TomlTable[]) ?? [];
+    expect(
+      restarts.length,
+      `${fileName} declares no [[restart]] block, so it inherits Fly's on-failure ` +
+        `default, which does not restart on the code-0 exit this server produces`
+    ).toBeGreaterThan(0);
+
+    for (const restart of restarts) {
+      expect(
+        restart.policy,
+        `${fileName} declares '${String(restart.policy)}'; only 'always' covers a clean exit`
+      ).toBe("always");
+    }
+  });
+
   it.each(listFlyConfigs())("%s routes to the port the server listens on", (fileName) => {
     const config = readFlyConfig(fileName);
     const env = (config.env as TomlTable) ?? {};


### PR DESCRIPTION
Closes #2288.

`scripts/check_fly_config_drift.sh` (added in #2284) compared memory, CPU kind/count, and health-check presence between a committed Fly config and the running machine. It did not compare `restart.policy` — the fourth attribute found diverged during the 2026-09-01 investigation.

`on-failure` ignores exit code 0 by definition: Fly reads a clean exit as "the job finished" and declines to restart. This server exits 0 on a cadence (#2094), and `policy = 'always'` exists specifically to cover that. Nothing compared the declared policy against the running one, so the divergence survived until someone read the machine by hand.

## Did the restart policy cause the outage? No — and the evidence is unambiguous

The issue raised this as an open question, on the theory that the process exited on its own, `on-failure` declined to restart it, and the later operator stop landed on an already-dead instance. **The machine's Fly event log refutes that**, so this PR is a hardening measure, not an incident fix.

The event history for the affected machine (still retained, read via `flyctl machine status`):

```
stopped    │ exit    │ flyd   │ 15:56:43.97 │ exit_code=0,oom_killed=false,requested_stop=true
starting   │ start   │ proxy  │ 15:56:45.28 │
started    │ start   │ flyd   │ 15:56:47.37 │
destroying │ destroy │ user   │ 15:57:15.02 │
destroyed  │ destroy │ flyd   │ 15:57:20.44 │
```

Three independent points, each sufficient on its own:

1. **The machine restarted.** A full boot followed the 15:56:42 exit — `Machine started in 2.093s` — and it was serving again by ~15:56:55. It was alive for roughly 28 seconds before the operator touched it. The claim that `on-failure` stranded it is directly contradicted.
2. **That exit was not the spontaneous #2094 clean exit.** flyd recorded `requested_stop=true`, meaning the stop was requested through the platform rather than the process ending on its own.
3. **The teardown has an explicit operator origin.** Fly attributes the 15:57:15 event `SOURCE: user`, and it is a `destroy`, not a `stop`. The first proxy `no known healthy instances` error appears at 15:57:50 — 35 seconds *after* the destroy, never before it.

So the drift was found *during* the incident investigation; it did not contribute to the incident.

One honest caveat: I could not reproduce the general mechanism from live logs. Fly's retention is short and the currently-deployed instances are quiet — neither shows the periodic code-0 exit pattern today. That `on-failure` strands a clean exit in this deployment rests on the repo's own 2026-08-05 verification note (recorded in `fly.toml`), not on anything I observed. The drift remains a genuine latent risk on that basis.

## Changes

- **`scripts/check_fly_config_drift.sh`** parses `[[restart]] policy` from the config, following the existing `[[vm]]` block-scoped parsing so a `policy` key under another table cannot be mistaken for it, and reads the live value at `.[].config.restart.policy`. Policies are ranked (`always` > `on-failure` > `no`) so drift is reported only on a genuine **downgrade** — a machine running something stronger than its file is not flagged.
- **`tests/contract/fly_deploy_config.test.ts`** asserts `[[restart]] policy = 'always'` across **every** `fly*.toml`, not just `fly.toml`. Needs no credentials, runs on every PR, and complements the credential-requiring live check.
- **`fly.sandbox.toml`** gains the `[[restart]]` block that new assertion caught it missing. Without one it inherited Fly's `on-failure` default. Note the double brackets: `[restart]` fails flyctl validation with "cannot unmarshal object into Go struct field Config.restart".

The exit contract is preserved and extended. An unreadable live policy or an unrecognized declared one sets **exit 2**, never 0 — checked after drift, so exit 1 still wins when both apply. "I could not check" must not read as "it is fine".

## Verification — run against live machines, not constructed

Verifying this against a live target is what #2284 deferred, so it is the point of this PR. All Fly access was read-only; nothing was deployed, restarted, or recreated.

Two apps with running machines were used. One runs `always`, the other `on-failure` — a real, currently-live instance of exactly the drift class this guard is for, which the check had been missing.

| # | Config declares | Machine runs | Expected | Result |
|---|---|---|---|---|
| 1 | `always` | `always` | no drift | **exit 0** |
| 2 | `always` | `on-failure` | DRIFT | **exit 1** |
| 3 | `on-failure` (weakened copy) | `always` | machine stronger, no drift | **exit 0** |
| 4 | `on-failure` (weakened copy) | `on-failure` | match | **exit 0** |
| 5 | no `[[restart]]` block | `on-failure` | warn, not silent | **exit 0 + WARNING** |
| 6 | `sometimes` (unrecognized) | `always` | undetermined | **exit 2** |
| 7 | `no` (weakened copy) | `always` | machine stronger, no drift | **exit 0** |

Case 2 is the guard firing on a live machine. Its output:

```
DRIFT: machine runs restart policy 'on-failure', weaker than the 'always' <config> declares
       'on-failure' does not restart on exit code 0; this server exits 0 (neotoma#2094)
```

**Proving it is not passing by construction.** Cases 3, 4 and 7 use a copy of `fly.toml` with a one-line diff touching only the restart policy — the same method that caught the CPU-kind case in #2284:

```
111c111
<   policy = 'always'
---
>   policy = 'on-failure'
```

Against the same machine that reports drift in case 2, the weakened copy reports none: the comparison is reading the value, and it is directional rather than a bare equality check.

**The contract test caught a real gap before it was written to pass.** Added first, it failed on `fly.sandbox.toml` — which genuinely had no `[[restart]]` block — then passed once the block was added:

```
AssertionError: fly.sandbox.toml declares no [[restart]] block, so it inherits Fly's
on-failure default, which does not restart on the code-0 exit this server produces
```

Case 5 then became case 2's shape: with the sandbox config now declaring `always`, the script reports drift against that live machine where it previously reported none.

Also run: `shellcheck` clean on the script; `flyctl config validate` passes on all three configs; `tests/contract/` green (191 passed, `fly_deploy_config` 25/25); type-check, lint and prettier clean.

Pre-existing unrelated failures: 16 failures across 8 test files (`replay_graph`, `cursor_hook_stop_backfill`, `fixture_mcp_store_replay`, `hook_failure_hint`, `mcp_target_id_identity_conflict`, `turn_summary`, `v0.2.0_ingestion`, `sidebar_external_links`) reproduce identically on a pristine `origin/main` worktree. None touch Fly config or this script.

## Note

One of the instances checked is live on `on-failure` while its config now declares `always`, and its guest is 1024MB against a declared 2GB. This PR does not change any running machine — applying it needs a deploy, which is deliberately left to an operator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
