### PR TITLE
fix(mcp-proxy): key session-loss recovery on JSON-RPC -32001, not message prose (#2312)

### DIFF
--- a/src/proxy/mcp_stdio_proxy.test.ts
+++ b/src/proxy/mcp_stdio_proxy.test.ts
@@ -28,6 +28,32 @@ function jsonResponse(obj: unknown, opts: { status?: number; sessionId?: string 
   return new Response(JSON.stringify(obj), { status: opts.status ?? 200, headers });
 }
 
+/**
+ * The unknown-session 404 body emitted by `src/actions.ts`, copied verbatim —
+ * including the `-32001` code the neotoma#2312 predicate keys on.
+ */
+const SERVER_404_SESSION_LOST_BODY = {
+  jsonrpc: "2.0",
+  id: null,
+  error: {
+    code: -32001,
+    message:
+      "Not Found: MCP session is unknown or expired on this API instance. The client should re-initialize by sending a new InitializeRequest without a session ID. If you run multiple replicas, enable sticky sessions for POST /mcp (or route /mcp to a single instance).",
+  },
+};
+
+/** A genuine routing 404 — no `-32001`, so it must surface as an error and never retry. */
+function routingNotFoundResponse(): Response {
+  return jsonResponse(
+    {
+      jsonrpc: "2.0",
+      id: null,
+      error: { code: -32601, message: "Not Found: no such route" },
+    },
+    { status: 404 }
+  );
+}
+
 /** Mirrors the current `404 … session is unknown on this API instance` body from src/actions.ts. */
 function sessionLostResponse(): Response {
   return jsonResponse(
@@ -120,6 +146,89 @@ describe("isRecoverableMcpSessionLostError", () => {
     );
     expect(isRecoverableMcpSessionLostError(404, "rate limited")).toBe(false);
     expect(isRecoverableMcpSessionLostError(503, "rate limited")).toBe(false);
+  });
+
+  // neotoma#2312: the predicate is keyed on the JSON-RPC error code, not the
+  // status or the prose alone.
+  it("matches the real server 404 body verbatim, including error.code -32001", () => {
+    expect(
+      isRecoverableMcpSessionLostError(404, JSON.stringify(SERVER_404_SESSION_LOST_BODY))
+    ).toBe(true);
+  });
+
+  it("does NOT match a genuine routing 404 that carries no -32001", () => {
+    // A missing route / misconfigured downstream URL must surface, never retry.
+    expect(
+      isRecoverableMcpSessionLostError(
+        404,
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: null,
+          error: { code: -32601, message: "Not Found: no such route" },
+        })
+      )
+    ).toBe(false);
+    expect(isRecoverableMcpSessionLostError(404, "<html><body>404 Not Found</body></html>")).toBe(
+      false
+    );
+  });
+
+  it("does NOT treat an auth 401 carrying -32001 as session loss", () => {
+    // src/actions.ts returns -32001 on four separate auth failures. Replaying
+    // initialize cannot fix a credential problem, so these must not recover.
+    for (const message of [
+      "Invalid or expired Bearer token. Remove Authorization from mcp.json and click Connect to re-authenticate.",
+      "Unauthorized: Authentication required",
+    ]) {
+      expect(
+        isRecoverableMcpSessionLostError(
+          401,
+          JSON.stringify({ jsonrpc: "2.0", id: null, error: { code: -32001, message } })
+        )
+      ).toBe(false);
+    }
+  });
+
+  it("does NOT match an unrelated -32001 on 404/503 whose message is not session loss", () => {
+    expect(
+      isRecoverableMcpSessionLostError(
+        503,
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: null,
+          error: { code: -32001, message: "Service Unavailable: upstream database is down" },
+        })
+      )
+    ).toBe(false);
+  });
+
+  /**
+   * The case that distinguishes the body-keyed predicate from a message-only
+   * one: an envelope whose prose says the session is unknown but whose JSON-RPC
+   * code is something else. Keying on `-32001` makes the code authoritative
+   * whenever one is present, so borrowed or proxied copy cannot spoof recovery.
+   */
+  it("does NOT recover on a session-unknown message carrying a non--32001 code", () => {
+    expect(
+      isRecoverableMcpSessionLostError(
+        404,
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: null,
+          error: {
+            code: -32601,
+            message: "Not Found: MCP session is unknown or expired on this API instance.",
+          },
+        })
+      )
+    ).toBe(false);
+  });
+
+  it("still recovers when the body is not parseable JSON-RPC but says the session is unknown", () => {
+    // A server that wraps or strips the envelope must not regress recovery.
+    expect(
+      isRecoverableMcpSessionLostError(404, "Not Found: MCP session is unknown or expired")
+    ).toBe(true);
   });
 });
 
@@ -280,6 +389,98 @@ describe("dispatchCore", () => {
     const err = emitted[0] as { id: number; error: { code: number; message: string } };
     expect(err.id).toBe(11);
     expect(err.error.message).toMatch(/recovery exhausted after 3 attempts/);
+  });
+
+  // neotoma#2312 — the incident shape: a single-machine restart drops the
+  // in-memory session, and the very next tool call gets the verbatim 404 body.
+  it("recovers from the verbatim server 404 session-loss body after a restart", async () => {
+    const loop = createLoopState();
+    loop.session.sessionId = "S1";
+    loop.lastInitializeBody = JSON.stringify({
+      jsonrpc: "2.0",
+      id: 0,
+      method: "initialize",
+      params: { clientInfo: { name: "test-proxy", version: "1.0.0" } },
+    });
+
+    const calls: string[] = [];
+    const sentSessionHeaders: (string | undefined)[] = [];
+    const send: DispatchDeps["send"] = async (headers, body) => {
+      const method = methodOf(body);
+      calls.push(method);
+      sentSessionHeaders.push(headers["mcp-session-id"]);
+      if (method === "initialize") return jsonResponse({ result: {} }, { sessionId: "S2" });
+      return calls.filter((m) => m === "tools/call").length === 1
+        ? jsonResponse(SERVER_404_SESSION_LOST_BODY, { status: 404 })
+        : jsonResponse({ jsonrpc: "2.0", id: 7, result: { ok: true } });
+    };
+
+    const { deps, emitted } = makeDeps(send);
+    await dispatchCore(deps, loop, baseConfig, {
+      jsonrpc: "2.0",
+      id: 7,
+      method: "tools/call",
+      params: {},
+    });
+
+    expect(calls).toEqual(["tools/call", "initialize", "tools/call"]);
+    // The replayed initialize must not carry the dead session id.
+    expect(sentSessionHeaders[0]).toBe("S1");
+    expect(sentSessionHeaders[1]).toBeUndefined();
+    expect(loop.session.sessionId).toBe("S2");
+    expect(emitted).toEqual([{ jsonrpc: "2.0", id: 7, result: { ok: true } }]);
+  });
+
+  it("does NOT retry a genuine routing 404 — it surfaces as an error", async () => {
+    const loop = createLoopState();
+    loop.session.sessionId = "S1";
+    loop.lastInitializeBody = JSON.stringify({ jsonrpc: "2.0", id: 0, method: "initialize" });
+
+    let calls = 0;
+    const { deps, emitted } = makeDeps(
+      scriptedSend([
+        () => {
+          calls++;
+          return routingNotFoundResponse();
+        },
+      ])
+    );
+
+    await dispatchCore(deps, loop, baseConfig, {
+      jsonrpc: "2.0",
+      id: 13,
+      method: "tools/call",
+      params: {},
+    });
+
+    expect(calls).toBe(1); // no replay, no retry
+    expect(loop.session.sessionId).toBe("S1"); // session left intact
+    expect(emitted).toHaveLength(1);
+    expect((emitted[0] as { error?: unknown }).error).toBeDefined();
+  });
+
+  it("does not retry initialize even on a 404 carrying -32001 session loss", async () => {
+    const loop = createLoopState();
+    let calls = 0;
+    const { deps, emitted } = makeDeps(
+      scriptedSend([
+        () => {
+          calls++;
+          return jsonResponse(SERVER_404_SESSION_LOST_BODY, { status: 404 });
+        },
+      ])
+    );
+
+    await dispatchCore(deps, loop, baseConfig, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {},
+    });
+
+    expect(calls).toBe(1); // the client owns the handshake
+    expect(emitted).toHaveLength(1);
+    expect((emitted[0] as { error?: unknown }).error).toBeDefined();
   });
 
   it("does not retry a failed initialize (the client owns the handshake)", async () => {

--- a/src/proxy/mcp_stdio_proxy.ts
+++ b/src/proxy/mcp_stdio_proxy.ts
@@ -132,18 +132,70 @@ export class SessionState {
   }
 }
 
+/** JSON-RPC error code `src/actions.ts` uses for an unknown/expired MCP session. */
+const MCP_SESSION_LOST_RPC_CODE = -32001;
+
+/** Statuses on which a session-loss body is honoured. 401 is deliberately absent — see below. */
+const SESSION_LOST_STATUSES = new Set([404, 503]);
+
 /**
- * Exported for unit tests — matches `src/actions.ts` Streamable HTTP unknown-session
- * copy. Accepts 404 (current, spec-compliant status per MCP Streamable HTTP session
- * management) and 503 (prior status, retained so this proxy still recovers against
- * older/unpatched Neotoma server instances).
+ * Extract `error.code` from a JSON-RPC error envelope, or null when the body is
+ * not parseable JSON-RPC. A non-JSON body (an HTML 404 from a proxy in front of
+ * the app, say) yields null and is judged on its message text alone.
  */
-export function isRecoverableMcpSessionLostError(status: number, bodyText: string): boolean {
-  if (status !== 404 && status !== 503) return false;
+function jsonRpcErrorCode(bodyText: string): number | null {
+  try {
+    const parsed = JSON.parse(bodyText) as unknown;
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return null;
+    const err = (parsed as { error?: unknown }).error;
+    if (typeof err !== "object" || err === null) return null;
+    const code = (err as { code?: unknown }).code;
+    return typeof code === "number" ? code : null;
+  } catch {
+    return null;
+  }
+}
+
+/** The session-unknown copy emitted by `src/actions.ts`, matched case-insensitively. */
+function hasSessionUnknownMessage(bodyText: string): boolean {
   const t = bodyText.toLowerCase();
   return (
     t.includes("mcp session is unknown") || t.includes("session is unknown on this api instance")
   );
+}
+
+/**
+ * True when a downstream response means "your MCP session is gone, re-initialize"
+ * (neotoma#2312). Exported for unit tests.
+ *
+ * Keyed on THREE things together, and each one is load-bearing:
+ *
+ * 1. **Status is 404 or 503.** 404 is the spec-compliant status per MCP Streamable
+ *    HTTP session management (neotoma#1923); 503 was the prior status and is retained
+ *    so this proxy still recovers against older/unpatched Neotoma server instances.
+ *    401 is deliberately excluded — `src/actions.ts` returns `-32001` on four separate
+ *    auth failures (invalid/expired bearer, encryption-mode token, unauthenticated POST,
+ *    invalid connection id). Those are not session loss, and replaying `initialize`
+ *    against them would spin the retry loop against a credential problem the replay
+ *    cannot fix, burning `maxAttempts` and masking the real error from the operator.
+ *
+ * 2. **The body carries JSON-RPC `error.code === -32001`.** This is what distinguishes
+ *    a session loss from a genuine routing 404 (a missing route, a misconfigured
+ *    downstream URL), which must surface as an error rather than be retried.
+ *
+ * 3. **The message says the session is unknown.** The code alone is not sufficient,
+ *    since `-32001` is reused for auth; the message keeps an unrelated future
+ *    `-32001` on 404/503 from being read as session loss.
+ *
+ * A body that is not parseable JSON-RPC (no code recoverable) still qualifies on the
+ * message alone, so a server that wraps or strips the envelope does not regress
+ * recovery that worked before this change.
+ */
+export function isRecoverableMcpSessionLostError(status: number, bodyText: string): boolean {
+  if (!SESSION_LOST_STATUSES.has(status)) return false;
+  if (!hasSessionUnknownMessage(bodyText)) return false;
+  const code = jsonRpcErrorCode(bodyText);
+  return code === null || code === MCP_SESSION_LOST_RPC_CODE;
 }
 
 export interface ProxyLoopState {


### PR DESCRIPTION
Closes #2312.

## What this changes

`isRecoverableMcpSessionLostError` in `src/proxy/mcp_stdio_proxy.ts` now keys the session-loss decision on the **JSON-RPC error code `-32001`**, as #2312 and the ADR on that issue specify, rather than on the message prose alone.

The predicate requires all three of:

1. **Status is 404 or 503.** 404 is the spec-compliant status from #1923; 503 is retained so the proxy still recovers against older/unpatched server instances.
2. **A session-unknown message.**
3. **`error.code === -32001`**, when the body parses as a JSON-RPC error envelope.

A body that is *not* parseable JSON-RPC still qualifies on the message alone, so a server that wraps or strips the envelope does not regress recovery that already worked.

`dispatchCore` is untouched — `clearSession()`, the cached `initialize` replay, `maxAttempts` with backoff, and the initialize-never-retried rule all stay as they are.

## Important: most of #2312 had already landed

#2312 states the predicate is `if (status !== 503) return false;`. **That is no longer true on `main`.** PR #1743 (merged 2026-09-06) had already widened it to `if (status !== 404 && status !== 503) return false;` and added 404 coverage. Verified by reverting to the pre-#1743 predicate, which fails 3 existing tests.

So four of the five acceptance criteria were already met before this PR:

- 404 + session-unknown triggers replay-and-retry — already met by #1743
- A genuine routing 404 is not retried — already met (its body carries no session-unknown message)
- `initialize` is never retried — already met, covered by an existing test
- A 404 regression test sits next to the 503 test — already met by #1743

What was **not** done is the error-code keying #2312 asks for. That is what this PR adds, plus tests for the cases the issue and ADR call out explicitly.

### The narrow behavioural delta

Because the server's session-unknown *message* and its `-32001` *code* always travel together, the message-only predicate on `main` and this code-keyed one agree on every response the server actually emits today. They differ on exactly one shape: **a 404/503 whose message says the session is unknown but whose code is not `-32001`.** `main` recovers on that; this PR does not.

This is a robustness change rather than a behaviour fix for the incident. Its value is that the code becomes authoritative whenever one is present, so the predicate cannot be tripped by copy that merely resembles the session-unknown message (a proxy echoing an upstream body, say), and it matches what the ADR signed off on.

### `-32001` is genuinely emitted — and is also reused for auth

Confirmed in `src/actions.ts:2089`: the unknown-session 404 does carry `-32001`. But the same code is returned on **four separate 401 auth failures** (invalid/expired bearer, encryption-mode token, unauthenticated POST, invalid connection id). So `-32001` **alone** is not a safe key — the status allow-list excluding 401 is load-bearing, exactly as the ADR and Buteo's legal review both flagged. Replaying `initialize` against a credential failure would burn `maxAttempts` on an error the replay can never clear, and hide it from the operator. There is a test for this.

## Tests

Nine new cases in `src/proxy/mcp_stdio_proxy.test.ts`, alongside the existing 503/404 ones:

- the verbatim server 404 body end-to-end through `dispatchCore` (session cleared, `initialize` replayed without the dead session id, request retried, succeeds)
- a genuine routing 404 (`-32601`) — surfaces as an error, no replay, session left intact
- `initialize` receiving a 404 + `-32001` — still not retried
- an auth 401 carrying `-32001` — not treated as session loss
- an unrelated `-32001` on 503 — not session loss
- a non-JSON body with a session-unknown message — still recovers
- a session-unknown message under a non-`-32001` code — does not recover (the one discriminating case)

### Fail-then-pass

The last case is the only one that discriminates this predicate from `main`'s, so it is the honest fail-then-pass. Both runs rebuilt `dist/` in between, and the revert was confirmed absent from *both* `src/` and `dist/`:

**Reverted to `main`'s predicate** (`revert-check: src=0, dist=0` occurrences of the new constant):
```
FAIL src/proxy/mcp_stdio_proxy.test.ts > isRecoverableMcpSessionLostError >
  does NOT recover on a session-unknown message carrying a non--32001 code
AssertionError: expected true to be false // Object.is equality
 Tests  1 failed | 26 passed (27)
```

**With the fix** (`fix-present-check: src=2, dist=2`):
```
 Test Files  1 passed (1)
      Tests  27 passed (27)
```

On the `dist/` hazard from a sibling PR: I probed it directly. These tests execute the **TypeScript source**, not built output — reverting the source without rebuilding still changed the result. `dist/` is only a global-setup precondition (`vitest.global_setup.ts` refuses to start without it). I rebuilt between every revert and re-run regardless.

## Full suite

`npm test` — **5,335 passed**, 0 failures, 79 skipped, 3 todo, across 530 files (7 skipped). Baseline on main was 5,326; the +9 are the new cases.

## What remains unverified

**Acceptance criterion 3 — "verified against a real restart, not only a unit test" — is NOT verified.** A real restart against production was out of bounds for this work: the instance was in a crash loop for several hours today and was only just recovered. The closest approximation is the `dispatchCore` test driving the verbatim server 404 body through a fake downstream that fails once and then succeeds. Genuine restart verification still needs doing by someone who can safely cycle an instance.

This also matters more than usual for this particular change, since the delta over `main` is the narrow one described above — the real-restart path was already covered by #1743's predicate, and this PR does not alter it.

## Out of scope

#2070 (removing the session model to match the 2026-07-28 MCP spec) is untouched. I found nothing in the current session-affinity design that makes this fix ineffective: the 404 + `-32001` branch fires precisely when a non-initialize POST arrives with a session id absent from the in-memory `mcpTransports` map, which is exactly the restart case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
