### PR TITLE
fix(reducer): keep corrections durable under the last_write policy

### DIFF
--- a/src/reducers/observation_reducer.ts
+++ b/src/reducers/observation_reducer.ts
@@ -32,6 +32,14 @@ export interface Observation {
    * those rank last within their `source_priority` bucket.
    */
   observation_source?: ObservationSourceRankValue | null;
+  /**
+   * True only for observations created by `createCorrection`
+   * (src/services/correction.ts). Never client-settable — see that module
+   * for the write path. Lets `lastWriteWins` partition candidates so a
+   * correction is not silently reverted by a later, non-correction write
+   * (issue #2033). Absent/false for all other observations.
+   */
+  is_correction?: boolean | null;
   fields: Record<string, unknown>;
   created_at: string;
   user_id: string;
@@ -310,6 +318,18 @@ export class ObservationReducer {
 
   /**
    * Last Write Wins strategy
+   *
+   * #2033: a `correct()` observation (`is_correction: true`, stamped only by
+   * `createCorrection`) must survive a later, non-correction write — the
+   * documented "corrections always win" contract (#1541) applied to
+   * merge_array, but not to last_write, the default for every
+   * auto-discovered field. When any candidate carries the marker, restrict
+   * resolution to the correction-marked candidates only (mirroring the
+   * priority-gated union in `mergeArray`); corrections remain mutually
+   * last-write among themselves via the existing observed_at DESC sort.
+   * Ordinary numeric `source_priority` is intentionally NOT read here — that
+   * would reintroduce the general priority-vs-last_write mismatch #1755
+   * deliberately declined to fix.
    */
   private lastWriteWins(
     field: string,
@@ -320,7 +340,10 @@ export class ObservationReducer {
     // down to those where this field is non-null, so the input list can be
     // empty for fields whose only observation is null. Return a sentinel
     // no-value result in that case; the caller drops it from the snapshot.
-    const latest = observations[0];
+    const correctionObservations = observations.filter((obs) => obs.is_correction === true);
+    const candidates = correctionObservations.length > 0 ? correctionObservations : observations;
+
+    const latest = candidates[0];
     if (!latest) {
       return { value: undefined, source_observation_id: "" };
     }

--- a/src/repositories/sqlite/local_db_adapter.ts
+++ b/src/repositories/sqlite/local_db_adapter.ts
@@ -24,6 +24,7 @@ type QueryResult<T> = {
 /** Columns stored as 0/1 in SQLite that should be returned as boolean */
 const BOOLEAN_COLUMNS: Record<string, Set<string>> = {
   schema_registry: new Set(["active", "test"]),
+  observations: new Set(["is_correction"]),
 };
 
 const JSON_COLUMNS: Record<string, Set<string>> = {

--- a/src/repositories/sqlite/sqlite_client.ts
+++ b/src/repositories/sqlite/sqlite_client.ts
@@ -461,6 +461,12 @@ export async function ensureSchema(database: DbDatabase): Promise<void> {
     // support fast collapse_by grouping on retrieve_entities.
     await addColumnIfMissing(db, "observations", "canonical_key", "TEXT");
     await addColumnIfMissing(db, "observations", "sighting_source_id", "TEXT");
+    // Durable correction marker (#2033): stamped ONLY by createCorrection
+    // (src/services/correction.ts), never accepted from client request
+    // bodies on the generic store/store_structured paths. Lets the reducer
+    // partition last_write candidates so a correction survives a later,
+    // lower-priority write instead of being silently outdated by observed_at.
+    await addColumnIfMissing(db, "observations", "is_correction", "INTEGER");
     await db
       .prepare(
         "CREATE INDEX IF NOT EXISTS idx_observations_canonical_key ON observations(canonical_key, user_id)"

--- a/src/services/correction.ts
+++ b/src/services/correction.ts
@@ -103,6 +103,10 @@ export async function createCorrection(params: CreateCorrectionParams): Promise<
     observed_at: new Date().toISOString(),
     specificity_score: 1.0,
     source_priority: 1000,
+    // #2033: durable correction marker, stamped ONLY here. Never accept this
+    // from client request bodies on the generic store/store_structured paths
+    // — see observation_reducer.ts lastWriteWins for how the reducer uses it.
+    is_correction: true,
     fields: { [field]: value },
     user_id,
   };

--- a/tests/integration/correction_durability_last_write.test.ts
+++ b/tests/integration/correction_durability_last_write.test.ts
@@ -1,0 +1,235 @@
+/**
+ * End-to-end regression tests for issue #2033:
+ * correct() is not durable — a priority-1000 correction was silently
+ * reverted by any later-observed_at write under the default `last_write`
+ * merge policy (the default for every auto-discovered field).
+ *
+ * Exercises the REAL write path (`createObservation` / `createCorrection` /
+ * `recomputeSnapshot`) against a live local DB, and separately confirms the
+ * MCP `correct` action and the HTTP `/correct` route both funnel through the
+ * same `createCorrection` service and produce an identical, durable
+ * resolution — locking the single-call-surface contract Eng's spec relies
+ * on (see tests/integration/mcp_actions_matrix.test.ts for the sibling MCP
+ * action-matrix coverage this augments).
+ */
+
+import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
+import { db } from "../../src/db.js";
+import { NeotomaServer } from "../../src/server.js";
+import { randomUUID } from "crypto";
+import { createObservation } from "../../src/services/observation_storage.js";
+import { createCorrection } from "../../src/services/correction.js";
+import { recomputeSnapshot } from "../../src/services/snapshot_computation.js";
+import { seedTestSchema, cleanupTestSchema } from "../helpers/test_schema_helpers.js";
+
+const testUserId = "00000000-0000-0000-0000-000000000000";
+const testEntityType = "correction_durability_2033";
+
+function callMCPAction(server: NeotomaServer, actionName: string, params: any): Promise<any> {
+  const methodName = actionName.replace(/_([a-z])/g, (_: string, letter: string) =>
+    letter.toUpperCase()
+  );
+  return (server as any)[methodName](params);
+}
+
+describe("correct() durability against last_write (#2033)", () => {
+  const createdEntityIds: string[] = [];
+
+  beforeAll(async () => {
+    await seedTestSchema(new NeotomaServer(), testEntityType, {
+      field: { type: "string", required: false },
+    });
+  });
+
+  afterAll(async () => {
+    await cleanupTestSchema(testEntityType);
+  });
+
+  afterEach(async () => {
+    if (createdEntityIds.length > 0) {
+      await db.from("observations").delete().in("entity_id", createdEntityIds);
+      await db.from("entity_snapshots").delete().in("entity_id", createdEntityIds);
+      await db.from("entities").delete().in("id", createdEntityIds);
+      createdEntityIds.length = 0;
+    }
+  });
+
+  it("P0 repro: correction on an auto-discovered (last_write) field survives a later routine re-ingest", async () => {
+    const entityId = `ent_2033_repro_${randomUUID()}`;
+    createdEntityIds.push(entityId);
+
+    await createObservation({
+      entity_id: entityId,
+      entity_type: testEntityType,
+      schema_version: "1.0",
+      source_id: null,
+      interpretation_id: null,
+      observed_at: new Date(Date.now() - 3000).toISOString(),
+      specificity_score: 1.0,
+      source_priority: 100,
+      observation_source: "import",
+      fields: { field: "A" },
+      user_id: testUserId,
+      idempotency_key: `2033-original-${randomUUID()}`,
+    });
+
+    await createCorrection({
+      entity_id: entityId,
+      entity_type: testEntityType,
+      field: "field",
+      value: "B",
+      schema_version: "1.0",
+      user_id: testUserId,
+      idempotency_key: `2033-correction-${randomUUID()}`,
+    });
+
+    // Routine re-ingest AFTER the correction, later observed_at, default
+    // priority, non-correction observation_source — the exact repro shape.
+    await createObservation({
+      entity_id: entityId,
+      entity_type: testEntityType,
+      schema_version: "1.0",
+      source_id: null,
+      interpretation_id: null,
+      observed_at: new Date(Date.now() + 3000).toISOString(),
+      specificity_score: 1.0,
+      source_priority: 100,
+      observation_source: "import",
+      fields: { field: "A" },
+      user_id: testUserId,
+      idempotency_key: `2033-reingest-${randomUUID()}`,
+    });
+
+    const snapshot = await recomputeSnapshot(entityId, testUserId);
+
+    expect(snapshot).not.toBeNull();
+    expect(snapshot!.snapshot.field).toBe("B");
+  });
+
+  it("MCP correct action and HTTP /correct-equivalent createCorrection call both stamp a durable marker", async () => {
+    const server = new NeotomaServer();
+    (server as any).authenticatedUserId = testUserId;
+
+    const mcpEntityId = `ent_2033_mcp_${randomUUID()}`;
+    createdEntityIds.push(mcpEntityId);
+
+    await createObservation({
+      entity_id: mcpEntityId,
+      entity_type: testEntityType,
+      schema_version: "1.0",
+      source_id: null,
+      interpretation_id: null,
+      observed_at: new Date(Date.now() - 3000).toISOString(),
+      specificity_score: 1.0,
+      source_priority: 100,
+      observation_source: "import",
+      fields: { field: "before-mcp-correction" },
+      user_id: testUserId,
+      idempotency_key: `2033-mcp-original-${randomUUID()}`,
+    });
+
+    // MCP surface
+    await callMCPAction(server, "correct", {
+      user_id: testUserId,
+      idempotency_key: `2033-mcp-correct-${randomUUID()}`,
+      entity_id: mcpEntityId,
+      entity_type: testEntityType,
+      field: "field",
+      value: "after-mcp-correction",
+    });
+
+    // Later, lower-priority re-ingest via the generic write path.
+    await createObservation({
+      entity_id: mcpEntityId,
+      entity_type: testEntityType,
+      schema_version: "1.0",
+      source_id: null,
+      interpretation_id: null,
+      observed_at: new Date(Date.now() + 3000).toISOString(),
+      specificity_score: 1.0,
+      source_priority: 100,
+      observation_source: "import",
+      fields: { field: "before-mcp-correction" },
+      user_id: testUserId,
+      idempotency_key: `2033-mcp-reingest-${randomUUID()}`,
+    });
+
+    const mcpSnapshot = await recomputeSnapshot(mcpEntityId, testUserId);
+    expect(mcpSnapshot!.snapshot.field).toBe("after-mcp-correction");
+
+    // Confirm the underlying observation row from the MCP surface carries the
+    // same server-stamped marker createCorrection() sets directly (locks that
+    // MCP does not bypass the shared service and stamp independently).
+    const { data: mcpCorrectionRows } = await db
+      .from("observations")
+      .select("*")
+      .eq("entity_id", mcpEntityId)
+      .eq("user_id", testUserId);
+    const mcpCorrectionRow = (mcpCorrectionRows ?? []).find(
+      (row: any) => row.fields?.field === "after-mcp-correction"
+    );
+    expect(mcpCorrectionRow).toBeDefined();
+    expect(mcpCorrectionRow!.is_correction).toBe(true);
+  });
+
+  it("a client-supplied source_priority: 1000 via the generic store path does NOT receive correction-partition treatment (spoofing guard)", async () => {
+    const entityId = `ent_2033_spoof_${randomUUID()}`;
+    createdEntityIds.push(entityId);
+
+    await createObservation({
+      entity_id: entityId,
+      entity_type: testEntityType,
+      schema_version: "1.0",
+      source_id: null,
+      interpretation_id: null,
+      observed_at: new Date(Date.now() - 3000).toISOString(),
+      specificity_score: 1.0,
+      source_priority: 100,
+      observation_source: "import",
+      fields: { field: "legit-original" },
+      user_id: testUserId,
+      idempotency_key: `2033-spoof-original-${randomUUID()}`,
+    });
+
+    // A caller forging source_priority: 1000 through the ordinary
+    // createObservation/store path (NOT createCorrection) must not be
+    // treated as a durable correction — is_correction is never set here.
+    await createObservation({
+      entity_id: entityId,
+      entity_type: testEntityType,
+      schema_version: "1.0",
+      source_id: null,
+      interpretation_id: null,
+      observed_at: new Date(Date.now() - 1000).toISOString(),
+      specificity_score: 1.0,
+      source_priority: 1000,
+      observation_source: "import",
+      fields: { field: "forged-priority-1000" },
+      user_id: testUserId,
+      idempotency_key: `2033-spoof-forged-${randomUUID()}`,
+    });
+
+    // A later, ordinary write at default priority.
+    await createObservation({
+      entity_id: entityId,
+      entity_type: testEntityType,
+      schema_version: "1.0",
+      source_id: null,
+      interpretation_id: null,
+      observed_at: new Date(Date.now() + 3000).toISOString(),
+      specificity_score: 1.0,
+      source_priority: 100,
+      observation_source: "import",
+      fields: { field: "later-ordinary-write" },
+      user_id: testUserId,
+      idempotency_key: `2033-spoof-later-${randomUUID()}`,
+    });
+
+    const snapshot = await recomputeSnapshot(entityId, testUserId);
+
+    // Pure last_write by observed_at — the forged priority-1000 write does
+    // NOT survive being superseded, because it was never stamped
+    // is_correction by createCorrection.
+    expect(snapshot!.snapshot.field).toBe("later-ordinary-write");
+  });
+});

--- a/tests/unit/observation_reducer_last_write_correction_durability.test.ts
+++ b/tests/unit/observation_reducer_last_write_correction_durability.test.ts
@@ -1,0 +1,301 @@
+/**
+ * Regression tests for issue #2033:
+ * a correct() observation (`is_correction: true`) on a `last_write` field
+ * must survive a later, non-correction write — the "corrections always win"
+ * contract (#1541) already honoured by `merge_array`, extended here to
+ * `last_write`, the default merge policy for every auto-discovered field.
+ *
+ * The reducer partitions `last_write` candidates on the `is_correction`
+ * marker (stamped only by `createCorrection`, never client-settable): when
+ * any candidate is correction-marked, only correction-marked candidates are
+ * considered. Corrections remain mutually last-write among themselves via
+ * the existing observed_at DESC sort. Ordinary numeric `source_priority` is
+ * NOT read by this partition — #1755 intentionally left source_priority
+ * inert for last_write fields, and this fix must not reintroduce that for
+ * non-correction writes.
+ *
+ * Hermetic: mocks schemaRegistry.loadActiveSchema (no DB), consistent with
+ * tests/unit/observation_reducer_merge_array_correction.test.ts.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { ObservationReducer, type Observation } from "../../src/reducers/observation_reducer.js";
+
+vi.mock("../../src/services/schema_registry.js", () => ({
+  DEFAULT_OBSERVATION_SOURCE_PRIORITY: [
+    "sensor",
+    "workflow_state",
+    "llm_summary",
+    "human",
+    "import",
+  ] as const,
+  schemaRegistry: {
+    loadActiveSchema: vi.fn(),
+  },
+}));
+
+vi.mock("../../src/services/schema_definitions.js", () => ({
+  getSchemaDefinition: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock("../../src/services/field_validation.js", () => ({
+  validateFieldWithConverters: vi
+    .fn()
+    .mockImplementation((_field: string, value: unknown, _fieldDef: unknown) => ({
+      isValid: true,
+      value,
+      shouldRouteToRawFragments: false,
+    })),
+}));
+
+import { schemaRegistry } from "../../src/services/schema_registry.js";
+
+const testEntityId = "ent_test_last_write_correction_2033";
+const testEntityType = "auto_discovered_fixture_2033";
+const testUserId = "00000000-0000-0000-0000-000000000000";
+
+function makeObs(
+  overrides: Partial<Observation> & { fields: Record<string, unknown> }
+): Observation {
+  return {
+    id: "obs_default",
+    entity_id: testEntityId,
+    entity_type: testEntityType,
+    schema_version: "1.0.0",
+    source_id: "src_default",
+    observed_at: "2026-01-01T00:00:00Z",
+    specificity_score: 1.0,
+    source_priority: 100,
+    created_at: "2026-01-01T00:00:00Z",
+    user_id: testUserId,
+    ...overrides,
+  };
+}
+
+describe("ObservationReducer - last_write correction durability (#2033)", () => {
+  const reducer = new ObservationReducer();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (schemaRegistry.loadActiveSchema as any).mockResolvedValue({
+      id: "schema-2033",
+      entity_type: testEntityType,
+      schema_version: "1.0.0",
+      schema_definition: {
+        fields: {
+          field: { type: "string", required: false },
+          other_field: { type: "string", required: false },
+        },
+        identity_opt_out: "heuristic_canonical_name",
+      },
+      // Auto-discovered schemas default every field to last_write — the
+      // exact policy shape buildSchemaFromExtractedFields produces.
+      reducer_config: {
+        merge_policies: {
+          field: { strategy: "last_write" },
+          other_field: { strategy: "last_write" },
+        },
+      },
+      active: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("P0 repro: a correction survives a later lower-priority write with a later observed_at", async () => {
+    const original = makeObs({
+      id: "obs_a",
+      observed_at: "2026-01-01T00:00:00Z",
+      source_priority: 100,
+      observation_source: "import",
+      fields: { field: "A" },
+    });
+    const correction = makeObs({
+      id: "obs_correction_b",
+      source_id: null,
+      observed_at: "2026-01-02T00:00:00Z",
+      source_priority: 1000,
+      is_correction: true,
+      fields: { field: "B" },
+    });
+    // Routine re-ingest AFTER the correction, default priority, non-correction.
+    const reIngest = makeObs({
+      id: "obs_reingest_a_again",
+      observed_at: "2026-01-03T00:00:00Z",
+      source_priority: 100,
+      observation_source: "import",
+      fields: { field: "A" },
+    });
+
+    const snapshot = await reducer.computeSnapshot(testEntityId, [
+      original,
+      correction,
+      reIngest,
+    ]);
+
+    expect(snapshot!.snapshot.field).toBe("B");
+    expect(snapshot!.provenance.field).toBe("obs_correction_b");
+  });
+
+  it("corrections remain mutually last-write among themselves", async () => {
+    const firstCorrection = makeObs({
+      id: "obs_correction_1",
+      source_id: null,
+      observed_at: "2026-01-01T00:00:00Z",
+      source_priority: 1000,
+      is_correction: true,
+      fields: { field: "first-correction" },
+    });
+    const secondCorrection = makeObs({
+      id: "obs_correction_2",
+      source_id: null,
+      observed_at: "2026-01-02T00:00:00Z",
+      source_priority: 1000,
+      is_correction: true,
+      fields: { field: "second-correction" },
+    });
+    const laterLowerPriorityWrite = makeObs({
+      id: "obs_reingest",
+      observed_at: "2026-01-03T00:00:00Z",
+      source_priority: 100,
+      observation_source: "import",
+      fields: { field: "reingest-should-not-win" },
+    });
+
+    const snapshot = await reducer.computeSnapshot(testEntityId, [
+      firstCorrection,
+      secondCorrection,
+      laterLowerPriorityWrite,
+    ]);
+
+    // Second (more recent) correction wins over the first.
+    expect(snapshot!.snapshot.field).toBe("second-correction");
+    expect(snapshot!.provenance.field).toBe("obs_correction_2");
+  });
+
+  it("ordinary source_priority on last_write fields is unchanged for non-correction writes (#1755)", async () => {
+    // A non-correction write with an elevated (non-default) source_priority
+    // must NOT be treated as load-bearing on a last_write field — only
+    // observed_at governs when no observation is correction-marked. This
+    // locks #1755's standing decision so this fix cannot reintroduce
+    // priority-based resolution for the general case.
+    const higherPriorityButOlder = makeObs({
+      id: "obs_high_priority_old",
+      observed_at: "2026-01-01T00:00:00Z",
+      source_priority: 500,
+      observation_source: "import",
+      fields: { field: "high-priority-old" },
+    });
+    const lowerPriorityButNewer = makeObs({
+      id: "obs_low_priority_new",
+      observed_at: "2026-01-02T00:00:00Z",
+      source_priority: 100,
+      observation_source: "import",
+      fields: { field: "low-priority-new" },
+    });
+
+    const snapshot = await reducer.computeSnapshot(testEntityId, [
+      higherPriorityButOlder,
+      lowerPriorityButNewer,
+    ]);
+
+    // Pure observed_at DESC — the newer, lower-priority write wins, exactly
+    // as before this change (source_priority is not read on this path).
+    expect(snapshot!.snapshot.field).toBe("low-priority-new");
+    expect(snapshot!.provenance.field).toBe("obs_low_priority_new");
+  });
+
+  it("empty/never-corrected field resolves exactly as pure last_write (partition is a no-op)", async () => {
+    const obs1 = makeObs({
+      id: "obs_never_corrected_1",
+      observed_at: "2026-01-01T00:00:00Z",
+      fields: { field: "first" },
+    });
+    const obs2 = makeObs({
+      id: "obs_never_corrected_2",
+      observed_at: "2026-01-02T00:00:00Z",
+      fields: { field: "second" },
+    });
+
+    const snapshot = await reducer.computeSnapshot(testEntityId, [obs1, obs2]);
+
+    expect(snapshot!.snapshot.field).toBe("second");
+    expect(snapshot!.provenance.field).toBe("obs_never_corrected_2");
+  });
+
+  it("multi-field independence: correcting field A does not affect sibling field B's last_write resolution", async () => {
+    const fieldACorrection = makeObs({
+      id: "obs_field_a_correction",
+      source_id: null,
+      observed_at: "2026-01-01T00:00:00Z",
+      source_priority: 1000,
+      is_correction: true,
+      fields: { field: "corrected-a" },
+    });
+    const fieldALaterReingest = makeObs({
+      id: "obs_field_a_reingest",
+      observed_at: "2026-01-05T00:00:00Z",
+      source_priority: 100,
+      observation_source: "import",
+      fields: { field: "reingested-a" },
+    });
+    const fieldBEarlier = makeObs({
+      id: "obs_field_b_early",
+      observed_at: "2026-01-02T00:00:00Z",
+      fields: { other_field: "b-early" },
+    });
+    const fieldBLater = makeObs({
+      id: "obs_field_b_late",
+      observed_at: "2026-01-03T00:00:00Z",
+      fields: { other_field: "b-late" },
+    });
+
+    const snapshot = await reducer.computeSnapshot(testEntityId, [
+      fieldACorrection,
+      fieldALaterReingest,
+      fieldBEarlier,
+      fieldBLater,
+    ]);
+
+    // field stays corrected (survives the later reingest)...
+    expect(snapshot!.snapshot.field).toBe("corrected-a");
+    // ...while other_field resolves by plain last_write, uncorrected.
+    expect(snapshot!.snapshot.other_field).toBe("b-late");
+  });
+
+  it("computeSnapshotWithDefaults (unseeded type, no schema) also honours the correction marker", async () => {
+    (schemaRegistry.loadActiveSchema as any).mockResolvedValue(null);
+
+    const original = makeObs({
+      id: "obs_unseeded_a",
+      entity_type: "unseeded_entity_2033",
+      observed_at: "2026-01-01T00:00:00Z",
+      fields: { field: "A" },
+    });
+    const correction = makeObs({
+      id: "obs_unseeded_correction",
+      entity_type: "unseeded_entity_2033",
+      source_id: null,
+      observed_at: "2026-01-02T00:00:00Z",
+      source_priority: 1000,
+      is_correction: true,
+      fields: { field: "B" },
+    });
+    const reIngest = makeObs({
+      id: "obs_unseeded_reingest",
+      entity_type: "unseeded_entity_2033",
+      observed_at: "2026-01-03T00:00:00Z",
+      fields: { field: "A" },
+    });
+
+    const snapshot = await reducer.computeSnapshot(testEntityId, [
+      original,
+      correction,
+      reIngest,
+    ]);
+
+    expect(snapshot!.snapshot.field).toBe("B");
+  });
+});


### PR DESCRIPTION
Fixes #2033.

## The bug

A priority-1000 correction was silently reverted by any later-`observed_at` write. `lastWriteWins` returned `observations[0]` from a list sorted on `observed_at` DESC and never read `source_priority`, so an ordinary priority-0 extraction landing after a correction won outright.

This contradicts two documented guarantees:

- `docs/specs/MCP_SPEC.md:1415` — "Corrections always win in entity snapshot computation (priority 1000)."
- `docs/subsystems/interpretations.md:176` — "corrections (`source_priority = 1000`) always win."

Blast radius, counted in `src/services/schema_definitions.ts`: **332 of 379** shipped field policies are `last_write` (36 `highest_priority`, 11 `merge_array`). `last_write` is also the default for any field that does not declare a strategy, so every auto-discovered field is affected. `highest_priority`, `merge_array`, and the deletion checks already honoured priority correctly — `last_write` was the outlier.

The failure shape is the dangerous one: the correction takes effect immediately and reverts later, so it looks like it worked.

## The fix

Adds an `is_correction` marker stamped **only** by `createCorrection`, never accepted from client request bodies. When any candidate carries it, `lastWriteWins` resolves within the correction-marked candidates, mirroring the priority-gated union already used by `mergeArray`. Corrections remain mutually last-write among themselves via the existing `observed_at` sort.

Ordinary numeric `source_priority` is deliberately **not** read in `last_write`. That would reintroduce the general priority-vs-`last_write` mismatch that #1755 explicitly declined to fix, and it is a larger behavioural change than this bug requires. A dedicated marker keeps the blast radius to corrections alone.

## What the tests looked like red

Reverting only the `lastWriteWins` hunk and re-running `tests/unit/observation_reducer_last_write_correction_durability.test.ts`: **4 of 6 tests fail**. With the hunk restored, 6/6 pass. The coverage is real, not decoration.

Verified green on this branch against current `main`:

- `tests/unit/observation_reducer_last_write_correction_durability.test.ts` — 6/6
- `tests/integration/correction_durability_last_write.test.ts` — 3/3, including a spoofing guard asserting that a client-supplied `source_priority: 1000` via the generic store path does **not** receive correction-partition treatment
- `tests/unit/conversation_session_uuid_bridge.test.ts` — passes; it asserts last_write overwrite for an *absent prior value*, so it was not pinning this bug
- `tests/unit/observation_reducer_provenance.test.ts` — 4/4

## Provenance of this change

The implementation is pre-existing work recovered from a stranded local branch: staged but never committed, on a base ~1000 commits behind `main`, with no remote branch. It was one power-cycle from being lost. I committed it as-authored, then cherry-picked onto current `main`; the only conflict was in `sqlite_client.ts`, where `main` has since made `addColumnIfMissing` and `.run()` async. Resolved by keeping `main`'s async form and adding the new column in the same style. The design and its rationale comments are the original author's and were preserved.

## Related, not in scope

- **#1755** (closed) is the same root cause from the `--source-priority` angle. It was closed with the `SOURCE_PRIORITY_IGNORED` advisory (PR #1774) rather than a reducer change; its QA checklist item "eval asserts `--source-priority` is now honored" remains unchecked, marked deferred. This PR does not change that general behaviour.
- That advisory **does not fire for `correct()`** — `src/services/correction.ts` has no reference to `source_priority_warning`. Worth a follow-up, since the one operation whose purpose is to override still gets no warning when its priority is ignored.
- **#2026** (open) — `retrieve_field_provenance` throws on a NULL `source_id`, which corrections always carry. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)