### PR TITLE
fix(ci): retry the operator deploy's authenticated read probe within its 90s budget

### DIFF
--- a/.github/workflows/deploy-operator-instance.yml
+++ b/.github/workflows/deploy-operator-instance.yml
@@ -311,10 +311,24 @@ jobs:
 
           # (e) AUTHENTICATED READ PROBE — exercises the database, not just the
           #     HTTP listener. This is the check /health cannot make.
-          #     Budget 90s: a cold read against the operator's ~20GB graph
-          #     legitimately takes 14-18s after a restart, so a short timeout
-          #     would report a false failure on every deploy. Anything beyond
-          #     90s is the wedged-DB signature, not slowness.
+          #     Budget 90s total, spent as retries with backoff (below), not a
+          #     single curl call. A cold read against the operator's ~20GB
+          #     graph legitimately takes 14-18s after a restart: (a)-(d) above
+          #     only prove the HTTP listener is up, not that the DB layer has
+          #     finished its own boot-time seeding and warmed its page cache.
+          #     One request landing in that window can get a 502 — server- or
+          #     proxy-side — even though the instance recovers a few seconds
+          #     later. Confirmed on 2026-09-06 (run 34039966130): the probe's
+          #     own curl measured exactly 14.3s from request start to the 502,
+          #     matching this comment's own 14-18s cold-read figure. A single
+          #     attempt cannot tell a transient cold-boot 502 from a wedged
+          #     DB; retrying inside the SAME 90s budget can, without weakening
+          #     what still counts as failure — reads still have to come back
+          #     inside 90s, and every attempt is logged so a real outage is
+          #     just as visible as before, not quieter.
+          #
+          #     Anything that fails for the full 90s is the wedged-DB
+          #     signature, not slowness.
           if [ -z "${READ_PROBE_TOKEN:-}" ]; then
             echo "FAIL: OPERATOR_INSTANCE_TOKEN is not set — cannot verify the"
             echo "instance actually serves reads. /health alone has passed"
@@ -322,14 +336,51 @@ jobs:
             echo "deploy verified."
             exit 1
           fi
-          CODE=$(curl -s -o /tmp/entities.json -w '%{http_code}' --max-time 90 \
-                   -H "Authorization: Bearer $READ_PROBE_TOKEN" \
-                   "https://$HOST/entities?limit=1" || echo "000")
-          if [ "$CODE" != "200" ]; then
-            echo "FAIL: authenticated read returned HTTP $CODE (000 = timeout/no response)."
-            echo "The instance is not serving reads even if /health is green."
-            exit 1
-          fi
+
+          READ_PROBE_DEADLINE=$(( $(date +%s) + 90 ))
+          ATTEMPT=0
+          CODE=""
+          while :; do
+            ATTEMPT=$((ATTEMPT + 1))
+            REMAINING=$(( READ_PROBE_DEADLINE - $(date +%s) ))
+            if [ "$REMAINING" -le 0 ]; then
+              echo "FAIL: authenticated read did not return 200 within the 90s budget"
+              echo "(last HTTP code: ${CODE:-none}, $((ATTEMPT - 1)) attempt(s))."
+              echo "The instance is not serving reads even if /health is green."
+              exit 1
+            fi
+
+            # --max-time caps THIS attempt only, never below 10s so a single
+            # try has a fair shot even late in the budget; the outer deadline
+            # above is what actually enforces the 90s ceiling. Timing comes
+            # from curl's own %{time_total}, not shell `date` arithmetic —
+            # GNU date's sub-second %N is not portable (BSD/macOS date lacks
+            # it), and curl already measures this precisely.
+            ATTEMPT_TIMEOUT=$(( REMAINING < 10 ? 10 : REMAINING ))
+            RESULT=$(curl -s -o /tmp/entities.json -w '%{http_code} %{time_total}' --max-time "$ATTEMPT_TIMEOUT" \
+                     -H "Authorization: Bearer $READ_PROBE_TOKEN" \
+                     "https://$HOST/entities?limit=1" || echo "000 0")
+            CODE="${RESULT%% *}"
+            ELAPSED_S="${RESULT#* }"
+
+            if [ "$CODE" = "200" ]; then
+              echo "OK authenticated read: HTTP 200 on attempt $ATTEMPT after ${ELAPSED_S}s"
+              break
+            fi
+
+            # Distinguish "the proxy answered" from "nothing answered" so a
+            # future failure is diagnosable from this log alone, without
+            # needing flyctl logs from a window that may have already rolled
+            # off the buffer (see run 34039966130, where the buffer had
+            # rolled past the incident by the time it was investigated).
+            case "$CODE" in
+              000) SOURCE="no response (client-side timeout or connection error)" ;;
+              502|503|504) SOURCE="proxy/app 502-class — Fly proxy returned this even though (a)-(d) passed; app may not have finished booting its DB layer" ;;
+              *) SOURCE="unexpected HTTP $CODE from the app itself" ;;
+            esac
+            echo "Attempt $ATTEMPT: HTTP ${CODE:-000} after ${ELAPSED_S}s — $SOURCE. Retrying (${REMAINING}s left in budget)…"
+            sleep 3
+          done
           node -e '
             const j = require("/tmp/entities.json");
             const rows = Array.isArray(j) ? j : (j.entities ?? j.data ?? j.results);


### PR DESCRIPTION
## What

Check (e) of `deploy-operator-instance.yml` — the authenticated read probe — now spends its existing 90s budget as retries with 3s backoff instead of a single `curl` call. Same pass/fail contract: a real read outage still fails after the full 90s. Each attempt now logs its HTTP code and curl's own `%{time_total}`, and classifies the failure (no response / 502-504 / other) so a future incident is diagnosable from the workflow log alone.

## Why

Run 34039966130 (2026-09-06) failed check (e) with **HTTP 502 exactly 14.3s** after the request started — landing inside the same 14-18s cold-read window the check's own comment already documents. Diagnosis, from the run's own logs (the live `flyctl logs` buffer had already rolled past the incident, twice over, by the time this was investigated — two later deploys had pushed it out):

- The app machine reached `started` at 14:43:24Z and passed flyctl's own smoke checks at 14:43:43Z — ~19s after the restart began.
- `startHTTPServer()` in `src/actions.ts` runs 8 sequential schema-seed steps and only calls `tryListen()` — the code path that makes `/health` and `/ready` answer at all — after every one finishes. A separate cold-boot log capture confirmed an 18s gap between "Machine started" and the first schema-seed log line.
- The authenticated read landed at 14:43:46Z, ~22s after restart began: right after the listener opened, against a SQLite-backed store (a Fly volume-mounted ~20GB file, no separate DB service) with a cold OS page cache.
- No `response_timeout` in `fly.toml`/`fly.operator.toml`, no matching timeout constant anywhere in the codebase, and no documented Fly platform default explains a fixed 14s cutoff. Fly's own docs describe a 502 right after deploy as an app-not-ready-yet symptom ("increase your health check grace period"), not a named proxy timer.

This does not settle whether the 502 was raised by the app or by Fly's proxy on the app's behalf — the log buffer no longer covers that window. What the run's own curl output does establish is that a single request landed in a window a cold read is documented to legitimately need 14-18s for, and got a 502 instead of the 200 the same kind of read gets once warm.

## Why this doesn't weaken the check

The check existed because a green `/health` once coexisted with a total read outage (ateles#577). Retrying inside the same 90s ceiling closes exactly the gap this run exposed (one bad-timing request ≠ a wedged DB) without touching what still counts as a real failure — reads still have to succeed inside 90s, or the deploy is reported broken exactly as before.

## Verification

- `python3 -c "import yaml; yaml.safe_load(...)"` — YAML parses.
- `shellcheck` on the extracted `run:` block — no new warnings (one pre-existing SC2155 on an unrelated line).
- Dry-ran the retry loop standalone against both a transient-failure-then-success sequence and a permanent-failure sequence — confirms it retries correctly and still exits 1 after the budget is exhausted.

No deploy, restart, or credential access was performed. No `flyctl` mutation ran against the operator instance; all commands were `status`/`machine status`/`releases`/`logs` reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)