### PR TITLE
fix(ops): declare the grace period Fly actually honours (60s, not 120s)

### DIFF
--- a/fly.operator.toml
+++ b/fly.operator.toml
@@ -94,10 +94,26 @@
   # genuine problem rather than being impatient. If a future instance is
   # legitimately slower than this, fix the instance — do not raise the timeout
   # until the check can no longer fail.
+  # grace_period 60s, which is also the ceiling Fly enforces. A service check
+  # declaring more is silently lowered:
+  #
+  #   WARN Service HTTP check has a grace period greater than 1 minute (2m0s);
+  #        this will be lowered to 1 minute
+  #
+  # `flyctl config validate` prints that and still exits 0, so the larger value
+  # parses, deploys, and reads as authoritative while never taking effect. This
+  # file previously declared 120s and justified it by the [deploy]
+  # release_command plus boot migrations — neither of which it bought. The
+  # release_command runs in its own ephemeral machine before the app machine
+  # starts, so it is not inside this budget at all.
+  #
+  # 60s is not tight. Measured on the largest operator instance (2 CPU / 8GB,
+  # 20GB volume) on 2026-09-01: 17.7s from machine start to first passing
+  # check, migrations and readiness probe included.
   [[http_service.checks]]
     interval = '30s'
     timeout = '30s'
-    grace_period = '120s'
+    grace_period = '60s'
     method = 'GET'
     path = '/ready'
 

--- a/fly.sandbox.toml
+++ b/fly.sandbox.toml
@@ -78,10 +78,26 @@ primary_region = 'lhr'
   # and answers 200 through a total read outage, so it is never a check target.
   # Timeouts match the other configs: sized for a slow-but-alive server, since
   # a check that flaps on a working instance is worse than none.
+  # grace_period 60s, which is also the ceiling Fly enforces. A service check
+  # declaring more is silently lowered:
+  #
+  #   WARN Service HTTP check has a grace period greater than 1 minute (2m0s);
+  #        this will be lowered to 1 minute
+  #
+  # `flyctl config validate` prints that and still exits 0, so the larger value
+  # parses, deploys, and reads as authoritative while never taking effect. This
+  # file previously declared 120s and justified it by the [deploy]
+  # release_command plus boot migrations — neither of which it bought. The
+  # release_command runs in its own ephemeral machine before the app machine
+  # starts, so it is not inside this budget at all.
+  #
+  # 60s is not tight. Measured on the largest operator instance (2 CPU / 8GB,
+  # 20GB volume) on 2026-09-01: 17.7s from machine start to first passing
+  # check, migrations and readiness probe included.
   [[http_service.checks]]
     interval = '30s'
     timeout = '30s'
-    grace_period = '120s'
+    grace_period = '60s'
     method = 'GET'
     path = '/ready'
 

--- a/fly.toml
+++ b/fly.toml
@@ -83,12 +83,26 @@ primary_region = 'lhr'
   # instance that answers "not ready" is diagnosable; one that answers nothing
   # is indistinguishable from a network fault.
   #
-  # grace_period 120s: the [deploy] release_command seeds schemas and
-  # migrations run at boot, both before the server listens.
+  # grace_period 60s, which is also the ceiling Fly enforces. A service check
+  # declaring more is silently lowered:
+  #
+  #   WARN Service HTTP check has a grace period greater than 1 minute (2m0s);
+  #        this will be lowered to 1 minute
+  #
+  # `flyctl config validate` prints that and still exits 0, so the larger value
+  # parses, deploys, and reads as authoritative while never taking effect. This
+  # file previously declared 120s and justified it by the [deploy]
+  # release_command plus boot migrations — neither of which it bought. The
+  # release_command runs in its own ephemeral machine before the app machine
+  # starts, so it is not inside this budget at all.
+  #
+  # 60s is not tight. Measured on the largest operator instance (2 CPU / 8GB,
+  # 20GB volume) on 2026-09-01: 17.7s from machine start to first passing
+  # check, migrations and readiness probe included.
   [[http_service.checks]]
     interval = '30s'
     timeout = '30s'
-    grace_period = '120s'
+    grace_period = '60s'
     method = 'GET'
     path = '/ready'
 

--- a/tests/contract/fly_deploy_config.test.ts
+++ b/tests/contract/fly_deploy_config.test.ts
@@ -54,6 +54,23 @@ const MIN_MEMORY_MB = 2048;
  */
 const MIN_CHECK_TIMEOUT_SECONDS = 25;
 
+/**
+ * Fly silently clamps a *service* check's grace period to one minute:
+ *
+ *   WARN Service HTTP check has a grace period greater than 1 minute (2m0s);
+ *        this will be lowered to 1 minute
+ *
+ * `flyctl config validate` prints that as a warning and still exits 0, so a
+ * larger value parses, deploys, and reads as authoritative while never taking
+ * effect. Declaring one states a boot budget the platform does not grant.
+ *
+ * This is an upper bound deliberately, paired with the lower bound below. The
+ * lower bound alone is what let `120s` sit in all three configs unnoticed: it
+ * was satisfied, so nothing failed, and the file kept asserting a number that
+ * was discarded at deploy time.
+ */
+const MAX_SERVICE_CHECK_GRACE_SECONDS = 60;
+
 type TomlValue = string | number | boolean;
 type TomlTable = { [key: string]: TomlValue | TomlTable | TomlTable[] };
 
@@ -238,10 +255,21 @@ describe("fly_deploy_config.all_configs", () => {
         `${fileName} would flap against a loaded instance answering in 13-24s`
       ).toBeGreaterThanOrEqual(MIN_CHECK_TIMEOUT_SECONDS);
 
-      // A grace period shorter than boot marks a starting machine unhealthy:
-      // the [deploy] release_command seeds schemas and migrations run before
-      // the server listens.
+      // A grace period shorter than boot marks a starting machine unhealthy
+      // while migrations run before the server listens. Measured cold boot to
+      // first passing check on the largest operator instance (2 CPU / 8GB,
+      // 20GB volume) was 17.7s on 2026-09-01, so 60s carries roughly 3x
+      // headroom over the real number.
       expect(durationToSeconds(check.grace_period)).toBeGreaterThanOrEqual(60);
+
+      // ...and no more than the platform actually honours, so the file cannot
+      // claim a budget Fly discards. See MAX_SERVICE_CHECK_GRACE_SECONDS.
+      expect(
+        durationToSeconds(check.grace_period),
+        `${fileName} declares a grace period Fly clamps to ` +
+          `${MAX_SERVICE_CHECK_GRACE_SECONDS}s; the declared value is never what runs`
+      ).toBeLessThanOrEqual(MAX_SERVICE_CHECK_GRACE_SECONDS);
+
       expect(durationToSeconds(check.interval)).toBeGreaterThan(0);
     }
   });


### PR DESCRIPTION
## The mismatch

`fly.toml`, `fly.operator.toml`, and `fly.sandbox.toml` each declared:

```toml
[[http_service.checks]]
  grace_period = '120s'
```

Fly clamps *service* check grace periods to 60s, and says so during validation:

```
WARN Service HTTP check has a grace period greater than 1 minute (2m0s); this will be lowered to 1 minute
```

`flyctl config validate` prints that and still exits 0, so the larger value parsed, deployed, and read as authoritative while never taking effect. The clamp is also visible in the deployed machine config, which echoes `"grace_period": "2m0s"` back while the platform enforces 60.

## Severity: low, stated accurately

The check is declared under `[http_service]`, so it is a service check gating load-balancer routing only. It does not restart the machine, and `[[restart]] policy = 'always'` covers process exits. Nothing was broken by this.

What was wrong is that the files asserted a boot budget they did not receive, and a reader would reasonably rely on it. This is a correctness-of-documentation fix with a measurement behind it, not an incident.

## The justification was independently wrong

Both comments credited the `[deploy] release_command` for needing the extra time:

> grace_period 120s: the [deploy] release_command seeds schemas and migrations run at boot, both before the server listens.

The `release_command` runs in its own ephemeral machine that Fly destroys before the app machine starts. It was never inside this budget, clamp or no clamp. Only the boot-time migrations were ever in scope.

## Measurement

Taken from a boot that had already happened, so nothing in production was restarted, redeployed, or otherwise touched to obtain it. Fly's machine event log and check timestamps on the largest operator instance (2 CPU / 8GB, 20GB volume — the real data volume, not a small instance) give:

| Event | Time (UTC) |
|---|---|
| machine `start` | `18:47:55.916` |
| check first `passing` | `18:48:13.632` |
| **start → passing** | **17.7s** |

That interval includes boot-time migrations and the `/ready` probe's real database read, which is what #2284 made the check exercise.

60s carries roughly 3x headroom over the measured number, so declaring 60s costs nothing real and stops the file from claiming a budget the platform discards.

## Which fix, and why

Lowered to `'60s'` rather than keeping 120 with a caveat. A declared value nobody gets is precisely the thing that misleads the next reader, and the measurement shows 60s is not tight. The comments now record the clamp, the measured boot time, and the corrected `release_command` reasoning, so the next person changing this does not re-derive it.

`fly.sandbox.toml` had the same 120s block and is fixed identically.

## Contract assertion

`tests/contract/fly_deploy_config.test.ts` already asserted `grace_period >= 60`. A lower bound alone is what let `120s` sit in all three configs unnoticed — it was satisfied, so nothing failed. This adds the matching upper bound at the clamp ceiling.

Verified in the order that matters:

- **Before the config change:** 3 failed | 19 passed — one failure per config, each reading `expected 120 to be less than or equal to 60`.
- **After:** 22 passed.

Needs no credentials and runs in CI.

## Notes

- The 22 unrelated failures in the full local suite (SPA routing, CLI dist smoke, hooks) reproduce on unmodified `origin/main` in a fresh worktree — they need a built `dist/`, which CI produces. No Fly-config test is among them.
- Coordinating with #2291, which also touches `fly.sandbox.toml` and this test file. This branch is cut from current `origin/main`; whichever lands second should rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)