### PR TITLE
docs: add verification discipline to the agent instructions

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -42,6 +42,17 @@ Full constraints in `docs/foundation/agent_instructions_rules.mdc` and `.claude/
 
 **Validation checklist** in `docs/foundation/agent_instructions_rules.mdc`.
 
+## Verification discipline
+
+Derived from repeated cross-repo failures, all of one shape: a mechanism reported success while doing nothing.
+
+- **A write that reports success has not necessarily happened — read it back.** `/store` accepts undeclared fields and routes them to `raw_fragments`, so a store returns 2xx while the field you cared about is silently not on the entity. A correction can return `success: true` and write nothing. After any write that matters, retrieve the entity and assert the specific field holds the value you wrote. Never treat a 2xx or `success: true` as evidence that data landed.
+- **Validate the instrument before believing the measurement.** A zero or an empty result is a claim about the query before it is a claim about the data. Field-name drift across records (`github_number` / `issue_number` / `number`), a value stored qualified (`owner/repo`) but queried bare, and an MCP tool name used as a REST route (which 404s into an empty result) have each produced a confident, wrong zero. Prove the query non-zero on a case known to be positive before reporting an absence.
+- **A test that cannot fail on the thing it watches is decoration.** Before trusting a test as coverage, revert the fix and confirm it goes red. A test written against current behaviour ratifies the bug rather than catching it.
+- **Fail closed on the field that carries the safety meaning.** When a value is absent, unrecognized, or malformed, default to the restrictive branch — and give absence a single spelling, normalizing sentinels (`""`, `"none"`, `"unassigned"`) to it rather than letting a truthy placeholder pass as a real value.
+- **Extend the mechanism that already generalizes; do not build a parallel one.** Search the code for the existing path before adding another, and reuse the existing entity or relationship type rather than minting a near-duplicate — a second type covering the same meaning splits every future query across both.
+- **A mechanism that does not bind is not a control.** A linter no workflow invokes, a step carrying `continue-on-error`, or a verdict posted as a comment enforces nothing. When adding a control, name what fails when it is violated.
+
 ## Configuration
 
 - **`foundation-config.yaml`** — Repository-specific settings (conventions, security, workflows)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,17 @@ Full constraints in `docs/foundation/agent_instructions_rules.mdc` and `.Codex/r
 
 **Validation checklist** in `docs/foundation/agent_instructions_rules.mdc`.
 
+## Verification discipline
+
+Derived from repeated cross-repo failures, all of one shape: a mechanism reported success while doing nothing.
+
+- **A write that reports success has not necessarily happened — read it back.** `/store` accepts undeclared fields and routes them to `raw_fragments`, so a store returns 2xx while the field you cared about is silently not on the entity. A correction can return `success: true` and write nothing. After any write that matters, retrieve the entity and assert the specific field holds the value you wrote. Never treat a 2xx or `success: true` as evidence that data landed.
+- **Validate the instrument before believing the measurement.** A zero or an empty result is a claim about the query before it is a claim about the data. Field-name drift across records (`github_number` / `issue_number` / `number`), a value stored qualified (`owner/repo`) but queried bare, and an MCP tool name used as a REST route (which 404s into an empty result) have each produced a confident, wrong zero. Prove the query non-zero on a case known to be positive before reporting an absence.
+- **A test that cannot fail on the thing it watches is decoration.** Before trusting a test as coverage, revert the fix and confirm it goes red. A test written against current behaviour ratifies the bug rather than catching it.
+- **Fail closed on the field that carries the safety meaning.** When a value is absent, unrecognized, or malformed, default to the restrictive branch — and give absence a single spelling, normalizing sentinels (`""`, `"none"`, `"unassigned"`) to it rather than letting a truthy placeholder pass as a real value.
+- **Extend the mechanism that already generalizes; do not build a parallel one.** Search the code for the existing path before adding another, and reuse the existing entity or relationship type rather than minting a near-duplicate — a second type covering the same meaning splits every future query across both.
+- **A mechanism that does not bind is not a control.** A linter no workflow invokes, a step carrying `continue-on-error`, or a verdict posted as a comment enforces nothing. When adding a control, name what fails when it is violated.
+
 ## Configuration
 
 - **`foundation-config.yaml`** — Repository-specific settings (conventions, security, workflows)

--- a/scripts/setup_claude_instructions.sh
+++ b/scripts/setup_claude_instructions.sh
@@ -385,6 +385,17 @@ Full constraints in `docs/foundation/agent_instructions_rules.mdc` and `.claude/
 
 **Validation checklist** in `docs/foundation/agent_instructions_rules.mdc`.
 
+## Verification discipline
+
+Derived from repeated cross-repo failures, all of one shape: a mechanism reported success while doing nothing.
+
+- **A write that reports success has not necessarily happened — read it back.** `/store` accepts undeclared fields and routes them to `raw_fragments`, so a store returns 2xx while the field you cared about is silently not on the entity. A correction can return `success: true` and write nothing. After any write that matters, retrieve the entity and assert the specific field holds the value you wrote. Never treat a 2xx or `success: true` as evidence that data landed.
+- **Validate the instrument before believing the measurement.** A zero or an empty result is a claim about the query before it is a claim about the data. Field-name drift across records (`github_number` / `issue_number` / `number`), a value stored qualified (`owner/repo`) but queried bare, and an MCP tool name used as a REST route (which 404s into an empty result) have each produced a confident, wrong zero. Prove the query non-zero on a case known to be positive before reporting an absence.
+- **A test that cannot fail on the thing it watches is decoration.** Before trusting a test as coverage, revert the fix and confirm it goes red. A test written against current behaviour ratifies the bug rather than catching it.
+- **Fail closed on the field that carries the safety meaning.** When a value is absent, unrecognized, or malformed, default to the restrictive branch — and give absence a single spelling, normalizing sentinels (`""`, `"none"`, `"unassigned"`) to it rather than letting a truthy placeholder pass as a real value.
+- **Extend the mechanism that already generalizes; do not build a parallel one.** Search the code for the existing path before adding another, and reuse the existing entity or relationship type rather than minting a near-duplicate — a second type covering the same meaning splits every future query across both.
+- **A mechanism that does not bind is not a control.** A linter no workflow invokes, a step carrying `continue-on-error`, or a verdict posted as a comment enforces nothing. When adding a control, name what fails when it is violated.
+
 ## Configuration
 
 - **`foundation-config.yaml`** — Repository-specific settings (conventions, security, workflows)


### PR DESCRIPTION
Six standing rules derived from repeated failures across this repo and its operational layer, all of one shape: **a mechanism reported success while doing nothing.**

Two are Neotoma-specific and are the reason this lands here rather than only in the operational-layer repo:

- **A write that reports success has not necessarily happened.** `/store` accepts undeclared fields and routes them to `raw_fragments`, so a store returns 2xx while the field you cared about is silently not on the entity. Observed as 68 task and 497 `email_message` shells from one producer nesting its fields under a `"snapshot"` key, and again as `body` / `owning_agent` being undeclared on the task schema — four separate agents hit that in a single day. A correction can likewise return `success: true` and write nothing. The rule: retrieve and assert the field, never trust the status code.
- **Validate the instrument before believing the measurement.** An MCP tool name used as a REST route 404s into an empty result, which reads as a confident zero rather than an error. Compounded by field-name drift across records (`github_number` / `issue_number` / `number`) and values stored qualified (`owner/repo`) but queried bare — three independent false zeros on one dataset in one day, one reporting 0% where the truth was 94.8%.

The remaining four are general: a test that cannot fail on what it watches is decoration; fail closed on the field carrying the safety meaning, giving absence a single spelling; extend the mechanism that already generalizes rather than minting a near-duplicate type that splits every future query; and a control that binds nothing is not a control.

## On the render targets

`.claude/CLAUDE.md` and `AGENTS.md` are generated files. The section was added to `scripts/setup_claude_instructions.sh` — which carries the `CLAUDE.md` content as an inline heredoc and is therefore the source of truth — and then applied to both targets so they stay in sync.

The generator could not do that regeneration itself here: it early-exits with `No rules directory found ... skipping Claude instruction sync` when the foundation submodule is not initialized. So the text was applied directly to the targets and is byte-identical to what the generator now emits. Flagging this explicitly because "never hand-edit a render target" is one of the rules this change is arguing for, and the exception should be visible rather than quiet.

Worth noting separately: the generated instructions reference `docs/foundation/agent_instructions_rules.mdc` twice, and **that file does not exist in this repo** — so the "Full constraints in ..." and "Validation checklist in ..." pointers both dangle. Not fixed here (out of scope), but it is an instance of the first rule: a pointer to a missing document enforces nothing.

Companion PR in the operational-layer repo: markmhendrickson/ateles#727, which carries the longer form with per-rule enforcement status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)