### PR TITLE
fix(mcp): let every creatable relationship type also be deleted

### DIFF
--- a/src/tool_definitions.ts
+++ b/src/tool_definitions.ts
@@ -1,4 +1,5 @@
 import { getOpenApiInputSchemaOrThrow } from "./shared/openapi_schema.js";
+import { RelationshipTypeSchema } from "./shared/action_schemas.js";
 
 export type ToolInputSchema = Record<string, unknown>;
 
@@ -10,16 +11,20 @@ export interface ToolDefinition {
   _meta?: Record<string, unknown>;
 }
 
-const RELATIONSHIP_TYPE_ENUM = [
-  "PART_OF",
-  "CORRECTS",
-  "REFERS_TO",
-  "SETTLES",
-  "DUPLICATE_OF",
-  "DEPENDS_ON",
-  "SUPERSEDES",
-  "EMBEDS",
-];
+/**
+ * Relationship types advertised by the hand-built tool schemas
+ * (`delete_relationship`, `restore_relationship`, `get_relationship_snapshot`).
+ *
+ * Derived from `RelationshipTypeSchema` — the SAME Zod enum the server parses
+ * these three requests with — rather than restated as a literal. Until #1972
+ * this was a local 8-member list while `create_relationship` (whose schema
+ * comes from OpenAPI) advertised 28, so an edge written with any of the other
+ * 20 types was advertised to MCP clients as undeletable: a schema-validating
+ * client refused the call before it reached a server that would have accepted
+ * it. Reading the advertisement off the validator makes that class of drift
+ * unrepresentable here instead of merely fixed once.
+ */
+const RELATIONSHIP_TYPE_ENUM: readonly string[] = RelationshipTypeSchema.options;
 
 /**
  * Build the complete list of Neotoma MCP tool definitions.
@@ -636,7 +641,8 @@ export function buildToolDefinitions(
         properties: {
           relationship_type: {
             type: "string",
-            description: "Relationship type (e.g. PART_OF, REFERS_TO, EMBEDS)",
+            description:
+              "Exact relationship type of the existing edge. Accepts the same set create_relationship writes: structural types (PART_OF, REFERS_TO, EMBEDS) and domain types (works_at, related_to, owns).",
             enum: RELATIONSHIP_TYPE_ENUM,
           },
           source_entity_id: {
@@ -699,7 +705,8 @@ export function buildToolDefinitions(
         properties: {
           relationship_type: {
             type: "string",
-            description: "Relationship type (e.g. PART_OF, REFERS_TO, EMBEDS)",
+            description:
+              "Exact relationship type of the existing edge. Accepts the same set create_relationship writes: structural types (PART_OF, REFERS_TO, EMBEDS) and domain types (works_at, related_to, owns).",
             enum: RELATIONSHIP_TYPE_ENUM,
           },
           source_entity_id: {

--- a/tests/contract/relationship_type_enum_parity.test.ts
+++ b/tests/contract/relationship_type_enum_parity.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Contract test: relationship_type vocabulary parity across MCP tools (#1972, step 1).
+ *
+ * `create_relationship` derives its `relationship_type` enum from the OpenAPI
+ * definition (28 members). `delete_relationship`, `restore_relationship`, and
+ * `get_relationship_snapshot` hand-built their schemas from a local 8-member
+ * literal in `src/tool_definitions.ts`. The result was a one-way door: an edge
+ * written with any of the other 20 types (`works_at`, `related_to`, `owns`, …)
+ * was advertised to MCP clients as undeletable, because a schema-validating
+ * client refuses the call before it ever reaches the server — whose Zod schema
+ * would have accepted it.
+ *
+ * These assertions fail if any of the four tools' advertised type sets diverge
+ * again, which is the durable half of the fix: re-widening one copy by hand
+ * would simply reset the clock.
+ */
+
+import { describe, expect, it } from "vitest";
+import { buildToolDefinitions } from "../../src/tool_definitions.js";
+import { RelationshipTypeSchema } from "../../src/shared/action_schemas.js";
+
+type EnumProperty = { type?: string; enum?: string[] };
+
+/** Every MCP tool that takes a `relationship_type` naming an existing edge. */
+const RELATIONSHIP_TYPE_TOOLS = [
+  "create_relationship",
+  "delete_relationship",
+  "restore_relationship",
+  "get_relationship_snapshot",
+] as const;
+
+function relationshipTypeEnum(toolName: string): string[] {
+  const definition = buildToolDefinitions().find((tool) => tool.name === toolName);
+  expect(definition, `tool definition missing: ${toolName}`).toBeTruthy();
+
+  const properties = (definition!.inputSchema as { properties?: Record<string, EnumProperty> })
+    .properties;
+  const relationshipType = properties?.relationship_type;
+  expect(relationshipType, `${toolName} does not declare relationship_type`).toBeTruthy();
+  expect(relationshipType!.type).toBe("string");
+  expect(
+    relationshipType!.enum,
+    `${toolName} declares relationship_type without an enum`
+  ).toBeTruthy();
+
+  return relationshipType!.enum!;
+}
+
+describe("relationship_type enum parity across MCP tools (#1972)", () => {
+  it("advertises an identical type set on every relationship tool", () => {
+    const baseline = relationshipTypeEnum("create_relationship");
+
+    for (const toolName of RELATIONSHIP_TYPE_TOOLS) {
+      expect(
+        [...relationshipTypeEnum(toolName)].sort(),
+        `${toolName} advertises a different relationship_type set than create_relationship`
+      ).toEqual([...baseline].sort());
+    }
+  });
+
+  it("advertises exactly what the server's Zod schema accepts", () => {
+    // The server validates with RelationshipTypeSchema. A tool advertising a
+    // narrower set makes valid calls unreachable; a wider set promises calls
+    // the server will reject. Both are contract breaks.
+    const serverAccepts = [...RelationshipTypeSchema.options].sort();
+
+    for (const toolName of RELATIONSHIP_TYPE_TOOLS) {
+      expect(
+        [...relationshipTypeEnum(toolName)].sort(),
+        `${toolName} advertises a type set the server does not exactly accept`
+      ).toEqual(serverAccepts);
+    }
+  });
+
+  it("lets every creatable type also be deleted and restored", () => {
+    // The original defect, stated as behaviour rather than as set equality:
+    // every type create_relationship accepts must be nameable at delete and
+    // restore, or the edge it writes becomes undeletable through MCP.
+    const creatable = relationshipTypeEnum("create_relationship");
+    const deletable = new Set(relationshipTypeEnum("delete_relationship"));
+    const restorable = new Set(relationshipTypeEnum("restore_relationship"));
+
+    const undeletable = creatable.filter((type) => !deletable.has(type));
+    const unrestorable = creatable.filter((type) => !restorable.has(type));
+
+    expect(undeletable, "types that can be created but not deleted").toEqual([]);
+    expect(unrestorable, "types that can be created but not restored").toEqual([]);
+  });
+
+  it("includes the domain types, not only the canonical structural ones", () => {
+    // Guards against a "fix" that quietly settles on the 8-member structural
+    // set everywhere, which would restore parity by breaking creation instead.
+    for (const toolName of RELATIONSHIP_TYPE_TOOLS) {
+      expect(relationshipTypeEnum(toolName)).toEqual(
+        expect.arrayContaining(["PART_OF", "EMBEDS", "works_at", "related_to", "invested_in"])
+      );
+    }
+  });
+});


### PR DESCRIPTION
## The defect

`create_relationship` builds its `relationship_type` enum from the OpenAPI definition — **28 members**. `delete_relationship`, `restore_relationship`, and `get_relationship_snapshot` hand-built theirs from a local **8-member** literal in `src/tool_definitions.ts`.

So an edge written with any of the other 20 types (`works_at`, `related_to`, `owns`, `invested_in`, …) was advertised to MCP clients as **undeletable**. A schema-validating client refuses the call against the narrow enum before it ever reaches the server — whose Zod schema (`RelationshipTypeSchema`) would have accepted it. A one-way door: the graph could accumulate edges no MCP caller could remove.

Confirmed against the deployed production tool surface, not only source: the live `delete_relationship` schema advertises exactly the 8 structural types while `create_relationship` and `store`'s `relationships` array both advertise 28.

`get_relationship_snapshot` shared the same literal and is fixed by the same change — it was not named in the parent issue but has the identical defect.

## The fix

Derive `RELATIONSHIP_TYPE_ENUM` from `RelationshipTypeSchema` — the same Zod enum the server already parses all three of these requests with (`DeleteRelationshipRequestSchema`, `RestoreRelationshipRequestSchema`, `RelationshipSnapshotRequestSchema`).

Deliberately *not* widening the 8-member literal to 28 by hand. The vocabulary is currently restated in six places; a hand-widened copy would be a seventh, and the next divergence waiting to happen. Reading the advertisement off the validator that actually gates the request makes the two structurally incapable of disagreeing — the advertised set is now a projection of the accepted set rather than a copy of it.

The two `relationship_type` property descriptions are updated to match, since "e.g. PART_OF, REFERS_TO, EMBEDS" implied a structural-only vocabulary.

## Anti-regression test

`tests/contract/relationship_type_enum_parity.test.ts` asserts:

1. All four relationship tools advertise an identical type set.
2. Each advertises exactly what the server's Zod schema accepts — a narrower set makes valid calls unreachable, a wider set promises calls the server rejects.
3. Every type `create_relationship` accepts is nameable at delete and restore (the original defect, stated as behaviour rather than set equality).
4. The set includes domain types, not only structural ones — guarding against a future "fix" that restores parity by narrowing creation to the 8 instead.

**All four fail on the parent commit**, listing exactly the 20 types creatable but not deletable.

## Verification

- Full suite on this branch: **22 failed / 5381 passed / 54 skipped** (551 files).
- Same suite on clean `origin/main`: **25 failed / 5394 passed / 54 skipped**.
- Every failing file on this branch also fails on `main`; the set difference in the regression direction is **empty**. The failures are pre-existing and flaky (counts move between runs on identical code) — `v0.2.0_ingestion`, `turn_summary`, `inspector_content_negotiation`, `mcp_target_id_identity_conflict`, and others unrelated to relationships.
- `tsc --noEmit` clean; `eslint` 0 errors (328 pre-existing warnings); prettier clean.

## Scope

Widening only — no previously-accepted input starts being rejected, so this is not a tightening change under the change-guardrails rules and needs no legacy-payload fixture flip.

Deliberately **not** included, as the rest of #1972: the registry table, `register_relationship_type`, collapsing all six copies of the vocabulary, the hierarchical validator.

### Adjacent, not touched

`store`'s relationships array validates `relationship_type` as an open `z.string()` (`StoreRelationshipInputSchema`, `src/shared/action_schemas.ts`) while advertising the closed 28-member enum. An unknown type therefore passes Zod and throws at the service layer *after* entities persist — and `store` is not transactional, so the entities are orphaned. That is a separate code path from the three tool schemas changed here and is left alone rather than pulled into this PR.

---

Parent: #1972. This is **step 1** of its sequence and is independently shippable — it fixes a live bug on its own and does not depend on the registry work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
