### PR TITLE
fix(db): an abandoned request must not kill the server (#2316)

### DIFF
--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,8 +61,8 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **594**
-- Backend and repo Vitest files: **559**
+- Total automated test files: **596**
+- Backend and repo Vitest files: **561**
 - Frontend Vitest files: **9**
 - Playwright spec files: **26**
 
@@ -72,7 +72,7 @@ flowchart TD
 | Vitest unit tests | 164 |
 | Vitest service tests | 44 |
 | Source-adjacent tests | 66 |
-| Vitest integration tests | 167 |
+| Vitest integration tests | 168 |
 | Vitest CLI tests | 78 |
 | Vitest contract tests | 18 |
 | Vitest security tests | 7 |
@@ -404,7 +404,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm run test:integration` or `npx vitest run tests/integration`
 **Requirements:** Database configured; remote-dependent subsets additionally need `RUN_REMOTE_TESTS=1`.
-**Files (167):**
+**Files (168):**
 - `tests/integration/aauth_attribution_stamping.test.ts`
 - `tests/integration/aauth_mcp_capability_parity.test.ts`
 - `tests/integration/aauth_mcp_initialize_admission.test.ts`
@@ -438,6 +438,7 @@ flowchart TD
 - `tests/integration/csp_local_http.test.ts`
 - `tests/integration/cursor_hook_stop_backfill.test.ts`
 - `tests/integration/dashboard_stats.test.ts`
+- `tests/integration/db_abort_client_disconnect_survival.test.ts`
 - `tests/integration/describe_entity_type.test.ts`
 - `tests/integration/describe_instance_policy_auth.test.ts`
 - `tests/integration/docs_route.test.ts`

--- a/src/repositories/worker/worker_file_database.ts
+++ b/src/repositories/worker/worker_file_database.ts
@@ -328,6 +328,16 @@ class WorkerConnection {
       entry.cleanup();
       entry.reject(error);
     }
+    // Reclamation is routine on this path — an aborting client or an expired
+    // budget — but it is worth a line: each of these was an unhandled
+    // rejection that killed the process before #2316, and a reclamation storm
+    // (the crash-loop signature) is otherwise invisible. Deliberately does not
+    // claim whether a caller was waiting: this promise is consumed by
+    // `routeRead` and by `guardAbandonedRead` before any caller reaches it, so
+    // that is not knowable here.
+    if (entries.length > 0) {
+      logger.warn(`DB reclaimed ${entries.length} in-flight statement(s): ${error.message}`);
+    }
   }
 
   /**
@@ -362,7 +372,7 @@ class WorkerConnection {
     }
     const worker = this.ensureWorker();
     const id = this.nextId++;
-    return new Promise((resolve, reject) => {
+    return new Promise<unknown>((resolve, reject) => {
       let timer: ReturnType<typeof setTimeout> | undefined;
       let onAbort: (() => void) | undefined;
       const cleanup = () => {
@@ -479,6 +489,40 @@ function toBindValue(value: unknown): unknown {
   return value;
 }
 
+/**
+ * Make a read's promise safe to abandon (#2316).
+ *
+ * Reads are the only statements that can be reclaimed out from under their
+ * caller: an abort or a statement timeout rejects them on the SERVER's
+ * schedule, whenever the client hangs up or the budget expires, not when the
+ * caller chooses to look. A caller that has already walked away — an express
+ * handler that returned once its client disconnected, an SSE request whose
+ * response closed — never attaches a handler, and Node's default
+ * `--unhandled-rejections=throw` turns that rejection into an unhandled
+ * exception that kills the process. One abandoned HTTP request must never be
+ * able to do that.
+ *
+ * So attach a no-op catch to a DERIVED promise, which marks the rejection
+ * handled without altering the promise we hand back: callers that DO await
+ * still receive the real `WorkerDbAbortError` / `WorkerDbTimeoutError` and can
+ * still map it to a response. Nothing is swallowed for anyone who is listening.
+ *
+ * Scoped deliberately narrowly — reads on the reader pool only:
+ *   - Writes are NOT guarded. `routeWrite` and everything inside a transaction
+ *     ignore the abort signal and are never timed out, precisely so a caller
+ *     hanging up mid-write cannot leave a half-applied mutation. A write that
+ *     fails is a real fault whose rejection must stay loud.
+ *   - This is not a process-wide handler. A blanket
+ *     `process.on("uncaughtException")` would keep the server alive through
+ *     genuine faults — a corrupt migration, an OOM — and is its own defect;
+ *     the crash-worthy cases must still crash. This guards one known-benign
+ *     class of rejection at the one boundary that produces it.
+ */
+function guardAbandonedRead<T>(read: Promise<T>): Promise<T> {
+  void read.catch(() => {});
+  return read;
+}
+
 class WorkerStatement implements DbStatement {
   constructor(
     private readonly db: WorkerFileDatabase,
@@ -496,12 +540,12 @@ class WorkerStatement implements DbStatement {
 
   get(...params: unknown[]): Promise<unknown> {
     const bound = normalizeParams(params).map(toBindValue);
-    return this.db.routeRead("get", this.sql, bound);
+    return guardAbandonedRead(this.db.routeRead("get", this.sql, bound));
   }
 
   all(...params: unknown[]): Promise<unknown[]> {
     const bound = normalizeParams(params).map(toBindValue);
-    return this.db.routeRead("all", this.sql, bound) as Promise<unknown[]>;
+    return guardAbandonedRead(this.db.routeRead("all", this.sql, bound) as Promise<unknown[]>);
   }
 }
 

--- a/tests/integration/db_abort_client_disconnect_survival.test.ts
+++ b/tests/integration/db_abort_client_disconnect_survival.test.ts
@@ -1,0 +1,272 @@
+/**
+ * A client that hangs up mid-query must not kill the server (#2316).
+ *
+ * The bug being guarded is "the process dies", so these tests assert process
+ * LIVENESS, not error shape. An in-process test cannot do that: the crash is an
+ * unhandled rejection escaping to Node's default `--unhandled-rejections=throw`
+ * handler, and vitest installs its own handler that catches it — which is
+ * exactly why the existing unit coverage in
+ * `tests/unit/db_worker_file_database.test.ts` passed throughout the outage.
+ * So each case runs a real server in a CHILD PROCESS, disconnects a client
+ * mid-query, and then asserts the child is still alive AND still serving.
+ *
+ * Reproduced trace this guards (production, Fly v25, Node 20):
+ *
+ *   WorkerDbAbortError: DB request aborted by caller
+ *       at EventTarget.onAbort (worker_file_database.js:338:34)
+ *       at AbortController.abort (node:internal/abort_controller:392:5)
+ *       at ServerResponse.onClose (middleware/db_abort_context.js:32:28)
+ *       at emitCloseNT (node:_http_server:1019:10)
+ *
+ * The neon `PendingException` SIGABRT reported alongside it is downstream of
+ * this same unhandled rejection: with the rejection handled, twelve
+ * back-to-back mid-statement worker terminations leave the process alive, so
+ * it needs no separate guard. `expectAliveAndServing` covers both, since a
+ * SIGABRT would fail the liveness assertion just as an exit(1) does.
+ */
+
+import { spawn, type ChildProcess } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterAll, afterEach, describe, expect, it } from "vitest";
+
+const workDir = mkdtempSync(path.join(tmpdir(), "neotoma-abort-survival-"));
+const repoRoot = path.resolve(__dirname, "..", "..");
+/** Child entry scripts go here so bare imports resolve; removed in afterAll. */
+const entryDir = mkdtempSync(path.join(repoRoot, "node_modules", ".neotoma-abort-test-"));
+const entries: string[] = [];
+let nextEntry = 0;
+
+let child: ChildProcess | undefined;
+
+afterEach(() => {
+  child?.kill("SIGKILL");
+  child = undefined;
+});
+
+afterAll(() => {
+  for (const entry of entries) rmSync(entry, { force: true });
+  rmSync(entryDir, { recursive: true, force: true, maxRetries: 2 });
+  rmSync(workDir, { recursive: true, force: true, maxRetries: 2 });
+});
+
+/**
+ * A minimal server that reproduces the production topology: the real
+ * `dbAbortContext` middleware over the real `WorkerFileDatabase`, with a
+ * handler that leaves a slow read in flight when its client goes away.
+ *
+ * Deliberately not the full Neotoma app — booting that needs auth, schemas and
+ * migrations, none of which are part of this bug, and all of which would make a
+ * failure ambiguous between "crashed on abort" and "failed to start".
+ */
+function serverSource(dbPath: string, statementTimeoutMs = 0): string {
+  return `
+import http from "node:http";
+import express from "express";
+import { WorkerFileDatabase } from ${JSON.stringify(path.join(repoRoot, "dist/repositories/worker/worker_file_database.js"))};
+import { dbAbortContext } from ${JSON.stringify(path.join(repoRoot, "dist/middleware/db_abort_context.js"))};
+
+const db = new WorkerFileDatabase(${JSON.stringify(dbPath)}, {
+  readerWorkers: 1,               // 1 reader == the production saturation case
+  statementTimeoutMs: ${statementTimeoutMs}, // 0 == abort is the only lever, as in the outage
+});
+
+await db.exec("CREATE TABLE load (id INTEGER PRIMARY KEY, v TEXT)");
+await db.exec(
+  "WITH RECURSIVE cnt(x) AS (SELECT 1 UNION ALL SELECT x+1 FROM cnt WHERE x<4000) " +
+  "INSERT INTO load (v) SELECT hex(randomblob(96)) FROM cnt"
+);
+const SLOW = "SELECT COUNT(*) AS n FROM load a, load b WHERE a.v < b.v";
+
+const app = express();
+app.use(dbAbortContext());
+
+// Liveness probe: must not touch the DB, so it answers even if a reader is
+// wedged, and a green answer means "the process is up" and nothing more.
+app.get("/ping", (_req, res) => res.json({ ok: true }));
+
+// A fast read, to prove the DB layer still SERVES after a reclamation rather
+// than merely surviving one.
+app.get("/fast", async (_req, res) => {
+  try {
+    res.json(await db.prepare("SELECT 1 AS ok").get());
+  } catch (e) {
+    res.status(500).json({ error: String(e && e.message) });
+  }
+});
+
+// The abandoned slow read. The handler starts it and stops caring, which is
+// what an SSE handler and an early-returning handler both do in production.
+app.get("/slow", (_req, res) => {
+  void db.prepare(SLOW).get();
+  res.writeHead(200, { "Content-Type": "text/plain" });
+  res.write("started");
+});
+
+// A read left to exceed its statement budget with nobody waiting. Same
+// reclamation path as the abort, reached by the timeout instead — so this
+// needs no client disconnect at all.
+app.get("/runaway", (_req, res) => {
+  void db.prepare(SLOW).get();
+  res.json({ started: true });
+});
+
+// The production trigger: a long-lived SSE stream the client is EXPECTED to
+// abandon, with a read in flight behind it.
+app.get("/events/stream", (_req, res) => {
+  void db.prepare(SLOW).get();
+  res.writeHead(200, {
+    "Content-Type": "text/event-stream; charset=utf-8",
+    "Cache-Control": "no-cache, no-transform",
+    Connection: "keep-alive",
+  });
+  res.write("event: open\\ndata: {}\\n\\n");
+});
+
+const server = http.createServer(app);
+server.listen(0, "127.0.0.1", () => {
+  process.stdout.write("LISTENING " + server.address().port + "\\n");
+});
+`;
+}
+
+/** Boot the child server and resolve its base URL once it reports LISTENING. */
+async function startServer(
+  name: string,
+  statementTimeoutMs = 0
+): Promise<{ base: string; child: ChildProcess }> {
+  const dir = mkdtempSync(path.join(workDir, `${name}-`));
+  // The entry file must live INSIDE the repo tree: Node resolves bare imports
+  // (`express`) from the importing file's directory upward, and a script in
+  // the OS temp dir finds no node_modules. The database still lives in the
+  // temp dir, so nothing durable is written into the checkout.
+  const entry = path.join(entryDir, `server-${name}-${process.pid}-${nextEntry++}.mjs`);
+  entries.push(entry);
+  writeFileSync(entry, serverSource(path.join(dir, "db.sqlite"), statementTimeoutMs));
+
+  const proc = spawn(process.execPath, [entry], {
+    cwd: repoRoot,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let stderr = "";
+  proc.stderr?.on("data", (d) => (stderr += String(d)));
+
+  const port = await new Promise<string>((resolve, reject) => {
+    let out = "";
+    const timer = setTimeout(
+      () => reject(new Error(`server did not start in 60s.\nstderr:\n${stderr}`)),
+      60_000
+    );
+    proc.stdout?.on("data", (d) => {
+      out += String(d);
+      const m = out.match(/LISTENING (\d+)/);
+      if (m) {
+        clearTimeout(timer);
+        resolve(m[1]!);
+      }
+    });
+    proc.once("exit", (code) => {
+      clearTimeout(timer);
+      reject(new Error(`server exited early (code ${code}).\nstderr:\n${stderr}`));
+    });
+  });
+
+  // Surface the child's own crash output in the failure message — without it a
+  // regression here reads only as "expected true, got false".
+  (proc as ChildProcess & { __stderr?: () => string }).__stderr = () => stderr;
+  return { base: `http://127.0.0.1:${port}`, child: proc };
+}
+
+/**
+ * Issue a request and destroy the socket mid-flight, the way a client that
+ * gives up does. `fetch` cannot express this — its abort tears down cleanly —
+ * so drop to a raw socket and destroy it.
+ */
+async function connectThenDisconnect(base: string, urlPath: string): Promise<void> {
+  const http = await import("node:http");
+  await new Promise<void>((resolve) => {
+    const req = http.get(`${base}${urlPath}`, (res) => {
+      res.once("data", () => {
+        // First byte received == the handler has run and left a read in flight.
+        // Destroy now so `close` fires on the ServerResponse with the read
+        // still executing, which is what triggers the abort path.
+        req.destroy();
+        resolve();
+      });
+    });
+    req.on("error", () => resolve());
+  });
+}
+
+/** The assertion that actually encodes the bug: still alive, still serving. */
+async function expectAliveAndServing(
+  base: string,
+  proc: ChildProcess,
+  label: string
+): Promise<void> {
+  // Give the abort path time to run, terminate the reader, and (pre-fix) crash.
+  await new Promise((r) => setTimeout(r, 2_000));
+
+  const stderr = (proc as ChildProcess & { __stderr?: () => string }).__stderr?.() ?? "";
+  expect(
+    proc.exitCode === null && proc.signalCode === null,
+    `${label}: server process died (exit=${proc.exitCode}, signal=${proc.signalCode}).\n` +
+      `stderr:\n${stderr}`
+  ).toBe(true);
+
+  // Alive is necessary but not sufficient — it must still answer.
+  const ping = await fetch(`${base}/ping`);
+  expect(ping.status, `${label}: /ping after disconnect`).toBe(200);
+
+  // And the DB layer must have recovered its reader, not just avoided dying.
+  const fast = await fetch(`${base}/fast`);
+  expect(fast.status, `${label}: DB read after disconnect`).toBe(200);
+  expect(await fast.json()).toEqual({ ok: 1 });
+}
+
+describe("client disconnect during an in-flight DB read (#2316)", () => {
+  it("survives a slow read abandoned by client disconnect", async () => {
+    const started = await startServer("slow");
+    child = started.child;
+
+    await connectThenDisconnect(started.base, "/slow");
+    await expectAliveAndServing(started.base, started.child, "slow read");
+  }, 120_000);
+
+  it("survives an SSE stream abandoned by the client", async () => {
+    const started = await startServer("sse");
+    child = started.child;
+
+    await connectThenDisconnect(started.base, "/events/stream");
+    await expectAliveAndServing(started.base, started.child, "SSE stream");
+  }, 120_000);
+
+  it("survives a read that outlives its statement timeout with nobody waiting", async () => {
+    // Same reclamation path (`abandon` -> `failInFlight`), reached by the
+    // statement-timeout branch rather than the abort branch. Found while
+    // fixing #2316 and not in the issue: a single runaway query killed the
+    // server on its own, with no client disconnect involved. Guarding only
+    // the abort branch would have left that half of the bug live.
+    const started = await startServer("runaway", 500);
+    child = started.child;
+
+    const res = await fetch(`${started.base}/runaway`);
+    expect(res.status).toBe(200);
+    await expectAliveAndServing(started.base, started.child, "statement timeout");
+  }, 120_000);
+
+  it("survives a reconnect loop of abandoned SSE streams", async () => {
+    // The outage was a LOOP: daemons reconnect their subscriptions on every
+    // restart, so the server met this path repeatedly rather than once. One
+    // survived abort would not have kept the instance up.
+    const started = await startServer("loop");
+    child = started.child;
+
+    for (let i = 0; i < 5; i += 1) {
+      await connectThenDisconnect(started.base, "/events/stream");
+      await new Promise((r) => setTimeout(r, 150));
+    }
+    await expectAliveAndServing(started.base, started.child, "SSE reconnect loop");
+  }, 180_000);
+});


### PR DESCRIPTION
Fixes #2316.

A client that hung up while a DB read was in flight took the whole process down. Because clients reconnect immediately, that became a crash loop — a ~2.5 hour outage that blocked its own recovery.

## What the bug actually is

The issue reads the stack trace as a throw from inside an `EventTarget` listener. It isn't. It is an **unhandled rejection**, and the distinction determined the fix.

`abandon()` → `failInFlight()` → `entry.reject(error)` is a plain promise rejection; nothing throws synchronously. But a caller that has already walked away — an express handler that returned when its client disconnected, an SSE request whose response closed — never attaches a handler. Node's default `--unhandled-rejections=throw` then reports the rejection at the site where the rejected promise was *constructed*, which is `onAbort`. That's why the trace points there.

Reproduced byte-for-byte against `main` before changing anything, including the `ServerResponse.onClose` → `db_abort_context.js:32` → `emitCloseNT` frames from the production capture.

## Which design, and why

The issue offers two: treat the abort as expected control flow that settles the promise, or keep `abandon()` and add a missing caller handler. The code settles it — **`abandon()` is correct and is kept**:

> Terminating is the only lever available: the worker runs each statement synchronously to completion before it reads its next message, so a cancel opcode could not be observed until the statement it was meant to cancel had already finished.

There is no "settle it gently" option; reclaiming the reader *requires* killing the worker. And no caller is positioned to catch it, because the rejection happens on the **server's** schedule (client hangs up, budget expires), not the caller's — by then the caller is gone. So the guard has to make the promise safe to abandon.

**Altitude mattered.** The first attempt guarded inside `WorkerConnection.request()` and did not work: `routeRead` is an `async` function, so it derives a *fresh* promise from the guarded one, and that derived promise is what an abandoned caller leaves unhandled. The guard belongs at the public boundary (`WorkerStatement.get`/`.all`), where callers actually hold the promise.

## Scope

Deliberately narrow:

- **Reads only.** Writes and everything inside a transaction ignore the abort signal and are never timed out — precisely so a caller hanging up mid-write cannot leave a half-applied mutation. A failed write stays loud.
- **Not a process-wide handler.** There are currently no `uncaughtException` / `unhandledRejection` handlers anywhere in `src/`, and this PR does not add one. A blanket handler would keep the server alive through corrupt migrations and OOM — its own defect. Crash-worthy faults must still crash. This guards one known-benign class of rejection at the one boundary that produces it.
- **Callers that await are unaffected.** The no-op catch is attached to a *derived* promise, so anyone listening still receives the real `WorkerDbAbortError` / `WorkerDbTimeoutError` and can still map it to a response. Verified explicitly.

## Also fixed: the statement-timeout branch (not in the issue)

`abandon()` has two callers. The timeout branch reaches the same reclamation path and had the **identical** defect — a single runaway query killed the server with no client disconnect involved at all. Guarding only the abort branch would have left half the bug live. Covered by its own test.

## The neon `PendingException` panic needs no separate guard

It is downstream of this same unhandled rejection: Node begins tearing the process down while a JS exception is pending, and the worker's native SQLite binding asserts during that teardown. Tested directly — with the rejection merely *handled*, **twelve** back-to-back mid-statement `terminate()` calls leave the process alive and no panic fires. The two exit codes (`1` and `134`) really are one bug, as the issue says.

## Tests — fail-then-pass

The bug is "the process dies", so the tests assert **process liveness**, not error shape. They run a real server in a **child process**, which is load-bearing: vitest installs its own rejection handler, which is exactly why the existing unit coverage in `db_worker_file_database.test.ts` (which does assert `rejects.toBeInstanceOf(WorkerDbAbortError)`) passed throughout the outage. Each case asserts the child is still alive *and* still serving a fresh DB read afterwards.

| Test | on `main` | with fix |
|---|---|---|
| slow read abandoned by client disconnect | ✗ | ✓ |
| SSE stream abandoned by the client | ✗ | ✓ |
| read outliving its statement timeout, nobody waiting | ✗ | ✓ |
| reconnect loop of abandoned SSE streams (×5) | ✗ | ✓ |

On `main` all four fail with the production stack in the failure message and `exit=1`. With the fix, 4/4 pass. The reconnect-loop case exists because the outage was a *loop*, not a single abort.

**Full suite:** 5,326 passed, 79 skipped, 3 todo, across 530 files — 0 failures.

## Investigated, reported, not fixed here

**`/events/stream` 404 in 2,463 ms.** Not in this code path; out of scope. Three independent causes found, and the latency is its own bug:

1. `findSubscriptionRow` (`src/services/subscriptions/subscription_actions.ts:148-181`) selects on `entity_type` **only, with no `user_id` filter**, then filters by user in JS with an N+1 `entities` lookup per candidate. The only usable index (`idx_entity_snapshots_user_type`) leads with `user_id`, so this is a **full table scan of every subscription snapshot in the instance**, JSON-decoding each row. That is the 2.4s.
2. A 404 specifically means *no row* — the handler has a separate 410 branch for `active: false`. So the most likely cause of a 404 on a live id is a **principal mismatch**: `/events/stream` reads `user_id` from the query string while `/subscribe` reads it from the body, and EventSource cannot send an `Authorization` header, so browser clients routinely fall back to a guest token on this endpoint and resolve to a different `userId` than the one that created the subscription.
3. `getSubscriptionStatus` collapses "no such subscription" and "exists but owned by another user" into the same `null`, so the 404 cannot currently be told apart from a genuine miss.

Worth its own issue; the fix is an index plus a `user_id` predicate, plus distinguishing those two cases in the log.

**`NEOTOMA_DB_READER_WORKERS` default of 2.** Not changed here, per scope. Data point for that decision: the machine is `shared-cpu-2x` with 2 CPUs (`fly.toml`), so the default of 2 readers already matches CPU count — raising it trades queueing for context-switching on the same two shared cores rather than adding real capacity. Saturation is an aggravating factor, not the cause, and with this fix a saturated pool no longer escalates to a crash. If it is raised, the machine likely needs more CPUs first.

## A premise in the issue that did not hold

> `WorkerDbAbortError` from the abort path is caught where it is raised

It is not raised, and it cannot be caught where the trace points. It is a rejection surfaced at its construction site by Node's default handler. Catching "where it is raised" would mean wrapping `abandon()` in a try/catch, which would do nothing — the process would still die.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
