### PR TITLE
feat(snapshots): resolve attachment through a declared layer (#2340)

### DIFF
--- a/src/services/attachment_resolution.ts
+++ b/src/services/attachment_resolution.ts
@@ -1,0 +1,181 @@
+/**
+ * Attachment Resolution Service (Domain Layer) — #2340
+ *
+ * Implements the approved contract:
+ *
+ *   A snapshot is a function of the observations *attached to* an entity,
+ *   where attachment is resolved through a declared resolution layer, rather
+ *   than of the observations whose `entity_id` column equals the entity.
+ *
+ * This module IS that declared resolution layer. It is the single seam every
+ * snapshot fetch should go through, so that merge's union and split's
+ * difference become two resolution rules over one mechanism rather than two
+ * traversals with two cycle guards.
+ *
+ * ## What it resolves today
+ *
+ * Exactly one rule is live: the entity-grained merge alias
+ * (`entities.merged_to_entity_id`). Asking for an entity that was merged away
+ * resolves to its survivor, transitively. That is behaviour-preserving —
+ * merge already rewrites `observations.entity_id` to the survivor, so the
+ * resolved set is identical to today's flat fetch for every entity that is
+ * not itself a tombstone. See `tests/integration/attachment_resolution_
+ * equivalence.test.ts`, which pins that equivalence and passed unchanged
+ * before and after this module landed.
+ *
+ * The observation-grained rules — split's difference-on-source and
+ * union-on-target, and merge's append-based redirect — are deliberately NOT
+ * here yet. They arrive with the `split_entity` / `merge_entities` redesigns
+ * (#2329), which this module unblocks. The seam is built first, on purpose,
+ * so those changes are a new resolution rule in one place rather than a new
+ * fetch in a dozen.
+ *
+ * ## Guards
+ *
+ * Resolution is bounded by a cycle guard (a visited set) and a maximum depth.
+ * Exceeding either is reported through `truncated` / `truncationReason`,
+ * never silently truncated. This is deliberate: the two existing pointer-
+ * follows in the codebase have neither guard —
+ * `entity_queries.ts:getEntityWithProvenance` recurses into itself with no
+ * visited set, and `cli/index.ts` resolves exactly one hop — so a declared
+ * resolution layer that inherited those defects on day one would be no
+ * improvement. `entity_merge.ts` blocks merging an already-merged entity on
+ * either side, which prevents a two-cycle but does not prevent chains
+ * (A→B, then C→B, then B→D builds depth), so the bound is load-bearing.
+ *
+ * The read path degrades rather than throws: a cycle or an over-deep chain
+ * returns the best-resolved set with `truncated: true` and logs, because a
+ * snapshot read that throws takes down every caller of `recomputeSnapshot`,
+ * whereas one that reports the anomaly leaves the store readable while the
+ * inconsistency is repaired.
+ */
+
+import { db } from "../db.js";
+import { logger } from "../utils/logger.js";
+import type { Observation } from "../reducers/observation_reducer.js";
+
+/**
+ * Maximum number of alias hops followed before resolution is declared
+ * over-deep. Merge chains are pathological beyond a couple of hops; 32 is far
+ * above anything legitimate while still bounding a runaway.
+ */
+export const MAX_ATTACHMENT_RESOLUTION_DEPTH = 32;
+
+export type AttachmentTruncationReason = "cycle" | "depth";
+
+export interface AttachmentResolution {
+  /**
+   * The entity the requested id resolves to after following the declared
+   * resolution rules. Equals the requested id when nothing redirects.
+   */
+  resolvedEntityId: string;
+  /** The observations attached to the resolved entity, for this user. */
+  observations: Observation[];
+  /** The full hop path, starting at the requested id. Useful for diagnosis. */
+  path: string[];
+  /** True when a guard stopped resolution before it reached a fixed point. */
+  truncated: boolean;
+  truncationReason?: AttachmentTruncationReason;
+}
+
+/**
+ * Follow the entity-grained merge alias to a fixed point, bounded by a
+ * visited set and a depth cap. Pure traversal — no observation reads.
+ */
+export async function resolveAttachmentTarget(
+  entityId: string,
+  userId: string
+): Promise<{
+  resolvedEntityId: string;
+  path: string[];
+  truncated: boolean;
+  truncationReason?: AttachmentTruncationReason;
+}> {
+  const path: string[] = [entityId];
+  const visited = new Set<string>([entityId]);
+  let current = entityId;
+
+  for (let depth = 0; depth < MAX_ATTACHMENT_RESOLUTION_DEPTH; depth++) {
+    const { data: row, error } = await db
+      .from("entities")
+      .select("id, merged_to_entity_id")
+      .eq("id", current)
+      .eq("user_id", userId)
+      .single();
+
+    // A missing entity row is not an error here: observations can be fetched
+    // for an id with no `entities` row (the CLI recompute path does exactly
+    // that), and the flat fetch never consulted `entities` at all. Resolving
+    // to the id as given preserves that behaviour.
+    if (error || !row) {
+      return { resolvedEntityId: current, path, truncated: false };
+    }
+
+    const next = (row as { merged_to_entity_id?: string | null }).merged_to_entity_id;
+    if (!next) {
+      return { resolvedEntityId: current, path, truncated: false };
+    }
+
+    if (visited.has(next)) {
+      logger.warn(
+        `[AttachmentResolution] cycle in merge aliases for entity ${entityId} ` +
+          `(path length ${path.length}); resolution stopped at ${current}`
+      );
+      return {
+        resolvedEntityId: current,
+        path,
+        truncated: true,
+        truncationReason: "cycle",
+      };
+    }
+
+    visited.add(next);
+    path.push(next);
+    current = next;
+  }
+
+  logger.warn(
+    `[AttachmentResolution] merge-alias chain for entity ${entityId} exceeded ` +
+      `MAX_ATTACHMENT_RESOLUTION_DEPTH=${MAX_ATTACHMENT_RESOLUTION_DEPTH}; ` +
+      `resolution stopped at ${current}`
+  );
+  return {
+    resolvedEntityId: current,
+    path,
+    truncated: true,
+    truncationReason: "depth",
+  };
+}
+
+/**
+ * The observations attached to an entity, under the declared resolution
+ * layer. This is what a snapshot is a function of.
+ *
+ * Behaviour-preserving today: for any entity that is not itself a merge
+ * tombstone, the resolved id equals the requested id and the returned set is
+ * exactly what `.eq("entity_id", entityId)` returns.
+ */
+export async function resolveAttachedObservations(
+  entityId: string,
+  userId: string
+): Promise<AttachmentResolution> {
+  const target = await resolveAttachmentTarget(entityId, userId);
+
+  const { data, error } = await db
+    .from("observations")
+    .select("*")
+    .eq("entity_id", target.resolvedEntityId)
+    .eq("user_id", userId);
+
+  if (error) {
+    throw new Error(`Failed to fetch attached observations: ${error.message}`);
+  }
+
+  return {
+    resolvedEntityId: target.resolvedEntityId,
+    observations: (data ?? []) as Observation[],
+    path: target.path,
+    truncated: target.truncated,
+    truncationReason: target.truncationReason,
+  };
+}

--- a/src/services/snapshot_computation.ts
+++ b/src/services/snapshot_computation.ts
@@ -14,6 +14,7 @@ import {
   entityIdTenantSalt,
   generateEntityId,
 } from "./entity_resolution.js";
+import { resolveAttachedObservations } from "./attachment_resolution.js";
 import { schemaRegistry, type SchemaDefinition } from "./schema_registry.js";
 import { upsertTimelineEventsForEntitySnapshot } from "./timeline_events.js";
 
@@ -56,14 +57,20 @@ export async function recomputeSnapshot(
   entityId: string,
   userId: string
 ): Promise<SnapshotRecord | null> {
-  const { data: observations, error } = await db
-    .from("observations")
-    .select("*")
-    .eq("entity_id", entityId)
-    .eq("user_id", userId);
+  // #2340: a snapshot is a function of the observations ATTACHED to the
+  // entity, resolved through the declared resolution layer, not of the rows
+  // whose `entity_id` column equals the entity. See attachment_resolution.ts.
+  const attached = await resolveAttachedObservations(entityId, userId);
 
-  if (error) throw new Error(`Failed to fetch observations for recomputation: ${error.message}`);
-  if (!observations || observations.length === 0) return null;
+  // A redirected id owns no snapshot of its own. When the requested entity
+  // resolves elsewhere (today: it is a merge tombstone), the survivor's rows
+  // must NOT be written back under the requested id — that would manufacture
+  // a duplicate snapshot on a tombstone, which the flat fetch never did
+  // because the rows had already moved. Preserve the null.
+  if (attached.resolvedEntityId !== entityId) return null;
+
+  const observations = attached.observations;
+  if (observations.length === 0) return null;
 
   const computed = await observationReducer.computeSnapshot(entityId, observations);
   if (!computed) {

--- a/tests/integration/attachment_resolution_equivalence.test.ts
+++ b/tests/integration/attachment_resolution_equivalence.test.ts
@@ -1,0 +1,317 @@
+/**
+ * Equivalence test for the attachment-resolution contract (#2340).
+ *
+ * The contract:
+ *
+ *   A snapshot is a function of the observations *attached to* an entity,
+ *   where attachment is resolved through a declared resolution layer, rather
+ *   than of the observations whose `entity_id` column equals the entity.
+ *
+ * This test is the whole safety argument for that change. It pins the
+ * OBSERVABLE behaviour of `recomputeSnapshot` across the three shapes that
+ * exist today, so that swapping the flat `.eq("entity_id", …)` fetch for a
+ * resolver provably does not move any snapshot:
+ *
+ *   (a) plain entity, no merge and no split  → snapshot unchanged
+ *   (b) split-then-recompute                 → the SAME two snapshots as the
+ *                                              in-place implementation yields
+ *   (c) merge-then-recompute                 → the SAME one snapshot
+ *
+ * It is written to pass BEFORE the resolver lands (against the flat fetch)
+ * and to keep passing AFTER, unchanged. A diff in this file accompanying the
+ * resolver change would mean the migration altered a snapshot, which is a
+ * regression rather than a migration.
+ *
+ * On top of equivalence it pins the resolver's own guarantees that have no
+ * pre-change counterpart: an alias CHAIN must resolve fully (the existing
+ * one-hop follow at cli/index.ts under-resolves), a CYCLE must not hang, and
+ * depth must be bounded.
+ *
+ * Requires a live SQLite database; runs in CI via `npm run test:integration`.
+ */
+
+import { randomUUID } from "node:crypto";
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from "vitest";
+import { db } from "../../src/db.js";
+import { recomputeSnapshot, deleteSnapshot } from "../../src/services/snapshot_computation.js";
+import { resolveAttachedObservations } from "../../src/services/attachment_resolution.js";
+
+const TEST_USER = "test-attach-2340";
+// A dedicated, user-scoped entity type. Deliberately NOT a built-in type:
+// the reducer projects a snapshot through the ACTIVE schema, so borrowing a
+// shared type would couple these assertions to whatever another test file
+// happens to have registered for it when the whole suite runs.
+const ENTITY_TYPE = "attach_probe_2340";
+
+const ids = {
+  plain: "ent_attach_plain_2340",
+  splitSource: "ent_attach_split_src_2340",
+  splitTarget: "ent_attach_split_tgt_2340",
+  mergeFrom: "ent_attach_merge_from_2340",
+  mergeTo: "ent_attach_merge_to_2340",
+  chainA: "ent_attach_chain_a_2340",
+  chainB: "ent_attach_chain_b_2340",
+  chainC: "ent_attach_chain_c_2340",
+  cycleA: "ent_attach_cycle_a_2340",
+  cycleB: "ent_attach_cycle_b_2340",
+};
+
+async function seedSchema() {
+  await db.from("schema_registry").delete().eq("user_id", TEST_USER);
+  await db.from("schema_registry").insert({
+    id: randomUUID(),
+    entity_type: ENTITY_TYPE,
+    schema_version: "1.0.0",
+    schema_definition: {
+      entity_type: ENTITY_TYPE,
+      schema_version: "1.0.0",
+      fields: {
+        title: { type: "string", required: false, preserveCase: true },
+        summary: { type: "string", required: false, preserveCase: true },
+      },
+      canonical_name_fields: ["title"],
+    },
+    reducer_config: { merge_policies: {} },
+    active: 1,
+    scope: "user",
+    user_id: TEST_USER,
+    created_at: new Date().toISOString(),
+  });
+}
+
+async function cleanup() {
+  await db.from("observations").delete().eq("user_id", TEST_USER);
+  await db.from("entity_snapshots").delete().eq("user_id", TEST_USER);
+  await db.from("entities").delete().eq("user_id", TEST_USER);
+}
+
+async function insertEntity(id: string, mergedTo: string | null = null) {
+  await db.from("entities").insert({
+    id,
+    entity_type: ENTITY_TYPE,
+    canonical_name: id,
+    user_id: TEST_USER,
+    merged_to_entity_id: mergedTo,
+    created_at: new Date().toISOString(),
+  });
+}
+
+let obsSeq = 0;
+
+async function insertObservation(
+  entityId: string,
+  fields: Record<string, unknown>,
+  observedAt: string
+) {
+  const id = `obs_attach_2340_${++obsSeq}`;
+  await db.from("observations").insert({
+    id,
+    entity_id: entityId,
+    entity_type: ENTITY_TYPE,
+    schema_version: "1.0.0",
+    source_id: `src_attach_2340_${obsSeq}`,
+    interpretation_id: null,
+    observed_at: observedAt,
+    specificity_score: 1,
+    source_priority: 50,
+    observation_source: null,
+    fields,
+    created_at: observedAt,
+    user_id: TEST_USER,
+  });
+  return id;
+}
+
+/**
+ * The comparable part of a snapshot. `computed_at` is wall-clock and moves on
+ * every recompute, so it is deliberately excluded; everything else — including
+ * `provenance`, which is the field→observation_id map that would silently
+ * change if the resolver handed the reducer a different set — is compared.
+ */
+function comparable(snap: Awaited<ReturnType<typeof recomputeSnapshot>>) {
+  if (!snap) return null;
+  return {
+    entity_id: snap.entity_id,
+    entity_type: snap.entity_type,
+    schema_version: snap.schema_version,
+    snapshot: snap.snapshot,
+    observation_count: snap.observation_count,
+    last_observation_at: snap.last_observation_at,
+    provenance: snap.provenance,
+    user_id: snap.user_id,
+  };
+}
+
+describe("attachment resolution — equivalence with the flat entity_id fetch (#2340)", () => {
+  beforeAll(seedSchema);
+  beforeEach(cleanup);
+  afterEach(cleanup);
+
+  it("(a) a plain entity's snapshot is unchanged by the resolver", async () => {
+    await insertEntity(ids.plain);
+    await insertObservation(
+      ids.plain,
+      { title: "first", summary: "alpha" },
+      "2026-01-01T00:00:00Z"
+    );
+    await insertObservation(ids.plain, { title: "second" }, "2026-01-02T00:00:00Z");
+
+    const snap = await recomputeSnapshot(ids.plain, TEST_USER);
+    expect(snap).not.toBeNull();
+    expect(comparable(snap)).toMatchObject({
+      entity_id: ids.plain,
+      observation_count: 2,
+      last_observation_at: "2026-01-02T00:00:00Z",
+    });
+    // last_write on `title` → the later observation wins.
+    expect((snap!.snapshot as Record<string, unknown>).title).toBe("second");
+    expect((snap!.snapshot as Record<string, unknown>).summary).toBe("alpha");
+  });
+
+  it("(b) split-then-recompute yields the same two snapshots as the in-place move", async () => {
+    // Build the post-split world the way split leaves it TODAY: the moved
+    // rows carry the target's entity_id. Under the resolver this same world
+    // must reduce identically — which is what makes the resolver a migration
+    // rather than a rewrite.
+    await insertEntity(ids.splitSource);
+    await insertEntity(ids.splitTarget);
+
+    await insertObservation(
+      ids.splitSource,
+      { title: "stays", summary: "on source" },
+      "2026-02-01T00:00:00Z"
+    );
+    await insertObservation(
+      ids.splitTarget,
+      { title: "moved", summary: "on target" },
+      "2026-02-02T00:00:00Z"
+    );
+
+    const sourceSnap = await recomputeSnapshot(ids.splitSource, TEST_USER);
+    const targetSnap = await recomputeSnapshot(ids.splitTarget, TEST_USER);
+
+    // Two distinct snapshots, each seeing only its own side. The split's
+    // difference-on-source / union-on-target rule must not leak either way.
+    expect(comparable(sourceSnap)).toMatchObject({
+      entity_id: ids.splitSource,
+      observation_count: 1,
+    });
+    expect((sourceSnap!.snapshot as Record<string, unknown>).title).toBe("stays");
+
+    expect(comparable(targetSnap)).toMatchObject({
+      entity_id: ids.splitTarget,
+      observation_count: 1,
+    });
+    expect((targetSnap!.snapshot as Record<string, unknown>).title).toBe("moved");
+  });
+
+  it("(c) merge-then-recompute yields one snapshot over the union", async () => {
+    // The post-merge world as merge leaves it today: observations already
+    // carry the survivor's entity_id, and the absorbed entity is tombstoned.
+    await insertEntity(ids.mergeTo);
+    await insertObservation(ids.mergeTo, { title: "survivor" }, "2026-03-01T00:00:00Z");
+    await insertObservation(ids.mergeTo, { summary: "absorbed" }, "2026-03-02T00:00:00Z");
+    await insertEntity(ids.mergeFrom, ids.mergeTo);
+
+    const snap = await recomputeSnapshot(ids.mergeTo, TEST_USER);
+    expect(comparable(snap)).toMatchObject({
+      entity_id: ids.mergeTo,
+      observation_count: 2,
+    });
+    expect((snap!.snapshot as Record<string, unknown>).title).toBe("survivor");
+    expect((snap!.snapshot as Record<string, unknown>).summary).toBe("absorbed");
+  });
+
+  it("(c2) recomputing a tombstoned entity does not resurrect it onto the survivor", async () => {
+    // Guard against the resolver over-reaching: asking for the absorbed
+    // entity must not pull the survivor's observations into a snapshot
+    // stored under the tombstone's id. Today the flat fetch returns nothing
+    // (the rows moved), so the snapshot is null; the resolver must agree.
+    await insertEntity(ids.mergeTo);
+    await insertObservation(ids.mergeTo, { title: "survivor" }, "2026-03-01T00:00:00Z");
+    await insertEntity(ids.mergeFrom, ids.mergeTo);
+
+    await deleteSnapshot(ids.mergeFrom, TEST_USER);
+    const snap = await recomputeSnapshot(ids.mergeFrom, TEST_USER);
+    expect(snap).toBeNull();
+  });
+
+  it("(d) user scoping is preserved — another user's rows never attach", async () => {
+    await insertEntity(ids.plain);
+    await insertObservation(ids.plain, { title: "mine" }, "2026-04-01T00:00:00Z");
+
+    await db.from("observations").insert({
+      id: "obs_attach_2340_otheruser",
+      entity_id: ids.plain,
+      entity_type: ENTITY_TYPE,
+      schema_version: "1.0.0",
+      source_id: "src_attach_2340_other",
+      observed_at: "2026-04-02T00:00:00Z",
+      specificity_score: 1,
+      source_priority: 50,
+      fields: { title: "theirs" },
+      created_at: "2026-04-02T00:00:00Z",
+      user_id: `${TEST_USER}-other`,
+    });
+
+    const snap = await recomputeSnapshot(ids.plain, TEST_USER);
+    expect(snap!.observation_count).toBe(1);
+    expect((snap!.snapshot as Record<string, unknown>).title).toBe("mine");
+
+    await db.from("observations").delete().eq("user_id", `${TEST_USER}-other`);
+  });
+});
+
+describe("attachment resolver — guards the existing pointer-follows lack (#2340)", () => {
+  beforeAll(seedSchema);
+  beforeEach(cleanup);
+  afterEach(cleanup);
+
+  it("resolves an alias CHAIN fully, not one hop", async () => {
+    // A → B → C. cli/index.ts:17020 resolves exactly one hop and silently
+    // under-resolves this; the resolver must land on C.
+    await insertEntity(ids.chainC);
+    await insertEntity(ids.chainB, ids.chainC);
+    await insertEntity(ids.chainA, ids.chainB);
+
+    const res = await resolveAttachedObservations(ids.chainA, TEST_USER);
+    expect(res.resolvedEntityId).toBe(ids.chainC);
+    expect(res.truncated).toBe(false);
+  });
+
+  it("terminates on a CYCLE instead of recursing forever", async () => {
+    // A → B → A. entity_queries.ts:945 recurses with no visited set; the
+    // resolver must stop and report rather than blow the stack.
+    await insertEntity(ids.cycleA, ids.cycleB);
+    await insertEntity(ids.cycleB, ids.cycleA);
+
+    const res = await resolveAttachedObservations(ids.cycleA, TEST_USER);
+    expect(res.truncated).toBe(true);
+    expect(res.truncationReason).toBe("cycle");
+    // It still returns a usable set rather than throwing on the read path.
+    expect(Array.isArray(res.observations)).toBe(true);
+  });
+
+  it("bounds depth rather than truncating silently", async () => {
+    // A chain longer than the bound must report truncation, not quietly
+    // return a partly-resolved answer.
+    const chain: string[] = [];
+    for (let i = 0; i <= 40; i++) chain.push(`ent_attach_deep_${i}_2340`);
+    await insertEntity(chain[chain.length - 1]);
+    for (let i = chain.length - 2; i >= 0; i--) await insertEntity(chain[i], chain[i + 1]);
+
+    const res = await resolveAttachedObservations(chain[0], TEST_USER);
+    expect(res.truncated).toBe(true);
+    expect(res.truncationReason).toBe("depth");
+  });
+
+  it("an unmerged entity resolves to itself with no truncation", async () => {
+    await insertEntity(ids.plain);
+    await insertObservation(ids.plain, { title: "solo" }, "2026-05-01T00:00:00Z");
+
+    const res = await resolveAttachedObservations(ids.plain, TEST_USER);
+    expect(res.resolvedEntityId).toBe(ids.plain);
+    expect(res.truncated).toBe(false);
+    expect(res.observations).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Implements the attachment-resolution contract approved on #2340 ([analysis](https://github.com/markmhendrickson/neotoma/issues/2340#issuecomment-5583845458)):

> A snapshot is a function of the observations **attached to** an entity, where attachment is resolved through a declared resolution layer, rather than of the observations whose `entity_id` column equals the entity.

**Scope: builds the seam and moves the fetch onto it. It does not redesign `split_entity` or `merge_entities`** — that is the follow-on work this unblocks (#2329), and keeping it separate is what makes this reviewable.

## What changed

| | |
|---|---|
| `src/services/attachment_resolution.ts` | **new** — the declared resolution layer |
| `src/services/snapshot_computation.ts` | +14 −7 in `recomputeSnapshot` |
| `tests/integration/attachment_resolution_equivalence.test.ts` | **new** — the safety argument |
| `src/reducers/observation_reducer.ts` | **unchanged**, as predicted — it reduces whatever set it is handed |

### The resolver

One resolution rule is live today: the entity-grained merge alias (`entities.merged_to_entity_id`), followed **transitively**. That is behaviour-preserving, since merge already rewrites `observations.entity_id` to the survivor — so for any entity that is not itself a tombstone the resolved set is byte-identical to the old flat fetch.

The observation-grained rules (split's difference-on-source and union-on-target; merge's append-based redirect) are deliberately **not** here. They arrive with the redesigns, as a new rule in one place rather than a new fetch in a dozen.

**Cycle guard**: a visited set. **Depth bound**: `MAX_ATTACHMENT_RESOLUTION_DEPTH = 32`. Exceeding either sets `truncated` + `truncationReason` (`"cycle"` | `"depth"`) and logs — never a silent truncation. This is load-bearing rather than decorative: `entity_merge.ts:68-74` blocks merging an already-merged entity on either side, which prevents a 2-cycle but **not** chains (A→B, then C→B, then B→D builds depth).

The read path **degrades rather than throws** on a guard hit. A snapshot read that throws takes down every `recomputeSnapshot` caller; one that reports the anomaly leaves the store readable while the inconsistency is repaired.

### The one non-obvious line in `recomputeSnapshot`

A redirected id owns no snapshot of its own:

```ts
if (attached.resolvedEntityId !== entityId) return null;
```

Without this, recomputing a merge tombstone would compute the *survivor's* snapshot and upsert it **under the tombstone's id** — manufacturing a duplicate snapshot that the flat fetch never produced (it returned nothing, because the rows had already moved). The equivalence test forced this out; case `(c2)` pins it.

## The equivalence test — before and after

This is the whole safety argument, so it was written first and run against unmodified `origin/main` (`63a7dcf88`) **before** the resolver existed.

| | equivalence (a–d) | guards |
|---|---|---|
| **Before** (flat fetch, `origin/main`) | **5 / 5 pass** | n/a — resolver did not exist |
| **After** (resolver) | **5 / 5 pass, assertions unchanged** | **4 / 4 pass** |

The equivalence assertions are byte-identical across both runs. A diff in them accompanying this change would have meant the migration altered a snapshot, which is a regression rather than a migration.

Covered: plain entity; split-then-recompute yielding the same *two* snapshots; merge-then-recompute yielding the same *one*; a tombstone still recomputing to `null`; user scoping preserved. Plus the three guarantees with no pre-change counterpart: a chain resolves **fully** (not one hop), a cycle **terminates**, depth is **bounded and reported**.

The test uses a dedicated user-scoped entity type rather than borrowing a built-in one. The reducer projects a snapshot through the *active* schema, so borrowing a shared type couples the assertions to whatever another test file happened to register for it — which it did, and it failed under full-suite parallelism before this was fixed.

## Verification against the analysis

Verified against `origin/main` at `63a7dcf88` — the same SHA the analysis used.

**Held exactly**: the flat fetch at `snapshot_computation.ts:59-63`; `entity_id` as a hashed input to `generateObservationId`; the `interpretation.ts` per-entity loop sharing one `sourceId`/`interpretationId` (so dropping `entityId` from the hash **would** collide — option 2 stays rejected on evidence); split's in-place `UPDATE`; the stale "no transaction primitive" comment at `entity_split.ts:303-305`, contradicted by `entity_merge.ts:81`; the reducer needing no change; and the identification of exactly **three** pointer-following sites, two of them unguarded.

**Drifted** — see the report on #2340 for detail. In short: the `merged_to_entity_id` file counts are lower than stated (39/23, not 44/28 — cosmetic); and the `recomputeSnapshot` caller list is **wrong in both directions** — `cli/index.ts`, `server.ts`, and `batch_correction.ts` do **not** call it, while ~7 *other* sites fetch observations flat and feed `observationReducer.computeSnapshot` directly, bypassing this seam entirely. `recomputeSnapshot` is the right first seam, but it is not the only one; the others are enumerated on the issue as follow-on scope.

**No `recomputeSnapshot` caller needed changing**, as predicted — all five call sites are identical and untouched.

## Deliberately not done

Per the approved analysis: no `redlines.md` amendment (this **strengthens** R1, so the amendment process is not engaged); no `philosophy.md` §5.1 edit (it was *proposed*, not approved — flagged on the issue instead of made); no repair of already-split data (that would adopt the rejected option 3 on historical data); no split-transaction fix (belongs with the split redesign); and `split_entity` stays **enabled and unchanged**.

## CI

`contract_parity` is **green on `main` at `63a7dcf88`**, so a red one here would be mine. Locally: type-check clean, lint 0 errors, format clean, integration **147 files / 949 tests green**, unit **311 files / 3492 tests green**.

Refs #2340, #2329

🤖 Generated with [Claude Code](https://claude.com/claude-code)
