### PR TITLE
fix(search): recency tie-break + merged-entity embedding purge

### DIFF
--- a/docs/subsystems/search/search.md
+++ b/docs/subsystems/search/search.md
@@ -29,37 +29,30 @@ interface SearchQuery {
 
 ## Ranking Algorithm
 
+`retrieve_entities` search ranks by **relevance first**. Recency is a **tie-break only** — it does not blend into the relevance score and is not an opt-in parameter.
+
+Order when comparing two candidates:
+
+1. **Relevance score** (higher first) — lexical token score, or semantic rank (`compareSearchRank`).
+2. **Recency tie-break** — prefer the entity with the more recent `entity_snapshots.last_observation_at`, scored via shared `recencyDecay` (`memory_export.ts`, half-life 30 days). Undated / non-finite timestamps share a low floor and lose to any dated row; equal decay falls through.
+3. **Stable fallthrough** (only when score and recency are indistinguishable):
+   - Lexical (strict + partial-overlap share one sort): `canonical_name` ascending, then `entity_id` ascending.
+   - Semantic: original KNN position ascending.
+
 ```typescript
-function rankResults(results: Record[], query: string): Record[] {
-  return results
-    .map((r) => ({ record: r, score: calculateScore(r, query) }))
-    .sort((a, b) => {
-      if (a.score !== b.score) return b.score - a.score;
-      // Tiebreaker 1: created_at
-      if (a.record.created_at !== b.record.created_at) {
-        return b.record.created_at.localeCompare(a.record.created_at);
-      }
-      // Tiebreaker 2: id
-      return a.record.id.localeCompare(b.record.id);
-    })
-    .map(({ record }) => record);
-}
-function calculateScore(record: Record, query: string): number {
-  let score = 0;
-  const regex = new RegExp(query, "gi");
-
-  // Exact match in type
-  if (record.type.toLowerCase() === query.toLowerCase()) score += 10;
-
-  // Match count in raw_text
-  const matches = record.raw_text?.match(regex);
-  score += matches?.length || 0;
-
-  return score;
+// Contract sketch — implementation: entity_handlers.ts
+// compareByRecency / lexicalMatches.sort / compareSearchRank
+function compareSearchCandidates(a, b): number {
+  if (a.score !== b.score) return b.score - a.score; // relevance
+  const byRecency = compareByRecency(a.last_observation_at, b.last_observation_at);
+  if (byRecency !== 0) return byRecency; // more recent first
+  // lexical: canonical_name then entity_id
+  // semantic: KNN index order
+  return stableKeyCompare(a, b);
 }
 ```
 
-**Determinism:** Same query + same DB state → same order
+**Determinism:** Same query + same DB state (including every candidate’s `last_observation_at`) → same order. Recency uses wall-clock age via `recencyDecay`; undated ties resolve on the stable fallthrough keys above, not on `created_at`.
 
 ## Retrieval fallback strategies
 

--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,8 +61,8 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **596**
-- Backend and repo Vitest files: **561**
+- Total automated test files: **598**
+- Backend and repo Vitest files: **563**
 - Frontend Vitest files: **9**
 - Playwright spec files: **26**
 
@@ -71,7 +71,7 @@ flowchart TD
 |---|---:|
 | Vitest unit tests | 164 |
 | Vitest service tests | 44 |
-| Source-adjacent tests | 66 |
+| Source-adjacent tests | 68 |
 | Vitest integration tests | 168 |
 | Vitest CLI tests | 78 |
 | Vitest contract tests | 18 |
@@ -331,7 +331,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- src`
 **Requirements:** Basic `.env` if required by the module under test.
-**Files (66):**
+**Files (68):**
 - `src/cli/parse_cli_corrected_value.test.ts`
 - `src/crypto/crypto.test.ts`
 - `src/proxy/mcp_stdio_proxy.test.ts`
@@ -342,6 +342,7 @@ flowchart TD
 - `src/semver_compat.test.ts`
 - `src/services/__tests__/csv_chunking.test.ts`
 - `src/services/__tests__/deletion.test.ts`
+- `src/services/__tests__/entity_merge_embedding_purge.test.ts`
 - `src/services/__tests__/entity_semantic_search.test.ts`
 - `src/services/__tests__/local_auth.test.ts`
 - `src/services/__tests__/local_entity_embedding.test.ts`
@@ -387,6 +388,7 @@ flowchart TD
 - `src/services/rendered_page/publish.test.ts`
 - `src/services/route_shadowing.test.ts`
 - `src/services/sync/peer_health.test.ts`
+- `src/shared/action_handlers/__tests__/entity_handlers_ranking.test.ts`
 - `src/shared/action_handlers/entity_handlers.test.ts`
 - `src/shared/action_schemas.test.ts`
 - `src/shared/spawn_platform.test.ts`

--- a/src/repositories/sqlite/sqlite_driver.ts
+++ b/src/repositories/sqlite/sqlite_driver.ts
@@ -63,6 +63,20 @@ class SqliteDatabaseImpl {
     this.db = new DatabaseCtor(path);
   }
 
+  /**
+   * The underlying native driver instance (better-sqlite3's `Database`, or
+   * `node:sqlite`'s `DatabaseSync`) — distinct from this wrapper. Extension
+   * loaders like sqlite-vec call `db.loadExtension(...)` on the NATIVE
+   * object; this wrapper exposes `prepare`/`exec`/`pragma`/`transaction`
+   * instead, so passing the wrapper itself to `sqliteVec.load()` fails with
+   * "db.loadExtension is not a function" regardless of platform. Exposed so
+   * callers that need the native handle (extension loading) don't have to
+   * reach into this class's private field.
+   */
+  nativeHandle(): any {
+    return this.db;
+  }
+
   prepare(sql: string): SqliteStatementImpl {
     return new SqliteStatementImpl(this.db.prepare(sql));
   }

--- a/src/services/__tests__/entity_merge_embedding_purge.test.ts
+++ b/src/services/__tests__/entity_merge_embedding_purge.test.ts
@@ -34,6 +34,7 @@ import { generateEntityId } from "../entity_resolution.js";
 
 const EMBEDDING_DIM = 1536;
 const userId = "test-user-merge-embedding-purge";
+const otherUserId = "test-user-merge-embedding-purge-other";
 const entityType = "contact";
 
 /** Deterministic 1536-dim embedding: identical vector for every seed so every
@@ -44,6 +45,12 @@ const entityType = "contact";
 function makeEmbedding(): number[] {
   const arr = new Array(EMBEDDING_DIM).fill(0) as number[];
   arr[0] = 1;
+  return arr;
+}
+
+function makeDistantEmbedding(): number[] {
+  const arr = new Array(EMBEDDING_DIM).fill(0) as number[];
+  arr[1] = 1;
   return arr;
 }
 
@@ -79,6 +86,7 @@ async function rawKnnEntityIds(k: number): Promise<string[]> {
 async function cleanup(): Promise<void> {
   const rawDb = await getDb();
   await db.from("entity_embedding_rows").delete().eq("user_id", userId);
+  await db.from("entity_embedding_rows").delete().eq("user_id", otherUserId);
   if (rawDb instanceof AsyncSqliteDatabase) {
     // entity_embeddings_vec has no user_id column; sweep orphaned vec rows by
     // rejoining against entity_embedding_rows (already cleared above), so any
@@ -92,7 +100,9 @@ async function cleanup(): Promise<void> {
     }
   }
   await db.from("entities").delete().eq("user_id", userId);
+  await db.from("entities").delete().eq("user_id", otherUserId);
   await db.from("entity_snapshots").delete().eq("user_id", userId);
+  await db.from("entity_snapshots").delete().eq("user_id", otherUserId);
 }
 
 describe("mergeEntities purges the merged-away entity's local embedding row", () => {
@@ -102,8 +112,10 @@ describe("mergeEntities purges the merged-away entity's local embedding row", ()
   it("frees the KNN slot the merged-away entity occupied, rather than leaving it a permanent candidate", async () => {
     const survivorName = "Live Survivor";
     const mergedAwayName = "Stale Duplicate";
+    const otherUserName = "Other User Neighbor";
     const survivorId = generateEntityId(entityType, survivorName);
     const mergedAwayId = generateEntityId(entityType, mergedAwayName);
+    const otherUserEntityId = generateEntityId(entityType, otherUserName);
 
     await db.from("entities").insert({
       id: survivorId,
@@ -129,6 +141,13 @@ describe("mergeEntities purges the merged-away entity's local embedding row", ()
       entity_id: mergedAwayId,
       embedding: makeEmbedding(),
       user_id: userId,
+      entity_type: entityType,
+      merged: false,
+    });
+    await storeLocalEntityEmbedding({
+      entity_id: otherUserEntityId,
+      embedding: makeDistantEmbedding(),
+      user_id: otherUserId,
       entity_type: entityType,
       merged: false,
     });
@@ -162,5 +181,17 @@ describe("mergeEntities purges the merged-away entity's local embedding row", ()
       .select("entity_id")
       .eq("entity_id", mergedAwayId);
     expect(remaining ?? []).toHaveLength(0);
+
+    const { data: otherUserRows } = await db
+      .from("entity_embedding_rows")
+      .select("entity_id, user_id")
+      .eq("entity_id", otherUserEntityId)
+      .eq("user_id", otherUserId);
+    expect(otherUserRows ?? []).toEqual([
+      {
+        entity_id: otherUserEntityId,
+        user_id: otherUserId,
+      },
+    ]);
   });
 });

--- a/src/services/__tests__/entity_merge_embedding_purge.test.ts
+++ b/src/services/__tests__/entity_merge_embedding_purge.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Regression test: mergeEntities must purge the merged-away entity's local
+ * (sqlite-vec) embedding row, not just mark `entities.merged_to_entity_id`
+ * and delete its `entity_snapshots` row.
+ *
+ * Why "consumes a KNN slot" and not "absent from results": `merged` on
+ * `entity_embedding_rows` is written `false` at insert time
+ * (entity_snapshot_embedding.ts) and nothing else ever flips it, so a
+ * merged-away entity's embedding row survives forever with `merged=0`.
+ * `searchLocalEntityEmbeddings` (local_entity_embedding.ts) already re-filters
+ * merged entities out of hydrated results at the handler layer
+ * (entity_handlers.ts:1043-ish), so "merged entity absent from results" is
+ * already true today and asserting only that would prove nothing about this
+ * defect. The actual defect is structural: the vec0 `k`-nearest-neighbor
+ * search runs FIRST (`WHERE v.embedding MATCH ? AND k = ?`), and the
+ * `AND (?=1 OR r.merged=0)` filter is applied to the joined rows only AFTER
+ * the k nearest neighbors are already fixed. So a merged-away row that is a
+ * true nearest neighbor occupies one of the k slots and can push a live
+ * entity out of the KNN result set entirely, before any merged-aware filter
+ * ever runs. This test proves that directly: it runs the same raw vec0 KNN
+ * query shape used in production with a small k, and asserts the merged-away
+ * entity's rowid is gone from the RAW KNN row set after the fix — i.e. the
+ * slot it used to occupy is now free for a live entity, not merely that the
+ * caller-facing result list happens to exclude it.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { db } from "../../db.js";
+import { getDb } from "../../repositories/db/connection.js";
+import { storeLocalEntityEmbedding, ensureSqliteVecLoaded } from "../local_entity_embedding.js";
+import { AsyncSqliteDatabase } from "../../repositories/sqlite/sqlite_driver.js";
+import { mergeEntities } from "../entity_merge.js";
+import { generateEntityId } from "../entity_resolution.js";
+
+const EMBEDDING_DIM = 1536;
+const userId = "test-user-merge-embedding-purge";
+const entityType = "contact";
+
+/** Deterministic 1536-dim embedding: identical vector for every seed so every
+ * candidate is an exact-distance (tied) nearest neighbor of the query — this
+ * makes which rows occupy the k slots purely a function of insertion/rowid
+ * order, not embedding geometry, so the test is not measuring cosine/L2
+ * behavior, only slot occupancy. */
+function makeEmbedding(): number[] {
+  const arr = new Array(EMBEDDING_DIM).fill(0) as number[];
+  arr[0] = 1;
+  return arr;
+}
+
+/** Raw KNN row set for entity_id, using the exact query shape production uses
+ * (local_entity_embedding.ts searchLocalEntityEmbeddings), with an explicit
+ * small k so slot starvation is observable without needing hundreds of rows. */
+async function rawKnnEntityIds(k: number): Promise<string[]> {
+  const rawDb = await getDb();
+  if (!(rawDb instanceof AsyncSqliteDatabase)) {
+    throw new Error("test requires AsyncSqliteDatabase backend");
+  }
+  const loaded = ensureSqliteVecLoaded(rawDb.rawDb());
+  if (!loaded) {
+    throw new Error("sqlite-vec did not load in this test environment");
+  }
+  const float32 = new Float32Array(makeEmbedding());
+  const embeddingBlob = Buffer.from(float32.buffer, float32.byteOffset, float32.byteLength);
+  const rows = (await rawDb
+    .prepare(
+      `
+    SELECT r.entity_id, v.distance
+    FROM entity_embeddings_vec v
+    INNER JOIN entity_embedding_rows r ON r.rowid = v.rowid
+    WHERE v.embedding MATCH ? AND k = ?
+      AND r.user_id = ?
+    ORDER BY v.distance
+  `
+    )
+    .all(embeddingBlob, k, userId)) as Array<{ entity_id: string; distance: number }>;
+  return rows.map((r) => r.entity_id);
+}
+
+async function cleanup(): Promise<void> {
+  const rawDb = await getDb();
+  await db.from("entity_embedding_rows").delete().eq("user_id", userId);
+  if (rawDb instanceof AsyncSqliteDatabase) {
+    // entity_embeddings_vec has no user_id column; sweep orphaned vec rows by
+    // rejoining against entity_embedding_rows (already cleared above), so any
+    // vec0 row with no matching entity_embedding_rows entry is test debris.
+    try {
+      await rawDb.exec(
+        `DELETE FROM entity_embeddings_vec WHERE rowid NOT IN (SELECT rowid FROM entity_embedding_rows)`
+      );
+    } catch {
+      // vec0 table may not exist yet on first run
+    }
+  }
+  await db.from("entities").delete().eq("user_id", userId);
+  await db.from("entity_snapshots").delete().eq("user_id", userId);
+}
+
+describe("mergeEntities purges the merged-away entity's local embedding row", () => {
+  beforeEach(cleanup);
+  afterEach(cleanup);
+
+  it("frees the KNN slot the merged-away entity occupied, rather than leaving it a permanent candidate", async () => {
+    const survivorName = "Live Survivor";
+    const mergedAwayName = "Stale Duplicate";
+    const survivorId = generateEntityId(entityType, survivorName);
+    const mergedAwayId = generateEntityId(entityType, mergedAwayName);
+
+    await db.from("entities").insert({
+      id: survivorId,
+      entity_type: entityType,
+      canonical_name: survivorName,
+      user_id: userId,
+    });
+    await db.from("entities").insert({
+      id: mergedAwayId,
+      entity_type: entityType,
+      canonical_name: mergedAwayName,
+      user_id: userId,
+    });
+
+    await storeLocalEntityEmbedding({
+      entity_id: survivorId,
+      embedding: makeEmbedding(),
+      user_id: userId,
+      entity_type: entityType,
+      merged: false,
+    });
+    await storeLocalEntityEmbedding({
+      entity_id: mergedAwayId,
+      embedding: makeEmbedding(),
+      user_id: userId,
+      entity_type: entityType,
+      merged: false,
+    });
+
+    // Sanity: both rows currently occupy KNN slots (k=2, exactly the two rows
+    // seeded) before any merge happens.
+    const beforeMerge = await rawKnnEntityIds(2);
+    expect(beforeMerge).toEqual(expect.arrayContaining([survivorId, mergedAwayId]));
+
+    await mergeEntities({
+      fromEntityId: mergedAwayId,
+      toEntityId: survivorId,
+      userId,
+      mergedBy: "test",
+    });
+
+    // The defect: with k=1 (a single available slot) and the merged-away row
+    // still a live vec0 candidate, it could win that one slot over the
+    // survivor purely on insertion order — starving the survivor out of a
+    // 1-slot KNN window. After the fix, the merged-away row is gone from the
+    // raw KNN candidate set entirely, so the survivor is guaranteed the slot.
+    const afterMergeSingleSlot = await rawKnnEntityIds(1);
+    expect(afterMergeSingleSlot).not.toContain(mergedAwayId);
+    expect(afterMergeSingleSlot).toEqual([survivorId]);
+
+    // Directly confirm the row is gone from entity_embedding_rows, not merely
+    // filtered out of this particular query — the storage-level assertion the
+    // task calls for, distinct from "absent from a caller-facing result".
+    const { data: remaining } = await db
+      .from("entity_embedding_rows")
+      .select("entity_id")
+      .eq("entity_id", mergedAwayId);
+    expect(remaining ?? []).toHaveLength(0);
+  });
+});

--- a/src/services/entity_merge.ts
+++ b/src/services/entity_merge.ts
@@ -234,6 +234,37 @@ export async function mergeEntities(params: MergeEntitiesParams): Promise<MergeR
         )
         .run(fromEntityId, userId);
 
+      // 10. Purge the merged-away entity's local (sqlite-vec) embedding row.
+      // `entity_embedding_rows.merged` is written false at insert time and
+      // nothing else in the codebase ever flips it, so without this the row
+      // survives forever and stays a KNN candidate: searchLocalEntityEmbeddings
+      // runs the vec0 k-nearest-neighbor search BEFORE applying `merged = 0`,
+      // so a merged-away row that is a true nearest neighbor consumes one of
+      // the k slots and can push a live entity out of the result window
+      // entirely — a silent, compounding recall regression (every merge makes
+      // it worse). Deleted here, inside the same atomic transaction as the
+      // rest of the merge, rather than as a best-effort post-mutation step,
+      // since this is a correctness issue for retrieval, not just bookkeeping.
+      const embeddingRow = (await tx
+        .prepare(`SELECT rowid FROM entity_embedding_rows WHERE entity_id = ?`)
+        .get(fromEntityId)) as { rowid: number } | undefined;
+      if (embeddingRow) {
+        // entity_embeddings_vec is a virtual table created lazily by
+        // local_entity_embedding.ts only once sqlite-vec loads; guard its
+        // delete so a platform where the extension never loaded still lets
+        // the always-present entity_embedding_rows delete proceed.
+        try {
+          await tx
+            .prepare(`DELETE FROM entity_embeddings_vec WHERE rowid = ?`)
+            .run(embeddingRow.rowid);
+        } catch {
+          // sqlite-vec not loaded on this platform — nothing to clean up there.
+        }
+        await tx
+          .prepare(`DELETE FROM entity_embedding_rows WHERE rowid = ?`)
+          .run(embeddingRow.rowid);
+      }
+
       return { observations_moved, relationships_repointed: repointed.length };
     }
   );

--- a/src/services/entity_merge.ts
+++ b/src/services/entity_merge.ts
@@ -246,8 +246,8 @@ export async function mergeEntities(params: MergeEntitiesParams): Promise<MergeR
       // rest of the merge, rather than as a best-effort post-mutation step,
       // since this is a correctness issue for retrieval, not just bookkeeping.
       const embeddingRow = (await tx
-        .prepare(`SELECT rowid FROM entity_embedding_rows WHERE entity_id = ?`)
-        .get(fromEntityId)) as { rowid: number } | undefined;
+        .prepare(`SELECT rowid FROM entity_embedding_rows WHERE entity_id = ? AND user_id = ?`)
+        .get(fromEntityId, userId)) as { rowid: number } | undefined;
       if (embeddingRow) {
         // entity_embeddings_vec is a virtual table created lazily by
         // local_entity_embedding.ts only once sqlite-vec loads; guard its
@@ -261,8 +261,8 @@ export async function mergeEntities(params: MergeEntitiesParams): Promise<MergeR
           // sqlite-vec not loaded on this platform — nothing to clean up there.
         }
         await tx
-          .prepare(`DELETE FROM entity_embedding_rows WHERE rowid = ?`)
-          .run(embeddingRow.rowid);
+          .prepare(`DELETE FROM entity_embedding_rows WHERE rowid = ? AND user_id = ?`)
+          .run(embeddingRow.rowid, userId);
       }
 
       return { observations_moved, relationships_repointed: repointed.length };

--- a/src/services/local_entity_embedding.ts
+++ b/src/services/local_entity_embedding.ts
@@ -16,14 +16,23 @@ let sqliteVecLoaded: boolean | null = null;
 /**
  * Load sqlite-vec extension lazily. Caches success/failure.
  * Returns true if loaded, false if failed (e.g. wrong platform).
+ *
+ * sqlite-vec's `load()` calls `db.loadExtension(...)` on the object it is
+ * given, which only exists on the NATIVE driver instance (better-sqlite3's
+ * `Database` / node:sqlite's `DatabaseSync`) — not on this repo's
+ * `SqliteDatabaseImpl` wrapper (`prepare`/`exec`/`pragma`/`transaction`
+ * only). Passing the wrapper here always threw "db.loadExtension is not a
+ * function" regardless of platform, so semantic search silently degraded to
+ * lexical everywhere sqlite-vec was reachable at all. Fixed by unwrapping to
+ * the native handle via `nativeHandle()` before calling `sqliteVec.load()`.
  */
 export function ensureSqliteVecLoaded(db: SqliteDatabase): boolean {
   if (sqliteVecLoaded !== null) {
     return sqliteVecLoaded;
   }
   try {
-    const sqliteVec = createRequireFromMeta("sqlite-vec") as { load: (d: SqliteDatabase) => void };
-    sqliteVec.load(db);
+    const sqliteVec = createRequireFromMeta("sqlite-vec") as { load: (d: unknown) => void };
+    sqliteVec.load(db.nativeHandle());
     sqliteVecLoaded = true;
     return true;
   } catch (err) {

--- a/src/services/memory_export.ts
+++ b/src/services/memory_export.ts
@@ -150,7 +150,13 @@ function typeWeightFor(entityType: string): number {
   return 1;
 }
 
-function recencyDecay(
+/**
+ * Exponential recency decay: 1.0 at age 0, halving every `halfLifeDays`.
+ * Exported so other ranking call sites (e.g. the search tie-break in
+ * `shared/action_handlers/entity_handlers.ts`) reuse this exact math rather
+ * than reimplementing recency scoring in parallel.
+ */
+export function recencyDecay(
   lastObservationAtMs: number,
   nowMs: number,
   halfLifeDays = RECENCY_HALF_LIFE_DAYS

--- a/src/shared/action_handlers/__tests__/entity_handlers_ranking.test.ts
+++ b/src/shared/action_handlers/__tests__/entity_handlers_ranking.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Integration tests for retrieve_entities search ranking (issue: no recency
+ * term anywhere in the ranking chain — a stale entity can permanently outrank
+ * a live one purely because its canonical_name sorts earlier alphabetically).
+ *
+ * These exercise the real SQLite-backed `lexical_typed` search path via
+ * `queryEntitiesWithCount`, seeding two entities whose lexical relevance score
+ * is identical (same canonical_name shape, same snapshot content) but whose
+ * `last_observation_at` differs — so the only thing that can break the tie is
+ * the tie-break rule itself.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { db } from "../../../db.js";
+import { queryEntitiesWithCount } from "../entity_handlers.js";
+import { generateEntityId } from "../../../services/entity_resolution.js";
+
+const userId = "test-user-ranking-tiebreak";
+const entityType = "contact";
+
+async function cleanup(): Promise<void> {
+  await db.from("entities").delete().eq("user_id", userId);
+  await db.from("entity_snapshots").delete().eq("user_id", userId);
+  await db.from("schema_registry").delete().eq("user_id", userId);
+}
+
+/**
+ * `last_observation_at` lives on `entity_snapshots`, not `entities` (the
+ * `entities` table only carries `first_seen_at`/`last_seen_at`). Lexical
+ * search reads canonical_name from `entities` but reads recency from the
+ * joined `entity_snapshots` row — so the fixture must seed both.
+ */
+async function seedEntityWithObservationTime(
+  entityId: string,
+  canonicalName: string,
+  lastObservationAt: string
+): Promise<void> {
+  await db.from("entities").insert({
+    id: entityId,
+    entity_type: entityType,
+    canonical_name: canonicalName,
+    user_id: userId,
+  });
+  await db.from("entity_snapshots").insert({
+    entity_id: entityId,
+    entity_type: entityType,
+    schema_version: "1",
+    canonical_name: canonicalName,
+    snapshot: "{}",
+    computed_at: lastObservationAt,
+    observation_count: 1,
+    last_observation_at: lastObservationAt,
+    provenance: "{}",
+    user_id: userId,
+  });
+}
+
+describe("search ranking tie-break (recency, not alphabetical)", () => {
+  beforeEach(async () => {
+    await cleanup();
+    // Register `contact` as an active schema type so the search text "contact"
+    // routes through the lexical_typed path (lexicalSearchEntityIds), which is
+    // where the alphabetical tie-break lives.
+    await db.from("schema_registry").insert({
+      id: `schema_${userId}`,
+      entity_type: entityType,
+      schema_version: "1",
+      schema_definition: "{}",
+      reducer_config: "{}",
+      active: 1,
+      created_at: new Date().toISOString(),
+      user_id: userId,
+      scope: "test",
+    });
+  });
+
+  afterEach(cleanup);
+
+  it("prefers the recently-observed entity over the alphabetically-earlier one when lexical scores tie", async () => {
+    // "Aaron Widgetco" sorts before "Zach Widgetco" alphabetically, but is
+    // stale (observed a year ago). "Zach Widgetco" is live (observed today).
+    // Both are `contact` entities and both canonical_names contain the search
+    // term "widgetco" as a substring in the same position (single-token
+    // match, no snapshot content), so their strict lexical scores are exactly
+    // equal — the only thing that can differ is the tie-break.
+    const staleName = "Aaron Widgetco";
+    const liveName = "Zach Widgetco";
+    const staleId = generateEntityId(entityType, staleName);
+    const liveId = generateEntityId(entityType, liveName);
+
+    const oneYearAgo = new Date(Date.now() - 365 * 86_400_000).toISOString();
+    const now = new Date().toISOString();
+
+    await seedEntityWithObservationTime(staleId, staleName, oneYearAgo);
+    await seedEntityWithObservationTime(liveId, liveName, now);
+
+    const result = await queryEntitiesWithCount({
+      userId,
+      search: "contact widgetco",
+      includeSnapshots: false,
+      limit: 10,
+      offset: 0,
+    });
+
+    expect(result.search_mode).toBe("lexical_typed");
+    const ids = result.entities.map((e) => e.entity_id);
+    expect(ids).toEqual(expect.arrayContaining([staleId, liveId]));
+
+    const liveRank = ids.indexOf(liveId);
+    const staleRank = ids.indexOf(staleId);
+    // The live (recently-observed) entity must outrank the stale one. Before
+    // the fix, this failed: alphabetical tie-break put "Aaron Contact"
+    // (stale) ahead of "Zach Contact" (live) even though it is a year old.
+    expect(liveRank).toBeLessThan(staleRank);
+  });
+});

--- a/src/shared/action_handlers/entity_handlers.ts
+++ b/src/shared/action_handlers/entity_handlers.ts
@@ -4,7 +4,7 @@ import {
   normalizeEntityTypeFilter,
   computeNextCursor,
 } from "../../services/entity_queries.js";
-import { BOOKKEEPING_ENTITY_TYPES } from "../../services/memory_export.js";
+import { BOOKKEEPING_ENTITY_TYPES, recencyDecay } from "../../services/memory_export.js";
 import { suggestSingular } from "../../services/entity_type_guard.js";
 import { logger } from "../../utils/logger.js";
 import { semanticSearchEntities } from "../../services/entity_semantic_search.js";
@@ -149,13 +149,50 @@ export function shouldExcludeBookkeepingFromSearch(entityType?: string): boolean
 type SnapshotRow = {
   entity_id: string;
   snapshot?: unknown;
+  last_observation_at?: string | null;
 };
 
 type LexicalMatch = {
   entityId: string;
   canonicalName: string;
   score: number;
+  lastObservationAt?: string | null;
 };
+
+/**
+ * Recency tie-break (extends the exponential decay already implemented for
+ * `memory export --order importance` in services/memory_export.ts, rather
+ * than introducing parallel decay math here).
+ *
+ * Applied ONLY when two results are otherwise exactly tied — never blended
+ * into the relevance score itself. Rationale: blending recency into the score
+ * (or defaulting it on as an always-applied ranking factor) would change
+ * result ORDER for every existing search caller, a behavioral change no
+ * caller has opted into and none of today's callers can be shown not to
+ * depend on. The alphabetical tie-break it replaces
+ * (`canonical_name.localeCompare`) has no such justification: two results
+ * that score identically on relevance have no principled order today, so
+ * breaking that specific tie by recency fixes the reported defect (a stale
+ * entity permanently outranking a live one by name-sort accident) with the
+ * smallest possible change in observable behavior — non-tied orderings are
+ * completely unaffected.
+ *
+ * Returns negative when `aLastObservationAt` should sort first (more
+ * recent/higher decay), positive when `b` should, 0 when equally
+ * undated/indistinguishable (falls through to the next tie-break key).
+ */
+function compareByRecency(
+  aLastObservationAt: string | null | undefined,
+  bLastObservationAt: string | null | undefined,
+  nowMs: number = Date.now()
+): number {
+  const aMs = aLastObservationAt ? Date.parse(aLastObservationAt) : NaN;
+  const bMs = bLastObservationAt ? Date.parse(bLastObservationAt) : NaN;
+  const aDecay = recencyDecay(aMs, nowMs);
+  const bDecay = recencyDecay(bMs, nowMs);
+  if (aDecay === bDecay) return 0;
+  return bDecay - aDecay;
+}
 
 // Re-export the shared normalizer (imported above) so existing references to
 // `normalizeSearchText` from this module keep resolving (#1572).
@@ -325,7 +362,9 @@ function compareSearchRank(
   bEntityType: string,
   orderMap: Map<string, number>,
   searchTokens: string[],
-  orderedIds: string[]
+  orderedIds: string[],
+  aLastObservationAt?: string | null,
+  bLastObservationAt?: string | null
 ): number {
   const ai = orderMap.get(aEntityId) ?? 9999;
   const bi = orderMap.get(bEntityId) ?? 9999;
@@ -333,6 +372,13 @@ function compareSearchRank(
   const bRank = orderedIds.length - bi + entityTypeKeywordBoost(bEntityType, searchTokens);
   if (bRank !== aRank) {
     return bRank - aRank;
+  }
+  // Recency tie-break (see compareByRecency) before falling back to KNN
+  // position, which — like alphabetical order — has no meaning once scores
+  // are exactly equal.
+  const recencyCompare = compareByRecency(aLastObservationAt, bLastObservationAt);
+  if (recencyCompare !== 0) {
+    return recencyCompare;
   }
   return ai - bi;
 }
@@ -478,13 +524,14 @@ async function lexicalSearchEntityIds(params: LexicalSearchEntityIdsParams): Pro
 
   const entityIds = entities.map((entity: { id: string }) => entity.id);
   const snapshotMap = new Map<string, unknown>();
+  const lastObservationAtMap = new Map<string, string | null>();
   const chunkSize = 500;
 
   for (let i = 0; i < entityIds.length; i += chunkSize) {
     const chunk = entityIds.slice(i, i + chunkSize);
     const { data: snapshots, error: snapshotsError } = await db
       .from("entity_snapshots")
-      .select("entity_id, snapshot")
+      .select("entity_id, snapshot, last_observation_at")
       .in("entity_id", chunk);
 
     if (snapshotsError) {
@@ -493,6 +540,7 @@ async function lexicalSearchEntityIds(params: LexicalSearchEntityIdsParams): Pro
 
     for (const snapshot of (snapshots || []) as SnapshotRow[]) {
       snapshotMap.set(snapshot.entity_id, snapshot.snapshot);
+      lastObservationAtMap.set(snapshot.entity_id, snapshot.last_observation_at ?? null);
     }
   }
 
@@ -514,6 +562,7 @@ async function lexicalSearchEntityIds(params: LexicalSearchEntityIdsParams): Pro
     normalizedSnapshot: string;
     searchableText: string;
     textTokens: string[];
+    lastObservationAt: string | null;
   };
 
   const candidates: Candidate[] = [];
@@ -535,6 +584,7 @@ async function lexicalSearchEntityIds(params: LexicalSearchEntityIdsParams): Pro
       fragmentTextByEntityId.get(entity.id)
     );
     const textTokens = textTokensForEntityMatch(searchTokens, entity.entity_type, typeFilterTokens);
+    const lastObservationAt = lastObservationAtMap.get(entity.id) ?? null;
     candidates.push({
       id: entity.id,
       canonical_name: entity.canonical_name,
@@ -543,6 +593,7 @@ async function lexicalSearchEntityIds(params: LexicalSearchEntityIdsParams): Pro
       normalizedSnapshot,
       searchableText,
       textTokens,
+      lastObservationAt,
     });
     if (matchesSearchTokens(searchableText, textTokens)) {
       let score = 0;
@@ -568,6 +619,7 @@ async function lexicalSearchEntityIds(params: LexicalSearchEntityIdsParams): Pro
       lexicalMatches.push({
         entityId: entity.id,
         canonicalName: entity.canonical_name,
+        lastObservationAt,
         score,
       });
     }
@@ -625,6 +677,7 @@ async function lexicalSearchEntityIds(params: LexicalSearchEntityIdsParams): Pro
           entityId: candidate.id,
           canonicalName: candidate.canonical_name,
           score,
+          lastObservationAt: candidate.lastObservationAt,
         });
       }
     }
@@ -633,6 +686,14 @@ async function lexicalSearchEntityIds(params: LexicalSearchEntityIdsParams): Pro
   lexicalMatches.sort((a, b) => {
     if (b.score !== a.score) {
       return b.score - a.score;
+    }
+    // Recency tie-break (see compareByRecency): a stale entity should not
+    // permanently outrank a live one purely because its canonical_name sorts
+    // earlier. Only reached when scores are exactly equal, so no ordering
+    // that already discriminates between results is affected.
+    const recencyCompare = compareByRecency(a.lastObservationAt, b.lastObservationAt);
+    if (recencyCompare !== 0) {
+      return recencyCompare;
     }
     const canonicalCompare = a.canonicalName.localeCompare(b.canonicalName);
     if (canonicalCompare !== 0) {
@@ -1062,7 +1123,9 @@ export async function queryEntitiesWithCount(params: QueryEntitiesParams): Promi
               b.entity_type,
               orderMap,
               searchTokens,
-              entityIds
+              entityIds,
+              a.last_observation_at,
+              b.last_observation_at
             )
           );
           total = semanticTotal;

--- a/src/shared/action_schemas.ts
+++ b/src/shared/action_schemas.ts
@@ -525,7 +525,16 @@ const RetrieveEntitiesRequestBaseSchema = z
      * result set (#1562).
      */
     entity_types: z.array(z.string()).optional(),
-    search: z.string().optional(),
+    /**
+     * Free-text search. When relevance scores tie, more recently observed
+     * entities (`entity_snapshots.last_observation_at`) rank first.
+     */
+    search: z
+      .string()
+      .optional()
+      .describe(
+        "Free-text search. When relevance scores tie, more recently observed entities (last_observation_at) rank first."
+      ),
     /**
      * Distance threshold for semantic search (L2, range ~0.9–1.5 in practice).
      * Results with distance >= threshold are dropped. Lower = stricter matching.


### PR DESCRIPTION
## What

Design basis: no design applies — internal ranking/cleanup; no schema, workflow, task, or OpenAPI surface change

Closes #2355

Fixes two retrieval defects reported against `retrieve_entities` search ranking and entity merge, plus a blocking pre-existing bug found while writing the merge test.

### 1. Search ranking has no recency term — ties break alphabetically, not by recency

Verified on origin/main (`63a7dcf88`): none of `last_observation_at`, `computed_at`, or `created_at` appears in any ranking function. Lexical strict scoring, the partial-overlap fallback, and semantic ranking (`compareSearchRank`) all break ties on `canonical_name.localeCompare` / KNN position — so a stale entity can permanently outrank a live one purely because its name sorts earlier. Callers cannot compensate: `action_schemas.ts` explicitly rejects combining `search` with `sort_by`/`sort_order`.

**Design decision** (per the task's explicit request to state reasoning): apply recency **only as a tie-break**, replacing the alphabetical/KNN-position tie-break — not blended into the relevance score, and not behind an opt-in parameter.

- Blending recency into the score, or defaulting an opt-in parameter on, changes result **order for every existing search caller** — a behavioral change none of today's callers asked for and none can be shown not to depend on current ordering.
- A purely opt-in parameter defaulting off would not fix the reported problem for any existing caller, and `action_schemas.ts` has no surface for a caller to opt into recency without a schema change — a larger, riskier change than justified here.
- The tie-break is the only place in the ranking chain where current behavior (alphabetical order / arbitrary KNN position) has **zero justification**: two results that score identically on relevance have no principled order today. Replacing that specific tie-break fixes the reported defect with the smallest possible change in observable behavior — every non-tied ordering is completely unaffected.

**Implementation**: extends (does not reimplement) the exponential decay already in `memory_export.ts` (`RECENCY_HALF_LIFE_DAYS = 30`), exporting `recencyDecay()` for reuse rather than writing new decay math. Applied at all three tie-break sites: lexical strict scoring, the partial-overlap fallback (same combined sort), and semantic `compareSearchRank`. The lexical candidate pipeline now carries `entity_snapshots.last_observation_at` alongside `canonical_name`/`snapshot` so it's available at the tie-break.

### 2. Merged entities keep stale embedding rows forever, permanently consuming KNN slots

Verified on origin/main: `mergeEntities` sets `merged_to_entity_id` and deletes the `entity_snapshots` row for the merged-away entity, but **never touches** `entity_embedding_rows` or `entity_embeddings_vec`. The `merged` column on `entity_embedding_rows` is only ever written `false`, at insert time (`entity_snapshot_embedding.ts`); nothing else in `src/` ever flips it, and no background job outside `src/` prunes these rows either.

This does not leak into caller-facing results (`entity_handlers.ts` re-filters on hydration), but it's not merely a stale flag: `searchLocalEntityEmbeddings`'s vec0 query runs the k-nearest-neighbor `MATCH` search **first**, and applies `AND (?=1 OR r.merged=0)` only to the already-fixed k-row result set. A merged-away row that is a true nearest neighbor consumes one of the k KNN slots *before* the merged filter ever sees it — silently pushing a live entity out of the result window. This is a recall regression that compounds with every merge, and merging duplicates is the normal, encouraged graph-grooming operation.

**Fix**: `mergeEntities` now deletes the merged-away entity's `entity_embeddings_vec` and `entity_embedding_rows` rows as an additional step inside the *same atomic transaction* as the rest of the merge (not a best-effort post-mutation step), since this is a retrieval-correctness issue, not bookkeeping. Guards the vec0 delete so a platform where sqlite-vec never loaded still lets the always-present `entity_embedding_rows` delete proceed.

### 3. (Found while building the test for #2, fixed first since it blocks any KNN-level test) sqlite-vec could not load at all

`ensureSqliteVecLoaded` passed this repo's `SqliteDatabaseImpl` wrapper (`prepare`/`exec`/`pragma`/`transaction`) directly to sqlite-vec's `load()`, which calls `db.loadExtension(...)` on whatever it's given. That method only exists on the **native** driver instance (better-sqlite3's `Database`, or `node:sqlite`'s `DatabaseSync`) — never on the wrapper — so the extension load always threw `"db.loadExtension is not a function"` regardless of platform, and local semantic search silently degraded to lexical everywhere. Fixed by adding `SqliteDatabaseImpl.nativeHandle()` and calling `sqliteVec.load()` on that instead. Without this fix, sqlite-vec never loads in this environment and no test can observe real KNN behavior — which is how it was found.

## Tests (RED before, GREEN after — stated explicitly per the task's requirement)

- `src/shared/action_handlers/__tests__/entity_handlers_ranking.test.ts` — seeds a stale entity (`"Aaron Widgetco"`, `last_observation_at` 1 year ago) and a live one (`"Zach Widgetco"`, `last_observation_at` now) that tie exactly on lexical score, searched via the real `lexical_typed` path (`queryEntitiesWithCount`). **Red**: `expected 1 to be less than 0` — the stale entity (alphabetically first) ranked ahead of the live one. **Green**: the live entity ranks first.
- `src/services/__tests__/entity_merge_embedding_purge.test.ts` — per the task's explicit requirement that the test prove **KNN slot consumption**, not mere result-absence (which already passes today via the hydration filter and would prove nothing): seeds a survivor and a merged-away entity with identical (tied) embeddings, confirms both occupy KNN slots at `k=2`, merges them, then re-runs the same raw vec0 KNN query production uses with `k=1` (a single available slot). **Red**: `expected [ merged_id ] to not include merged_id` — the merged-away row could still win the one slot over the survivor by insertion order. **Green**: the merged-away row is gone from the raw KNN candidate set entirely, so the survivor is guaranteed the slot; also asserts directly against `entity_embedding_rows` that the row is gone from storage.

## Regression sweep

Ran well beyond the new tests, with zero failures:
- `src/services`, `src/shared`, `src/repositories`: 707 tests passed
- `tests/unit`: 164 files / 1786 tests passed
- `tests/integration`: 146 files / 940 tests passed
- Full `npm test` standalone: 532 files / 5351 tests passed (exit 0)
- `npm run test:integration` standalone: 146 files / 940 tests passed (exit 0)

Note on `SKIP_TESTS`: the pre-commit hook's own combined `npm test` + `npm run test:integration` invocation hit an unreproducible failure on this shared, heavily concurrent dev host (multiple sibling agent sessions running their own dev servers/tests on overlapping ports at the time). Both suites were independently verified green standalone, twice, immediately before committing (figures above). Used the hook's own `SKIP_TESTS=1 SKIP_TESTS_REASON=...` escape hatch with that reasoning recorded, per repo convention — never `--no-verify`.

## Existing issues checked

Searched for open issues before filing: #1808/#1807 are a broader recall-tiers/hot-warm-cold redesign proposal (different scope, no recency tie-break or merge-embedding-purge mentioned); #2269 is about merged-entity **filtering from results** (already correct via hydration), not KNN slot consumption (the actual defect here). No existing issue covers either defect fixed in this PR, so no new issue was filed — going straight to a PR with tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

