### PR TITLE
fix(mcp): honour source_entity_id/target_entity_id in list_relationships (#2205)

### DIFF
--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,8 +61,8 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **588**
-- Backend and repo Vitest files: **553**
+- Total automated test files: **589**
+- Backend and repo Vitest files: **554**
 - Frontend Vitest files: **9**
 - Playwright spec files: **26**
 
@@ -72,7 +72,7 @@ flowchart TD
 | Vitest unit tests | 163 |
 | Vitest service tests | 43 |
 | Source-adjacent tests | 66 |
-| Vitest integration tests | 166 |
+| Vitest integration tests | 167 |
 | Vitest CLI tests | 77 |
 | Vitest contract tests | 17 |
 | Vitest security tests | 7 |
@@ -402,7 +402,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm run test:integration` or `npx vitest run tests/integration`
 **Requirements:** Database configured; remote-dependent subsets additionally need `RUN_REMOTE_TESTS=1`.
-**Files (166):**
+**Files (167):**
 - `tests/integration/aauth_attribution_stamping.test.ts`
 - `tests/integration/aauth_mcp_capability_parity.test.ts`
 - `tests/integration/aauth_mcp_initialize_admission.test.ts`
@@ -487,6 +487,7 @@ flowchart TD
 - `tests/integration/mcp_graph_variations.test.ts`
 - `tests/integration/mcp_handler_cross_user_scoping.test.ts`
 - `tests/integration/mcp_invalid_bearer_auth.test.ts`
+- `tests/integration/mcp_list_relationships_entity_filters.test.ts`
 - `tests/integration/mcp_npm_check_update_capability_delta.test.ts`
 - `tests/integration/mcp_npm_check_update.test.ts`
 - `tests/integration/mcp_oauth_token_endpoint.test.ts`

--- a/src/server.ts
+++ b/src/server.ts
@@ -3389,86 +3389,127 @@ export class NeotomaServer {
           ? "outbound"
           : "both";
 
+    // Tag each row with the direction it was matched on, relative to the
+    // entity the caller asked about. For the source_entity_id /
+    // target_entity_id filters the anchor is that filter's entity, so an
+    // edge matched by source_entity_id is "outbound" from it. When both are
+    // supplied (the delete-discovery path named in the tool description) the
+    // source is the anchor.
+    const anchorEntityId =
+      parsed.source_entity_id ?? parsed.target_entity_id ?? parsed.entity_id ?? null;
+    const directionFor = (row: {
+      source_entity_id?: string;
+      target_entity_id?: string;
+    }): string => {
+      if (anchorEntityId && row.source_entity_id === anchorEntityId) return "outbound";
+      if (anchorEntityId && row.target_entity_id === anchorEntityId) return "inbound";
+      return "both";
+    };
+
+    const decorate = (
+      row: {
+        relationship_key: string;
+        snapshot?: unknown;
+        last_observation_at?: string;
+        source_entity_id?: string;
+        target_entity_id?: string;
+      },
+      direction?: string
+    ) => ({
+      ...row,
+      id: row.relationship_key, // Add id field for backward compatibility
+      direction: direction ?? directionFor(row),
+      // Include snapshot metadata as top-level for backward compatibility
+      metadata: row.snapshot,
+      // Add created_at field per MCP_SPEC.md 3.16 (use last_observation_at as created_at)
+      created_at: row.last_observation_at,
+    });
+
     const relationships: any[] = [];
 
-    // Query relationship_snapshots instead of relationships table
-    if (normalizedDirection === "outbound" || normalizedDirection === "both") {
-      let outboundQuery = db
-        .from("relationship_snapshots")
-        .select("*")
-        .eq("source_entity_id", parsed.entity_id)
-        .eq("user_id", userId);
+    // Query relationship_snapshots instead of relationships table.
+    //
+    // `source_entity_id` / `target_entity_id` / bare `relationship_type` are
+    // declared on ListRelationshipsRequestSchema (whose .refine accepts any
+    // one of them alone) and implemented by the HTTP /list_relationships
+    // handler, but this MCP handler previously filtered ONLY on
+    // `parsed.entity_id`. A call passing just source_entity_id therefore ran
+    // `.eq("source_entity_id", undefined)` and returned a confident zero for
+    // edges that demonstrably exist. Mirror the HTTP branch order here so
+    // both surfaces answer the same question the same way (issue #2205).
+    const useDirectionalEntityIdPath =
+      !parsed.source_entity_id && !parsed.target_entity_id && Boolean(parsed.entity_id);
+
+    if (!useDirectionalEntityIdPath) {
+      let query = db.from("relationship_snapshots").select("*").eq("user_id", userId);
 
       // Exclude soft-deleted edges at the DB via the materialized `is_live`
-      // column (#1570), so dead edges are never loaded into memory. Audit
-      // reads pass include_deleted=true to skip this filter.
+      // column (#1570). Audit reads pass include_deleted=true to skip this.
       if (!parsed.include_deleted) {
-        outboundQuery = outboundQuery.eq("is_live", 1);
+        query = query.eq("is_live", 1);
       }
 
+      if (parsed.source_entity_id) {
+        query = query.eq("source_entity_id", parsed.source_entity_id);
+      }
+      if (parsed.target_entity_id) {
+        query = query.eq("target_entity_id", parsed.target_entity_id);
+      }
       if (parsed.relationship_type) {
-        outboundQuery = outboundQuery.eq("relationship_type", parsed.relationship_type);
+        query = query.eq("relationship_type", parsed.relationship_type);
       }
 
-      const { data: outbound, error: outboundError } = await outboundQuery;
-
-      if (!outboundError && outbound) {
-        relationships.push(
-          ...outbound.map(
-            (r: {
-              relationship_key: string;
-              snapshot?: unknown;
-              last_observation_at?: string;
-            }) => ({
-              ...r,
-              id: r.relationship_key, // Add id field for backward compatibility
-              direction: "outbound",
-              // Include snapshot metadata as top-level for backward compatibility
-              metadata: r.snapshot,
-              // Add created_at field per MCP_SPEC.md 3.16 (use last_observation_at as created_at)
-              created_at: r.last_observation_at,
-            })
-          )
-        );
+      const { data, error } = await query;
+      if (!error && data) {
+        relationships.push(...data.map((r: any) => decorate(r)));
       }
-    }
+    } else {
+      if (normalizedDirection === "outbound" || normalizedDirection === "both") {
+        let outboundQuery = db
+          .from("relationship_snapshots")
+          .select("*")
+          .eq("source_entity_id", parsed.entity_id)
+          .eq("user_id", userId);
 
-    if (normalizedDirection === "inbound" || normalizedDirection === "both") {
-      let inboundQuery = db
-        .from("relationship_snapshots")
-        .select("*")
-        .eq("target_entity_id", parsed.entity_id)
-        .eq("user_id", userId);
+        // Exclude soft-deleted edges at the DB via the materialized `is_live`
+        // column (#1570), so dead edges are never loaded into memory. Audit
+        // reads pass include_deleted=true to skip this filter.
+        if (!parsed.include_deleted) {
+          outboundQuery = outboundQuery.eq("is_live", 1);
+        }
 
-      // Exclude soft-deleted edges at the DB via `is_live` (#1570).
-      if (!parsed.include_deleted) {
-        inboundQuery = inboundQuery.eq("is_live", 1);
+        if (parsed.relationship_type) {
+          outboundQuery = outboundQuery.eq("relationship_type", parsed.relationship_type);
+        }
+
+        const { data: outbound, error: outboundError } = await outboundQuery;
+
+        if (!outboundError && outbound) {
+          relationships.push(...outbound.map((r: any) => decorate(r, "outbound")));
+        }
       }
 
-      if (parsed.relationship_type) {
-        inboundQuery = inboundQuery.eq("relationship_type", parsed.relationship_type);
-      }
+      if (normalizedDirection === "inbound" || normalizedDirection === "both") {
+        let inboundQuery = db
+          .from("relationship_snapshots")
+          .select("*")
+          .eq("target_entity_id", parsed.entity_id)
+          .eq("user_id", userId);
 
-      const { data: inbound, error: inboundError } = await inboundQuery;
+        // Exclude soft-deleted edges at the DB via `is_live` (#1570).
+        if (!parsed.include_deleted) {
+          inboundQuery = inboundQuery.eq("is_live", 1);
+        }
 
-      if (!inboundError && inbound) {
-        relationships.push(
-          ...inbound.map(
-            (r: {
-              relationship_key: string;
-              snapshot?: unknown;
-              last_observation_at?: string;
-            }) => ({
-              ...r,
-              id: r.relationship_key, // Add id field for backward compatibility
-              direction: "inbound",
-              // Include snapshot metadata as top-level for backward compatibility
-              metadata: r.snapshot,
-              // Add created_at field per MCP_SPEC.md 3.16 (use last_observation_at as created_at)
-              created_at: r.last_observation_at,
-            })
-          )
-        );
+        if (parsed.relationship_type) {
+          inboundQuery = inboundQuery.eq("relationship_type", parsed.relationship_type);
+        }
+
+        const { data: inbound, error: inboundError } = await inboundQuery;
+
+        if (!inboundError && inbound) {
+          relationships.push(...inbound.map((r: any) => decorate(r, "inbound")));
+        }
       }
     }
 
@@ -3490,9 +3531,9 @@ export class NeotomaServer {
     });
 
     // Soft-deleted edges were already excluded at the DB via the `is_live`
-    // predicate on each direction's query (#1570), so `relationships` holds
-    // only live edges on the default path (all edges when include_deleted).
-    // `total` therefore reflects the correct post-filter count.
+    // predicate on each query (#1570), so `relationships` holds only live
+    // edges on the default path (all edges when include_deleted). `total`
+    // therefore reflects the correct post-filter count.
     const paginated = relationships.slice(parsed.offset, parsed.offset + parsed.limit);
 
     return this.buildTextResponse({

--- a/tests/integration/mcp_list_relationships_entity_filters.test.ts
+++ b/tests/integration/mcp_list_relationships_entity_filters.test.ts
@@ -1,0 +1,259 @@
+/**
+ * Integration test: MCP list_relationships entity-id filters (#2205).
+ *
+ * ListRelationshipsRequestSchema declares `source_entity_id` and
+ * `target_entity_id` alongside `entity_id`, and its `.refine` accepts any one
+ * of them alone. The HTTP /list_relationships handler implements all three.
+ * The MCP handler (NeotomaServer.listRelationships) filtered ONLY on
+ * `entity_id`, so a call passing just `source_entity_id` ran
+ * `.eq("source_entity_id", undefined)` and returned a confident **zero** for
+ * edges that demonstrably exist — while `entity_id` + direction on the same
+ * entity returned them. The tool description points callers at
+ * `source_entity_id` + `target_entity_id` for delete-type discovery, so the
+ * broken path was the documented one.
+ *
+ * The contract asserted here is the EQUIVALENCE between the two query paths:
+ *   - source_entity_id === entity_id + direction: outbound
+ *   - target_entity_id === entity_id + direction: inbound
+ * Testing the equivalence directly (rather than "returns > 0 rows") is what
+ * catches a partial fix that wires up one filter and not the other.
+ */
+
+import { createHash } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { NeotomaServer } from "../../src/server.js";
+import { db } from "../../src/db.js";
+
+const OWNER_USER_ID = "00000000-0000-0000-0000-0000000022a5";
+
+function makeEntityId(tag: string): string {
+  const hex = createHash("sha256").update(tag).digest("hex").slice(0, 24);
+  return `ent_${hex}`;
+}
+
+type McpResponse = { content: Array<{ type: string; text: string }> };
+
+type ListResult = {
+  relationships: Array<{
+    relationship_key: string;
+    relationship_type: string;
+    source_entity_id: string;
+    target_entity_id: string;
+    direction: string;
+  }>;
+  total: number;
+  limit: number;
+  offset: number;
+};
+
+async function listRelationships(
+  server: NeotomaServer,
+  params: Record<string, unknown>
+): Promise<ListResult> {
+  const raw = (await (
+    server as unknown as Record<string, (p: unknown) => Promise<McpResponse>>
+  ).listRelationships(params)) as McpResponse;
+  return JSON.parse(raw.content[0].text) as ListResult;
+}
+
+const keysOf = (result: ListResult): string[] =>
+  result.relationships.map((r) => r.relationship_key).sort();
+
+describe("MCP list_relationships entity-id filters (#2205)", () => {
+  let server: NeotomaServer;
+
+  const runId = Date.now();
+  const hubId = makeEntityId(`lr-filters-hub-${runId}`);
+  const childAId = makeEntityId(`lr-filters-child-a-${runId}`);
+  const childBId = makeEntityId(`lr-filters-child-b-${runId}`);
+  const parentId = makeEntityId(`lr-filters-parent-${runId}`);
+  const entityIds = [hubId, childAId, childBId, parentId];
+
+  // Two outbound edges from the hub (differing types) and one inbound edge to
+  // it, so the outbound/inbound equivalences are distinguishable and a
+  // relationship_type filter has something to narrow.
+  const edges = [
+    { type: "PART_OF", source: hubId, target: childAId },
+    { type: "REFERS_TO", source: hubId, target: childBId },
+    { type: "PART_OF", source: parentId, target: hubId },
+  ] as const;
+
+  const relationshipKeys = edges.map((e) => `${e.type}:${e.source}:${e.target}`);
+
+  async function seedEdge(
+    relationshipType: string,
+    sourceId: string,
+    targetId: string
+  ): Promise<void> {
+    const relationshipKey = `${relationshipType}:${sourceId}:${targetId}`;
+    const now = new Date().toISOString();
+
+    await db.from("relationship_observations").insert({
+      id: createHash("sha256").update(`${relationshipKey}:${OWNER_USER_ID}:obs`).digest("hex"),
+      relationship_key: relationshipKey,
+      source_entity_id: sourceId,
+      target_entity_id: targetId,
+      relationship_type: relationshipType,
+      source_priority: 1,
+      metadata: {},
+      canonical_hash: createHash("sha256")
+        .update(`${relationshipKey}:${OWNER_USER_ID}`)
+        .digest("hex"),
+      user_id: OWNER_USER_ID,
+      observed_at: now,
+      provenance: {},
+    });
+
+    await db.from("relationship_snapshots").upsert({
+      relationship_key: relationshipKey,
+      relationship_type: relationshipType,
+      source_entity_id: sourceId,
+      target_entity_id: targetId,
+      schema_version: "1.0",
+      snapshot: {},
+      computed_at: now,
+      observation_count: 1,
+      last_observation_at: now,
+      provenance: {},
+      user_id: OWNER_USER_ID,
+      is_live: 1,
+    });
+  }
+
+  beforeAll(async () => {
+    server = new NeotomaServer();
+    // Set authenticated user directly — avoids needing a real MCP initialize
+    // handshake (same approach as relationship_delete_discovery_mcp.test.ts).
+    (server as unknown as { authenticatedUserId: string }).authenticatedUserId = OWNER_USER_ID;
+
+    for (const id of entityIds) {
+      await db.from("entities").insert({
+        id,
+        user_id: OWNER_USER_ID,
+        entity_type: "note",
+        canonical_name: id,
+      });
+    }
+
+    for (const edge of edges) {
+      await seedEdge(edge.type, edge.source, edge.target);
+    }
+  });
+
+  afterAll(async () => {
+    await db.from("relationship_snapshots").delete().in("relationship_key", relationshipKeys);
+    await db.from("relationship_observations").delete().in("relationship_key", relationshipKeys);
+    await db.from("entities").delete().in("id", entityIds);
+  });
+
+  it("baseline: entity_id + direction returns the seeded edges", async () => {
+    // Guards the instrument itself: if this is zero, the fixture is wrong and
+    // the equivalence assertions below would pass vacuously (0 === 0).
+    const outbound = await listRelationships(server, {
+      entity_id: hubId,
+      direction: "outbound",
+      user_id: OWNER_USER_ID,
+    });
+    expect(outbound.total).toBe(2);
+
+    const inbound = await listRelationships(server, {
+      entity_id: hubId,
+      direction: "inbound",
+      user_id: OWNER_USER_ID,
+    });
+    expect(inbound.total).toBe(1);
+  });
+
+  it("source_entity_id returns the same edges as entity_id + direction: outbound", async () => {
+    const viaEntityId = await listRelationships(server, {
+      entity_id: hubId,
+      direction: "outbound",
+      user_id: OWNER_USER_ID,
+    });
+    const viaSource = await listRelationships(server, {
+      source_entity_id: hubId,
+      user_id: OWNER_USER_ID,
+    });
+
+    expect(viaSource.total).toBe(viaEntityId.total);
+    expect(keysOf(viaSource)).toEqual(keysOf(viaEntityId));
+    // Non-vacuous: the equivalence is over a non-empty set.
+    expect(keysOf(viaSource).length).toBeGreaterThan(0);
+  });
+
+  it("target_entity_id returns the same edges as entity_id + direction: inbound", async () => {
+    const viaEntityId = await listRelationships(server, {
+      entity_id: hubId,
+      direction: "inbound",
+      user_id: OWNER_USER_ID,
+    });
+    const viaTarget = await listRelationships(server, {
+      target_entity_id: hubId,
+      user_id: OWNER_USER_ID,
+    });
+
+    expect(viaTarget.total).toBe(viaEntityId.total);
+    expect(keysOf(viaTarget)).toEqual(keysOf(viaEntityId));
+    expect(keysOf(viaTarget).length).toBeGreaterThan(0);
+  });
+
+  it("source_entity_id + target_entity_id discovers the type of a specific edge", async () => {
+    // The path the tool description sends callers down before
+    // delete_relationship: "pass both source_entity_id and target_entity_id to
+    // discover the relationship_type".
+    const result = await listRelationships(server, {
+      source_entity_id: hubId,
+      target_entity_id: childBId,
+      user_id: OWNER_USER_ID,
+    });
+
+    expect(result.total).toBe(1);
+    expect(result.relationships[0].relationship_type).toBe("REFERS_TO");
+    expect(result.relationships[0].source_entity_id).toBe(hubId);
+    expect(result.relationships[0].target_entity_id).toBe(childBId);
+  });
+
+  it("combines relationship_type with source_entity_id", async () => {
+    const result = await listRelationships(server, {
+      source_entity_id: hubId,
+      relationship_type: "PART_OF",
+      user_id: OWNER_USER_ID,
+    });
+
+    expect(result.total).toBe(1);
+    expect(result.relationships[0].relationship_key).toBe(`PART_OF:${hubId}:${childAId}`);
+  });
+
+  it("tags rows with the direction relative to the filtered entity", async () => {
+    const viaSource = await listRelationships(server, {
+      source_entity_id: hubId,
+      user_id: OWNER_USER_ID,
+    });
+    // Assert the population first: `every` on an empty array is vacuously
+    // true, so without this the case would pass against the unfixed handler.
+    expect(viaSource.relationships).toHaveLength(2);
+    expect(viaSource.relationships.every((r) => r.direction === "outbound")).toBe(true);
+
+    const viaTarget = await listRelationships(server, {
+      target_entity_id: hubId,
+      user_id: OWNER_USER_ID,
+    });
+    expect(viaTarget.relationships).toHaveLength(1);
+    expect(viaTarget.relationships.every((r) => r.direction === "inbound")).toBe(true);
+  });
+
+  it("scopes the entity-id filters to the authenticated user", async () => {
+    // Tenant isolation must hold on the newly wired path too — a filter that
+    // forgets .eq("user_id") would leak another tenant's edges.
+    const otherUserServer = new NeotomaServer();
+    (otherUserServer as unknown as { authenticatedUserId: string }).authenticatedUserId =
+      "00000000-0000-0000-0000-0000000022a6";
+
+    const result = await listRelationships(otherUserServer, {
+      source_entity_id: hubId,
+      user_id: "00000000-0000-0000-0000-0000000022a6",
+    });
+
+    expect(result.total).toBe(0);
+  });
+});


### PR DESCRIPTION
Fixes #2205.

## The zero was real

Reproduced against a live instance with a known-good edge before changing anything:

| Query | Result |
|---|---|
| `entity_id` + `direction: outbound` | 2 edges |
| `source_entity_id` (same entity) | **0** |
| `target_entity_id` (the target of one of those edges) | **0** |

Same edges, same tenant, same call — one path finds them, the other returns a confident zero.

## Cause

The MCP handler never read `source_entity_id` or `target_entity_id` at all. It filtered only on `parsed.entity_id`:

```ts
.eq("source_entity_id", parsed.entity_id)   // undefined when only source_entity_id was passed
```

With `entity_id` absent, both direction queries ran `.eq(..., undefined)` and matched nothing.

This is not a deliberate semantic difference between the two query paths:

- All three filters are declared on the **shared** `ListRelationshipsRequestSchema`, whose `.refine` explicitly accepts any one of them alone.
- The HTTP `/list_relationships` handler implements all three branches correctly.
- The MCP tool description tells callers to pass **both** `source_entity_id` and `target_entity_id` to discover an edge's `relationship_type` before `delete_relationship` — so the broken path was the documented one.

Both filter directions were affected, which is broader than the issue records (it describes only `source_entity_id`). A `relationship_type`-only call — also permitted by the `.refine` — returned zero for the same reason.

## Fix

Mirror the HTTP handler's branch order in the MCP handler so both surfaces answer the same question the same way. Each row's `direction` is tagged relative to the entity actually filtered on. The `entity_id` + direction path keeps its existing two-query shape and per-direction tagging, so its behaviour is unchanged.

## Test

`tests/integration/mcp_list_relationships_entity_filters.test.ts` asserts the **equivalence** that is the real contract, rather than "returns more than zero rows":

- `source_entity_id` returns the same edge set as `entity_id` + `direction: outbound`
- `target_entity_id` returns the same edge set as `entity_id` + `direction: inbound`
- `source` + `target` together resolve a specific edge's type (the delete-discovery path)
- `relationship_type` composes with `source_entity_id`
- rows carry the correct `direction` tag
- the new path stays scoped to the authenticated user (tenant isolation)

Every equivalence runs over a **non-empty** fixture and asserts the population, so a partial fix wiring up one filter and not the other still fails, and no case passes vacuously on an empty set. A baseline case guards the fixture itself.

### Verified to fail when the fix is reverted

Reverting `src/server.ts` and rerunning the same test: **5 of 7 cases fail**, with exactly the reported symptom.

```
✓ baseline: entity_id + direction returns the seeded edges
× source_entity_id returns the same edges as entity_id + direction: outbound
× target_entity_id returns the same edges as entity_id + direction: inbound
× source_entity_id + target_entity_id discovers the type of a specific edge
× combines relationship_type with source_entity_id
× tags rows with the direction relative to the filtered entity
✓ scopes the entity-id filters to the authenticated user

AssertionError: expected +0 to be 2
Tests  5 failed | 2 passed (7)
```

The two that still pass on reverted code are the fixture baseline (uses the working `entity_id` path) and tenant isolation (asserts 0, so a broken filter also yields 0 — it guards against a leak the fix could introduce, not against the bug).

With the fix applied, all 7 pass.

## Why it survived

The existing `list_relationships variations` tests assert against **direct DB queries** rather than the MCP handler's own output, so they never exercised the handler's filter logic.

## Other verification

- Relationship suites (7 files, 51 tests): pass
- Contract MCP/CLI parity + tenant isolation matrix (27 tests): pass
- `tsc --noEmit`: clean
- `eslint src`: 0 errors
- `prettier --check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
