### PR TITLE
fix(ci): stop treating superseded/cancelled CI as red in operator autodeploy, fix silent escalation

### DIFF
--- a/.github/workflows/deploy-operator-instance.yml
+++ b/.github/workflows/deploy-operator-instance.yml
@@ -66,6 +66,7 @@ on:
 permissions:
   contents: read
   actions: read # read CI conclusions for the commit being deployed
+  issues: write # file/comment the escalation issue on deploy failure (see "Escalate on failure")
 
 # NOT cancel-in-progress. `flyctl deploy` on a single-machine app with an
 # attached volume is not atomic: cancelling mid-deploy can leave the machine
@@ -147,6 +148,20 @@ jobs:
           # This workflow's own check-run must be ignored, or it waits on
           # itself forever. Its check-run name is this job's name ("deploy"),
           # which is also matched below.
+          #
+          # `cancelled` is treated as PENDING, not FAILED, up front: CI test
+          # lanes runs under `concurrency: { group: ci-test-lanes-<ref>,
+          # cancel-in-progress: true }`, so a rapid follow-up push to main
+          # cancels the in-progress lane run for the OLDER commit currently
+          # being polled here. That cancellation says nothing about whether
+          # this SHA is red — it means CI never got to render a verdict for
+          # it, because a newer commit pushed while its lanes were still
+          # running. Failing the deploy on that basis produced a false
+          # "CI is not green" escalation on 2026-09-01 and 2026-09-06 for
+          # commits whose lanes were in fact never actually red — see the
+          # PR that introduced this comment for the run evidence. A run
+          # that stays cancelled all the way to DEADLINE is reported as
+          # inconclusive (not asserted red) in the timeout branch below.
           while :; do
             RAW=$(gh api "repos/$REPO/commits/$SHA/check-runs" --paginate \
                     --jq '.check_runs[] | [.name, .status, (.conclusion // "")] | @tsv' || true)
@@ -156,6 +171,7 @@ jobs:
             else
               PENDING=0
               FAILED=""
+              CANCELLED=""
               while IFS=$'\t' read -r NAME STATUS CONCLUSION; do
                 [ -z "${NAME:-}" ] && continue
                 # Skip this workflow's own runs (deploy, and any sibling step).
@@ -168,6 +184,14 @@ jobs:
                 fi
                 case "$CONCLUSION" in
                   success|skipped|neutral) ;;
+                  cancelled)
+                    # Not evidence of red — see comment above. Keep polling;
+                    # a fresh run for this SHA may still land (e.g. after a
+                    # `workflow_dispatch` re-run), and if not, the timeout
+                    # branch reports it as inconclusive rather than failed.
+                    PENDING=$((PENDING + 1))
+                    CANCELLED="${CANCELLED}${NAME}; "
+                    ;;
                   *) FAILED="${FAILED}${NAME} (${CONCLUSION}); " ;;
                 esac
               done <<< "$RAW"
@@ -182,12 +206,22 @@ jobs:
                 echo "OK: all check-runs green on $SHA."
                 break
               fi
-              echo "Waiting on $PENDING in-progress check-run(s)…"
+              if [ -n "$CANCELLED" ]; then
+                echo "Waiting on $PENDING check-run(s), including cancelled (likely superseded by a newer push): $CANCELLED"
+              else
+                echo "Waiting on $PENDING in-progress check-run(s)…"
+              fi
             fi
 
             if [ "$(date +%s)" -ge "$DEADLINE" ]; then
-              echo "FAIL: timed out after 45m waiting for CI on $SHA."
-              echo "Not deploying. This is a failure, not a pass — see the escalation below."
+              if [ -n "${CANCELLED:-}" ] && [ -z "${FAILED:-}" ]; then
+                echo "INCONCLUSIVE: timed out after 45m; $SHA's CI was superseded/cancelled ($CANCELLED) and never re-ran to a verdict."
+                echo "This is NOT evidence main is red — most likely a newer commit landed and this SHA's CI lane was cancelled by its own concurrency group before finishing."
+                echo "Not deploying without a green verdict. See the escalation below; a subsequent green merge will deploy normally."
+              else
+                echo "FAIL: timed out after 45m waiting for CI on $SHA."
+                echo "Not deploying. This is a failure, not a pass — see the escalation below."
+              fi
               exit 1
             fi
             sleep 30
@@ -407,6 +441,19 @@ jobs:
             gh label create autodeploy-failure --repo "$REPO" \
               --description "Automatic deploy to the operator instance failed" \
               --color B60205 2>/dev/null || true
-            gh issue create --repo "$REPO" --title "$TITLE" \
-              --label autodeploy-failure --body "$BODY"
+
+            # The label is a nice-to-have for triage filtering, not a
+            # precondition for the issue existing: `gh issue create --label`
+            # HARD-FAILS if the named label is missing (e.g. `gh label
+            # create` above failed silently on a transient error or a
+            # permissions gap), and that failure used to take the entire
+            # escalation down with it — filing NO issue at all while this
+            # step still reported "failure" in the Actions UI. Create the
+            # issue unconditionally first, then best-effort attach the
+            # label, so a label hiccup never suppresses the escalation
+            # itself.
+            ISSUE_URL=$(gh issue create --repo "$REPO" --title "$TITLE" --body "$BODY")
+            echo "Escalated by opening $ISSUE_URL"
+            gh issue edit "$ISSUE_URL" --repo "$REPO" --add-label autodeploy-failure \
+              || echo "Note: could not attach the autodeploy-failure label (issue above was still filed)."
           fi

--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,8 +61,8 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **589**
-- Backend and repo Vitest files: **554**
+- Total automated test files: **590**
+- Backend and repo Vitest files: **555**
 - Frontend Vitest files: **9**
 - Playwright spec files: **26**
 
@@ -74,7 +74,7 @@ flowchart TD
 | Source-adjacent tests | 66 |
 | Vitest integration tests | 167 |
 | Vitest CLI tests | 77 |
-| Vitest contract tests | 17 |
+| Vitest contract tests | 18 |
 | Vitest security tests | 7 |
 | Vitest subscription tests | 5 |
 | Vitest agent tests | 1 |
@@ -660,10 +660,11 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/contract`
 **Requirements:** Generated contract artifacts present when the suite expects them.
-**Files (17):**
+**Files (18):**
 - `tests/contract/cli_handler_dist_smoke.test.ts`
 - `tests/contract/contract_mapping.test.ts`
 - `tests/contract/contract_mcp_cli_parity.test.ts`
+- `tests/contract/deploy_workflow_ci_gate.test.ts`
 - `tests/contract/deploy_workflow_config.test.ts`
 - `tests/contract/fly_deploy_config.test.ts`
 - `tests/contract/get_entities_alias.test.ts`

--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,8 +61,8 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **590**
-- Backend and repo Vitest files: **555**
+- Total automated test files: **592**
+- Backend and repo Vitest files: **557**
 - Frontend Vitest files: **9**
 - Playwright spec files: **26**
 
@@ -74,7 +74,7 @@ flowchart TD
 | Source-adjacent tests | 66 |
 | Vitest integration tests | 167 |
 | Vitest CLI tests | 77 |
-| Vitest contract tests | 18 |
+| Vitest contract tests | 19 |
 | Vitest security tests | 7 |
 | Vitest subscription tests | 6 |
 | Vitest agent tests | 1 |
@@ -660,7 +660,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/contract`
 **Requirements:** Generated contract artifacts present when the suite expects them.
-**Files (18):**
+**Files (19):**
 - `tests/contract/cli_handler_dist_smoke.test.ts`
 - `tests/contract/contract_mapping.test.ts`
 - `tests/contract/contract_mcp_cli_parity.test.ts`
@@ -676,6 +676,7 @@ flowchart TD
 - `tests/contract/openclaw_plugin.test.ts`
 - `tests/contract/package_contents.test.ts`
 - `tests/contract/package_scripts.test.ts`
+- `tests/contract/relationship_type_enum_parity.test.ts`
 - `tests/contract/sdk_client_store_shape.test.ts`
 - `tests/contract/update_schema_incremental_canonical_parity_2018.test.ts`
 - `tests/contract/vite_config.test.ts`

--- a/tests/contract/deploy_workflow_ci_gate.test.ts
+++ b/tests/contract/deploy_workflow_ci_gate.test.ts
@@ -1,0 +1,96 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * Contract test over the operator deploy workflow's "Wait for CI" gate and
+ * "Escalate on failure" step, added alongside the fix for two regressions
+ * (see PR #2301 / issue #2303):
+ *
+ *  1. `cancelled` check-run conclusions (produced when a rapid follow-up push
+ *     cancels an in-progress `ci-test-lanes-<ref>` concurrency-group run for
+ *     an older commit) were treated identically to `failure`, hard-failing
+ *     the deploy on a false "CI is not green" verdict for a commit that was
+ *     never actually red.
+ *  2. The escalation step lacked `issues: write` and hard-failed on
+ *     `gh issue create --label autodeploy-failure` whenever the preceding
+ *     `gh label create` silently failed — so 0 issues were ever filed across
+ *     6 recorded autodeploy failures.
+ *
+ * These are shell-embedded behaviors inside YAML, not TypeScript units, so
+ * this test follows the existing pattern in
+ * `deploy_workflow_config.test.ts`: assert against the workflow's source
+ * text rather than executing the step live. It cannot invoke `gh api` here,
+ * so it does not simulate the live poll loop end-to-end; it asserts the
+ * specific source-level properties that are necessary for the fix to hold.
+ */
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "..", "..");
+const WORKFLOW = ".github/workflows/deploy-operator-instance.yml";
+
+function readWorkflow(): string {
+  return fs.readFileSync(path.join(repoRoot, WORKFLOW), "utf8");
+}
+
+describe("deploy_workflow_ci_gate_and_escalation", () => {
+  it("grants issues: write, without which the escalation issue can never be filed", () => {
+    const wf = readWorkflow();
+    const permsBlock = wf.match(/^permissions:\n((?:^ {2}.+\n)+)/m)?.[1] ?? "";
+    expect(permsBlock).toMatch(/^\s*issues:\s*write\b/m);
+  });
+
+  it("does not classify a cancelled check-run conclusion as FAILED", () => {
+    const wf = readWorkflow();
+    // The case statement's fallthrough `*)` arm appends to FAILED. `cancelled`
+    // must have its own arm ABOVE that fallthrough, or it silently re-inherits
+    // the failure classification this PR exists to remove.
+    const caseBlock = wf.match(/case "\$CONCLUSION" in([\s\S]*?)esac/)?.[1] ?? "";
+    expect(caseBlock).toMatch(/cancelled\)/);
+    const cancelledArmIndex = caseBlock.indexOf("cancelled)");
+    const fallthroughIndex = caseBlock.indexOf("*)");
+    expect(cancelledArmIndex).toBeGreaterThan(-1);
+    expect(fallthroughIndex).toBeGreaterThan(-1);
+    expect(cancelledArmIndex).toBeLessThan(fallthroughIndex);
+    // The cancelled arm must count toward PENDING (keep polling), not FAILED.
+    const cancelledArm = caseBlock.slice(cancelledArmIndex, fallthroughIndex);
+    expect(cancelledArm).toMatch(/PENDING=\$\(\(PENDING \+ 1\)\)/);
+    expect(cancelledArm).not.toMatch(/FAILED="\$\{FAILED\}/);
+  });
+
+  it("reports timeout as inconclusive (not a hard FAIL assertion of red) when only cancellations were seen", () => {
+    const wf = readWorkflow();
+    const timeoutBlock =
+      wf.match(/if \[ "\$\(date \+%s\)" -ge "\$DEADLINE" \]; then([\s\S]*?)\n\s*exit 1\n\s*fi/)?.[1] ??
+      "";
+    expect(timeoutBlock).toMatch(/INCONCLUSIVE/);
+    // Must still refuse to deploy either way (exit 1 unconditionally reached).
+    expect(wf).toMatch(/INCONCLUSIVE[\s\S]*?exit 1/);
+  });
+
+  it("creates the escalation issue unconditionally before attempting to attach the label", () => {
+    const wf = readWorkflow();
+    // Match the real create assignment, not the comment mentioning
+    // `gh issue create --label` (that comment is historical rationale and
+    // would false-red if we naively indexOf("gh issue create")).
+    expect(wf).toMatch(
+      /ISSUE_URL=\$\(gh issue create --repo "\$REPO" --title "\$TITLE" --body "\$BODY"\)/,
+    );
+    // Exclude YAML/shell comment lines: the historical rationale still mentions
+    // `gh issue create --label`, which must not false-red this assertion.
+    expect(wf).not.toMatch(/^[^#\n]*gh issue create[^\n]*--label/m);
+
+    // Capture through the || guard on the edit continuation so we assert
+    // the non-fatal attach, not just the first line of `gh issue edit`.
+    const escalation =
+      wf.match(/gh label create autodeploy-failure[\s\S]*?gh issue edit[\s\S]*?\|\|[\s\S]*?\n/)?.[0] ??
+      "";
+    expect(escalation).not.toBe("");
+    expect(escalation.indexOf("ISSUE_URL=$(gh issue create")).toBeLessThan(
+      escalation.indexOf("gh issue edit"),
+    );
+    expect(escalation).toMatch(/gh issue edit[\s\S]*?\|\|/);
+  });
+});


### PR DESCRIPTION
## What is broken

Two independent, unrelated defects were both firing on `deploy-operator-instance.yml`, and a third (this issue's own escalation mechanism) meant nobody was ever told.

### 1. `cancelled` CI check-runs treated as red (3 of 6 recorded runs: 33530741735, 33533942535 partial, 34031108288, 34031253198)

`CI test lanes` runs under `concurrency: { group: ci-test-lanes-${{ github.ref }}, cancel-in-progress: true }`. When a second commit lands on `main` seconds after the first, GitHub cancels the first commit's in-progress lane run. The "Wait for CI to pass on this commit" gate in the deploy workflow polls check-runs for the *exact* SHA it is deploying and hard-fails the instant any check-run's conclusion is not `success`/`skipped`/`neutral` — so a `cancelled` conclusion (meaning "superseded, never rendered a verdict") was treated identically to `failure` (meaning "actually red").

Evidence — run `34031253198` (2026-09-06), polling commit A:
```
FAIL: CI is not green on <sha-A> — graph_render_smoke (cancelled); site_export (cancelled); eval_combined (cancelled); baseline (cancelled); agentic_evals (cancelled); eval_scenarios (cancelled);
```
A second commit (B) landed on `main` ~3 minutes later; its own `CI test lanes` run completed with conclusion `success`. Commit A's lanes were not red — they were cancelled by commit B's push before finishing, per the CI workflow's own concurrency group. Same pattern on 2026-09-01 (run `33530741735`, commit `fde0fcf4`) and again on 2026-09-06 (run `34031108288`, commit `49106f4d`).

### 2. `Verify deploy` failing on a real 401 from the read probe (3 of 6 recorded runs: 34031160077, 33588589885, 33533942535)

Checks (a)-(d) — `/health`, `git_sha`, page bytes, always-on — all pass. Check (e), the authenticated read probe (`GET /entities?limit=1` with `OPERATOR_INSTANCE_TOKEN`), returns **HTTP 401** every time, not a timeout. This is a credential problem on the operator's instance, not a code defect — **out of scope for this PR, operator action required** (see below).

### 3. The escalation step has never fired — 0 issues filed, ever

`gh issue list --repo "$REPO" --state open --label autodeploy-failure` and `gh issue create --label autodeploy-failure` both need `issues: write`, but this workflow's `permissions:` block only grants `contents: read` and `actions: read`. Every `gh label create` call failed for the same reason and was swallowed by `|| true`; the following `gh issue create --label autodeploy-failure` then hard-failed because `gh` refuses to attach a label that doesn't exist — taking the entire escalation step down with it on every single failing run. Confirmed: `gh issue list --repo markmhendrickson/neotoma --label autodeploy-failure --state all` returns zero issues despite 6 failing runs designed to file one.

This is the "reporting without binding" defect: every autodeploy failure since 2026-09-01 has been completely silent.

## What this PR fixes

- `permissions:` now includes `issues: write`.
- "Wait for CI" now tracks `cancelled` separately from real failure conclusions. Cancelled check-runs keep the gate polling (a fresh verdict may still land); at the 45m timeout, a SHA whose only non-green conclusions are `cancelled` is reported as **inconclusive**, not asserted red — and the deploy still correctly refuses to proceed without an actual green verdict.
- The escalation step now creates the issue unconditionally, then best-effort attaches the label — so a label problem can never again suppress the issue itself.

## What this PR does NOT fix (operator action required)

- **Check (e) 401**: `OPERATOR_INSTANCE_TOKEN` is being rejected by the instance's authenticated-read endpoint. This is a credential issue on the operator's own instance — rotate/verify the token in the repo secret `OPERATOR_INSTANCE_TOKEN`. Not attempted here per scope (no credential rotation or reads).

## Is this the same failure as #2146?

**No — different workflow, different trigger, different root cause.** #2146 is `deploy-pages-site.yml`, triggered on `release: published`, deploying to the `github-pages` GitHub Environment. Every failing run since v0.21.0 fails in ~1 second with zero steps executed:
```
Tag "v0.21.0" is not allowed to deploy to github-pages due to environment protection rules.
```
Confirmed via `gh api repos/markmhendrickson/neotoma/environments/github-pages`: `deployment_branch_policy.custom_branch_policies: true` with an active `branch_policy` protection rule. This is a repo **Settings → Environments → github-pages → Deployment branches and tags** rule, most likely one that allow-lists branch patterns (e.g. `main`) but not tag patterns (releases deploy from a tag like `v0.21.0`, not a branch). This is **not expressible in any workflow file or repo config** — it lives entirely in GitHub's environment protection settings and requires operator action in the Settings UI:

> Settings → Environments → `github-pages` → Deployment branches and tags → add a tag rule matching release tags (e.g. `v*`).

Commented on #2146 with this finding, cross-referencing this PR.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #2303
