### PR TITLE
fix(openapi): declare /recompute_snapshots_by_type so the auth matrix probes it

### DIFF
--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,8 +61,8 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **594**
-- Backend and repo Vitest files: **559**
+- Total automated test files: **596**
+- Backend and repo Vitest files: **561**
 - Frontend Vitest files: **9**
 - Playwright spec files: **26**
 
@@ -72,7 +72,7 @@ flowchart TD
 | Vitest unit tests | 164 |
 | Vitest service tests | 44 |
 | Source-adjacent tests | 66 |
-| Vitest integration tests | 167 |
+| Vitest integration tests | 168 |
 | Vitest CLI tests | 78 |
 | Vitest contract tests | 18 |
 | Vitest security tests | 7 |
@@ -404,7 +404,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm run test:integration` or `npx vitest run tests/integration`
 **Requirements:** Database configured; remote-dependent subsets additionally need `RUN_REMOTE_TESTS=1`.
-**Files (167):**
+**Files (168):**
 - `tests/integration/aauth_attribution_stamping.test.ts`
 - `tests/integration/aauth_mcp_capability_parity.test.ts`
 - `tests/integration/aauth_mcp_initialize_admission.test.ts`
@@ -523,6 +523,7 @@ flowchart TD
 - `tests/integration/plan_body_raw_fragment_backfill.test.ts`
 - `tests/integration/process_issues_skill.test.ts`
 - `tests/integration/public_key_registry.test.ts`
+- `tests/integration/recompute_snapshots_by_type_idempotent.test.ts`
 - `tests/integration/record_activity_attribution.test.ts`
 - `tests/integration/relationship_agent_attribution_api.test.ts`
 - `tests/integration/relationship_delete_discovery_mcp.test.ts`

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -7636,6 +7636,74 @@ paths:
                 type: object
                 additionalProperties: true
 
+  /recompute_snapshots_by_type:
+    post:
+      summary: Recompute snapshots by entity type
+      description: |
+        Recompute every snapshot the calling user owns for one entity type,
+        re-applying the active schema (canonical name, timeline events) and
+        refreshing embeddings. Scoped to the authenticated user's own
+        snapshots. Use `dry_run` to count and list the affected entities
+        without writing.
+      operationId: recomputeSnapshotsByType
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - entity_type
+              properties:
+                entity_type:
+                  type: string
+                  description: Entity type whose snapshots are recomputed.
+                dry_run:
+                  type: boolean
+                  default: false
+                  description: When true, report the entities that would be recomputed without writing.
+      responses:
+        "200":
+          description: Recompute results, or the dry-run preview when `dry_run` is true.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                properties:
+                  entity_type:
+                    type: string
+                  dry_run:
+                    type: boolean
+                    description: Present only on a dry-run response.
+                  entities_to_recompute:
+                    type: integer
+                    description: Dry run only — number of snapshots that would be recomputed.
+                  entity_ids:
+                    type: array
+                    description: Dry run only — ids of the snapshots that would be recomputed.
+                    items:
+                      type: string
+                  total:
+                    type: integer
+                    description: Number of snapshots found for the entity type.
+                  recomputed:
+                    type: integer
+                    description: Number of snapshots successfully recomputed.
+                  errors:
+                    type: integer
+                    description: Number of snapshots that failed to recompute.
+                  error_details:
+                    type: array
+                    description: Present only when at least one snapshot failed.
+                    items:
+                      type: object
+                      properties:
+                        entity_id:
+                          type: string
+                        error:
+                          type: string
+
   /subscribe:
     post:
       summary: Create a substrate event subscription (webhook or SSE)

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -7645,6 +7645,23 @@ paths:
         refreshing embeddings. Scoped to the authenticated user's own
         snapshots. Use `dry_run` to count and list the affected entities
         without writing.
+
+        Retry / idempotency (intrinsic — no `idempotency_key`):
+        - The same `{ entity_type, dry_run }` body is safe to retry after
+          transport failure. This is maintenance recompute, not
+          `ingest` / `store` / `correct`, so there is no request-ledger key.
+        - On the live path (`dry_run: false` or omitted), each retry re-runs
+          `recomputeSnapshot` per owned entity: a deterministic upsert of
+          derived snapshot and timeline rows from the current observation
+          set. It does not create duplicate entities or observations.
+        - Response counters (`total` / `recomputed` / `errors`) are per
+          invocation, not cached across retries.
+        - Opportunistic `canonical_name` evolution inside `recomputeSnapshot`
+          converges; subsequent retries with an unchanged observation set
+          do not keep renaming.
+        Unknown top-level request fields are intentionally tolerated
+        (handler uses a non-strict Zod object), matching peer maintenance
+        POSTs such as `/health_check_snapshots`.
       operationId: recomputeSnapshotsByType
       requestBody:
         required: true

--- a/scripts/security/protected_routes_manifest.json
+++ b/scripts/security/protected_routes_manifest.json
@@ -1109,6 +1109,19 @@
       ]
     },
     {
+      "path": "/recompute_snapshots_by_type",
+      "method": "POST",
+      "operation_id": "recomputeSnapshotsByType",
+      "requires_auth": true,
+      "sandbox_allowed": "none",
+      "expected_no_auth_status": [
+        401
+      ],
+      "expected_invalid_auth_status": [
+        401
+      ]
+    },
+    {
       "path": "/record_activity",
       "method": "GET",
       "operation_id": "getRecordActivity",

--- a/src/shared/contract_mappings.ts
+++ b/src/shared/contract_mappings.ts
@@ -709,6 +709,15 @@ export const OPENAPI_OPERATION_MAPPINGS: OpenApiOperationMapping[] = [
     cliCommand: "snapshots check",
   },
   {
+    operationId: "recomputeSnapshotsByType",
+    method: "post",
+    path: "/recompute_snapshots_by_type",
+    adapter: "cli",
+    cliCommand: "request --operation recomputeSnapshotsByType",
+    notes:
+      "Maintenance endpoint: rebuilds every snapshot of one entity type for the calling user. Scoped by user_id and blocked in sandbox mode (destructive route).",
+  },
+  {
     operationId: "publishRenderedPage",
     method: "post",
     path: "/rendered-pages/publish",

--- a/src/shared/openapi_types.ts
+++ b/src/shared/openapi_types.ts
@@ -2117,6 +2117,23 @@ export interface paths {
      *     refreshing embeddings. Scoped to the authenticated user's own
      *     snapshots. Use `dry_run` to count and list the affected entities
      *     without writing.
+     *
+     *     Retry / idempotency (intrinsic — no `idempotency_key`):
+     *     - The same `{ entity_type, dry_run }` body is safe to retry after
+     *       transport failure. This is maintenance recompute, not
+     *       `ingest` / `store` / `correct`, so there is no request-ledger key.
+     *     - On the live path (`dry_run: false` or omitted), each retry re-runs
+     *       `recomputeSnapshot` per owned entity: a deterministic upsert of
+     *       derived snapshot and timeline rows from the current observation
+     *       set. It does not create duplicate entities or observations.
+     *     - Response counters (`total` / `recomputed` / `errors`) are per
+     *       invocation, not cached across retries.
+     *     - Opportunistic `canonical_name` evolution inside `recomputeSnapshot`
+     *       converges; subsequent retries with an unchanged observation set
+     *       do not keep renaming.
+     *     Unknown top-level request fields are intentionally tolerated
+     *     (handler uses a non-strict Zod object), matching peer maintenance
+     *     POSTs such as `/health_check_snapshots`.
      */
     post: operations["recomputeSnapshotsByType"];
     delete?: never;

--- a/src/shared/openapi_types.ts
+++ b/src/shared/openapi_types.ts
@@ -2101,6 +2101,30 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/recompute_snapshots_by_type": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * Recompute snapshots by entity type
+     * @description Recompute every snapshot the calling user owns for one entity type,
+     *     re-applying the active schema (canonical name, timeline events) and
+     *     refreshing embeddings. Scoped to the authenticated user's own
+     *     snapshots. Use `dry_run` to count and list the affected entities
+     *     without writing.
+     */
+    post: operations["recomputeSnapshotsByType"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/subscribe": {
     parameters: {
       query?: never;
@@ -8377,6 +8401,59 @@ export interface operations {
         };
         content: {
           "application/json": {
+            [key: string]: unknown;
+          };
+        };
+      };
+    };
+  };
+  recomputeSnapshotsByType: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          /** @description Entity type whose snapshots are recomputed. */
+          entity_type: string;
+          /**
+           * @description When true, report the entities that would be recomputed without writing.
+           * @default false
+           */
+          dry_run?: boolean;
+        };
+      };
+    };
+    responses: {
+      /** @description Recompute results, or the dry-run preview when `dry_run` is true. */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            entity_type?: string;
+            /** @description Present only on a dry-run response. */
+            dry_run?: boolean;
+            /** @description Dry run only — number of snapshots that would be recomputed. */
+            entities_to_recompute?: number;
+            /** @description Dry run only — ids of the snapshots that would be recomputed. */
+            entity_ids?: string[];
+            /** @description Number of snapshots found for the entity type. */
+            total?: number;
+            /** @description Number of snapshots successfully recomputed. */
+            recomputed?: number;
+            /** @description Number of snapshots that failed to recompute. */
+            errors?: number;
+            /** @description Present only when at least one snapshot failed. */
+            error_details?: {
+              entity_id?: string;
+              error?: string;
+            }[];
+          } & {
             [key: string]: unknown;
           };
         };

--- a/tests/integration/recompute_snapshots_by_type_idempotent.test.ts
+++ b/tests/integration/recompute_snapshots_by_type_idempotent.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Arch Option B for PR #2313: POST /recompute_snapshots_by_type is
+ * intrinsically idempotent (upsert of derived state). Retries of the same
+ * live body must converge without creating entities/observations or needing
+ * an ingest-style idempotency_key (change_guardrails MUST #11 scopes that
+ * key to ingest/store/correct only).
+ */
+
+import { createServer } from "node:http";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { randomUUID } from "crypto";
+import { app } from "../../src/actions.js";
+import { db } from "../../src/db.js";
+import { NeotomaServer } from "../../src/server.js";
+import { LOCAL_DEV_USER_ID } from "../../src/services/local_auth.js";
+import { cleanupTestEntityType } from "../helpers/test_schema_helpers.js";
+
+const TEST_USER_ID = LOCAL_DEV_USER_ID;
+
+type RecomputeLiveResponse = {
+  entity_type: string;
+  total: number;
+  recomputed: number;
+  errors: number;
+  error_details?: Array<{ entity_id: string; error: string }>;
+};
+
+function stripVolatileSnapshot(row: {
+  snapshot?: unknown;
+  computed_at?: string | null;
+  last_observation_at?: string | null;
+  [key: string]: unknown;
+}): Record<string, unknown> {
+  const { computed_at: _c, last_observation_at: _l, ...rest } = row;
+  const snap = rest.snapshot;
+  if (snap && typeof snap === "object" && !Array.isArray(snap)) {
+    const inner = { ...(snap as Record<string, unknown>) };
+    delete inner.computed_at;
+    return { ...rest, snapshot: inner };
+  }
+  return rest;
+}
+
+describe("POST /recompute_snapshots_by_type intrinsic idempotency (arch Option B)", () => {
+  const entityType = `test_recompute_idemp_${randomUUID().replace(/-/g, "").slice(0, 8)}`;
+  const createdEntityIds: string[] = [];
+  const createdSourceIds: string[] = [];
+  let httpServer: ReturnType<typeof createServer>;
+  let apiBase = "";
+  let server: NeotomaServer;
+
+  beforeAll(async () => {
+    server = new NeotomaServer();
+    (server as unknown as { authenticatedUserId: string }).authenticatedUserId = TEST_USER_ID;
+
+    httpServer = createServer(app);
+    await new Promise<void>((resolve, reject) => {
+      httpServer.listen(0, "127.0.0.1", () => resolve());
+      httpServer.once("error", reject);
+    });
+    const addr = httpServer.address();
+    if (!addr || typeof addr === "string") {
+      throw new Error("expected TCP listen address");
+    }
+    apiBase = `http://127.0.0.1:${addr.port}`;
+
+    await db.from("schema_registry").insert({
+      entity_type: entityType,
+      schema_version: "1.0",
+      schema_definition: {
+        fields: {
+          name: { type: "string", required: false },
+          note: { type: "string", required: false },
+          schema_version: { type: "string", required: false },
+        },
+        canonical_name_fields: ["name"],
+        identity_opt_out: "heuristic_canonical_name",
+      },
+      reducer_config: {
+        merge_policies: {
+          name: { strategy: "last_write" },
+          note: { strategy: "last_write" },
+          schema_version: { strategy: "last_write" },
+        },
+      },
+      active: true,
+      scope: "user",
+      user_id: TEST_USER_ID,
+    });
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+
+    if (createdSourceIds.length > 0) {
+      await db.from("raw_fragments").delete().in("source_id", createdSourceIds);
+      await db.from("observations").delete().in("source_id", createdSourceIds);
+      await db.from("sources").delete().in("id", createdSourceIds);
+    }
+    if (createdEntityIds.length > 0) {
+      await db.from("timeline_events").delete().in("entity_id", createdEntityIds);
+      await db.from("entity_snapshots").delete().in("entity_id", createdEntityIds);
+      await db.from("observations").delete().in("entity_id", createdEntityIds);
+      await db.from("entities").delete().in("id", createdEntityIds);
+    }
+    await cleanupTestEntityType(entityType, TEST_USER_ID);
+  });
+
+  it("retries of live recompute converge (arch intrinsic-idempotency exception)", async () => {
+    const storeResult = await (
+      server as unknown as {
+        store: (p: Record<string, unknown>) => Promise<{ content: Array<{ text: string }> }>;
+      }
+    ).store({
+      user_id: TEST_USER_ID,
+      idempotency_key: `recompute-idemp-seed-${randomUUID()}`,
+      entities: [
+        {
+          entity_type: entityType,
+          schema_version: "1.0",
+          name: "Idempotent Recompute Fixture",
+          note: "seed",
+        },
+      ],
+    });
+    const seeded = JSON.parse(storeResult.content[0].text) as {
+      source_id?: string;
+      entities?: Array<{ entity_id: string }>;
+      error?: unknown;
+    };
+    expect(seeded.error).toBeUndefined();
+    expect(seeded.entities?.[0]?.entity_id).toBeTruthy();
+    const entityId = seeded.entities![0].entity_id;
+    createdEntityIds.push(entityId);
+    if (seeded.source_id) createdSourceIds.push(seeded.source_id);
+
+    const countRows = async () => {
+      const [{ count: entityCount }, { count: observationCount }, { count: snapshotCount }] =
+        await Promise.all([
+          db
+            .from("entities")
+            .select("id", { count: "exact", head: true })
+            .eq("entity_type", entityType)
+            .eq("user_id", TEST_USER_ID),
+          db
+            .from("observations")
+            .select("id", { count: "exact", head: true })
+            .eq("entity_type", entityType)
+            .eq("user_id", TEST_USER_ID),
+          db
+            .from("entity_snapshots")
+            .select("entity_id", { count: "exact", head: true })
+            .eq("entity_type", entityType)
+            .eq("user_id", TEST_USER_ID),
+        ]);
+      return {
+        entities: entityCount ?? 0,
+        observations: observationCount ?? 0,
+        snapshots: snapshotCount ?? 0,
+      };
+    };
+
+    const readSnapshotPayload = async () => {
+      const { data } = await db
+        .from("entity_snapshots")
+        .select("entity_id, entity_type, snapshot, computed_at, last_observation_at, observation_count")
+        .eq("entity_id", entityId)
+        .eq("user_id", TEST_USER_ID)
+        .maybeSingle();
+      expect(data).toBeTruthy();
+      return stripVolatileSnapshot(data as Record<string, unknown>);
+    };
+
+    const body = { entity_type: entityType, dry_run: false };
+
+    const firstRes = await fetch(`${apiBase}/recompute_snapshots_by_type`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    expect(firstRes.status).toBe(200);
+    const firstJson = (await firstRes.json()) as RecomputeLiveResponse;
+    expect(firstJson.entity_type).toBe(entityType);
+    expect(firstJson.total).toBeGreaterThanOrEqual(1);
+    expect(firstJson.recomputed).toBeGreaterThanOrEqual(1);
+    expect(firstJson.errors).toBe(0);
+
+    const countsAfterFirst = await countRows();
+    const snapshotAfterFirst = await readSnapshotPayload();
+
+    const secondRes = await fetch(`${apiBase}/recompute_snapshots_by_type`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    expect(secondRes.status).toBe(200);
+    const secondJson = (await secondRes.json()) as RecomputeLiveResponse;
+    expect(secondJson.entity_type).toBe(entityType);
+    expect(secondJson.errors).toBe(0);
+    // Counters are per invocation (not ledger-cached), but should still succeed.
+    expect(secondJson.total).toBe(firstJson.total);
+    expect(secondJson.recomputed).toBeGreaterThanOrEqual(1);
+
+    const countsAfterSecond = await countRows();
+    expect(countsAfterSecond.entities).toBe(countsAfterFirst.entities);
+    expect(countsAfterSecond.observations).toBe(countsAfterFirst.observations);
+    expect(countsAfterSecond.snapshots).toBe(countsAfterFirst.snapshots);
+
+    const snapshotAfterSecond = await readSnapshotPayload();
+    expect(snapshotAfterSecond).toEqual(snapshotAfterFirst);
+  });
+});


### PR DESCRIPTION
## What

`POST /recompute_snapshots_by_type` has been mounted and auth-enforced in `src/actions.ts` since the Phase 0 endpoints, and `src/services/sandbox_mode.ts` already lists it in `DESTRUCTIVE_ROUTES`. It had **no entry in `openapi.yaml`**, and because `scripts/security/sync_protected_routes_manifest.js` derives the manifest **from the spec**, it had **no row in `protected_routes_manifest.json`** — so the topology-aware negative auth matrix never enumerated it.

Found while comparing the sandbox destructive-route list against the security route manifest on #2008.

**This is not an exposure.** The handler resolves the caller via `getAuthenticatedUserId` and scopes both the snapshot query and `recomputeSnapshot` by `user_id`. It is a spec and test-coverage gap.

## The route's real contract (derived from the handler, not assumed)

| | |
|---|---|
| Request | `entity_type` (required, string), `dry_run` (optional boolean, default `false`) |
| Dry-run response | `{ entity_type, dry_run: true, entities_to_recompute, entity_ids[] }` |
| Live response | `{ entity_type, total, recomputed, errors, error_details? }` |
| Auth | Global `bearerAuth`; **401** on absent and on invalid credentials |
| Sandbox | `sandbox_allowed: "none"` — already a `DESTRUCTIVE_ROUTES` member |

`error_details` is `{ entity_id, error }[]`, present only when at least one snapshot fails. Per-entity failures are counted, not fatal — the loop continues and returns 200.

## Verification that nothing was weakened

The manifest expectations are generated, so the risk is that generated expectations quietly disagree with runtime behaviour. I probed the **real Express app** on a loopback port in a remote posture (`NEOTOMA_ENV=production`, public `X-Forwarded-For`):

| case | body | status |
|---|---|---|
| no auth | valid | **401** `AUTH_REQUIRED` |
| no auth | empty | **401** `AUTH_REQUIRED` |
| invalid bearer | valid | **401** `AUTH_INVALID` |
| invalid bearer | empty | **401** `AUTH_INVALID` |

Both body variants were probed deliberately: the handler validates its body *before* calling `getAuthenticatedUserId`, which would return 400-before-401 if the route were reachable unauthenticated. It is not — the auth middleware runs ahead of the handler, so the ordering is unreachable and the generated `[401]` expectations match observed behaviour exactly. The probe was scratch-only and is not part of this diff.

## Changes

- `openapi.yaml` — the operation, matching neighbouring conventions (no `tags` are used anywhere in this spec; global `security` applies; `additionalProperties: true` response style as per `/health_check_snapshots`).
- `src/shared/contract_mappings.ts` — required by `tests/contract/contract_mapping.test.ts` (every `operationId` must be mapped). Registered `adapter: "cli"` via the generic `request --operation` form: it is a maintenance endpoint with no MCP tool and no dedicated CLI command.
- `src/shared/openapi_types.ts` — regenerated (`npm run openapi:generate`).
- `scripts/security/protected_routes_manifest.json` — regenerated (`npm run security:manifest:write`); 120 → **121 rows**, 105 protected.

The new manifest row is emitted entirely by the generator with no override:

```json
{ "path": "/recompute_snapshots_by_type", "method": "POST",
  "operation_id": "recomputeSnapshotsByType", "requires_auth": true,
  "sandbox_allowed": "none",
  "expected_no_auth_status": [401], "expected_invalid_auth_status": [401] }
```

The matrix's manifest-sanity layer iterates every row, so the route is now covered by all five per-row assertions (schema shape, 401-on-no-auth, 401-on-invalid-auth, valid `sandbox_allowed`, and `sandbox_allowed=none` for auth-required routes).

## Verification

- `npm run type-check` — clean
- `npm run security:manifest:check` — in sync, 121 routes
- `npm run openapi:generate` — zero diff after regeneration (openapi-sync CI equivalent)
- `npm run format:check` — clean
- `tests/security` + `tests/contract` — **284 passed**, 1 skipped
- Full pre-commit gate — **529 + 145 test files passed**, 0 failed

## ⚠️ The gap is systemic — this route is not alone

The prompt for this fix asked whether one missing route was a one-off. It is not. Enumerating every route the server actually mounts and diffing against both the spec and the manifest finds **16 further routes that are auth-enforced at runtime but absent from `openapi.yaml` and therefore absent from the manifest** — the exact same class as the one fixed here, and equally unprobed by the auth matrix:

```
POST   /api/issues/add_message          POST   /entities/{id}/batch_correct
POST   /api/issues/status               GET    /entities/{id}/html
POST   /api/issues/submit               GET    /entities/{id}/markdown
GET    /bundles                         POST   /github/webhook
GET    /bundles/{name}                  GET    /sources/{id}/content
GET    /turns                           POST   /submit/{entity_type}
GET    /turns/{turn_key}                GET    /submit/{entity_type}/{entity_id}
                                        POST   /submit/{entity_type}/{entity_id}/message
```

Spot-checked rather than taken from the heuristic alone: `GET /turns` and `GET /bundles` both call `getAuthenticatedUserId`, and `/bundles` says so explicitly in a comment ("enforces the same auth contract as /turns"). `POST /entities/:id/batch_correct` is the Inspector's atomic multi-field save path.

Separately, ~10 unauthenticated routes are mounted but appear in neither the spec nor `RUNTIME_UNAUTH_ROUTES` (`/robots.txt`, `/.well-known/aauth-resource.json`, `/.well-known/mcp/server-card.json`, `/mcp-interaction-instructions`, `/openapi_actions.yaml`, `/mcp/oauth/google/{start,callback}`, `/sandbox/{terms,report,report/status}`, `/sandbox/aauth-only/store`) — the allow-list comment says such surfaces "MUST stay in this list, not slip silently through".

**The structural cause:** the manifest is spec-derived, so a route that is never added to `openapi.yaml` is invisible to the security matrix by construction, and nothing fails when that happens. Fixing routes one at a time does not close it — what would is a check that diffs mounted routes against the manifest and fails on an undeclared auth-enforced route, making the omission loud instead of silent. I have deliberately kept this PR to the single route it was scoped to; the sweep above is reported so the broader hole can be tracked on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
