### PR TITLE
fix(test): make the full local suite green on a clean checkout

### DIFF
--- a/.github/workflows/ci_test_lanes.yml
+++ b/.github/workflows/ci_test_lanes.yml
@@ -182,6 +182,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Build server (vitest.global_setup.ts requires dist/ before a raw `vitest run`)
+        run: npm run build:server
+
       - name: Run frontend Vitest suite
         run: npm run test:frontend
 
@@ -286,6 +289,9 @@ jobs:
           npm run build --prefix packages/client
           npm ci --prefix packages/cursor-hooks
           npm run build --prefix packages/cursor-hooks
+
+      - name: Build server (vitest.global_setup.ts requires dist/ before a raw `vitest run`)
+        run: npm run build:server
 
       - name: Run Tier 1 agentic evals
         run: npm run eval:tier1
@@ -412,6 +418,9 @@ jobs:
 
       - name: Protected routes manifest sync (G3 + manifest-sync)
         run: npm run security:manifest:check
+
+      - name: Build server (vitest.global_setup.ts requires dist/ before a raw `vitest run`)
+        run: npm run build:server
 
       - name: Topology auth matrix (G3)
         run: npm run test:security:auth-matrix

--- a/docs/developer/getting_started.md
+++ b/docs/developer/getting_started.md
@@ -110,20 +110,6 @@ npm run dev:full
 
 ## Run tests
 
-`npm test` runs the whole Vitest suite, which is wider than the CI baseline lane
-(that lane runs `npm run test:unit`). The extra lanes — `tests/integration`,
-`tests/fixtures` and `inspector/src` — need build artifacts a plain `npm install`
-does not produce, notably the built Inspector SPA at `dist/inspector` and
-`inspector/node_modules`. Without them a clean checkout that is green in CI still
-fails locally, which also blocks the pre-commit hook. Run the setup once per
-checkout:
-
-```bash
-npm run test:setup
-```
-
-Then:
-
 ```bash
 npm test
 npm run test:integration
@@ -131,6 +117,51 @@ npm run test:e2e
 npm run type-check
 npm run lint
 ```
+
+`npm test` runs the whole Vitest suite, which is wider than the CI baseline lane
+(that lane runs `npm run test:unit`). The extra lanes — `tests/integration`,
+`tests/fixtures` and `inspector/src` — reach build artifacts a plain `npm ci`
+does not produce: the built Inspector SPA at `dist/inspector`, the Inspector's
+own `inspector/node_modules`, and the compiled `packages/cursor-hooks/dist`.
+
+### Local prerequisites and the skip policy
+
+On a fresh clone those artifacts are absent, and the suites that need them
+**skip with a named reason** rather than fail. The reason is printed at the top
+of the run:
+
+```
+[neotoma] SKIP inspector-shell suites — missing prerequisite: built inspector assets — npm run build:inspector (or npm run test:setup)
+```
+
+So `npm test` and the pre-commit hook both pass on a fresh clone with no extra
+setup, and any failure you see is attributable to your own change. This is
+deliberate: a failure caused by a missing local build step is indistinguishable
+from a real regression, and that ambiguity is what drove contributors to
+`--no-verify`.
+
+To actually **run** the skipped suites — do this before trusting a green run on
+a change that touches the Inspector or the cursor hooks — install and build
+their prerequisites once per checkout:
+
+```bash
+npm run test:setup
+```
+
+Skips are opt-out by construction: the moment the artifact exists the suite runs
+again, with no flag to remember.
+
+### If `dist/` is missing
+
+`npm test` builds the server first via `pretest`, so this only bites when you
+invoke Vitest directly. A raw `npx vitest run` on an unbuilt checkout stops
+immediately with:
+
+```
+[neotoma] dist/ is missing. Run `npm test` (pretest builds server) or `npm run build:server` before `npx vitest run`.
+```
+
+rather than emitting hundreds of unrelated failures across `tests/cli/**`.
 
 ## Feature guides
 

--- a/docs/developer/getting_started.md
+++ b/docs/developer/getting_started.md
@@ -110,6 +110,20 @@ npm run dev:full
 
 ## Run tests
 
+`npm test` runs the whole Vitest suite, which is wider than the CI baseline lane
+(that lane runs `npm run test:unit`). The extra lanes — `tests/integration`,
+`tests/fixtures` and `inspector/src` — need build artifacts a plain `npm install`
+does not produce, notably the built Inspector SPA at `dist/inspector` and
+`inspector/node_modules`. Without them a clean checkout that is green in CI still
+fails locally, which also blocks the pre-commit hook. Run the setup once per
+checkout:
+
+```bash
+npm run test:setup
+```
+
+Then:
+
 ```bash
 npm test
 npm run test:integration

--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,15 +61,15 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **592**
-- Backend and repo Vitest files: **557**
+- Total automated test files: **593**
+- Backend and repo Vitest files: **558**
 - Frontend Vitest files: **9**
 - Playwright spec files: **26**
 
 ### Suite counts
 | Suite | Files |
 |---|---:|
-| Vitest unit tests | 163 |
+| Vitest unit tests | 164 |
 | Vitest service tests | 44 |
 | Source-adjacent tests | 66 |
 | Vitest integration tests | 167 |
@@ -109,7 +109,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/unit`
 **Requirements:** Basic `.env` if required by the module under test.
-**Files (163):**
+**Files (164):**
 - `tests/unit/aauth_admission.test.ts`
 - `tests/unit/aauth_attestation_apple_se.test.ts`
 - `tests/unit/aauth_attestation_revocation.test.ts`
@@ -265,6 +265,7 @@ flowchart TD
 - `tests/unit/submit_issue_dx.test.ts`
 - `tests/unit/subscription_types.test.ts`
 - `tests/unit/substrate_event_bus.test.ts`
+- `tests/unit/test_prerequisites.test.ts`
 - `tests/unit/timeline_events.test.ts`
 - `tests/unit/timeline_query.test.ts`
 - `tests/unit/turn_summary_widget.test.ts`

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "watch:full": "npm run dev",
     "watch:full:prod": "npm run dev:full:prod",
     "test": "vitest run",
+    "test:setup": "bash scripts/setup_test_env.sh",
     "test:unit": "vitest run tests/unit tests/services tests/agent tests/contract tests/security tests/cli tests/subscriptions",
     "test:frontend": "cross-env RUN_FRONTEND_TESTS=1 vitest run frontend/src",
     "test:integration": "vitest run tests/integration",

--- a/scripts/setup_test_env.sh
+++ b/scripts/setup_test_env.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# Prepare a fresh checkout to run the FULL Vitest suite (`npm test`).
+#
+# Why this exists
+# ---------------
+# The CI baseline lane runs `npm run test:unit`, which covers only
+#   tests/unit tests/services tests/agent tests/contract tests/security
+#   tests/cli tests/subscriptions
+# The pre-commit hook, by contrast, runs `npm test` (plain `vitest run`), which
+# ALSO picks up tests/integration, tests/fixtures, src/**, and inspector/src/**.
+# Those extra lanes need build artifacts CI's baseline job never produces, so a
+# clean checkout that is perfectly green in CI still fails locally — which is
+# what pushed contributors onto `--no-verify`.
+#
+# Everything below is either a step CI's baseline lane already performs, or a
+# build artifact that only the wider local lane requires. It installs and builds;
+# it does not run tests.
+#
+# Usage: ./scripts/setup_test_env.sh   (or: npm run test:setup)
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+echo "==> Installing root dependencies"
+npm ci
+
+# --- Steps mirrored from .github/workflows/ci_test_lanes.yml (baseline lane) ---
+
+echo "==> Initializing the inspector submodule (Vitest imports inspector sources)"
+git submodule update --init --depth 1 inspector || true
+
+echo "==> Building @neotoma/client, @neotoma/agent and cursor-hooks (hook tests import their dist/)"
+for pkg in client agent cursor-hooks; do
+  npm ci --prefix "packages/$pkg"
+  npm run build --prefix "packages/$pkg"
+done
+
+# opencode-plugin's tests import src/ directly, so no build is needed — but the
+# node_modules symlink for "@neotoma/client": "file:../client" must exist for
+# ESM resolution.
+npm ci --prefix packages/opencode-plugin
+
+echo "==> Building the server (required by the CLI tests)"
+npm run build:server
+
+# --- Steps the FULL suite needs that CI's baseline lane does not perform -------
+
+# tests/integration/{csp_local_http,embed_cross_origin_http,inspector_content_negotiation}
+# assert on the served SPA shell, so they need a real dist/inspector/index.html;
+# without it the mount serves 404/JSON and the assertions fail. This also
+# installs inspector/node_modules, which inspector/src/**/*.test.ts import from
+# (e.g. @xyflow/react in inspector/src/lib/graph_layout.ts).
+echo "==> Building the Inspector SPA (dist/inspector) and installing its dependencies"
+npm run build:inspector
+
+echo
+echo "Setup complete. Run the full suite with: npm test"

--- a/tests/cli/cli_infra_commands.test.ts
+++ b/tests/cli/cli_infra_commands.test.ts
@@ -27,9 +27,10 @@ function createTestDb(path: string, rows: Array<{ id: string; value: string }>):
 
 function readTestDbRows(path: string): Array<{ id: string; value: string }> {
   const db = new Database(path, { readonly: true });
-  const rows = db
-    .prepare("SELECT id, value FROM cli_test_records ORDER BY id")
-    .all() as Array<{ id: string; value: string }>;
+  const rows = db.prepare("SELECT id, value FROM cli_test_records ORDER BY id").all() as Array<{
+    id: string;
+    value: string;
+  }>;
   db.close();
   return rows;
 }
@@ -54,7 +55,10 @@ async function writeCliConfig(home: string, config: Record<string, unknown>): Pr
   await writeFile(join(configDir, "config.json"), JSON.stringify(config, null, 2));
 }
 
-async function execCliWithRepoRoot(command: string, repoRoot: string): Promise<{
+async function execCliWithRepoRoot(
+  command: string,
+  repoRoot: string
+): Promise<{
   stdout: string;
   stderr: string;
 }> {
@@ -274,7 +278,9 @@ describe("CLI infrastructure command smoke tests", () => {
     it("init --yes should complete in non-interactive mode", async () => {
       const dir = await mkdtemp(join(tmpdir(), "neotoma-cli-init-yes-"));
       const dataDir = join(dir, "data");
-      const { stdout } = await execAsync(`${CLI_PATH} init --yes --data-dir "${dataDir}" --skip-db --skip-env`);
+      const { stdout } = await execAsync(
+        `${CLI_PATH} init --yes --data-dir "${dataDir}" --skip-db --skip-env`
+      );
       expect(stdout).toMatch(/Neotoma initialized/i);
       expect(stdout).toMatch(/neotoma/i);
     });
@@ -306,30 +312,45 @@ describe("CLI infrastructure command smoke tests", () => {
       const isolatedHome = await mkdtemp(join(tmpdir(), "neotoma-cli-home-"));
       const isolatedCwd = await mkdtemp(join(tmpdir(), "neotoma-cli-cwd-"));
       const cliPathAbsolute = join(process.cwd(), "dist", "cli", "index.js");
-      const { stdout } = await execAsync(
-        `node "${cliPathAbsolute}" api start --background --env dev --json`,
-        {
-          cwd: isolatedCwd,
-          env: {
-            ...process.env,
-            HOME: isolatedHome,
-            USERPROFILE: isolatedHome,
-          },
+      // `api start --background` detaches a real `npm run dev:server`. Left
+      // running it is not merely untidy: the child inherits this process's
+      // env, so it boots against the SAME NEOTOMA_HTTP_PORT and the same
+      // .vitest SQLite file the rest of the run is using, and every leaked
+      // server adds contention until this test hangs to its 60s timeout in a
+      // full run (it passes in isolation, which is what disguised the leak).
+      // `api stop` cannot clean it up — that command kills a HARDCODED port
+      // (3080/3180), never the inherited one — so stop the PID we were handed.
+      let startedPid: number | undefined;
+      try {
+        const { stdout } = await execAsync(
+          `node "${cliPathAbsolute}" api start --background --env dev --json`,
+          {
+            cwd: isolatedCwd,
+            env: {
+              ...process.env,
+              HOME: isolatedHome,
+              USERPROFILE: isolatedHome,
+            },
+          }
+        );
+        const result = JSON.parse(stdout);
+        startedPid = typeof result.pid === "number" ? result.pid : undefined;
+        expect(result).toHaveProperty("ok", true);
+        expect(String(result.message ?? "")).toMatch(/started in background/i);
+      } finally {
+        if (startedPid !== undefined) {
+          // The child is detached, so it leads its own process group; the
+          // negative pid reaps `npm run dev:server` together with the node
+          // server it spawns. Killing only the npm wrapper orphans the server.
+          for (const target of [-startedPid, startedPid]) {
+            try {
+              process.kill(target, "SIGTERM");
+            } catch {
+              // Already gone (or never started) — nothing to reap.
+            }
+          }
         }
-      );
-      const result = JSON.parse(stdout);
-      expect(result).toHaveProperty("ok", true);
-      expect(String(result.message ?? "")).toMatch(/started in background/i);
-
-      // Cleanup background API for test isolation.
-      await execAsync(`node "${cliPathAbsolute}" api stop --env dev --json`, {
-        cwd: isolatedCwd,
-        env: {
-          ...process.env,
-          HOME: isolatedHome,
-          USERPROFILE: isolatedHome,
-        },
-      });
+      }
     });
 
     it("servers should report local URL when session env vars are set", async () => {
@@ -366,26 +387,27 @@ describe("CLI infrastructure command smoke tests", () => {
       await mkdir(configuredRepoRoot, { recursive: true });
       await setupTempNeotomaRepo(localRepoRoot);
       await setupTempNeotomaRepo(configuredRepoRoot);
-      await writeCliConfig(home, { project_root: configuredRepoRoot, repo_root: configuredRepoRoot });
+      await writeCliConfig(home, {
+        project_root: configuredRepoRoot,
+        repo_root: configuredRepoRoot,
+      });
 
       await execAsync(
         `node "${cliPathAbsolute}" site configure --umami-url https://umami.local.test --umami-website-id 11111111-1111-1111-1111-111111111111`,
         {
-        cwd: localRepoRoot,
-        env: {
-          ...process.env,
-          HOME: home,
-          USERPROFILE: home,
-          NEOTOMA_REPO_ROOT: "",
-        },
+          cwd: localRepoRoot,
+          env: {
+            ...process.env,
+            HOME: home,
+            USERPROFILE: home,
+            NEOTOMA_REPO_ROOT: "",
+          },
         }
       );
 
       const localEnv = await readFile(join(localRepoRoot, ".env"), "utf-8");
       expect(localEnv).toMatch(/VITE_UMAMI_URL=https:\/\/umami\.local\.test/);
-      expect(localEnv).toMatch(
-        /VITE_UMAMI_WEBSITE_ID=11111111-1111-1111-1111-111111111111/
-      );
+      expect(localEnv).toMatch(/VITE_UMAMI_WEBSITE_ID=11111111-1111-1111-1111-111111111111/);
       await expect(readFile(join(configuredRepoRoot, ".env"), "utf-8")).rejects.toBeDefined();
     });
 
@@ -459,9 +481,13 @@ describe("CLI infrastructure command smoke tests", () => {
       expect(backupResult.status).toBe("complete");
       expect(backupResult).toHaveProperty("backup_dir");
       expect(backupResult).toHaveProperty("backup_size");
-      expect((backupResult as { backup_size: { bytes: number; files: number; human: string } }).backup_size.bytes).toBeGreaterThan(0);
       expect(
-        (backupResult as { backup_size: { bytes: number; files: number; human: string } }).backup_size.human
+        (backupResult as { backup_size: { bytes: number; files: number; human: string } })
+          .backup_size.bytes
+      ).toBeGreaterThan(0);
+      expect(
+        (backupResult as { backup_size: { bytes: number; files: number; human: string } })
+          .backup_size.human
       ).toMatch(/\d/);
 
       const { stdout: restoreStdout } = await execAsync(
@@ -514,7 +540,9 @@ describe("CLI infrastructure command smoke tests", () => {
         root
       );
       const envText = await readFile(join(root, ".env"), "utf-8");
-      expect(envText).toMatch(new RegExp(`NEOTOMA_DATA_DIR=${newDir.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
+      expect(envText).toMatch(
+        new RegExp(`NEOTOMA_DATA_DIR=${newDir.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`)
+      );
       expect(envText).toMatch(/OPENAI_API_KEY=test-key/);
     });
 
@@ -676,9 +704,7 @@ describe("CLI infrastructure command smoke tests", () => {
     });
 
     it("--env flag is accepted by a command", async () => {
-      const { stdout } = await execAsync(
-        `${CLI_PATH} snapshots check --env development --json`
-      );
+      const { stdout } = await execAsync(`${CLI_PATH} snapshots check --env development --json`);
       const result = JSON.parse(stdout);
       expect(result).toHaveProperty("healthy");
     });

--- a/tests/fixtures/replay_graph.test.ts
+++ b/tests/fixtures/replay_graph.test.ts
@@ -57,19 +57,22 @@ describe("fixture replay snapshots", () => {
       },
     ];
 
-    const snapshot = await observationReducer.computeSnapshot(
-      "ent_test_contact",
-      observations
-    );
+    const snapshot = await observationReducer.computeSnapshot("ent_test_contact", observations);
 
-    const expectedPath = path.join(
-      process.cwd(),
-      "tests/fixtures/expected/contact_snapshot.json"
-    );
+    const expectedPath = path.join(process.cwd(), "tests/fixtures/expected/contact_snapshot.json");
     const expectedRaw = await fs.readFile(expectedPath, "utf-8");
     const expected = JSON.parse(expectedRaw);
 
-    expect(snapshot).toEqual(expected);
+    // The snapshot records the version of the schema it was computed under, so
+    // the fixture's frozen `schema_version` rots whenever that schema is
+    // deliberately revised — the contact schema went to 1.1 in #1924 (the
+    // leads-graph field additions) and this assertion then failed for a planned
+    // change rather than a regression. Compare the version against the schema
+    // that is actually active, and every other field against the fixture.
+    const { getSchemaDefinition } = await import("../../src/services/schema_definitions.js");
+    const activeContactVersion = getSchemaDefinition("contact")?.schema_version ?? "1.0";
+    expect(snapshot.schema_version).toBe(activeContactVersion);
+    expect({ ...snapshot, schema_version: null }).toEqual({ ...expected, schema_version: null });
 
     vi.useRealTimers();
   });
@@ -113,10 +116,7 @@ describe("fixture replay snapshots", () => {
       },
     ];
 
-    const snapshot = await observationReducer.computeSnapshot(
-      "ent_test_transaction",
-      observations
-    );
+    const snapshot = await observationReducer.computeSnapshot("ent_test_transaction", observations);
 
     const expectedPath = path.join(
       process.cwd(),

--- a/tests/helpers/test_prerequisites.ts
+++ b/tests/helpers/test_prerequisites.ts
@@ -1,0 +1,104 @@
+/**
+ * Hard prerequisites for the local `npm test` lane, and the named-skip contract
+ * that keeps a fresh clone honest.
+ *
+ * Why this exists (issue #2090)
+ * -----------------------------
+ * `npm test` — which is what the pre-commit hook runs — covers more than CI's
+ * baseline lane does: it additionally picks up `tests/integration`,
+ * `tests/fixtures`, `src/**` and `inspector/src/**`. Several of those tests
+ * shell out to, or serve, build artifacts that a plain `npm ci` does not
+ * produce: the Inspector SPA shell, the Inspector's own `node_modules`, and the
+ * compiled cursor-hooks package. On a fresh clone those tests FAILED, which is
+ * indistinguishable from "my change broke something" and is what pushed
+ * contributors onto `--no-verify`.
+ *
+ * The contract, per #2090's acceptance criteria: a missing hard prerequisite
+ * must produce a SKIP whose reason NAMES the prerequisite and the command that
+ * satisfies it — never a failure, and never a silent skip. Vitest does not
+ * surface a per-suite skip reason in its default reporter output, so
+ * `announceSkip()` also writes the reason to stderr. That is deliberate: the
+ * acceptance criterion is that the reason is visible in the run output, not
+ * merely encoded in a config file someone would have to go read.
+ *
+ * This is NOT a mechanism for muting inconvenient tests. Every entry below is a
+ * build artifact with a one-line remediation; nothing here is gated on a live
+ * network, a credential, or anything a contributor cannot produce locally.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+/**
+ * A hard prerequisite: an artifact the suite cannot synthesize, plus the exact
+ * command that produces it.
+ */
+export interface Prerequisite {
+  /** Greppable token naming the prerequisite. Appears verbatim in skip output. */
+  readonly name: string;
+  /** One-line remediation — a command a contributor can copy and run. */
+  readonly remediation: string;
+  /** Repo-relative path whose existence means the prerequisite is satisfied. */
+  readonly probePath: string;
+}
+
+export const BUILT_INSPECTOR_ASSETS: Prerequisite = {
+  name: "built inspector assets",
+  remediation: "npm run build:inspector (or npm run test:setup)",
+  probePath: path.join("dist", "inspector", "index.html"),
+};
+
+export const INSTALLED_INSPECTOR_DEPS: Prerequisite = {
+  name: "installed inspector dependencies",
+  remediation: "npm ci --prefix inspector (or npm run test:setup)",
+  probePath: path.join("inspector", "node_modules"),
+};
+
+export const BUILT_CURSOR_HOOK_PACKAGE: Prerequisite = {
+  name: "built cursor hook package",
+  remediation: "npm run build --prefix packages/cursor-hooks (or npm run test:setup)",
+  probePath: path.join("packages", "cursor-hooks", "dist", "stop.js"),
+};
+
+/** True when the prerequisite's artifact is present in this checkout. */
+export function hasPrerequisite(prereq: Prerequisite, root: string = REPO_ROOT): boolean {
+  return fs.existsSync(path.join(root, prereq.probePath));
+}
+
+/**
+ * The canonical skip reason. Byte-stable so triage can grep for it and so the
+ * docs and the code cannot drift apart.
+ */
+export function skipReason(prereq: Prerequisite): string {
+  return `missing prerequisite: ${prereq.name} — ${prereq.remediation}`;
+}
+
+const announced = new Set<string>();
+
+/**
+ * Print the skip reason to stderr, once per prerequisite per process.
+ *
+ * Vitest's default reporter prints a skipped suite without its reason, so a
+ * `describe.skipIf` alone would satisfy the letter of "skip, don't fail" while
+ * violating the part that matters: the contributor has to be able to SEE why,
+ * in the output they are already looking at.
+ */
+export function announceSkip(prereq: Prerequisite, subject: string): void {
+  const key = `${prereq.name}::${subject}`;
+  if (announced.has(key)) return;
+  announced.add(key);
+  process.stderr.write(`[neotoma] SKIP ${subject} — ${skipReason(prereq)}\n`);
+}
+
+/**
+ * `describe.skipIf(...)` companion: returns true when the suite must be skipped,
+ * and announces the reason on the way past.
+ */
+export function skipWithoutPrerequisite(prereq: Prerequisite, subject: string): boolean {
+  if (hasPrerequisite(prereq)) return false;
+  announceSkip(prereq, subject);
+  return true;
+}

--- a/tests/integration/csp_local_http.test.ts
+++ b/tests/integration/csp_local_http.test.ts
@@ -8,8 +8,18 @@ import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { app } from "../../src/actions.js";
+import {
+  BUILT_INSPECTOR_ASSETS,
+  skipWithoutPrerequisite,
+} from "../helpers/test_prerequisites.js";
 
-describe("CSP on loopback HTTP", () => {
+// Serving the Inspector HTML shell is the whole point of this assertion, so a
+// checkout without `dist/inspector/index.html` cannot exercise it. Skip with a
+// named reason rather than fail (issue #2090) — a bare `npm ci` does not build
+// the Inspector, and a failure there is indistinguishable from a real break.
+const SKIP = skipWithoutPrerequisite(BUILT_INSPECTOR_ASSETS, "CSP on loopback HTTP");
+
+describe.skipIf(SKIP)("CSP on loopback HTTP", () => {
   let httpServer: ReturnType<typeof createServer>;
   let base = "";
 

--- a/tests/integration/cursor_hook_stop_backfill.test.ts
+++ b/tests/integration/cursor_hook_stop_backfill.test.ts
@@ -21,10 +21,14 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  BUILT_CURSOR_HOOK_PACKAGE,
+  skipWithoutPrerequisite,
+} from "../helpers/test_prerequisites.js";
 
 const REPO_ROOT = resolve(__dirname, "..", "..");
 const STOP_HOOK = join(
@@ -60,7 +64,17 @@ function runHook(
   };
 }
 
-describe("cursor-hooks stop backfill integration", () => {
+// These tests spawn the COMPILED hook entrypoints under
+// packages/cursor-hooks/dist/. A bare `npm ci` never builds that package, so on
+// a fresh clone the dist is absent. Previously each test threw — a failure
+// indistinguishable from a real regression. Skip with a named reason instead
+// (issue #2090).
+const SKIP = skipWithoutPrerequisite(
+  BUILT_CURSOR_HOOK_PACKAGE,
+  "cursor-hooks stop backfill integration"
+);
+
+describe.skipIf(SKIP)("cursor-hooks stop backfill integration", () => {
   let scratchDir: string;
   let baseEnv: NodeJS.ProcessEnv;
 
@@ -85,11 +99,6 @@ describe("cursor-hooks stop backfill integration", () => {
   });
 
   it("emits followup_message by default when MCP store was skipped", () => {
-    if (!existsSync(STOP_HOOK)) {
-      throw new Error(
-        "cursor-hooks dist not built; run `npm --prefix packages/cursor-hooks run build`"
-      );
-    }
     const sessionId = "cursor-stop-backfill-1";
     const stop = runHook(
       STOP_HOOK,
@@ -111,9 +120,6 @@ describe("cursor-hooks stop backfill integration", () => {
   });
 
   it("counts wrapped Neotoma CallMcpTool store as a store", () => {
-    if (!existsSync(AFTER_TOOL_USE) || !existsSync(STOP_HOOK)) {
-      throw new Error("cursor-hooks dist not built");
-    }
     const sessionId = "cursor-stop-backfill-wrapped-store";
     const turnId = "turn-1";
 
@@ -155,9 +161,6 @@ describe("cursor-hooks stop backfill integration", () => {
   });
 
   it("nudges after wrapped external MCP calls before a Neotoma store", () => {
-    if (!existsSync(AFTER_TOOL_USE)) {
-      throw new Error("cursor-hooks dist not built");
-    }
     const seed = runHook(
       AFTER_TOOL_USE,
       {
@@ -182,9 +185,6 @@ describe("cursor-hooks stop backfill integration", () => {
   });
 
   it("does NOT emit followup_message when the agent already called store", () => {
-    if (!existsSync(AFTER_TOOL_USE) || !existsSync(STOP_HOOK)) {
-      throw new Error("cursor-hooks dist not built");
-    }
     const sessionId = "cursor-stop-backfill-2";
     const turnId = "turn-1";
 

--- a/tests/integration/embed_cross_origin_http.test.ts
+++ b/tests/integration/embed_cross_origin_http.test.ts
@@ -15,6 +15,10 @@ import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
 import type { Server } from "node:http";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  BUILT_INSPECTOR_ASSETS,
+  skipWithoutPrerequisite,
+} from "../helpers/test_prerequisites.js";
 
 const ALLOWED = "https://hub.opschudding.app";
 const DENIED = "https://evil.example";
@@ -48,7 +52,14 @@ describe("official cross-origin embed mode (allowlist configured)", () => {
     }
   });
 
-  it("embed shell gets frame-ancestors with the allowlisted origin and drops X-Frame-Options", async () => {
+  // The embed shell IS the built Inspector SPA: without `dist/inspector/index.html`
+  // the mount never installs, so `/embed/graph` 404s and no embed CSP is emitted.
+  // Skip with a named reason rather than fail (issue #2090). The five assertions
+  // below need no build artifact — they exercise CORS and XFO on API routes — so
+  // they keep running on a bare `npm ci` checkout.
+  it.skipIf(
+    skipWithoutPrerequisite(BUILT_INSPECTOR_ASSETS, "embed shell frame-ancestors")
+  )("embed shell gets frame-ancestors with the allowlisted origin and drops X-Frame-Options", async () => {
     const res = await fetch(`${base}/embed/graph`, { headers: { Accept: "text/html" } });
     const csp = res.headers.get("content-security-policy") ?? "";
     expect(csp).toContain("frame-ancestors");

--- a/tests/integration/fixture_mcp_store_replay.test.ts
+++ b/tests/integration/fixture_mcp_store_replay.test.ts
@@ -14,6 +14,7 @@ import { db } from "../../src/db.js";
 import { NeotomaServer } from "../../src/server.js";
 import { extractCreatedEntityIds, extractSourceId } from "../helpers/cross_layer_helpers.js";
 import { getEntityWithProvenance } from "../../src/services/entity_queries.js";
+import { getSchemaDefinition } from "../../src/services/schema_definitions.js";
 
 const FIXTURES_DIR = path.join(process.cwd(), "tests", "fixtures");
 const JSON_DIR = path.join(FIXTURES_DIR, "json");
@@ -109,7 +110,9 @@ function getKeyFieldsForEntityType(entityType: string): string[] {
     wallet: ["name", "status"],
     workout: ["name", "duration"],
   };
-  return map[entityType] ?? ["name", "id", "external_id", "title", "amount", "status", "description"];
+  return (
+    map[entityType] ?? ["name", "id", "external_id", "title", "amount", "status", "description"]
+  );
 }
 
 describe("Fixture MCP Store Replay", () => {
@@ -191,7 +194,9 @@ describe("Fixture MCP Store Replay", () => {
       const entityPayload = { ...record, entity_type: entityType };
 
       const idempotencyKey = `fixture-replay-${entityType}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-      const result = await (server as { store: (p: unknown) => Promise<{ content: Array<{ text: string }> }> }).store({
+      const result = await (
+        server as { store: (p: unknown) => Promise<{ content: Array<{ text: string }> }> }
+      ).store({
         user_id: TEST_USER_ID,
         entities: [entityPayload],
         idempotency_key: idempotencyKey,
@@ -227,7 +232,13 @@ describe("Fixture MCP Store Replay", () => {
         if (entityType === "contact" || entityType === "transaction") {
           expect(normalizedActual.entity_id).toBeDefined();
           expect(normalizedActual.entity_type).toBe(entityType);
-          expect(normalizedActual.schema_version).toBe("1.0");
+          // Assert the snapshot records the version of the schema it was
+          // actually computed under, rather than a frozen "1.0" literal. The
+          // literal silently rotted when the contact schema was bumped to 1.1
+          // (#1924, the leads-graph field additions): the check then failed for
+          // a deliberate schema change instead of for a real regression.
+          const activeSchemaVersion = getSchemaDefinition(entityType)?.schema_version ?? "1.0";
+          expect(normalizedActual.schema_version).toBe(activeSchemaVersion);
           expect(normalizedActual.snapshot).toBeDefined();
           expect(typeof (normalizedActual.snapshot as Record<string, unknown>)).toBe("object");
           expect(normalizedActual.observation_count).toBeDefined();

--- a/tests/integration/hook_failure_hint.test.ts
+++ b/tests/integration/hook_failure_hint.test.ts
@@ -23,8 +23,21 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  BUILT_CURSOR_HOOK_PACKAGE,
+  skipWithoutPrerequisite,
+} from "../helpers/test_prerequisites.js";
 
 const HOOK_DIR = resolve(__dirname, "../../packages/cursor-hooks/dist");
+
+// Both suites spawn the COMPILED hook entrypoints in HOOK_DIR. A bare `npm ci`
+// never builds packages/cursor-hooks, so on a fresh clone they are absent and
+// every spawn fails with a MODULE_NOT_FOUND that reads like a product break.
+// Skip with a named reason instead (issue #2090).
+const SKIP = skipWithoutPrerequisite(
+  BUILT_CURSOR_HOOK_PACKAGE,
+  "cursor-hooks failure-hint integration"
+);
 
 let stateDir: string;
 
@@ -68,7 +81,7 @@ afterEach(() => {
   if (existsSync(stateDir)) rmSync(stateDir, { recursive: true, force: true });
 });
 
-describe("cursor postToolUseFailure hook", () => {
+describe.skipIf(SKIP)("cursor postToolUseFailure hook", () => {
   it("creates a failure counter file for Neotoma-relevant tools", () => {
     const result = runHook("post_tool_use_failure.js", {
       session_id: "session-A",
@@ -111,7 +124,7 @@ describe("cursor postToolUseFailure hook", () => {
   });
 });
 
-describe("cursor postToolUse (after_tool_use) failure-hint surfacing", () => {
+describe.skipIf(SKIP)("cursor postToolUse (after_tool_use) failure-hint surfacing", () => {
   it("surfaces a one-shot hint via additional_context once the threshold trips", () => {
     const payload = {
       session_id: "session-C",

--- a/tests/integration/inspector_content_negotiation.test.ts
+++ b/tests/integration/inspector_content_negotiation.test.ts
@@ -23,6 +23,19 @@ import {
   installInspectorSpaFallback,
   installInspectorSpaShellEarly,
 } from "../../src/services/inspector_mount.js";
+import {
+  BUILT_INSPECTOR_ASSETS,
+  skipWithoutPrerequisite,
+} from "../helpers/test_prerequisites.js";
+
+// The two end-to-end blocks below install the real SPA mount against the real
+// bundled dist, so without `dist/inspector/index.html` they serve 404/JSON and
+// their assertions cannot hold. Skip those two with a named reason (issue
+// #2090); the pure-helper blocks above need no build artifact and always run.
+const SKIP_E2E = skipWithoutPrerequisite(
+  BUILT_INSPECTOR_ASSETS,
+  "inspector content-negotiation end-to-end"
+);
 
 type Server = ReturnType<express.Application["listen"]>;
 
@@ -173,7 +186,7 @@ describe("isEntityRenderedSurfacePath", () => {
 // End-to-end: early SPA-shell handler (registered BEFORE data routes)
 // ---------------------------------------------------------------------------
 
-describe("installInspectorSpaShellEarly — end-to-end", () => {
+describe.skipIf(SKIP_E2E)("installInspectorSpaShellEarly — end-to-end", () => {
   let server: Server | null = null;
 
   afterEach(() => {
@@ -289,7 +302,7 @@ describe("installInspectorSpaShellEarly — end-to-end", () => {
 // End-to-end: SPA fallback over HTTP
 // ---------------------------------------------------------------------------
 
-describe("installInspectorSpaFallback — end-to-end", () => {
+describe.skipIf(SKIP_E2E)("installInspectorSpaFallback — end-to-end", () => {
   let server: Server | null = null;
   let tempDir: string | null = null;
 

--- a/tests/integration/mcp_target_id_identity_conflict.test.ts
+++ b/tests/integration/mcp_target_id_identity_conflict.test.ts
@@ -66,23 +66,32 @@ describe("MCP store target_id identity conflicts", () => {
     createdEntityIds.push(canonicalIssueId);
     createdSourceIds.push(canonicalPayload.source_id as string);
 
-    const titleResult = await store({
+    // A second, SEPARATE issue that carries no GitHub identity of its own — the
+    // entity whose target_id the conflict assertion below tries to repoint onto
+    // the canonical issue's (github_number, repo). It keys on local_issue_id:
+    // #1778 made `title` deliberately non-identifying for issues, so a write
+    // with neither the (github_number, repo) composite nor local_issue_id now
+    // fails loudly (CanonicalNameUnresolvedError) rather than minting a
+    // title-keyed duplicate. Local identity keeps this fixture a distinct
+    // entity, which is all the conflict assertion needs from it.
+    const localResult = await store({
       user_id: userId,
       entities: [
         {
           entity_type: "issue",
-          title: `Title-keyed issue ${testRun}`,
+          title: `Local-keyed issue ${testRun}`,
+          local_issue_id: `local-${testRun}`,
           status: "open",
           data_source: testRun,
         },
       ],
-      idempotency_key: `${testRun}-title`,
+      idempotency_key: `${testRun}-local`,
     });
-    const titlePayload = JSON.parse(titleResult.content[0].text);
-    const titleIssueId = titlePayload.entities[0].entity_id as string;
-    createdEntityIds.push(titleIssueId);
-    createdSourceIds.push(titlePayload.source_id as string);
-    expect(titleIssueId).not.toBe(canonicalIssueId);
+    const localPayload = JSON.parse(localResult.content[0].text);
+    const localIssueId = localPayload.entities[0].entity_id as string;
+    createdEntityIds.push(localIssueId);
+    createdSourceIds.push(localPayload.source_id as string);
+    expect(localIssueId).not.toBe(canonicalIssueId);
 
     await expect(
       store({
@@ -91,7 +100,7 @@ describe("MCP store target_id identity conflicts", () => {
         entities: [
           {
             entity_type: "issue",
-            target_id: titleIssueId,
+            target_id: localIssueId,
             title: "Canonical GitHub issue",
             status: "open",
             github_number: githubNumber,
@@ -100,7 +109,7 @@ describe("MCP store target_id identity conflicts", () => {
           },
         ],
         idempotency_key: `${testRun}-conflict`,
-      }),
+      })
     ).rejects.toThrow(/Identity conflict: target_id/);
   });
 });

--- a/tests/integration/setup_v0.2.0_schemas.ts
+++ b/tests/integration/setup_v0.2.0_schemas.ts
@@ -2,62 +2,64 @@
 
 import { schemaRegistry } from "../../src/services/schema_registry";
 
+// `note` and `person` are BUILT-IN entity types, and the built-in definitions
+// are seeded at version "1.0" with their own field sets (note keys on
+// title/content, not name). Registering these fixtures at "1.0" therefore
+// collided with the seeded rows, `register` rejected the duplicate, the old
+// catch-all below swallowed that rejection, and the built-in schema stayed
+// active. The tests then extracted a `name` field that the ACTIVE schema did
+// not declare, so every field was dropped as unknown and interpretation runs
+// produced zero observations — surfacing only as `expected 0 to be greater
+// than 0` in IT-003 and IT-009, far from the real cause.
+//
+// Registering at a fixture-specific version keeps these schemas distinct from
+// the built-ins, and activating them makes them win schema resolution.
+const FIXTURE_SCHEMA_VERSION = "0.2.0-test";
+
 export async function setupTestSchemas() {
-  // Register note schema
-  try {
-    const noteSchema = await schemaRegistry.register({
-      entity_type: "note",
-      schema_version: "1.0",
-      schema_definition: {
-        fields: {
-          name: { type: "string", required: true },
-          content: { type: "string" },
-          created_at: { type: "date" },
-        },
-        identity_opt_out: "heuristic_canonical_name",
+  const noteSchema = await schemaRegistry.register({
+    entity_type: "note",
+    schema_version: FIXTURE_SCHEMA_VERSION,
+    schema_definition: {
+      fields: {
+        name: { type: "string", required: true },
+        content: { type: "string" },
+        created_at: { type: "date" },
       },
-      reducer_config: {
-        merge_policies: {
-          name: { strategy: "highest_priority" },
-          content: { strategy: "highest_priority" },
-          created_at: { strategy: "last_write" },
-        },
+      identity_opt_out: "heuristic_canonical_name",
+    },
+    reducer_config: {
+      merge_policies: {
+        name: { strategy: "highest_priority" },
+        content: { strategy: "highest_priority" },
+        created_at: { strategy: "last_write" },
       },
-    });
+    },
+  });
 
-    await schemaRegistry.activate("note", "1.0");
+  await schemaRegistry.activate("note", FIXTURE_SCHEMA_VERSION);
 
-    // Register person schema
-    const personSchema = await schemaRegistry.register({
-      entity_type: "person",
-      schema_version: "1.0",
-      schema_definition: {
-        fields: {
-          name: { type: "string", required: true },
-          email: { type: "string" },
-          phone: { type: "string" },
-        },
-        identity_opt_out: "heuristic_canonical_name",
+  const personSchema = await schemaRegistry.register({
+    entity_type: "person",
+    schema_version: FIXTURE_SCHEMA_VERSION,
+    schema_definition: {
+      fields: {
+        name: { type: "string", required: true },
+        email: { type: "string" },
+        phone: { type: "string" },
       },
-      reducer_config: {
-        merge_policies: {
-          name: { strategy: "highest_priority" },
-          email: { strategy: "highest_priority" },
-          phone: { strategy: "highest_priority" },
-        },
+      identity_opt_out: "heuristic_canonical_name",
+    },
+    reducer_config: {
+      merge_policies: {
+        name: { strategy: "highest_priority" },
+        email: { strategy: "highest_priority" },
+        phone: { strategy: "highest_priority" },
       },
-    });
+    },
+  });
 
-    await schemaRegistry.activate("person", "1.0");
+  await schemaRegistry.activate("person", FIXTURE_SCHEMA_VERSION);
 
-    return { noteSchema, personSchema };
-  } catch (error) {
-    // Schemas might already exist
-    console.log("Schemas already registered:", error);
-  }
+  return { noteSchema, personSchema };
 }
-
-
-
-
-

--- a/tests/integration/turn_summary.test.ts
+++ b/tests/integration/turn_summary.test.ts
@@ -176,6 +176,12 @@ describe("POST /turn_summary", () => {
           {
             entity_type: "issue",
             title: issueTitle,
+            // #1778 made `title` deliberately non-identifying for issues: a
+            // write carrying neither the (github_number, repo) composite nor
+            // local_issue_id now fails loudly instead of minting a title-keyed
+            // duplicate. This test is about the issues suffix on the status
+            // line, not issue identity, so give the fixture a local identity.
+            local_issue_id: `tsummary-${Date.now()}`,
             body: "an issue body",
             visibility: "private",
           },

--- a/tests/unit/test_prerequisites.test.ts
+++ b/tests/unit/test_prerequisites.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Covers the named-skip contract from issue #2090.
+ *
+ * The acceptance criterion is not "these suites stop failing" — it is that a
+ * missing hard prerequisite produces a skip whose REASON is visible in the run
+ * output and names both the prerequisite and its remediation. A silent skip is
+ * out of contract, and is exactly what these assertions exist to prevent
+ * someone from quietly introducing later.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  BUILT_CURSOR_HOOK_PACKAGE,
+  BUILT_INSPECTOR_ASSETS,
+  INSTALLED_INSPECTOR_DEPS,
+  REPO_ROOT,
+  hasPrerequisite,
+  skipReason,
+  type Prerequisite,
+} from "../helpers/test_prerequisites.js";
+
+const ALL: readonly Prerequisite[] = [
+  BUILT_INSPECTOR_ASSETS,
+  INSTALLED_INSPECTOR_DEPS,
+  BUILT_CURSOR_HOOK_PACKAGE,
+];
+
+describe("test prerequisites — skip-reason contract (#2090)", () => {
+  it("every reason names the prerequisite and a remediation command", () => {
+    for (const prereq of ALL) {
+      const reason = skipReason(prereq);
+      expect(reason).toContain("missing prerequisite: ");
+      expect(reason).toContain(prereq.name);
+      expect(reason).toContain(prereq.remediation);
+      // An em-dash separator keeps the two halves greppable apart.
+      expect(reason).toMatch(/^missing prerequisite: .+ — .+$/);
+    }
+  });
+
+  it("no reason is vague — each remediation is a runnable command", () => {
+    for (const prereq of ALL) {
+      expect(prereq.remediation).toMatch(/npm /);
+      expect(prereq.name.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  it("names are distinct so triage can grep one cluster at a time", () => {
+    expect(new Set(ALL.map((p) => p.name)).size).toBe(ALL.length);
+  });
+});
+
+describe("test prerequisites — probe behavior", () => {
+  it("reports absent against an empty tree", () => {
+    const empty = fs.mkdtempSync(path.join(os.tmpdir(), "neotoma-prereq-"));
+    try {
+      for (const prereq of ALL) {
+        expect(hasPrerequisite(prereq, empty)).toBe(false);
+      }
+    } finally {
+      fs.rmSync(empty, { recursive: true, force: true });
+    }
+  });
+
+  it("reports present once the probe path exists", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "neotoma-prereq-"));
+    try {
+      const target = path.join(root, BUILT_CURSOR_HOOK_PACKAGE.probePath);
+      fs.mkdirSync(path.dirname(target), { recursive: true });
+      fs.writeFileSync(target, "");
+      expect(hasPrerequisite(BUILT_CURSOR_HOOK_PACKAGE, root)).toBe(true);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("REPO_ROOT resolves to the checkout containing package.json", () => {
+    expect(fs.existsSync(path.join(REPO_ROOT, "package.json"))).toBe(true);
+  });
+});
+
+describe("dist/ fast-fail guard (#2090 AC 3)", () => {
+  it("global setup refuses on a missing dist/ and names the fix command", () => {
+    const source = fs.readFileSync(path.join(REPO_ROOT, "vitest.global_setup.ts"), "utf-8");
+    // The exact operator-facing string, asserted here so a reword cannot land
+    // without someone deciding to reword it.
+    expect(source).toContain("[neotoma] dist/ is missing. Run `npm test`");
+    expect(source).toContain("npm run build:server");
+    // Must probe the real server entrypoint, and must run before any suite.
+    expect(source).toContain('path.join(projectRoot, "dist", "index.js")');
+    expect(source).toContain("requireBuiltServer(projectRoot);");
+  });
+
+  it("the guard does not conflate the server dist with the inspector dist", () => {
+    const source = fs.readFileSync(path.join(REPO_ROOT, "vitest.global_setup.ts"), "utf-8");
+    const guard = source.slice(
+      source.indexOf("function requireBuiltServer"),
+      source.indexOf("function announceMissingPrerequisites")
+    );
+    // A present dist/index.js with an absent dist/inspector/ must NOT trip the
+    // hard guard — the inspector is a named skip, not a fatal prerequisite.
+    expect(guard).not.toContain("inspector");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,9 @@ import { fileURLToPath } from "url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+const frontendSrc = path.resolve(__dirname, "./frontend/src");
+const inspectorSrc = path.resolve(__dirname, "./inspector/src");
+
 /** When set to "1", run remote-dependent tests. Default: local-only (SQLite). */
 const runRemoteTests = process.env.RUN_REMOTE_TESTS === "1";
 
@@ -45,12 +48,45 @@ export default defineConfig({
     },
   },
   resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./frontend/src"),
-      "@shared": path.resolve(__dirname, "./src/shared"),
-      "@neotoma/client": path.resolve(__dirname, "./packages/client/src/index.ts"),
-      "@neotoma/agent": path.resolve(__dirname, "./packages/agent/src/index.ts"),
-    },
+    alias: [
+      // `@/...` is an alias in BOTH frontend/ and inspector/, each pointing at
+      // its OWN src/. A single static replacement can only serve one tree: with
+      // `@` hardwired to frontend/src, every inspector test whose module graph
+      // reached an `@/...` specifier failed to resolve
+      // (`Cannot find package '@/hooks/use_infra'`). Resolve by the IMPORTER's
+      // location so each tree gets its own `@`, and keep frontend/src as the
+      // default for every other importer.
+      {
+        find: /^@\//,
+        replacement: "@/",
+        customResolver(source, importer) {
+          const target =
+            importer && path.resolve(importer).startsWith(inspectorSrc + path.sep)
+              ? inspectorSrc
+              : frontendSrc;
+          const base = path.join(target, source.slice(2));
+          for (const candidate of [
+            base,
+            `${base}.ts`,
+            `${base}.tsx`,
+            path.join(base, "index.ts"),
+            path.join(base, "index.tsx"),
+          ]) {
+            if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) return candidate;
+          }
+          return base;
+        },
+      },
+      { find: "@shared", replacement: path.resolve(__dirname, "./src/shared") },
+      {
+        find: "@neotoma/client",
+        replacement: path.resolve(__dirname, "./packages/client/src/index.ts"),
+      },
+      {
+        find: "@neotoma/agent",
+        replacement: path.resolve(__dirname, "./packages/agent/src/index.ts"),
+      },
+    ],
   },
   test: {
     globals: true,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -22,6 +22,20 @@ const writeTestRunReport = process.env.WRITE_TEST_RUN_REPORT === "1";
 /** When set to "1", run performance benchmarks under tests/performance/. Default: excluded — they seed large datasets and are slow, so they stay out of the default `npm test` lane. Run via `npm run test:bench`. */
 const runBench = process.env.RUN_BENCH === "1";
 
+/**
+ * `inspector/` is a standalone package, not an npm workspace member, so a root
+ * `npm ci` does not install its dependencies. Its unit tests import modules
+ * that reach `@xyflow/react`, `@tanstack/react-query` and `lucide-react`, which
+ * then fail at MODULE LOAD — before any `describe` body runs, so an in-file
+ * `skipIf` cannot help. Excluding them is therefore the only way to skip rather
+ * than fail on a fresh clone (issue #2090).
+ *
+ * The skip is NOT silent: `vitest.global_setup.ts` prints the named reason and
+ * the `npm ci --prefix inspector` remediation on every run that lacks the deps.
+ * Install them and these suites run again with no flag to remember.
+ */
+const hasInspectorDeps = fs.existsSync(path.resolve(__dirname, "./inspector/node_modules"));
+
 export default defineConfig({
   plugins: [
     {
@@ -161,6 +175,9 @@ export default defineConfig({
       "tests/integration/payload/payload_submission.test.ts",
       // React/frontend tests: run only with RUN_FRONTEND_TESTS=1 (jsdom, optional)
       ...(!runFrontendTests ? ["frontend/src/**/*.test.ts", "frontend/src/**/*.test.tsx"] : []),
+      // Inspector unit tests when inspector/node_modules is absent — see
+      // `hasInspectorDeps` above. Reason is announced in global setup.
+      ...(!hasInspectorDeps ? ["inspector/src/**/*.test.ts", "inspector/src/**/*.spec.ts"] : []),
       // Known-bad: jsdom worker ESM/require error (html-encoding-sniffer)
       "frontend/src/components/SchemaDetail.test.tsx",
     ],

--- a/vitest.global_setup.ts
+++ b/vitest.global_setup.ts
@@ -1,6 +1,50 @@
 import path from "node:path";
-import { mkdirSync } from "node:fs";
+import { existsSync, mkdirSync } from "node:fs";
 import { fileURLToPath } from "node:url";
+import {
+  BUILT_CURSOR_HOOK_PACKAGE,
+  BUILT_INSPECTOR_ASSETS,
+  INSTALLED_INSPECTOR_DEPS,
+  announceSkip,
+  hasPrerequisite,
+} from "./tests/helpers/test_prerequisites.js";
+
+/**
+ * Fail fast, and legibly, when the compiled server is absent (issue #2090).
+ *
+ * `npm test` runs `pretest` (`build:server`) first, so this never trips there.
+ * A raw `npx vitest run` on an unbuilt checkout, however, used to produce
+ * hundreds of unrelated failures across `tests/cli/**` and the dist-smoke
+ * suites — a cascade that buried the one fact the contributor needed. Refuse
+ * before a single test file loads, and name the command that fixes it.
+ */
+function requireBuiltServer(projectRoot: string): void {
+  if (existsSync(path.join(projectRoot, "dist", "index.js"))) return;
+  const message =
+    "[neotoma] dist/ is missing. Run `npm test` (pretest builds server) or " +
+    "`npm run build:server` before `npx vitest run`.";
+  process.stderr.write(`${message}\n`);
+  throw new Error(message);
+}
+
+/**
+ * Announce, once per run, every hard prerequisite this checkout lacks.
+ *
+ * Suites gated on these skip themselves via `tests/helpers/test_prerequisites`,
+ * but a skip whose reason is invisible is out of contract per #2090 — the
+ * contributor has to be able to tell "this needs a build step I did not run"
+ * from "my change broke something" without leaving the run output.
+ */
+function announceMissingPrerequisites(): void {
+  const missing = [
+    [BUILT_INSPECTOR_ASSETS, "inspector-shell suites"],
+    [INSTALLED_INSPECTOR_DEPS, "inspector unit suites"],
+    [BUILT_CURSOR_HOOK_PACKAGE, "cursor-hooks suites"],
+  ] as const;
+  for (const [prereq, subject] of missing) {
+    if (!hasPrerequisite(prereq)) announceSkip(prereq, subject);
+  }
+}
 
 /**
  * Global Vitest setup.
@@ -11,6 +55,8 @@ import { fileURLToPath } from "node:url";
  */
 export default async function globalSetup() {
   const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)));
+  requireBuiltServer(projectRoot);
+  announceMissingPrerequisites();
   const vitestDir = path.join(projectRoot, ".vitest");
   mkdirSync(path.join(vitestDir, "sources"), { recursive: true });
 


### PR DESCRIPTION
## Summary

`npm test` — plain `vitest run`, which is what the **pre-commit hook** runs — failed **13 tests across 11 files** on a clean, unmodified checkout of `origin/main`. That is what has been forcing `--no-verify` bypasses.

**CI is GREEN on the exact same commit.** Run [34037071136](https://github.com/markmhendrickson/neotoma/actions/runs/34037071136) on `170b05447137d070c78a8d819669111c6081ff8f` — the commit this branch is based on — passed every job, and its `Run unit Vitest suite` step reported `Test Files 308 passed | 2 skipped (310)`, zero failures.

So the defect was **not in the tests being wrong about the product**. It was in the gap between the two lanes:

| | runs | covers |
|---|---|---|
| CI baseline | `npm run test:unit` | `tests/unit`, `tests/services`, `tests/agent`, `tests/contract`, `tests/security`, `tests/cli`, `tests/subscriptions` |
| pre-commit hook | `npm test` (`vitest run`) | all of the above **plus** `tests/integration`, `tests/fixtures`, `src/**`, `inspector/src/**` |

Everything in that "plus" column gated nothing. Four genuine defects had accumulated there unseen.

## Before / after

| | Test files | Tests |
|---|---|---|
| Before | **11 failed**, 540 passed, 3 skipped (554) | **13 failed**, 5457 passed, 14 skipped, 3 todo (5487) |
| After | **1 failed**, 550 passed, 3 skipped (554) | **1 failed**, 5478 passed, 14 skipped, 3 todo (5496) |

All 11 originally-failing files now pass. The single remaining failure is **not** one of them and **not** caused by this branch — see "Remaining failure" below.

The total test count rises 5487 → 5496 because the two `v0.2.0_ingestion` tests now execute real interpretation runs instead of passing vacuously (see (c)4).

`npm run type-check` is clean. `npm run lint` reports 0 errors (331 pre-existing `no-explicit-any` warnings, unchanged). `format:check`, `lint:site-copy`, `validate:test-catalog` and `validate:doc-deps` all pass.

## Per-failure classification

### (b) Missing local setup that CI performs, or that no documented step performs — 6 tests

| Test | Evidence |
|---|---|
| `inspector/src/lib/graph_layout.test.ts` | `Error: Cannot find package '@xyflow/react'`. It is declared in `inspector/package.json`, but `inspector/node_modules` does not exist — nothing installs it. |
| `csp_local_http` (1) | `expected 404 to be 200` for `GET /` — the mount has no `dist/inspector/index.html` to serve. |
| `inspector_content_negotiation` (4) | Two `expected 404 to be 200`, two `expected 'application/json' to match /text\/html/` — the SPA shell is absent, so the fallback cannot serve it. |
| `embed_cross_origin_http` (1) | `expected 'default-src \'none\'' to contain 'frame-ancestors'` — same missing shell. |

Verified by building: after `npm run build:inspector`, those 4 files pass with no test change. Note CI never runs any of them, and its baseline lane never builds the inspector either — so this is a setup gap, not a test defect.

**Fix:** adds `scripts/setup_test_env.sh` (`npm run test:setup`), which performs the CI baseline steps *plus* the two the wider local lane additionally needs, with a comment saying why each is there; and documents it in `docs/developer/getting_started.md`, which previously told contributors to run `npm test` with no mention of any prerequisite.

### (c) Real defects that CI structurally cannot catch — 5 tests

**1. Vitest alias defect (1 test) — `inspector/src/components/layout/sidebar_external_links.test.ts`**

`Cannot find package '@/hooks/use_infra'`, though `inspector/src/hooks/use_infra.ts` exists. `@/…` is an alias in **both** `frontend/` and `inspector/`, each pointing at its own `src/`, but the root `vitest.config.ts` hardwired `@` → `frontend/src`. Any inspector test whose module graph reached an `@/…` specifier could not resolve. Fixed by resolving the alias by the **importer's** tree; frontend keeps `frontend/src` (its 76 tests still pass, verified).

**2. Stale expectations vs. a deliberate schema change (2 tests) — `replay_graph`, `fixture_mcp_store_replay`**

Both asserted a frozen `schema_version` `"1.0"`; both got `"1.1"`. The `contact` schema was **intentionally** bumped to 1.1 in #1924 (leads-graph field additions). The assertions now check that the snapshot records the version of the schema it was **actually computed under** — still a real check, no longer one that rots on every planned bump. Not weakened: a snapshot recording the wrong version still fails.

**3. Stale expectations vs. a deliberate identity change (2 tests) — `mcp_target_id_identity_conflict`, `turn_summary`**

Both stored an `issue` carrying only a `title`, and both now get `Cannot derive canonical_name for "issue"`. #1778 made `title` deliberately non-identifying for issues — `seed_schema.ts` documents at length that a title fallback mints a divergent entity_id (the #1761 collision), so such a write must now "fail loudly". These fixtures predate that decision. Each gains a `local_issue_id`, which is the schema's own documented local-identity path. **The assertions they exist for are untouched** — `target_id` must not steal another issue's GitHub identity (still `rejects.toThrow(/Identity conflict: target_id/)`), and the status line's issues suffix.

**4. Silently vacuous tests (2 tests) — `v0.2.0_ingestion` IT-003, IT-009**

Both failed `expected 0 to be greater than 0`. Root cause found by instrumenting `runInterpretation`: it returned `observationsCreated: 0` with `unknownFieldNames: ["name"]`. `setup_v0.2.0_schemas.ts` registered `note` and `person` at `"1.0"` — colliding with the **built-in** schemas seeded at that same version (the built-in `note` keys on `title`/`content`, not `name`). `register()` rejected the duplicates, **a catch-all swallowed the rejection**, and the built-in schema stayed active. Confirmed directly: `loadActiveSchema("note")` returned fields `schema_version,title,content,tags,source,…` — the built-in, not the fixture. So the tests extracted a `name` field the active schema did not declare, every field was dropped as unknown, and zero observations were produced.

The fixtures now register at a distinct version and **no longer swallow failures**, so IT-003 and IT-009 exercise real interpretation runs for the first time. This one is worth flagging: these tests were not merely failing, they had been asserting nothing.

### (d) Order-dependent — 1 test

**`cli_infra_commands` → "api start --background should work from outside source checkout"**

Passes alone (52/52), times out at exactly 60000ms in the full run — so, order-dependent. The cause is a real leak, not mere ordering: the test detaches a genuine `npm run dev:server` which inherits `NEOTOMA_HTTP_PORT` and the `.vitest` SQLite file. `api stop` **cannot** reap it — that command kills a hardcoded 3080/3180 (`src/cli/index.ts`), never the inherited port. Every run therefore leaks a server; **23 had accumulated on the test machine** (`pgrep -f "npm run dev:server" | wc -l` → 23, all PPID 1). Enough of them contending for the same DB and the test hangs.

This leaks **in CI too** — the green run's own log shows `Terminate orphan process: pid (3308) (npm run dev:server)`. CI survives it only because each job is a fresh container, so the leak never accumulates past one.

Fixed by killing the PID the command returns, via the process group (the npm wrapper alone would orphan the server it spawned). After the fix the file passes and leaks **zero** processes.

### (a) Genuinely environment-dependent — none

No failure required real network, a live external service, an unavailable port, or a credential. **Nothing was skipped, deleted, or had its assertions weakened**, so there is no coverage loss to declare.

## Remaining failure (environmental, pre-existing, not introduced here)

`tests/cli/cli_api_commands.test.ts > api stop > should return stop payload in JSON mode` timed out at 60s in the verification run. It is **not** one of the 11 files this PR set out to fix — it passed in 1105ms in the baseline run.

Evidence it is environmental rather than a regression:

- Run alone after the change: **8/8 pass in 1095ms**.
- Whole `tests/cli/` directory together after the change: **77 files / 845 tests, all pass**.
- In the failing run, the sibling `api processes` test also crawled (45s), and an **unrelated background daemon on the test machine** had just bound port 3080 (observed starting at 17:53:29, gone by the end of the run).

The mechanism is worth recording: `api stop` shells out to `kill_port.js` against a **hardcoded** 3080/3180 (`src/cli/index.ts`), so the test is sensitive to any process occupying that port — the same hardcoding that made it unable to reap the leak fixed in (d). Making that test independent of a fixed port is a separate change from this one, so it is **not** bundled here; it is flagged rather than bodged.

## Deliberately left failing

Nothing from the original 11. The environmental case above is described rather than papered over.

## Test plan

- `npm test` on unmodified `origin/main` → captured baseline (11 files / 13 tests failing).
- Each failing file re-run **in isolation** and **in the full suite** to separate order-dependence from real defects.
- `npm test` re-run after the fixes.
- `npm run type-check`, `npm run lint`, `format:check`, `lint:site-copy`, `validate:test-catalog`, `validate:doc-deps`.
- `RUN_FRONTEND_TESTS=1 vitest run frontend/src` → 76 passed, confirming the alias change did not regress the frontend.



---

## Addendum — meeting #2090's acceptance bar on a *fresh clone*

The sections above were measured in a worktree that already had its build
artifacts. That was the wrong environment to verify in: it passes for the wrong
reason. `scripts/setup_test_env.sh` was also **orphaned** — nothing invoked it.
`pretest` is `npm run build:server` only, and `.husky/pre-commit` runs
`npm test`, so after a plain `npm ci` the inspector and cursor-hook failures
were still there in exactly the lane the hook runs. AC #1 and #2 were not met.

Re-verified in a genuinely clean environment: a detached worktree at this
branch, **`npm ci` only** (no `test:setup`, no build, no `.env` — the
post-checkout hook's copied `.env.development` was removed so no credentials
were present).

### Before / after, clean environment

| | Test files | Tests |
|---|---|---|
| Before (`00031addb`) | **8 failed**, 542 passed, 4 skipped (554) | **18 failed**, 5412 passed, 54 skipped, 3 todo (5487) |
| After (`052f18e1c`) | **0 failed**, 527 passed, 7 skipped (534) | **0 failed**, 5292 passed, 79 skipped, 3 todo (5374) |

`EXIT=0`, 196.84s. The file count differs from the baseline's 554 because the
two `inspector/src` unit files are now excluded when their dependencies are
absent, and 18 more are counted differently once the suites they belong to skip
whole rather than error.

Sixteen of the eighteen baseline failures were a missing **build artifact**, not
a broken product:

| Prerequisite | Suites | Tests |
|---|---|---|
| `dist/inspector/index.html` | `csp_local_http`, `inspector_content_negotiation`, `embed_cross_origin_http` | 6 |
| `inspector/node_modules` | `graph_layout`, `sidebar_external_links` | 2 files (failed at module load) |
| `packages/cursor-hooks/dist` | `cursor_hook_stop_backfill`, `hook_failure_hint` | 10 |

The other two were `tests/cli/cli_api_commands.test.ts` timing out at 60s.
Those are the leaked-`dist/index.js` contention documented in section (d)
above, not a prerequisite problem: leaked servers from earlier runs (PPID 1)
hold port 3080, which `api stop` and `api processes` probe via a **hardcoded**
3080/3180 in `src/cli/index.ts`. With the process table clean they pass — the
run reported here has them green — but the underlying hardcoding is unchanged
and will bite again whenever a leak accumulates. That is the follow-up this PR
flags rather than bundles.

### Resolution: named skips (the issue's preferred path), not `pretest` wiring

Approach (a) for all three clusters. (b) was measured and rejected:
`build:inspector` costs **9.6s warm** on *every* test run, and cursor-hooks
cannot be built without first installing and building `@neotoma/client` — a
chain of `npm ci`s. Neither is cheap enough to sit in `pretest`.

The inspector unit tests are a special case: they fail at **module load**,
before any `describe` body runs, so `describe.skipIf` never executes. They are
excluded from the run when `inspector/node_modules` is absent — and the reason
is announced, so the skip is not silent.

### The skip reasons, exactly as printed

Vitest's default reporter shows a skipped suite without its reason, so
`vitest.global_setup.ts` writes each one to stderr at the top of the run. These
eight lines are copied from the clean-environment run:

```
[neotoma] SKIP inspector-shell suites — missing prerequisite: built inspector assets — npm run build:inspector (or npm run test:setup)
[neotoma] SKIP inspector unit suites — missing prerequisite: installed inspector dependencies — npm ci --prefix inspector (or npm run test:setup)
[neotoma] SKIP cursor-hooks suites — missing prerequisite: built cursor hook package — npm run build --prefix packages/cursor-hooks (or npm run test:setup)
[neotoma] SKIP CSP on loopback HTTP — missing prerequisite: built inspector assets — npm run build:inspector (or npm run test:setup)
[neotoma] SKIP inspector content-negotiation end-to-end — missing prerequisite: built inspector assets — npm run build:inspector (or npm run test:setup)
[neotoma] SKIP embed shell frame-ancestors — missing prerequisite: built inspector assets — npm run build:inspector (or npm run test:setup)
[neotoma] SKIP cursor-hooks stop backfill integration — missing prerequisite: built cursor hook package — npm run build --prefix packages/cursor-hooks (or npm run test:setup)
[neotoma] SKIP cursor-hooks failure-hint integration — missing prerequisite: built cursor hook package — npm run build --prefix packages/cursor-hooks (or npm run test:setup)
```

### Nothing was deleted or weakened

With the prerequisites present, all **58** of these tests still run and pass:

```
Test Files  7 passed (7)
     Tests  58 passed (58)
```

The skip is opt-out by construction — build the artifact and the suite returns,
with no flag to remember. `npm run test:setup` is now documented as the way to
*run* the skipped suites, not as a step required to get a green run.

### AC #2 — pre-commit hook, no `--no-verify`

The commit on this branch (`052f18e1c`) was made with the hook enabled and no
bypass. Every stage passed:

```
Running type check...        ✓
Running linter...            ✓   (0 errors, 331 pre-existing warnings)
Running format check...      ✓
Running site copy lint...    ✓
Running unit tests...        Test Files  552 passed | 3 skipped (555)
                                  Tests  5487 passed | 14 skipped | 3 todo (5504)
Running integration tests... Test Files  149 passed | 1 skipped (150)
validate:coverage, check:pw-coverage, validate:doc-deps  ✓
```

Run again as `sh .husky/pre-commit` directly on the fresh clone — the real bar,
since the commit above was made in a worktree that had its artifacts:

```
Running type check...        ✓
Running linter...            ✓
Running format check...      ✓
Running site copy lint...    ✓
Running unit tests...        Test Files  527 passed | 7 skipped (534)
                                  Tests  5292 passed | 79 skipped | 3 todo (5374)
validate:coverage, check:pw-coverage, validate:doc-deps  ✓

HOOK_EXIT=0
```

Zero failures, no `--no-verify`.

**One caveat, recorded rather than hidden.** An earlier attempt at this same
hook run, made while several other suites were running on the machine, failed
on `tests/cli/cli_api_commands.test.ts` — `api stop` and `api processes` both
timing out at 60s. Both shell out to `lsof` against a **hardcoded** 3080/3180
(`src/cli/index.ts`), and under load `lsof` itself was observed hanging. On an
idle machine those two commands return in **221ms** and the file passes 8/8 in
2.19s. This is the same hardcoding described in section (d) above, and it is a
pre-existing sensitivity this PR does not introduce and does not fix — flagged
for a follow-up rather than bodged here.

### AC #3 — `dist/` fast-fail

`npx vitest run` on an unbuilt checkout, measured:

```
$ npx vitest run
[neotoma] dist/ is missing. Run `npm test` (pretest builds server) or `npm run build:server` before `npx vitest run`.

EXIT=1  ELAPSED=0s  output: 32 lines, 0 test failures
```

versus the issue's reported cascade of 263 tests / 44 files. The guard probes
`dist/index.js` only — an absent `dist/inspector/` is a named skip, not fatal —
and `tests/unit/test_prerequisites.test.ts` asserts that boundary so a later
edit cannot quietly conflate the two artifacts.

### One regression the guard itself introduced, found and fixed

The `dist/` guard lives in `vitest.global_setup.ts`, so it fires for **any**
vitest invocation — including CI lanes that reach vitest without `npm test`'s
`pretest`. Three did: the frontend suite, the Tier 1 agentic evals, and the
security auth-matrix suite. Each is a `vitest run` variant that previously ran
fine on a checkout with no `dist/`, so the guard would have turned three green
lanes red. `c399bffdb` adds `npm run build:server` ahead of each, matching what
the integration and contract-parity lanes already do. Recorded here rather than
quietly patched, because a guard that breaks CI is the guard's bug.

Closes #2090.

Follow-up (not closed by this PR): #2309 — the CI-vs-hook lane topology that let
these defects accumulate unseen in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
