### PR TITLE
fix(mcp-proxy): retry a failed initialize, never an auth rejection (#2321)

### DIFF
--- a/docs/developer/mcp/proxy.md
+++ b/docs/developer/mcp/proxy.md
@@ -8,27 +8,27 @@ Canonical Cursor wiring, screenshots, and transport choice live in **[`mcp_curso
 
 Stable **`mcp.json` `command` paths** stay at the repo-root `scripts/` filenames below (no subdirectory indirection). Optional relocation under e.g. `scripts/mcp_launchers/` with thin forwarders was deferred to avoid churn for operators who hardcode absolute paths. Shared behavior lives in **`scripts/lib/neotoma_mcp_source_env.sh`** (`.env.dev` → `.env` → `.env.development`, first file found) and **`scripts/lib/neotoma_mcp_resolve_downstream_url.sh`** (port-file + TCP probe for `MCP_PROXY_DOWNSTREAM_URL`, used by both HTTP proxy shims).
 
-| Script | Transport | Signing / worker | Reload | Default downstream / entry | Env files (via lib) |
-|--------|-----------|------------------|--------|------------------------------|---------------------|
-| `run_neotoma_mcp_stdio.sh` | stdio → in-process MCP | None (`dist/index.js` or `tsx src/index.ts`) | Manual reconnect after code change | n/a | `.env.dev`, `.env`, `.env.development` |
-| `run_neotoma_mcp_stdio_dev_watch.sh` | stdio → `tsx watch src/index.ts` | None | `tsx watch` (stdout risk; not for installed MCP) | n/a | same |
-| `run_neotoma_mcp_stdio_prod.sh` | stdio → in-process MCP | None; **`NEOTOMA_ENV=production`** | Manual | n/a | same |
-| `run_neotoma_mcp_stdio_prod_watch.sh` | stdio → plain `tsx src/index.ts` | None; prod env | Manual (comment warns: no `watch` on stdio) | n/a | same |
-| `run_neotoma_mcp_stdio_dev_shim.sh` | stdio → **`mcp_dev_shim`** | Worker default in-process MCP | Shim restarts worker on file change | n/a | same |
-| `run_neotoma_mcp_signed_stdio_dev_shim.sh` | stdio → shim → **HTTP `/mcp`** | **`mcp proxy --aauth`** (AAuth) | Shim + worker reload | `http://127.0.0.1:3080/mcp` unless port file / env | same |
-| `run_neotoma_mcp_unsigned_stdio_dev_shim.sh` | stdio → **`mcp proxy`** (no forced AAuth) | `neotoma mcp proxy` | No shim watch (restart MCP to pick up code) | `http://127.0.0.1:3080/mcp` unless port file / env | same |
-| `run_neotoma_mcp_unsigned_stdio_proxy.sh` | same as unsigned shim | Deprecated forwarder: **`exec`** unsigned shim | same | same | n/a |
+| Script                                       | Transport                                 | Signing / worker                               | Reload                                           | Default downstream / entry                         | Env files (via lib)                    |
+| -------------------------------------------- | ----------------------------------------- | ---------------------------------------------- | ------------------------------------------------ | -------------------------------------------------- | -------------------------------------- |
+| `run_neotoma_mcp_stdio.sh`                   | stdio → in-process MCP                    | None (`dist/index.js` or `tsx src/index.ts`)   | Manual reconnect after code change               | n/a                                                | `.env.dev`, `.env`, `.env.development` |
+| `run_neotoma_mcp_stdio_dev_watch.sh`         | stdio → `tsx watch src/index.ts`          | None                                           | `tsx watch` (stdout risk; not for installed MCP) | n/a                                                | same                                   |
+| `run_neotoma_mcp_stdio_prod.sh`              | stdio → in-process MCP                    | None; **`NEOTOMA_ENV=production`**             | Manual                                           | n/a                                                | same                                   |
+| `run_neotoma_mcp_stdio_prod_watch.sh`        | stdio → plain `tsx src/index.ts`          | None; prod env                                 | Manual (comment warns: no `watch` on stdio)      | n/a                                                | same                                   |
+| `run_neotoma_mcp_stdio_dev_shim.sh`          | stdio → **`mcp_dev_shim`**                | Worker default in-process MCP                  | Shim restarts worker on file change              | n/a                                                | same                                   |
+| `run_neotoma_mcp_signed_stdio_dev_shim.sh`   | stdio → shim → **HTTP `/mcp`**            | **`mcp proxy --aauth`** (AAuth)                | Shim + worker reload                             | `http://127.0.0.1:3080/mcp` unless port file / env | same                                   |
+| `run_neotoma_mcp_unsigned_stdio_dev_shim.sh` | stdio → **`mcp proxy`** (no forced AAuth) | `neotoma mcp proxy`                            | No shim watch (restart MCP to pick up code)      | `http://127.0.0.1:3080/mcp` unless port file / env | same                                   |
+| `run_neotoma_mcp_unsigned_stdio_proxy.sh`    | same as unsigned shim                     | Deprecated forwarder: **`exec`** unsigned shim | same                                             | same                                               | n/a                                    |
 
 ## Downstream URL and signing
 
-| Variable | Default / notes |
-|----------|-----------------|
-| `MCP_PROXY_DOWNSTREAM_URL` | `http://127.0.0.1:3080/mcp` when unset (override per environment). |
-| `MCP_PROXY_AAUTH` | When truthy, load `~/.neotoma/aauth/` keys and sign requests (`neotoma mcp proxy --aauth`). |
-| `MCP_PROXY_CLIENT_NAME`, `MCP_PROXY_CLIENT_VERSION`, `MCP_PROXY_AGENT_LABEL` | Self-report for `clientInfo` injection. |
-| `MCP_PROXY_BEARER_TOKEN`, `MCP_PROXY_CONNECTION_ID` | Optional auth headers. |
-| `MCP_PROXY_SESSION_PREFLIGHT`, `MCP_PROXY_SESSION_PREFLIGHT_BASE`, `MCP_PROXY_FAIL_CLOSED` | Trust / preflight behavior. See `src/cli/mcp_proxy.ts` and `src/proxy/mcp_stdio_proxy.ts`. |
-| `NEOTOMA_AAUTH_AUTHORITY_OVERRIDE` | Canonical host for signing when downstream uses `127.0.0.1` (often `localhost:<port>`). The signed **stdio shim** script can derive this from `MCP_PROXY_DOWNSTREAM_URL` when unset. |
+| Variable                                                                                   | Default / notes                                                                                                                                                                      |
+| ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `MCP_PROXY_DOWNSTREAM_URL`                                                                 | `http://127.0.0.1:3080/mcp` when unset (override per environment).                                                                                                                   |
+| `MCP_PROXY_AAUTH`                                                                          | When truthy, load `~/.neotoma/aauth/` keys and sign requests (`neotoma mcp proxy --aauth`).                                                                                          |
+| `MCP_PROXY_CLIENT_NAME`, `MCP_PROXY_CLIENT_VERSION`, `MCP_PROXY_AGENT_LABEL`               | Self-report for `clientInfo` injection.                                                                                                                                              |
+| `MCP_PROXY_BEARER_TOKEN`, `MCP_PROXY_CONNECTION_ID`                                        | Optional auth headers.                                                                                                                                                               |
+| `MCP_PROXY_SESSION_PREFLIGHT`, `MCP_PROXY_SESSION_PREFLIGHT_BASE`, `MCP_PROXY_FAIL_CLOSED` | Trust / preflight behavior. See `src/cli/mcp_proxy.ts` and `src/proxy/mcp_stdio_proxy.ts`.                                                                                           |
+| `NEOTOMA_AAUTH_AUTHORITY_OVERRIDE`                                                         | Canonical host for signing when downstream uses `127.0.0.1` (often `localhost:<port>`). The signed **stdio shim** script can derive this from `MCP_PROXY_DOWNSTREAM_URL` when unset. |
 
 > **Operator security note:** Hosted and operator-managed deployments should set **`MCP_PROXY_FAIL_CLOSED=1`** (or the equivalent `failClosed: true` proxy option) whenever AAuth signing is required. This prevents the proxy from forwarding unsigned downstream requests if signing or session preflight fails.
 
@@ -57,11 +57,11 @@ When **`NEOTOMA_MCP_USE_LOCAL_PORT_FILE=1`** (or `true`) is set in **`mcp.json` 
 
 **Verification:** on MCP spawn, stderr should show `[neotoma-mcp-signed-shim]` or `[neotoma-mcp-unsigned-stdio-dev-shim]` for port-file resolution lines, then `[neotoma-mcp-proxy] Starting proxy: downstream=…`.
 
-| Variable | Purpose |
-|----------|---------|
-| `NEOTOMA_MCP_USE_LOCAL_PORT_FILE` | `1` / `true` → resolve downstream URL from port files + TCP probe. |
+| Variable                              | Purpose                                                                         |
+| ------------------------------------- | ------------------------------------------------------------------------------- |
+| `NEOTOMA_MCP_USE_LOCAL_PORT_FILE`     | `1` / `true` → resolve downstream URL from port files + TCP probe.              |
 | `NEOTOMA_MCP_LOCAL_HTTP_PORT_PROFILE` | `dev` or `prod` — which port file(s) to read (preset A sets this per MCP slot). |
-| `NEOTOMA_MCP_PORT_PROBE_MS` | TCP probe timeout in ms (default `1200`, max `5000`). |
+| `NEOTOMA_MCP_PORT_PROBE_MS`           | TCP probe timeout in ms (default `1200`, max `5000`).                           |
 
 **CLI parity:** When the same env vars are set in the shell (not only in `mcp.json`), the **`neotoma` CLI** `resolveBaseUrl()` path uses the same profile rules and TCP probe after session port env and before `config.json` `base_url`, returning `http://localhost:<port>` so AAuth authority matches the API (for example `neotoma inspector admin unlock`). Profile follows **`NEOTOMA_MCP_LOCAL_HTTP_PORT_PROFILE`** if set, else **`NEOTOMA_ENV`**. Project root: `NEOTOMA_PROJECT_ROOT`, then `project_root` / `repo_root` in `~/.config/neotoma/config.json`, else `cwd`.
 
@@ -75,14 +75,34 @@ Streamable HTTP MCP keeps each session in **process memory** (`mcpTransports` in
 
 As of neotoma#1923, an unknown/expired session returns **404** (not 503), per the [MCP Streamable HTTP session management spec](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#session-management) — this lets spec-compliant clients auto-reinitialize instead of treating the server as unavailable. Servers predating that fix return 503 for the same condition; `neotoma mcp proxy` recognizes both.
 
-| Symptom | Typical cause | What to do |
-|--------|----------------|------------|
-| **400** — no session header on a non-`initialize` POST | Proxy never stored an id (failed init, stripped response header) or client skipped `initialize` | Restart the MCP server in the IDE; confirm proxy stderr shows a successful downstream `initialize` and that your reverse proxy **forwards** `mcp-session-id` on responses and requests (custom headers are not hop-by-hop but some templates hide unknown headers). |
-| **404** (or, against an older server, **503**) — session header present but unknown on this instance | **Load-balanced replicas** without affinity: `initialize` hit instance A, `tools/call` hit B | Use **sticky sessions** for `POST /mcp` (same as [`/mcp/oauth`](../subsystems/auth.md) guidance), scale MCP to **one** API replica for `/mcp`, or terminate TLS on a single Node process. |
-| **404** (or **503**) — same, while using **`neotoma mcp proxy`** | Transient replica drift or API restart after the IDE finished `initialize` | The proxy **replays `initialize` to downstream once** (without emitting a second `initialize` on stdout), captures a fresh `mcp-session-id`, and **retries the failing RPC once**. If the second attempt still fails, fix infra (sticky sessions / single `/mcp` worker) or restart the MCP client. |
-| **404** / **503** / **400** after deploy or restart | In-memory map cleared | Restart the MCP client once so `initialize` runs again. |
+| Symptom                                                                                                                        | Typical cause                                                                                              | What to do                                                                                                                                                                                                                                                                                          |
+| ------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **400** — no session header on a non-`initialize` POST                                                                         | Proxy never stored an id (failed init, stripped response header) or client skipped `initialize`            | Restart the MCP server in the IDE; confirm proxy stderr shows a successful downstream `initialize` and that your reverse proxy **forwards** `mcp-session-id` on responses and requests (custom headers are not hop-by-hop but some templates hide unknown headers).                                 |
+| **404** (or, against an older server, **503**) — session header present but unknown on this instance                           | **Load-balanced replicas** without affinity: `initialize` hit instance A, `tools/call` hit B               | Use **sticky sessions** for `POST /mcp` (same as [`/mcp/oauth`](../subsystems/auth.md) guidance), scale MCP to **one** API replica for `/mcp`, or terminate TLS on a single Node process.                                                                                                           |
+| **404** (or **503**) — same, while using **`neotoma mcp proxy`**                                                               | Transient replica drift or API restart after the IDE finished `initialize`                                 | The proxy **replays `initialize` to downstream once** (without emitting a second `initialize` on stdout), captures a fresh `mcp-session-id`, and **retries the failing RPC once**. If the second attempt still fails, fix infra (sticky sessions / single `/mcp` worker) or restart the MCP client. |
+| **404** / **503** / **400** after deploy or restart                                                                            | In-memory map cleared                                                                                      | Restart the MCP client once so `initialize` runs again.                                                                                                                                                                                                                                             |
+| `handshake_unreachable` — the first `initialize` never reached a server (CONNECT_TIMEOUT, ECONNREFUSED, socket closed)         | Backend down, restarting, or the wrong `--downstream-url`                                                  | The proxy already retried with backoff (neotoma#2321) and the backend stayed unreachable for the whole window. Check `/health` and the downstream URL, then restart the MCP client once the backend answers.                                                                                        |
+| `handshake_server_error` — the first `initialize` reached the server, which failed internally (5xx, or `-32603` through a 200) | Substrate crash surfacing through the handshake (e.g. neotoma#2316's "DB request aborted by caller")       | Also already retried. The server is broken rather than refusing you: check server logs and `/health`, redeploy if needed, then restart the MCP client.                                                                                                                                              |
+| `handshake_auth_rejected` — the first `initialize` was refused for authentication (401)                                        | Invalid/expired bearer, encryption-mode token required, unauthenticated POST, or invalid `X-Connection-Id` | **Not retried, deliberately** — a replay cannot fix a credential. Fix the credential: re-run `neotoma auth mcp-token`, or remove `Authorization` / `X-Connection-Id` from `mcp.json` and reconnect.                                                                                                 |
+| Tools appear missing / the agent answers about the graph "from silence"                                                        | An exhausted handshake leaves a session with no tools                                                      | An exhausted handshake is a **connection failure, not a missing tool** — its error says so explicitly (`NOT a missing tool`). Check proxy stderr for `initialize exhausted` before concluding a tool does not exist.                                                                                |
 
 When debugging, read the proxy line `Downstream error status=… body=…` (stderr): the JSON body includes the real `message` from Neotoma or the MCP SDK.
+
+### Handshake retry (neotoma#2321)
+
+Session-loss recovery cannot help an `initialize` that never succeeded — there is no session to recover and no cached handshake to replay — so a failed handshake used to be permanent for the life of the client. Every session opened during an outage stayed dark long after the backend recovered, while sessions already established were fine.
+
+The proxy now retries the handshake, but only on a failure a replay can fix: a transport failure that never reached a server, or a server that answered with its own internal error. An `initialize` refused for **authentication is never retried**, because retrying would hammer a server that is correctly rejecting a credential and mask the real cause.
+
+Retries are bounded twice over: by `NEOTOMA_MCP_PROXY_MAX_ATTEMPTS` (default 4) and by a wall-clock budget, `NEOTOMA_MCP_PROXY_HANDSHAKE_BUDGET_MS` (default 45s). The wall-clock bound matters because the proxy emits nothing until it resolves, so the client sits blocked on its own `initialize` timeout — 60s by default in the MCP SDK — for the whole retry window. Overrunning that would turn a recoverable handshake into a client-side abort.
+
+A recovered handshake looks like this on stderr — note the client never sees the intermediate failures, only the successful `initialize`:
+
+```
+[neotoma-mcp-proxy] initialize retry attempt=1/4 (retryable_transport): fetch failed cause=ECONNREFUSED — retrying
+[neotoma-mcp-proxy] initialize retry attempt=2/4 (retryable_server): downstream status=500 — retrying
+[neotoma-mcp-proxy] initialize recovered after 3 attempts
+```
 
 ## Related
 

--- a/src/proxy/mcp_stdio_proxy.test.ts
+++ b/src/proxy/mcp_stdio_proxy.test.ts
@@ -693,6 +693,53 @@ describe("dispatchCore initialize handshake retry (neotoma#2321)", () => {
     );
   });
 
+  it("still forwards an SSE initialize response, which the classifier now buffers", async () => {
+    // The handshake body has to be read to classify it, which consumes the
+    // stream, so the SSE frames are re-parsed out of the buffered text rather
+    // than streamed. A successful SSE handshake must still reach the client
+    // intact, and the neotoma#2272 correlation guard must still apply.
+    const loop = createLoopState();
+    const sse = `event: message\ndata: ${JSON.stringify({ jsonrpc: "2.0", id: 1, result: { ok: true } })}\n\n`;
+    const { deps, emitted } = makeDeps(
+      scriptedSend([
+        () =>
+          new Response(sse, {
+            status: 200,
+            headers: { "content-type": "text/event-stream", "mcp-session-id": "S3" },
+          }),
+      ])
+    );
+
+    await dispatchCore(deps, loop, baseConfig, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {},
+    });
+
+    expect(loop.session.sessionId).toBe("S3");
+    expect(emitted).toEqual([{ jsonrpc: "2.0", id: 1, result: { ok: true } }]);
+  });
+
+  it("drops a mis-correlated initialize response rather than delivering it (neotoma#2272)", async () => {
+    const loop = createLoopState();
+    const { deps, emitted } = makeDeps(
+      scriptedSend([() => jsonResponse({ jsonrpc: "2.0", id: 999, result: { notYours: true } })])
+    );
+
+    await dispatchCore(deps, loop, baseConfig, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {},
+    });
+
+    expect(emitted).toHaveLength(1);
+    const err = (emitted[0] as { error?: { message: string } }).error;
+    expect(err).toBeDefined();
+    expect(err!.message).toContain("did not correlate");
+  });
+
   it("leaves session-loss recovery for established sessions unchanged", async () => {
     // Non-regression on #2312/#2320: the handshake path must not have altered
     // how an established-then-lost session recovers.

--- a/src/proxy/mcp_stdio_proxy.test.ts
+++ b/src/proxy/mcp_stdio_proxy.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   backoffMs,
+  classifyInitializeFailure,
   createLoopState,
   dispatchCore,
   isJsonRpcResponse,
@@ -459,7 +460,13 @@ describe("dispatchCore", () => {
     expect((emitted[0] as { error?: unknown }).error).toBeDefined();
   });
 
-  it("does not retry initialize even on a 404 carrying -32001 session loss", async () => {
+  /**
+   * A 404 on the handshake is NOT session loss — there is no session yet — so it
+   * is classified `other_terminal` and surfaces without retry. This replaces the
+   * former "does not retry initialize even on a 404 carrying -32001" test: the
+   * assertion (one call, an error surfaced) is unchanged; only the reason is.
+   */
+  it("does not retry a handshake 404, which cannot be session loss (no session exists yet)", async () => {
     const loop = createLoopState();
     let calls = 0;
     const { deps, emitted } = makeDeps(
@@ -478,19 +485,19 @@ describe("dispatchCore", () => {
       params: {},
     });
 
-    expect(calls).toBe(1); // the client owns the handshake
+    expect(calls).toBe(1);
     expect(emitted).toHaveLength(1);
     expect((emitted[0] as { error?: unknown }).error).toBeDefined();
   });
 
-  it("does not retry a failed initialize (the client owns the handshake)", async () => {
+  it("does not retry a handshake rejected as a client error (400)", async () => {
     const loop = createLoopState();
     let calls = 0;
     const { deps, emitted } = makeDeps(
       scriptedSend([
         () => {
           calls++;
-          return sessionLostResponse();
+          return jsonResponse({ error: { code: -32600, message: "Bad Request" } }, { status: 400 });
         },
       ])
     );
@@ -502,9 +509,268 @@ describe("dispatchCore", () => {
       params: {},
     });
 
-    expect(calls).toBe(1); // no retry/replay for initialize itself
+    expect(calls).toBe(1); // a malformed handshake is not fixed by replaying it
     expect(emitted).toHaveLength(1);
     expect((emitted[0] as { error?: unknown }).error).toBeDefined();
+  });
+});
+
+/**
+ * Regression coverage for neotoma#2321 — a failed `initialize` was permanent.
+ *
+ * Session-loss recovery (#2312/#2320) never applied to the handshake: there is
+ * no session to recover and no cached handshake to replay. So a session whose
+ * `initialize` failed while the backend was unhealthy stayed dark for the life
+ * of the client, long after the backend was fixed and verified serving.
+ *
+ * These cover the three behaviours that fix has to get right together: retry
+ * what a replay can fix, never retry a credential rejection, and stay bounded.
+ */
+describe("dispatchCore initialize handshake retry (neotoma#2321)", () => {
+  /** The 401 + `-32001` body `src/actions.ts` returns on an invalid/expired bearer. */
+  function authRejectedResponse(): Response {
+    return jsonResponse(
+      {
+        jsonrpc: "2.0",
+        id: null,
+        error: {
+          code: -32001,
+          message:
+            "Invalid or expired Bearer token. Remove Authorization from mcp.json and click Connect to re-authenticate.",
+        },
+      },
+      { status: 401 }
+    );
+  }
+
+  it("retries a handshake that fails twice then succeeds, and the session establishes", async () => {
+    const loop = createLoopState();
+    let calls = 0;
+    const { deps, emitted } = makeDeps(async () => {
+      calls++;
+      if (calls === 1) throw new Error("fetch failed", { cause: new Error("ECONNREFUSED") });
+      if (calls === 2) return jsonResponse({ error: { code: -32603 } }, { status: 500 });
+      return jsonResponse({ jsonrpc: "2.0", id: 1, result: { ok: true } }, { sessionId: "S1" });
+    });
+
+    await dispatchCore(deps, loop, baseConfig, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {},
+    });
+
+    expect(calls).toBe(3);
+    // The effect that matters: the session is usable, not merely that a retry ran.
+    expect(loop.session.sessionId).toBe("S1");
+    // The client sees only the successful handshake — no error leaked mid-retry.
+    expect(emitted).toEqual([{ jsonrpc: "2.0", id: 1, result: { ok: true } }]);
+  });
+
+  it("retries a handshake whose crash surfaces as -32603 through an HTTP 200", async () => {
+    // neotoma#2316's "DB request aborted by caller": when the substrate crashes
+    // after response headers are sent, the status can no longer be restated, so
+    // the internal error rides out on an otherwise-successful response. Forwarded
+    // blindly, that is a handshake failure delivered as a handshake success.
+    const loop = createLoopState();
+    let calls = 0;
+    const { deps, emitted } = makeDeps(async () => {
+      calls++;
+      if (calls === 1) {
+        return jsonResponse({
+          jsonrpc: "2.0",
+          id: 1,
+          error: { code: -32603, message: "DB request aborted by caller" },
+        });
+      }
+      return jsonResponse({ jsonrpc: "2.0", id: 1, result: { ok: true } }, { sessionId: "S9" });
+    });
+
+    await dispatchCore(deps, loop, baseConfig, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {},
+    });
+
+    expect(calls).toBe(2);
+    expect(loop.session.sessionId).toBe("S9");
+    expect(emitted).toEqual([{ jsonrpc: "2.0", id: 1, result: { ok: true } }]);
+  });
+
+  it("never retries a handshake rejected for authentication, and says so distinguishably", async () => {
+    const loop = createLoopState();
+    let calls = 0;
+    const { deps, emitted } = makeDeps(async () => {
+      calls++;
+      return authRejectedResponse();
+    });
+
+    await dispatchCore(deps, loop, baseConfig, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {},
+    });
+
+    // Load-bearing: retrying would hammer a server correctly refusing a
+    // credential, burn the budget, and mask the real cause from the operator.
+    expect(calls).toBe(1);
+    expect(emitted).toHaveLength(1);
+    const err = (emitted[0] as { error: { message: string } }).error;
+    expect(err.message).toContain("handshake_auth_rejected");
+    // Distinguishable from the unreachable/server-error classes.
+    expect(err.message).not.toContain("handshake_unreachable");
+  });
+
+  it("does not read the shared -32001 code as auth when the status is not 401", async () => {
+    // -32001 is returned on four auth paths AND on session loss. Keying auth on
+    // the code alone would misclassify; the 401 status is the discriminator.
+    expect(
+      classifyInitializeFailure({
+        status: 500,
+        bodyText: JSON.stringify({ error: { code: -32001, message: "whatever" } }),
+      })
+    ).toBe("retryable_server");
+  });
+
+  it("bounds retries: an unreachable backend stops at maxAttempts and reports it as unreachable", async () => {
+    const loop = createLoopState();
+    let calls = 0;
+    const { deps, emitted } = makeDeps(
+      async () => {
+        calls++;
+        throw new Error("fetch failed", { cause: new Error("ECONNREFUSED") });
+      },
+      { maxAttempts: 3 }
+    );
+
+    await dispatchCore(deps, loop, baseConfig, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {},
+    });
+
+    expect(calls).toBe(3); // bounded, not infinite
+    expect(emitted).toHaveLength(1);
+    const err = (emitted[0] as { error: { message: string } }).error;
+    // A client that exhausted retries must be able to tell "the server is
+    // unreachable" from "this tool does not exist".
+    expect(err.message).toContain("handshake_unreachable");
+    expect(err.message).toContain("NOT a missing tool");
+  });
+
+  it("stops retrying when the wall-clock budget would be exceeded, before the client's own timeout", async () => {
+    // Attempt count alone is not a sufficient bound: the proxy emits nothing
+    // until it resolves, so the client sits blocked on its own initialize
+    // timeout for the whole window. Overrunning it turns a recoverable
+    // handshake into a client-side abort.
+    const loop = createLoopState();
+    let calls = 0;
+    let clock = 0;
+    const { emitted, deps } = makeDeps(
+      async () => {
+        calls++;
+        clock += 20_000; // each attempt burns 20s
+        throw new Error("fetch failed", { cause: new Error("ETIMEDOUT") });
+      },
+      { maxAttempts: 8 }
+    );
+
+    await dispatchCore({ ...deps, now: () => clock, handshakeBudgetMs: 45_000 }, loop, baseConfig, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {},
+    });
+
+    // Budget, not maxAttempts, is what stopped it.
+    expect(calls).toBeLessThan(8);
+    expect(calls).toBe(3);
+    expect((emitted[0] as { error: { message: string } }).error.message).toContain(
+      "handshake_unreachable"
+    );
+  });
+
+  it("leaves session-loss recovery for established sessions unchanged", async () => {
+    // Non-regression on #2312/#2320: the handshake path must not have altered
+    // how an established-then-lost session recovers.
+    const loop = createLoopState();
+    loop.session.sessionId = "S1";
+    loop.lastInitializeBody = JSON.stringify({ jsonrpc: "2.0", id: 0, method: "initialize" });
+
+    const calls: string[] = [];
+    const send: DispatchDeps["send"] = async (_headers, body) => {
+      const method = methodOf(body);
+      calls.push(method);
+      if (method === "initialize") return jsonResponse({ result: {} }, { sessionId: "S2" });
+      return calls.filter((m) => m === "tools/call").length === 1
+        ? sessionLostResponse()
+        : jsonResponse({ jsonrpc: "2.0", id: 7, result: { ok: true } });
+    };
+
+    const { deps, emitted } = makeDeps(send);
+    await dispatchCore(deps, loop, baseConfig, {
+      jsonrpc: "2.0",
+      id: 7,
+      method: "tools/call",
+      params: {},
+    });
+
+    expect(calls).toEqual(["tools/call", "initialize", "tools/call"]);
+    expect(loop.session.sessionId).toBe("S2");
+    expect(emitted).toEqual([{ jsonrpc: "2.0", id: 7, result: { ok: true } }]);
+  });
+});
+
+describe("classifyInitializeFailure (neotoma#2321)", () => {
+  it("classifies a connection failure as retryable transport", () => {
+    expect(classifyInitializeFailure({ networkError: true })).toBe("retryable_transport");
+    expect(classifyInitializeFailure({})).toBe("retryable_transport");
+  });
+
+  it("classifies 5xx and -32603 as retryable server errors", () => {
+    expect(classifyInitializeFailure({ status: 500 })).toBe("retryable_server");
+    expect(classifyInitializeFailure({ status: 502 })).toBe("retryable_server");
+    expect(
+      classifyInitializeFailure({
+        status: 200,
+        bodyText: JSON.stringify({ error: { code: -32603, message: "DB request aborted" } }),
+      })
+    ).toBe("retryable_server");
+  });
+
+  it("classifies every 401 auth path as auth_rejected regardless of body", () => {
+    for (const msg of [
+      "Invalid or expired Bearer token.",
+      "Encryption is enabled. Use MCP token from your private key",
+      "Unauthorized: Authentication required",
+      "Connection invalid or expired.",
+    ]) {
+      expect(
+        classifyInitializeFailure({
+          status: 401,
+          bodyText: JSON.stringify({ error: { code: -32001, message: msg } }),
+        })
+      ).toBe("auth_rejected");
+    }
+  });
+
+  it("never lets a retryable signal override an auth rejection", () => {
+    // A 401 body that also happens to carry -32603 must still fail closed.
+    expect(
+      classifyInitializeFailure({
+        status: 401,
+        bodyText: JSON.stringify({ error: { code: -32603 } }),
+      })
+    ).toBe("auth_rejected");
+  });
+
+  it("classifies non-auth 4xx as terminal, not retryable", () => {
+    expect(classifyInitializeFailure({ status: 400 })).toBe("other_terminal");
+    expect(classifyInitializeFailure({ status: 404 })).toBe("other_terminal");
+    expect(classifyInitializeFailure({ status: 403 })).toBe("other_terminal");
   });
 });
 

--- a/src/proxy/mcp_stdio_proxy.ts
+++ b/src/proxy/mcp_stdio_proxy.ts
@@ -198,6 +198,81 @@ export function isRecoverableMcpSessionLostError(status: number, bodyText: strin
   return code === null || code === MCP_SESSION_LOST_RPC_CODE;
 }
 
+/** JSON-RPC code for an internal server error — the substrate's own crash surfacing (neotoma#2316). */
+const MCP_INTERNAL_ERROR_RPC_CODE = -32603;
+
+/**
+ * How an `initialize` failure is classified (neotoma#2321). Exported for tests.
+ *
+ * The distinction that matters is not "did it fail" but "did anything happen
+ * server-side, and can a replay fix it":
+ *
+ * - `retryable_transport` — the request never reached a server that answered.
+ * - `retryable_server` — a server answered and reported its own failure.
+ * - `auth_rejected` — a server answered and refused the credential.
+ * - `other_terminal` — anything else; retrying is not known to be safe or useful.
+ */
+export type InitializeFailureClass =
+  | "retryable_transport"
+  | "retryable_server"
+  | "auth_rejected"
+  | "other_terminal";
+
+/**
+ * Classify a *handshake* failure (neotoma#2321).
+ *
+ * This is deliberately a separate predicate from {@link isRecoverableMcpSessionLostError},
+ * which answers a different question — "was an established session lost" — and
+ * must keep answering only that. On the initialize path there is no session yet,
+ * so session-loss reasoning does not apply at all.
+ *
+ * Each class is keyed on more than one signal, following the discipline
+ * neotoma#2320 established for the session-loss predicate:
+ *
+ * 1. **`auth_rejected` is keyed on HTTP 401**, not on `-32001`. `src/actions.ts`
+ *    returns `-32001` from four separate auth paths (invalid/expired bearer,
+ *    encryption-mode token, unauthenticated POST, invalid connection id) — and
+ *    every one of them returns **401**, while the session-loss path returns 404.
+ *    The status is therefore the reliable discriminator and the shared `-32001`
+ *    is not. Retrying an auth rejection would hammer a server that is correctly
+ *    refusing a credential a replay cannot change, so this exclusion is checked
+ *    FIRST and no later rule can override it.
+ *
+ * 2. **`retryable_server` requires evidence the server itself failed** — an HTTP
+ *    5xx, or a JSON-RPC `-32603`. The `-32603` arm is load-bearing beyond the
+ *    5xx one: when the crash happens after response headers are already sent,
+ *    `src/actions.ts` cannot restate the status, so the internal error rides out
+ *    through an otherwise-200 response. That is the exact shape of the
+ *    "DB request aborted by caller" handshake failure in neotoma#2316.
+ *
+ * 3. **A 4xx that is not 401 is `other_terminal`.** A 400 or a routing 404 is a
+ *    client/config error; replaying it just burns the budget and hides the cause.
+ *
+ * Note what is deliberately absent: no rule keys on `-32001` alone. Auth and
+ * session loss share that code, so it cannot by itself justify a retry.
+ */
+export function classifyInitializeFailure(input: {
+  status?: number;
+  bodyText?: string;
+  networkError?: boolean;
+}): InitializeFailureClass {
+  const { status, bodyText = "", networkError } = input;
+
+  // No usable HTTP response at all: nothing happened server-side, so replaying
+  // the handshake cannot duplicate any server-side effect.
+  if (networkError || status === undefined) return "retryable_transport";
+
+  // Checked before everything else — see (1) above.
+  if (status === 401) return "auth_rejected";
+
+  const code = jsonRpcErrorCode(bodyText);
+  if (status >= 500) return "retryable_server";
+  // A 2xx/3xx carrying an internal-error envelope — the crash-after-headers case.
+  if (code === MCP_INTERNAL_ERROR_RPC_CODE) return "retryable_server";
+
+  return "other_terminal";
+}
+
 export interface ProxyLoopState {
   session: SessionState;
   /** Last downstream initialize body (JSON), after clientInfo injection — replayed on session loss. */
@@ -420,6 +495,79 @@ async function forwardResponse(
   return answered;
 }
 
+/**
+ * Emit an already-buffered response body, preserving the neotoma#2272
+ * correlation guard.
+ *
+ * The initialize path has to read the body to classify it (a crash can surface
+ * as `-32603` through a 200 — neotoma#2321), which consumes the stream, so
+ * `forwardResponse` can no longer be used. This re-implements the same emit
+ * rules over text already in hand: SSE frames are parsed out of the buffer, a
+ * JSON body is parsed directly, and either way a payload whose id does not match
+ * the request is dropped rather than delivered as this call's answer.
+ */
+function emitBufferedResponse(
+  bodyText: string,
+  response: Response,
+  emit: EmitFn,
+  requestId: unknown,
+  originalMessage: Record<string, unknown>
+): void {
+  const contentType = response.headers.get("content-type") ?? "";
+  let answered = requestId === undefined;
+  const trackingEmit: EmitFn = (payload) => {
+    if (isJsonRpcResponse(payload) || Array.isArray(payload)) answered = true;
+    emit(payload);
+  };
+
+  const emitOne = (raw: string): void => {
+    try {
+      const payload = JSON.parse(raw);
+      const correlated = correlateResponse(payload, requestId);
+      if (correlated === null) {
+        log(
+          `Dropped mis-correlated downstream response (neotoma#2272): expected id=${JSON.stringify(requestId)}`
+        );
+        return;
+      }
+      trackingEmit(correlated);
+    } catch {
+      log(`Failed to decode initialize response payload: ${raw.slice(0, 200)}`);
+    }
+  };
+
+  if (contentType.includes("text/event-stream")) {
+    let currentEvent = "message";
+    for (const rawLine of bodyText.split("\n")) {
+      const line = rawLine.replace(/\r$/, "");
+      if (line === "") {
+        currentEvent = "message";
+        continue;
+      }
+      if (line.startsWith(":")) continue;
+      if (line.startsWith("event:")) {
+        currentEvent = line.slice(6).trim();
+        continue;
+      }
+      if (line.startsWith("data:")) {
+        if (currentEvent !== "message") continue;
+        emitOne(line.slice(5).trim());
+      }
+    }
+  } else if (bodyText) {
+    emitOne(bodyText);
+  }
+
+  if (!answered) {
+    emitErrorResponse(
+      originalMessage,
+      502,
+      "downstream response did not correlate to this request (neotoma#2272); it was dropped rather than delivered as your result — re-read the entity to confirm whether the write landed",
+      emit
+    );
+  }
+}
+
 /** Default per-request downstream timeout (ms) — below typical harness MCP timeouts so a hang retries rather than surfacing as "unavailable". */
 export const DEFAULT_REQUEST_TIMEOUT_MS = 15_000;
 /** Default total attempts (initial + retries) to recover a lost MCP session. */
@@ -482,6 +630,24 @@ export function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
   });
 }
 
+/**
+ * Wall-clock ceiling for retrying a failed handshake (neotoma#2321).
+ *
+ * Attempt count alone is not a sufficient bound here. The proxy is a stdio child
+ * and emits nothing until `dispatchCore` resolves, so the client sits blocked on
+ * its own `initialize` timeout for the whole retry window — 60s by default in the
+ * MCP SDK (`DEFAULT_REQUEST_TIMEOUT_MSEC`). Four attempts that each burn the full
+ * 15s request timeout plus backoff would total ~62s and blow past that, turning a
+ * recoverable handshake into a client-side abort — the very outcome this retry
+ * exists to prevent.
+ *
+ * 45s leaves headroom under the default client budget while still spanning the
+ * fast-failure cases this fix targets (ECONNREFUSED, socket close, 5xx/-32603 all
+ * return in well under a second, so the whole window is a couple of seconds of
+ * backoff). Overridable via NEOTOMA_MCP_PROXY_HANDSHAKE_BUDGET_MS.
+ */
+export const DEFAULT_HANDSHAKE_RETRY_BUDGET_MS = 45_000;
+
 /** Injected transport for {@link dispatchCore}: real impl wraps sendDownstream; tests pass a fake. */
 export interface DispatchDeps {
   send: (headers: Record<string, string>, body: string) => Promise<Response>;
@@ -489,6 +655,10 @@ export interface DispatchDeps {
   sleep: (ms: number) => Promise<void>;
   timeoutMs: number;
   maxAttempts: number;
+  /** Wall-clock ceiling for handshake retries. Tests inject a clock; production uses Date.now. */
+  now?: () => number;
+  /** Total ms the handshake retry loop may span. Defaults to DEFAULT_HANDSHAKE_RETRY_BUDGET_MS. */
+  handshakeBudgetMs?: number;
 }
 
 /**
@@ -503,8 +673,16 @@ export interface DispatchDeps {
  * cached `initialize` is replayed downstream and the message retried, up to
  * `maxAttempts` with exponential backoff. The client's stdout only ever sees
  * the final result, so backend restarts become invisible instead of failing
- * the whole session. `initialize` itself is never retried here — the client
- * owns the handshake.
+ * the whole session.
+ *
+ * `initialize` takes a SEPARATE path (neotoma#2321). Session-loss recovery
+ * cannot help a handshake that never established — there is no session to
+ * recover and no cached handshake to replay — so a failed `initialize` used to
+ * be permanent for the life of the client, leaving every session opened during
+ * an outage dark long after the backend recovered. It is now retried, but only
+ * on a classified failure ({@link classifyInitializeFailure}): a transport
+ * failure that never reached a server, or a server that answered with its own
+ * internal failure. An `initialize` refused for authentication is never retried.
  */
 export async function dispatchCore(
   deps: DispatchDeps,
@@ -536,6 +714,58 @@ export async function dispatchCore(
     }
   };
 
+  const now = deps.now ?? Date.now;
+  const handshakeBudgetMs =
+    deps.handshakeBudgetMs ??
+    envPositiveInt("NEOTOMA_MCP_PROXY_HANDSHAKE_BUDGET_MS") ??
+    DEFAULT_HANDSHAKE_RETRY_BUDGET_MS;
+  const handshakeStartedAt = now();
+
+  /**
+   * Decide whether a classified handshake failure gets another attempt, and log
+   * why. Returns false when the caller must surface a terminal error instead.
+   */
+  const shouldRetryHandshake = (cls: InitializeFailureClass, attempt: number): boolean => {
+    if (cls === "auth_rejected" || cls === "other_terminal") return false;
+    if (attempt >= deps.maxAttempts) return false;
+    const elapsed = now() - handshakeStartedAt;
+    const wait = backoffMs(attempt);
+    if (elapsed + wait >= handshakeBudgetMs) {
+      log(
+        `initialize retry budget exhausted after ${elapsed}ms (limit ${handshakeBudgetMs}ms) — surfacing the failure while the client is still waiting`
+      );
+      return false;
+    }
+    return true;
+  };
+
+  /** Terminal handshake error, with a class the client can act on. */
+  const emitHandshakeFailure = (cls: InitializeFailureClass, detail: string): void => {
+    if (cls === "auth_rejected") {
+      log(`initialize auth rejected — not retrying: ${detail.slice(0, 300)}`);
+      emitErrorResponse(
+        message,
+        401,
+        `handshake_auth_rejected: downstream refused the credential, so retrying cannot help. Check the bearer token, X-Connection-Id, or AAuth agent grant. ${detail}`,
+        deps.emit
+      );
+      return;
+    }
+    if (cls === "other_terminal") {
+      emitErrorResponse(message, 502, `handshake_failed: ${detail}`, deps.emit);
+      return;
+    }
+    const token =
+      cls === "retryable_transport" ? "handshake_unreachable" : "handshake_server_error";
+    log(`initialize exhausted (${token}) after ${deps.maxAttempts} attempts`);
+    emitErrorResponse(
+      message,
+      503,
+      `${token}: the Neotoma MCP server could not be reached or failed to complete the handshake after ${deps.maxAttempts} attempts. This is a connection failure, NOT a missing tool — tools are unavailable because the session never established, not because they do not exist. ${detail}`,
+      deps.emit
+    );
+  };
+
   let lastDetail = "";
   for (let attempt = 1; attempt <= deps.maxAttempts; attempt++) {
     try {
@@ -549,6 +779,32 @@ export async function dispatchCore(
       loopState.session.capture(resp.headers);
 
       if (resp.status < 400) {
+        // A handshake can fail through an otherwise-successful response: when the
+        // substrate crashes after headers are sent, `src/actions.ts` cannot restate
+        // the status, so `-32603` rides out on a 200 (neotoma#2316/#2321). Buffer
+        // the body once and classify before forwarding, or that failure is
+        // forwarded as a successful handshake and the session is dark for good.
+        if (isInit) {
+          const okText = await resp.text();
+          const cls = classifyInitializeFailure({ status: resp.status, bodyText: okText });
+          if (cls === "retryable_server") {
+            lastDetail = okText.slice(0, 300);
+            if (shouldRetryHandshake(cls, attempt)) {
+              log(
+                `initialize retry attempt=${attempt}/${deps.maxAttempts} (${cls}): downstream returned an internal error through a ${resp.status} response — retrying`
+              );
+              loopState.session.clearSession();
+              await deps.sleep(backoffMs(attempt));
+              continue;
+            }
+            emitHandshakeFailure(cls, lastDetail);
+            return;
+          }
+          if (attempt > 1) log(`initialize recovered after ${attempt} attempts`);
+          emitBufferedResponse(okText, resp, deps.emit, message.id, message);
+          return;
+        }
+
         const answered = await forwardResponse(resp, deps.emit, message.id);
         if (!answered) {
           // Every frame downstream sent belonged to a different request
@@ -565,6 +821,25 @@ export async function dispatchCore(
       }
 
       const errText = await resp.text();
+
+      // The handshake path (neotoma#2321): classify, then retry only what a
+      // replay can fix. Session-loss reasoning below is left untouched — it
+      // answers a different question and never applies before a session exists.
+      if (isInit) {
+        const cls = classifyInitializeFailure({ status: resp.status, bodyText: errText });
+        lastDetail = `status=${resp.status} ${errText.slice(0, 300)}`;
+        if (shouldRetryHandshake(cls, attempt)) {
+          log(
+            `initialize retry attempt=${attempt}/${deps.maxAttempts} (${cls}): downstream status=${resp.status} — retrying`
+          );
+          loopState.session.clearSession();
+          await deps.sleep(backoffMs(attempt));
+          continue;
+        }
+        emitHandshakeFailure(cls, lastDetail);
+        return;
+      }
+
       if (
         isRecoverableMcpSessionLostError(resp.status, errText) &&
         !isInit &&
@@ -588,6 +863,24 @@ export async function dispatchCore(
       }
     } catch (err) {
       lastDetail = describeNetworkError(err);
+
+      // A handshake that never reached a server (CONNECT_TIMEOUT, ECONNREFUSED,
+      // socket closed before a response). Nothing happened downstream, so a
+      // replay cannot duplicate a server-side effect (neotoma#2321).
+      if (isInit) {
+        const cls = classifyInitializeFailure({ networkError: true });
+        if (shouldRetryHandshake(cls, attempt)) {
+          log(
+            `initialize retry attempt=${attempt}/${deps.maxAttempts} (${cls}): ${lastDetail} — retrying`
+          );
+          loopState.session.clearSession();
+          await deps.sleep(backoffMs(attempt));
+          continue;
+        }
+        emitHandshakeFailure(cls, lastDetail);
+        return;
+      }
+
       // A transport error or timeout on a non-initialize call is treated as
       // a downstream restart window: drop the session, back off, re-handshake.
       if (!isInit && attempt < deps.maxAttempts) {


### PR DESCRIPTION
Closes #2321.

## The defect

Session-loss recovery (#2312 / #2320) works well for the case it was built for — a session established and then lost. It cannot help a handshake that **never** established: there is no session to recover and no cached `initialize` to replay. So a failed `initialize` was permanent for the life of the client. Every session opened during an outage stayed dark long after the backend was fixed and verified serving, while sessions already established were fine.

The window in which the backend had to be healthy was the single instant of session start.

## Verified against the code before changing it

- `dispatchCore` short-circuits on `isInit` in both failure paths (the `catch`, and the `>= 400` branch), returning after one attempt. Confirmed.
- All four auth paths in `src/actions.ts` return **HTTP 401** with `-32001`; the session-loss path returns **404**. So the status is a reliable discriminator and the shared `-32001` is not. Confirmed at each of the five `-32001` sites.
- `-32603` is returned as an HTTP **500** — but under `if (!res.headersSent)`. When the crash happens after headers are sent the status cannot be restated, so the internal error rides out through an otherwise-**200** response. That is the shape of #2316's "DB request aborted by caller", and the old code forwarded it as a *successful* handshake.

## Can a proxy-side retry actually help?

Yes — this was checked first, since a retry the client never waits for would be pointless.

The proxy is a stdio child that emits nothing until `dispatchCore` resolves, so the only question is whether the client's timeout exceeds the retry window. The MCP SDK's `DEFAULT_REQUEST_TIMEOUT_MSEC` is **60,000 ms**. The failures in #2321 (ECONNREFUSED, socket close, 5xx / `-32603`) all return in well under a second, so the whole retry window is the backoff — **~2.1 s across four attempts**. Comfortably inside the client's budget.

But the worst case is not: four attempts each burning the 15 s request timeout plus backoff totals **~62.1 s**, which *overruns* the 60 s client budget and would turn a recoverable handshake into a client-side abort — the very outcome the retry exists to prevent. So attempt count alone is not a sufficient bound, and this adds a **wall-clock budget** (45 s default, `NEOTOMA_MCP_PROXY_HANDSHAKE_BUDGET_MS`) alongside it.

## The predicate

`classifyInitializeFailure` is separate from `isRecoverableMcpSessionLostError`, which answers a different question and must keep answering only that. Following #2320's discipline, no class is keyed on a single signal, and **no rule keys on `-32001` alone** — auth and session loss share that code.

| Class | Signals | Retried |
|---|---|---|
| `retryable_transport` | No usable HTTP response (ECONNREFUSED, timeout, socket closed) | yes |
| `retryable_server` | HTTP 5xx, **or** `-32603` in the body (incl. through a 200) | yes |
| `auth_rejected` | **HTTP 401** | **never** |
| `other_terminal` | non-401 4xx (400, routing 404, 403) | no |

**How auth is excluded:** the 401 check runs *first* and no later rule can override it — a 401 body that also carries `-32603` still fails closed, which is covered by a test. Keying on the status rather than the code is what makes this robust: retrying would hammer a server correctly refusing a credential, burn the budget, and mask the real cause.

## Acceptance criteria

- [x] Retries with bounded backoff rather than failing permanently — and the **effect** is asserted: the session id is captured and usable, not merely that a retry ran.
- [x] Auth rejection is not retried and says so distinguishably (`handshake_auth_rejected`).
- [x] Exhausted retries are distinguishable from a missing tool — the error states it is a connection failure and `NOT a missing tool`, so a client cannot read session darkness as an absent tool and answer about the graph from silence. **This is met within the proxy** (the error the client receives), but the proxy cannot force a harness to *surface* that text to the model; making it visible in a given client is client-side and out of scope here (see ateles#808).
- [x] Regression test: a handshake fails N times then succeeds, beside the existing session-loss tests.

## Tests — fail-then-pass

Against **unmodified** proxy source: **11 failed**. The behavioural failure is the defect itself, not a missing export — `expected 1 to be 3`, i.e. the handshake failed once and was never retried.

With the fix: **41 passed**.

No build was involved. The #2317 hazard (tests importing `dist/`) was checked rather than assumed: with `dist/proxy/mcp_stdio_proxy.js` replaced by a throwing sentinel, all tests still passed — these tests execute TypeScript source, via vitest's `prefer-ts-source-for-js-specifiers` plugin.

Also covered: the SSE handshake path and the #2272 correlation guard, both of which changed shape because classifying the body consumes the stream.

## Full suite

**5,347 passed, 0 failures**, 530 files (79 skipped, 3 todo). The stated pre-#2320 baseline was 5,335; the difference is this PR's new tests.

## Scope

Handshake retry and its tests only. Does not touch #2070 (session model), `NEOTOMA_DB_READER_WORKERS`, the health check, or #2322's auth-ordering territory. Session-loss recovery for established sessions is unchanged and has a non-regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)