### PR TITLE
fix(mcp): enforce the observations attribution gate on the MCP store path (#2327)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -5369,6 +5369,34 @@ export class NeotomaServer {
       });
     }
 
+    // Attribution policy, "observations" write path (#2327).
+    //
+    // This MCP store core does not route through `createObservation`, so the
+    // "observations" gate that lives at observation_storage.ts:85 is never
+    // reached from here. It pre-computes the observation id for its dedup
+    // probe and inserts into `observations` directly, which is deliberate —
+    // but it means a seam placed only in the shared write helper is enforced
+    // on REST and silently inert on MCP. Called explicitly, mirroring the
+    // `assertCanWriteProtected` call below and the reasoning recorded for
+    // `assertStorePolicyAllows` above.
+    //
+    // Placement, for the same reason given above: a store call is not
+    // transactional, so denial must happen before anything is persisted.
+    // Gating next to the insert would reject only after `storeRawContent`
+    // had already written a source row. Once per call, not per entity —
+    // `enforceAttributionPolicy` does not read entity type, so the answer is
+    // identical for every row in the batch.
+    //
+    // Ordering: after `assertStorePolicyAllows`, not before. Instance store
+    // policy governs *what* may be stored; attribution governs *who* may
+    // store it. Keeping this order means an entity type the instance refuses
+    // is refused identically regardless of attribution.
+    {
+      const { enforceAttributionPolicy } = await import("./services/attribution_policy.js");
+      const { getCurrentAgentIdentity } = await import("./services/request_context.js");
+      enforceAttributionPolicy("observations", getCurrentAgentIdentity());
+    }
+
     // Plan mode: resolve deterministically, report planned actions per entity,
     // and skip every write (source row, observations, snapshots, relationships).
     if (!commit) {

--- a/tests/integration/anonymous_write_policy.test.ts
+++ b/tests/integration/anonymous_write_policy.test.ts
@@ -3,12 +3,25 @@
  * the service boundary.
  *
  * The policy helper is exercised directly in unit tests; this test
- * asserts that each of the five canonical write paths actually calls
- * `enforceAttributionPolicy` and therefore reject in `reject` mode,
- * regardless of transport. It runs against the local SQLite backend
- * without going through HTTP, because the enforcement seam is
- * deliberately placed inside the service (HTTP / MCP stdio / MCP HTTP
- * / CLI backup all reach the same code path).
+ * asserts that each of the five canonical write-path *service helpers*
+ * calls `enforceAttributionPolicy` and therefore rejects in `reject`
+ * mode. It runs against the local SQLite backend without going through
+ * HTTP.
+ *
+ * SCOPE — read this before trusting the file (#2327). This test proves
+ * the seam is present in the service helpers. It does NOT prove any
+ * transport reaches those helpers. An earlier version of this docblock
+ * claimed coverage held "regardless of transport … HTTP / MCP stdio /
+ * MCP HTTP / CLI backup all reach the same code path". That claim was
+ * false and it is why nobody looked: the MCP `store` core
+ * (`storeStructuredInternal`) does not route through
+ * `createObservation`, so `{"observations":"reject"}` was silently
+ * inert on the primary MCP write path while this file passed.
+ *
+ * Per-transport enforcement is asserted where the transport is actually
+ * dispatched — see `tests/integration/mcp_store_attribution_policy.test.ts`.
+ * Adding a helper here does not extend coverage to a transport; only
+ * dispatching that transport does.
  */
 
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";

--- a/tests/integration/mcp_store_attribution_policy.test.ts
+++ b/tests/integration/mcp_store_attribution_policy.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Integration test: the MCP `store` path evaluates the "observations"
+ * attribution gate (#2327).
+ *
+ * Why this test exists separately from
+ * `tests/integration/anonymous_write_policy.test.ts`: that test asserts,
+ * in its own docblock, that enforcement holds "regardless of transport
+ * … because the enforcement seam is deliberately placed inside the
+ * service (HTTP / MCP stdio / MCP HTTP / CLI backup all reach the same
+ * code path)" — and then calls `createObservation` directly. That is the
+ * REST path's helper. The MCP core (`storeStructuredInternal`) does not
+ * route through it: it pre-computes the observation id for its dedup
+ * probe and inserts into `observations` directly. So the transport claim
+ * was asserted by testing the one transport where it happened to hold,
+ * and `{"observations":"reject"}` silently did nothing on the primary
+ * MCP write path.
+ *
+ * This test dispatches an actual MCP tool call. It is the coverage the
+ * comment claimed and did not have.
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { db } from "../../src/db.js";
+import { NeotomaServer } from "../../src/server.js";
+
+const TEST_USER_ID = "00000000-0000-0000-0000-000000000000";
+
+const ENV_KEYS = [
+  "NEOTOMA_ATTRIBUTION_POLICY",
+  "NEOTOMA_MIN_ATTRIBUTION_TIER",
+  "NEOTOMA_ATTRIBUTION_POLICY_JSON",
+] as const;
+
+/** Count source rows written under a given idempotency key. */
+async function sourceCountForKey(key: string): Promise<number> {
+  const { data } = await db
+    .from("sources")
+    .select("id")
+    .eq("user_id", TEST_USER_ID)
+    .eq("idempotency_key", key);
+  return ((data ?? []) as unknown[]).length;
+}
+
+describe("MCP store honours the observations attribution policy (#2327)", () => {
+  let server: NeotomaServer;
+  const originalEnv: Record<string, string | undefined> = {};
+
+  beforeAll(() => {
+    for (const key of ENV_KEYS) originalEnv[key] = process.env[key];
+    server = new NeotomaServer();
+  });
+
+  afterAll(() => {
+    for (const key of ENV_KEYS) {
+      if (originalEnv[key] === undefined) delete process.env[key];
+      else process.env[key] = originalEnv[key];
+    }
+  });
+
+  afterEach(() => {
+    server.setSessionAgentIdentity(null);
+    for (const key of ENV_KEYS) {
+      if (originalEnv[key] === undefined) delete process.env[key];
+      else process.env[key] = originalEnv[key];
+    }
+  });
+
+  it("T1: rejects an MCP store when {\"observations\":\"reject\"} is configured", async () => {
+    process.env.NEOTOMA_ATTRIBUTION_POLICY_JSON = '{"observations":"reject"}';
+    const marker = `mcp-attr-t1-${Date.now()}`;
+
+    await expect(
+      server.executeToolForCli(
+        "store",
+        {
+          entities: [{ entity_type: "note", title: marker }],
+          idempotency_key: marker,
+        },
+        TEST_USER_ID
+      )
+    ).rejects.toThrow(/ATTRIBUTION_REQUIRED|Attribution policy|attribution/i);
+  });
+
+  it("T2: does not over-reject an AAuth-verified session under the same policy", async () => {
+    process.env.NEOTOMA_ATTRIBUTION_POLICY_JSON = '{"observations":"reject"}';
+    const marker = `mcp-attr-t2-${Date.now()}`;
+
+    // Inject the session identity the way the MCP transport does after the
+    // `initialize` handshake. `executeToolForCli` establishes its own request
+    // context from the session identity, so wrapping the call in an outer
+    // `runWithRequestContext` would be discarded — the session setter is the
+    // seam that actually reaches the gate on this transport.
+    server.setSessionAgentIdentity({
+      verified: true,
+      publicKey: '{"kty":"EC","crv":"P-256"}',
+      thumbprint: "tp-mcp-store-2327",
+      algorithm: "ES256",
+      sub: "agent:mcp-store:2327",
+      iss: "https://agent.example",
+    } as unknown as Parameters<NeotomaServer["setSessionAgentIdentity"]>[0]);
+
+    const result = await server.executeToolForCli(
+      "store",
+      {
+        entities: [{ entity_type: "note", title: marker, content: marker }],
+        idempotency_key: marker,
+      },
+      TEST_USER_ID
+    );
+    expect(result).toBeTruthy();
+  });
+
+  it("T3: the default policy is unchanged — an unconfigured store still succeeds", async () => {
+    for (const key of ENV_KEYS) delete process.env[key];
+    const marker = `mcp-attr-t3-${Date.now()}`;
+
+    const result = await server.executeToolForCli(
+      "store",
+      {
+        entities: [{ entity_type: "note", title: marker }],
+        idempotency_key: marker,
+      },
+      TEST_USER_ID
+    );
+    expect(result).toBeTruthy();
+  });
+
+  it("T4: nothing is persisted when the policy rejects", async () => {
+    process.env.NEOTOMA_ATTRIBUTION_POLICY_JSON = '{"observations":"reject"}';
+    const marker = `mcp-attr-t4-${Date.now()}`;
+
+    await expect(
+      server.executeToolForCli(
+        "store",
+        {
+          entities: [{ entity_type: "note", title: marker }],
+          idempotency_key: marker,
+        },
+        TEST_USER_ID
+      )
+    ).rejects.toThrow();
+
+    // This is what pins the gate to its placement. Gating next to the
+    // observation insert instead of before `storeRawContent` would leave
+    // T1 passing while a source row had already been written.
+    expect(await sourceCountForKey(marker)).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #2327. Implements the spec posted at https://github.com/markmhendrickson/neotoma/issues/2327#issuecomment-5582348834.

## The defect

`enforceAttributionPolicy("observations", …)` had **zero occurrences** in `src/server.ts`. The primary MCP `store` path (`storeStructuredInternal`) inserts observations directly rather than routing through `createObservation`, which is where that gate lives (`observation_storage.ts:85`). The only attribution gate the path evaluated was keyed `"sources"`, reached indirectly via `storeRawContent` (`raw_storage.ts:50`).

So an operator setting `NEOTOMA_ATTRIBUTION_POLICY_JSON={"observations":"reject"}` got a policy that is parsed, surfaced on `/session`, and enforced on nothing this path writes.

The parity is one-sided: REST's `storeStructuredForApi` **does** route through `createObservation` and gets the gate. Same tool name, same operator configuration, different enforcement.

Provenance *is* stamped on the MCP path (`server.ts:6128-6130`), so rows are attributable. What did not happen is the policy being evaluated. A policy-enforcement gap, not a provenance gap.

## The fix, and why it is a gate call rather than a reroute

Routing `storeStructuredInternal` through `createObservation` was considered and rejected. `createObservation` computes its own observation id with **five** arguments including `idempotency_key`; this path pre-computes with **four** (`server.ts:6083-6088`) and threads that id through its dedup probe (`:6094-6100`), the `deduplicated` flag (`:6155`, added for #1840), and the `insertedObservationIds` set (`:6138`).

Rerouting would either change content-addressed observation identity whenever an idempotency key is present — an R2 concern — or require passing the pre-computed id in, which `createObservation` has no parameter for. That is a refactor of identity semantics wearing the clothes of a one-line security fix. Convergence of the two store paths is worth doing deliberately, with id-stability tests, under its own issue.

**Placement** is before any persistence, not next to the insert. The comment already in this file states the rule: a store call is not transactional, so denial must happen before anything is persisted rather than mid-batch. Gating at the insert would reject only after `storeRawContent` had already written a source row — which is exactly what T4 pins.

Ordering is after `assertStorePolicyAllows`, not before: instance store policy governs *what* may be stored, attribution governs *who* may store it. Once per call, not per entity — `enforceAttributionPolicy` does not read entity type.

The `"sources"` gate reached via `storeRawContent` stays. Both write paths are genuinely exercised and an operator may configure them differently.

## The test, and its fail-then-pass evidence

`tests/integration/mcp_store_attribution_policy.test.ts` dispatches an **actual MCP tool call** rather than calling a service helper.

Pre-fix (`679006a3`, before the `server.ts` change):

```
FAIL  T1: rejects an MCP store when {"observations":"reject"} is configured
  AssertionError: promise resolved "{ content: [ { type: 'text', …(1) } ] }" instead of rejecting
FAIL  T4: nothing is persisted when the policy rejects
  AssertionError: promise resolved … instead of rejecting
     (payload shows a real observation row: "action":"created", "deduplicated":false)

Tests  2 failed | 2 passed (4)
```

Post-fix:

```
✓ tests/integration/mcp_store_attribution_policy.test.ts (4 tests)
Tests  4 passed (4)
```

T2 (no over-rejection with an AAuth-verified session) and T3 (default policy unchanged) pass in both runs — they guard against the fix tightening the default or over-rejecting, which it does not.

## The misleading comment, corrected

`tests/integration/anonymous_write_policy.test.ts` asserted in its docblock that coverage held *"regardless of transport … HTTP / MCP stdio / MCP HTTP / CLI backup all reach the same code path"*, and then called `createObservation` directly. That claim was false, and it is plausibly why nobody looked — a test whose header claims transport-independence and whose body exercises one transport answers the question before anyone asks it.

The docblock now states its real scope (it proves the seam is present in the *service helpers*, not that any transport reaches them) and points at the new test for per-transport coverage.

## Scope

Touches `src/server.ts` and two test files. Does not touch `attachment_resolution.ts`, `snapshot_computation.ts`, `entity_merge.ts`, `entity_split.ts`, `worker_file_database.ts`, or the file-upload surface — no collision with #2325, #2329, or #2343.

Deliberately **not** in scope, per the spec: the guest carve-out at `actions.ts:7182` and `NEOTOMA_AGENT_DEFAULT_DENY` at `agent_capabilities.ts:195`. Both are permissive *defaults*, not configured policies that do nothing. The distinction that keeps this scoped: #2327 is a lie; those are choices.

## Verification

All spec line references re-verified against `origin/main` @ `679006a3` (two commits past the spec's `63a7dcf8`; neither touched `server.ts`, `actions.ts`, or the attribution modules). Every reference held.

Part of the pattern tracked in #2334.

🤖 Generated with [Claude Code](https://claude.com/claude-code)