### PR TITLE
fix(snapshots): route every snapshot computation through the attachment seam (#2343)

### DIFF
--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,8 +61,8 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **596**
-- Backend and repo Vitest files: **561**
+- Total automated test files: **597**
+- Backend and repo Vitest files: **562**
 - Frontend Vitest files: **9**
 - Playwright spec files: **26**
 
@@ -72,7 +72,7 @@ flowchart TD
 | Vitest unit tests | 164 |
 | Vitest service tests | 44 |
 | Source-adjacent tests | 66 |
-| Vitest integration tests | 168 |
+| Vitest integration tests | 169 |
 | Vitest CLI tests | 78 |
 | Vitest contract tests | 18 |
 | Vitest security tests | 7 |
@@ -404,7 +404,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm run test:integration` or `npx vitest run tests/integration`
 **Requirements:** Database configured; remote-dependent subsets additionally need `RUN_REMOTE_TESTS=1`.
-**Files (168):**
+**Files (169):**
 - `tests/integration/aauth_attribution_stamping.test.ts`
 - `tests/integration/aauth_mcp_capability_parity.test.ts`
 - `tests/integration/aauth_mcp_initialize_admission.test.ts`
@@ -421,6 +421,7 @@ flowchart TD
 - `tests/integration/agentic_eval_matrix.test.ts`
 - `tests/integration/agents_directory_api.test.ts`
 - `tests/integration/anonymous_write_policy.test.ts`
+- `tests/integration/attachment_resolution_equivalence.test.ts`
 - `tests/integration/attribution_parity.test.ts`
 - `tests/integration/auto_link_retraction_organization_change.test.ts`
 - `tests/integration/cli_init_bootstrap.test.ts`

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -11769,20 +11769,28 @@ app.post("/health_check_snapshots", async (req, res) => {
     }
 
     let fixedCount = 0;
+    let redirectedCount = 0;
     if (auto_fix && staleEntities.length > 0) {
       // Recompute snapshots for stale entities using observationReducer
       const { observationReducer } = await import("./reducers/observation_reducer.js");
+      const { resolveOwnedObservations } = await import("./services/attachment_resolution.js");
 
       for (const entity of staleEntities) {
         try {
-          // Get all observations for this entity
-          const { data: observations } = await db
-            .from("observations")
-            .select("*")
-            .eq("entity_id", entity.entity_id)
-            .order("observed_at", { ascending: false });
-
-          if (!observations || observations.length === 0) continue;
+          // #2343: the observations ATTACHED to this entity, resolved through
+          // the declared layer, and null when the id is redirected — a
+          // tombstone owns no snapshot, so auto-fix must skip it rather than
+          // upsert the survivor's snapshot under the tombstone's id.
+          // `null` scope, deliberately: this endpoint's observation fetch was
+          // unscoped before #2343, and adding a user_id filter here would
+          // change which rows the reducer sees. Routing the fetch through the
+          // seam is this PR's job; tightening this endpoint's tenancy is not.
+          const observations = await resolveOwnedObservations(entity.entity_id, null);
+          if (observations === null) {
+            redirectedCount++;
+            continue;
+          }
+          if (observations.length === 0) continue;
 
           // Recompute snapshot
           const newSnapshot = await observationReducer.computeSnapshot(
@@ -11821,11 +11829,15 @@ app.post("/health_check_snapshots", async (req, res) => {
         staleEntities.length === 0
           ? "All snapshots healthy"
           : auto_fix
-            ? `Found ${staleEntities.length} stale snapshots, fixed ${fixedCount}`
+            ? `Found ${staleEntities.length} stale snapshots, fixed ${fixedCount}` +
+              (redirectedCount > 0
+                ? `, skipped ${redirectedCount} redirected (merged-away) id(s)`
+                : "")
             : `Found ${staleEntities.length} stale snapshots`,
       checked: staleSnapshots?.length || 0,
       stale: staleEntities.length,
       fixed: auto_fix ? fixedCount : undefined,
+      skipped_redirected: auto_fix ? redirectedCount : undefined,
       stale_snapshots: staleEntities,
     });
   } catch (error) {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -3174,7 +3174,20 @@ async function recomputeMergedDbSnapshots(targetDbPath: string): Promise<DbSnaps
     await db.prepare("DELETE FROM entity_snapshots").run();
     await db.prepare("DELETE FROM relationship_snapshots").run();
 
+    // #2343: the merge-import rebuild runs against an ARBITRARY target
+    // database opened by path, so it cannot use the service-layer seam (which
+    // resolves against the process's configured db). It shares the RULES via
+    // attachment_resolution_sqlite.ts instead — same merge-alias follow, same
+    // cycle guard, same depth bound.
+    const { resolveAttachmentTargetSqlite } =
+      await import("../services/attachment_resolution_sqlite.js");
+
     for (const entityId of entityIds) {
+      // A redirected id owns no snapshot of its own: skip it rather than
+      // writing the survivor's snapshot under a merge tombstone.
+      const target = await resolveAttachmentTargetSqlite(db, entityId);
+      if (target.resolvedEntityId !== entityId) continue;
+
       const observations = (
         await db
           .prepare(

--- a/src/repositories/sqlite/local_db_adapter.ts
+++ b/src/repositories/sqlite/local_db_adapter.ts
@@ -530,9 +530,29 @@ async function ensureEntityRowForSnapshot(
     .run(entityId, entityType, canonicalName, now, now, userId);
 }
 
+/**
+ * Recompute an entity snapshot from inside the adapter's observation-insert
+ * path (local backend parity).
+ *
+ * #2343: this deliberately does NOT delegate to the service-layer
+ * `recomputeSnapshot`. `src/db.ts` exports this very adapter as `db`, so the
+ * service function's own `db.from("observations")` fetch would re-enter the
+ * adapter while it is mid-insert. What it shares with the seam instead is the
+ * RULES: `attachment_resolution_sqlite.ts` expresses the same merge-alias
+ * resolution, the same cycle guard, and the same depth constant against the
+ * raw handle this layer has. See that module's header for why the split is
+ * structural rather than duplication.
+ */
 async function recomputeEntitySnapshot(db: DbDatabase, entityId: string): Promise<void> {
   const { ObservationReducer } = await import("../../reducers/observation_reducer.js");
   const reducer = new ObservationReducer();
+
+  // Resolution and ownership are different questions. A redirected id (a merge
+  // tombstone) resolves to its survivor but owns no snapshot row; writing the
+  // survivor's snapshot back under it would manufacture a duplicate the flat
+  // fetch never produced.
+  const { ownsSnapshotSqlite } = await import("../../services/attachment_resolution_sqlite.js");
+  if (!(await ownsSnapshotSqlite(db, entityId))) return;
 
   const rows = (await db
     .prepare("SELECT * FROM observations WHERE entity_id = ?")

--- a/src/server.ts
+++ b/src/server.ts
@@ -1002,19 +1002,22 @@ export class NeotomaServer {
     // Auto-fix if requested
     if (parsed.auto_fix && staleSnapshots.length > 0) {
       const { observationReducer } = await import("./reducers/observation_reducer.js");
+      const { resolveOwnedObservations } = await import("./services/attachment_resolution.js");
       let fixedCount = 0;
+      let redirectedCount = 0;
 
       for (const stale of staleSnapshots) {
         try {
-          // Get all observations
-          const { data: observations } = await db
-            .from("observations")
-            .select("*")
-            .eq("entity_id", stale.entity_id)
-            .eq("user_id", userId)
-            .order("observed_at", { ascending: false });
-
-          if (!observations || observations.length === 0) continue;
+          // #2343: the observations ATTACHED to this entity, through the
+          // declared resolution layer. `null` means the id is redirected (a
+          // merge tombstone): it owns no snapshot, so auto-fix skips it rather
+          // than upserting the survivor's snapshot under the tombstone's id.
+          const observations = await resolveOwnedObservations(stale.entity_id, userId);
+          if (observations === null) {
+            redirectedCount++;
+            continue;
+          }
+          if (observations.length === 0) continue;
 
           // Recompute snapshot
           const newSnapshot = await observationReducer.computeSnapshot(
@@ -1045,10 +1048,15 @@ export class NeotomaServer {
 
       return this.buildTextResponse({
         healthy: false,
-        message: `Found ${staleSnapshots.length} stale snapshots, fixed ${fixedCount}`,
+        message:
+          `Found ${staleSnapshots.length} stale snapshots, fixed ${fixedCount}` +
+          (redirectedCount > 0
+            ? `, skipped ${redirectedCount} redirected (merged-away) id(s)`
+            : ""),
         checked: potentiallyStale.length,
         stale: staleSnapshots.length,
         fixed: fixedCount,
+        skipped_redirected: redirectedCount,
         stale_snapshots: staleSnapshots,
       });
     }
@@ -6216,6 +6224,7 @@ export class NeotomaServer {
       }
     >();
     const { observationReducer } = await import("./reducers/observation_reducer.js");
+    const { resolveOwnedObservations } = await import("./services/attachment_resolution.js");
     for (const createdEntity of createdEntities) {
       try {
         const { data: priorSnapRow } = await db
@@ -6228,26 +6237,33 @@ export class NeotomaServer {
           (priorSnapRow?.snapshot as Record<string, unknown> | null | undefined) ?? {};
         priorSnapshotByEntityId.set(createdEntity.entityId, priorSnapshot);
 
-        // Get all observations for entity, scoped to the current user so
-        // cross-user data does not bleed into this user's snapshot.
-        const { data: allObservations, error: obsError } = await db
-          .from("observations")
-          .select("*")
-          .eq("entity_id", createdEntity.entityId)
-          .eq("user_id", userId)
-          .order("observed_at", { ascending: false });
-
-        if (obsError) {
+        // #2343: the observations ATTACHED to this entity, through the
+        // declared resolution layer (attachment_resolution.ts), scoped to the
+        // current user so cross-user data does not bleed into this snapshot.
+        // `null` means the id is redirected (a merge tombstone): it owns no
+        // snapshot, so nothing is upserted under it. That is not an error for
+        // the store caller — attaching an observation to a merged-away id is a
+        // legitimate write; only the snapshot ownership question says no.
+        let allObservations: unknown[] | null = null;
+        try {
+          allObservations = await resolveOwnedObservations(createdEntity.entityId, userId);
+        } catch (err) {
           logger.error(
             `Failed to get observations for entity ${createdEntity.entityId}:`,
-            obsError.message
+            err instanceof Error ? err.message : String(err)
+          );
+          continue;
+        }
+        if (allObservations === null) {
+          logger.info(
+            `[STORE] ${createdEntity.entityId} is redirected; no snapshot written under it.`
           );
           continue;
         }
 
         if (allObservations && allObservations.length > 0) {
           // Map database observations to reducer's expected format
-          const mappedObservations = allObservations.map((obs: any) => ({
+          const mappedObservations = (allObservations as any[]).map((obs: any) => ({
             id: obs.id,
             entity_id: obs.entity_id,
             entity_type: obs.entity_type,
@@ -6323,9 +6339,12 @@ export class NeotomaServer {
             schema: timelineSchema,
           });
 
-          // This path computes and upserts the snapshot inline instead of going
-          // through recomputeSnapshot(), so it must re-derive the entity-level
-          // canonical_name itself. Without this, a corrective observation (e.g.
+          // This path fetches through the attachment-resolution seam (#2343)
+          // but still computes and upserts the snapshot inline rather than via
+          // recomputeSnapshot(), because it also derives embeddings, timeline
+          // events with batch counts, and change events. So it must re-derive
+          // the entity-level canonical_name itself. Without this, a corrective
+          // observation (e.g.
           // stripping an emoji from `name` via target_id) updates the snapshot
           // while entities.canonical_name stays frozen at its creation value —
           // and canonical_name is what entity lists and search display.

--- a/src/services/attachment_resolution.ts
+++ b/src/services/attachment_resolution.ts
@@ -30,6 +30,27 @@
  * so those changes are a new resolution rule in one place rather than a new
  * fetch in a dozen.
  *
+ * ## Caller contract (#2343)
+ *
+ * Entity snapshots go through this module or through `recomputeSnapshot`.
+ * Never `.eq("entity_id", id)` → `observationReducer.computeSnapshot` for an
+ * entity snapshot: that is the bypass #2343 removed from ten sites.
+ *
+ *   - **Persisting** a snapshot → `resolveOwnedObservations` (or
+ *     `recomputeSnapshot`, which uses it). It returns `null` for a redirected
+ *     id, which is the guard that stops a survivor's snapshot being written
+ *     under a tombstone.
+ *   - **Reading** an observation set → `resolveAttachedObservations`.
+ *   - **Only the resolved id** (e.g. a point-in-time replay that applies its
+ *     own time filter) → `resolveAttachmentTarget`.
+ *   - **A raw SQLite handle** (the local adapter's insert path, the CLI's
+ *     merge-import against an arbitrary database file) → the same rules over
+ *     that handle, in `attachment_resolution_sqlite.ts`.
+ *
+ * **Resolution is not ownership.** Resolving answers "which observations
+ * attach here?"; owning answers "whose snapshot row is this?". Conflating
+ * them is how a resolution layer silently duplicates state.
+ *
  * ## Guards
  *
  * Resolution is bounded by a cycle guard (a visited set) and a maximum depth.
@@ -42,6 +63,14 @@
  * improvement. `entity_merge.ts` blocks merging an already-merged entity on
  * either side, which prevents a two-cycle but does not prevent chains
  * (A→B, then C→B, then B→D builds depth), so the bound is load-bearing.
+ *
+ * ## Tenancy scope
+ *
+ * `userId` is the caller's existing scope, passed through unchanged. `null`
+ * means "do not filter by user" and exists for the one legacy repair endpoint
+ * whose observation fetch was already unscoped: this layer replaces WHICH
+ * mechanism finds the rows, and must not quietly change WHICH rows are found.
+ * New callers should pass a real user id.
  *
  * The read path degrades rather than throws: a cycle or an over-deep chain
  * returns the best-resolved set with `truncated: true` and logs, because a
@@ -84,7 +113,7 @@ export interface AttachmentResolution {
  */
 export async function resolveAttachmentTarget(
   entityId: string,
-  userId: string
+  userId: string | null
 ): Promise<{
   resolvedEntityId: string;
   path: string[];
@@ -96,12 +125,14 @@ export async function resolveAttachmentTarget(
   let current = entityId;
 
   for (let depth = 0; depth < MAX_ATTACHMENT_RESOLUTION_DEPTH; depth++) {
-    const { data: row, error } = await db
-      .from("entities")
-      .select("id, merged_to_entity_id")
-      .eq("id", current)
-      .eq("user_id", userId)
-      .single();
+    // `userId === null` means the caller reads across tenants (one legacy
+    // repair endpoint does; see resolveAttachedObservations). Scoping is the
+    // caller's existing contract, not something this layer may tighten:
+    // narrowing a previously-unscoped fetch would change which observations
+    // the reducer sees, which is the one thing this migration must not do.
+    let entityQuery = db.from("entities").select("id, merged_to_entity_id").eq("id", current);
+    if (userId !== null) entityQuery = entityQuery.eq("user_id", userId);
+    const { data: row, error } = await entityQuery.single();
 
     // A missing entity row is not an error here: observations can be fetched
     // for an id with no `entities` row (the CLI recompute path does exactly
@@ -157,15 +188,17 @@ export async function resolveAttachmentTarget(
  */
 export async function resolveAttachedObservations(
   entityId: string,
-  userId: string
+  userId: string | null
 ): Promise<AttachmentResolution> {
   const target = await resolveAttachmentTarget(entityId, userId);
 
-  const { data, error } = await db
-    .from("observations")
-    .select("*")
-    .eq("entity_id", target.resolvedEntityId)
-    .eq("user_id", userId);
+  let obsQuery = db.from("observations").select("*").eq("entity_id", target.resolvedEntityId);
+  if (userId !== null) obsQuery = obsQuery.eq("user_id", userId);
+  // Ordered observed_at DESC because that is what every bypassing fetch this
+  // seam replaces already did (#2343), and the reducer's tie-breaks read the
+  // input order. Ordering here rather than at each call site keeps the set the
+  // reducer sees identical no matter which path asked for it.
+  const { data, error } = await obsQuery.order("observed_at", { ascending: false });
 
   if (error) {
     throw new Error(`Failed to fetch attached observations: ${error.message}`);
@@ -178,4 +211,45 @@ export async function resolveAttachedObservations(
     truncated: target.truncated,
     truncationReason: target.truncationReason,
   };
+}
+
+/**
+ * The observations a given entity id may compute and PERSIST its own snapshot
+ * from, under the declared resolution layer.
+ *
+ * This is `resolveAttachedObservations` plus the ownership question, and it
+ * exists because those are two different questions that are easy to conflate
+ * — conflating them is how a resolution layer silently duplicates state.
+ *
+ * Resolution answers *"which observations attach here?"*. Ownership answers
+ * *"whose snapshot row is this?"*. A merge tombstone resolves to its survivor,
+ * so a persisting caller that only resolved would compute the survivor's
+ * snapshot and write it back **under the tombstone's id** — manufacturing a
+ * duplicate snapshot the flat fetch never produced, because merge had already
+ * moved the rows. `recomputeSnapshot` learned this the hard way in #2342; this
+ * helper is that lesson made reusable so every persisting site inherits it
+ * rather than re-deriving it (#2343).
+ *
+ * Returns `null` — meaning *do not upsert under this id* — when the id is
+ * redirected. Returns an empty array only when the id genuinely owns no
+ * observations; callers that distinguish "delete the stale row" from "skip"
+ * should branch on that difference themselves.
+ *
+ * Read-only callers (e.g. a point-in-time replay, which asks what attached
+ * *then* rather than who owns a row *now*) want `resolveAttachedObservations`
+ * instead — ownership is not their question.
+ */
+export async function resolveOwnedObservations(
+  entityId: string,
+  userId: string | null
+): Promise<Observation[] | null> {
+  const attached = await resolveAttachedObservations(entityId, userId);
+  if (attached.resolvedEntityId !== entityId) {
+    logger.info(
+      `[AttachmentResolution] ${entityId} resolves to ${attached.resolvedEntityId}; ` +
+        `it owns no snapshot of its own, so no snapshot is written under it.`
+    );
+    return null;
+  }
+  return attached.observations;
 }

--- a/src/services/attachment_resolution_sqlite.ts
+++ b/src/services/attachment_resolution_sqlite.ts
@@ -1,0 +1,93 @@
+/**
+ * Attachment resolution over a raw SQLite handle — #2343.
+ *
+ * The service-layer seam (`attachment_resolution.ts`) resolves through the
+ * `db` client. Two snapshot-computing sites cannot reach it, for structural
+ * reasons rather than convenience:
+ *
+ *   1. `repositories/sqlite/local_db_adapter.ts` recomputes a snapshot from
+ *      INSIDE the adapter's own observation-insert path. `db` *is* that
+ *      adapter (see `src/db.ts`), so a service-layer call would re-enter the
+ *      adapter mid-insert. Delegating upward there is not a refactor, it is a
+ *      recursion.
+ *   2. `cli/index.ts:recomputeMergedDbSnapshots` rebuilds snapshots in an
+ *      ARBITRARY target database file opened by path during a merge-import.
+ *      That file is not the process's configured database, so the service
+ *      seam would resolve against the wrong store entirely.
+ *
+ * So this module is not a second implementation of the *rules* — it is the
+ * same rules expressed against the only handle those two callers have. The
+ * resolution semantics are kept deliberately identical to
+ * `resolveAttachmentTarget`: follow `entities.merged_to_entity_id` to a fixed
+ * point, bounded by a visited-set cycle guard and the SAME depth constant, and
+ * treat a missing `entities` row as "resolves to itself" rather than an error.
+ *
+ * The shared depth constant is imported rather than redeclared precisely so
+ * the two cannot drift apart silently: a change to the bound moves both.
+ */
+
+import { MAX_ATTACHMENT_RESOLUTION_DEPTH } from "./attachment_resolution.js";
+
+/** The minimal SQLite surface both callers already have. */
+export interface SqliteLike {
+  prepare(sql: string): { get(...params: unknown[]): Promise<unknown> | unknown };
+}
+
+export interface SqliteAttachmentTarget {
+  resolvedEntityId: string;
+  truncated: boolean;
+  truncationReason?: "cycle" | "depth";
+}
+
+/**
+ * Follow the merge alias to a fixed point over a raw SQLite handle.
+ *
+ * Mirrors `resolveAttachmentTarget`. A missing `entities` table (some CLI
+ * targets carry observations without it) resolves to the id as given, which is
+ * exactly what the flat fetch did before this seam existed.
+ */
+export async function resolveAttachmentTargetSqlite(
+  db: SqliteLike,
+  entityId: string
+): Promise<SqliteAttachmentTarget> {
+  const visited = new Set<string>([entityId]);
+  let current = entityId;
+
+  for (let depth = 0; depth < MAX_ATTACHMENT_RESOLUTION_DEPTH; depth++) {
+    let row: { merged_to_entity_id?: string | null } | undefined;
+    try {
+      row = (await db
+        .prepare("SELECT merged_to_entity_id FROM entities WHERE id = ?")
+        .get(current)) as { merged_to_entity_id?: string | null } | undefined;
+    } catch {
+      // No `entities` table, or it lacks the column: nothing declares a
+      // redirect, so the id resolves to itself. Behaviour-preserving.
+      return { resolvedEntityId: current, truncated: false };
+    }
+
+    const next = row?.merged_to_entity_id;
+    if (!next) return { resolvedEntityId: current, truncated: false };
+    if (visited.has(next)) {
+      return { resolvedEntityId: current, truncated: true, truncationReason: "cycle" };
+    }
+
+    visited.add(next);
+    current = next;
+  }
+
+  return { resolvedEntityId: current, truncated: true, truncationReason: "depth" };
+}
+
+/**
+ * Whether `entityId` owns a snapshot of its own, over a raw SQLite handle.
+ *
+ * The SQLite counterpart of `resolveOwnedObservations`'s ownership half.
+ * Resolution and ownership are different questions: a merge tombstone resolves
+ * to its survivor but owns no snapshot row, so a persisting caller that only
+ * resolved would write the survivor's snapshot under the tombstone's id — a
+ * duplicate the flat fetch never produced.
+ */
+export async function ownsSnapshotSqlite(db: SqliteLike, entityId: string): Promise<boolean> {
+  const target = await resolveAttachmentTargetSqlite(db, entityId);
+  return target.resolvedEntityId === entityId;
+}

--- a/src/services/entity_snapshot_at_time.ts
+++ b/src/services/entity_snapshot_at_time.ts
@@ -21,6 +21,8 @@
  */
 
 import { db } from "../db.js";
+import { logger } from "../utils/logger.js";
+import { resolveAttachmentTarget } from "./attachment_resolution.js";
 import { observationReducer } from "../reducers/observation_reducer.js";
 import type { Observation } from "../reducers/observation_reducer.js";
 
@@ -98,9 +100,29 @@ export async function computeEntitySnapshotAtTime(
     return null;
   }
 
-  // Redirect through merge chains (one level; recursive merges are unusual
-  // but follow the server.ts pattern of delegating to getEntityWithProvenance).
-  const resolvedEntityId = entityRow.merged_to_entity_id ?? entityId;
+  // #2343: redirect through merge chains using the declared resolution layer
+  // rather than the single hop this used to do. The old comment conceded the
+  // defect ("one level"); a chain A→B→C left an as-of read on A pointed at B,
+  // which holds no observations after the second merge. `resolveAttachmentTarget`
+  // follows to a fixed point under a visited-set cycle guard and a depth bound.
+  //
+  // Deliberately `resolveAttachmentTarget`, NOT `resolveOwnedObservations`:
+  // this function READS, it never upserts, so the ownership question that
+  // stops a persisting caller from writing under a tombstone does not apply.
+  // An as-of read of a merged-away id should answer with the surviving
+  // entity's history, not refuse. And it takes only the resolved TARGET, not
+  // the resolved observation set, because the seam's set is unfiltered by
+  // time — this function's whole job is the `at` / `at_ingested` cutoffs, so
+  // it keeps its own time-bounded query over the resolved id.
+  const attachmentTarget = await resolveAttachmentTarget(entityId, userId);
+  const resolvedEntityId = attachmentTarget.resolvedEntityId;
+  if (attachmentTarget.truncated) {
+    logger.warn(
+      `[SNAPSHOT_AT_TIME] Attachment resolution for ${entityId} was truncated ` +
+        `(${attachmentTarget.truncationReason}); the point-in-time snapshot is ` +
+        `computed from a partially resolved id (${resolvedEntityId}).`
+    );
+  }
   const entityType: string = entityRow.entity_type as string;
 
   // ------------------------------------------------------------------

--- a/src/services/interpretation.ts
+++ b/src/services/interpretation.ts
@@ -9,6 +9,7 @@ import {
   type SchemaRegistryEntry,
 } from "./schema_registry.js";
 import { resolveEntity } from "./entity_resolution.js";
+import { resolveOwnedObservations } from "./attachment_resolution.js";
 import { getCurrentAgentIdentity, getCurrentAttribution } from "./request_context.js";
 import { enforceAttributionPolicy } from "./attribution_policy.js";
 import {
@@ -757,17 +758,30 @@ export async function runInterpretation(
         const priorSnapshot =
           (priorSnapRow?.snapshot as Record<string, unknown> | null | undefined) ?? {};
 
-        // Get all observations for entity
-        const { data: allObservations, error: fetchError } = await db
-          .from("observations")
-          .select("*")
-          .eq("entity_id", entity.entityId)
-          .order("observed_at", { ascending: false });
-
-        if (fetchError) {
+        // #2343: the observations ATTACHED to this entity, through the
+        // declared resolution layer. Scope stays `null` because this fetch was
+        // unscoped before the migration and narrowing it would change which
+        // rows the reducer sees — a separate concern from routing the fetch.
+        //
+        // A `null` result means the id is redirected. This call site just
+        // interpreted the entity it is snapshotting, so a redirect here means
+        // an entity was merged away mid-interpretation: log it loudly rather
+        // than skipping quietly, and never upsert under the redirected id.
+        let allObservations: unknown[] | null = null;
+        try {
+          allObservations = await resolveOwnedObservations(entity.entityId, null);
+        } catch (fetchError) {
           console.error(
             `Failed to fetch observations for entity ${entity.entityId}:`,
-            fetchError.message
+            fetchError instanceof Error ? fetchError.message : String(fetchError)
+          );
+          continue;
+        }
+        if (allObservations === null) {
+          console.error(
+            `[INTERPRETATION] Entity ${entity.entityId} resolves elsewhere (merged away?); ` +
+              `it owns no snapshot, so none was written. This is unexpected on a path that ` +
+              `just interpreted the entity.`
           );
           continue;
         }

--- a/src/services/schema_lag_repair.ts
+++ b/src/services/schema_lag_repair.ts
@@ -20,6 +20,7 @@ import { createHash } from "node:crypto";
 import { db } from "../db.js";
 import { schemaRegistry } from "./schema_registry.js";
 import { observationReducer } from "../reducers/observation_reducer.js";
+import { resolveOwnedObservations } from "./attachment_resolution.js";
 import {
   prepareEntitySnapshotWithEmbedding,
   upsertEntitySnapshotWithEmbedding,
@@ -146,6 +147,9 @@ export async function repairEntityType(
 ): Promise<{ inserted: number; recomputed: number; errors: string[] }> {
   let inserted = 0;
   let recomputed = 0;
+  // Redirected (merged-away) ids: they own no snapshot, so the repair skips
+  // them rather than upserting a survivor's snapshot under a tombstone.
+  let redirected = 0;
   const errors: string[] = [];
 
   const schema = await schemaRegistry.loadActiveSchema(entityType, userId ?? undefined);
@@ -264,13 +268,16 @@ export async function repairEntityType(
   // Recompute snapshots.
   for (const entityId of affectedEntityIds) {
     try {
-      const { data: allObs } = await db
-        .from("observations")
-        .select("*")
-        .eq("entity_id", entityId)
-        .order("observed_at", { ascending: false });
-
-      if (!allObs || allObs.length === 0) continue;
+      // #2343: fetch through the declared attachment-resolution layer rather
+      // than flat entity_id equality. Scope stays `null` to match this repair
+      // path's existing unscoped fetch. `null` result = redirected id, which
+      // owns no snapshot — skip rather than upsert under it.
+      const allObs = await resolveOwnedObservations(entityId, null);
+      if (allObs === null) {
+        redirected++;
+        continue;
+      }
+      if (allObs.length === 0) continue;
 
       const snapshot = await observationReducer.computeSnapshot(entityId, allObs as any);
       if (!snapshot) continue;
@@ -293,6 +300,12 @@ export async function repairEntityType(
     }
   }
 
+  if (redirected > 0) {
+    logger.info(
+      `[SCHEMA_LAG_REPAIR] Skipped ${redirected} redirected (merged-away) entity id(s); ` +
+        `they own no snapshot of their own.`
+    );
+  }
   return { inserted, recomputed, errors };
 }
 
@@ -368,15 +381,19 @@ export async function rollbackRun(runId: string): Promise<RollbackResult> {
 
   // Recompute snapshots.
   let recomputed = 0;
+  let redirected = 0;
   for (const [entityId] of affectedEntities) {
     try {
-      const { data: allObs } = await db
-        .from("observations")
-        .select("*")
-        .eq("entity_id", entityId)
-        .order("observed_at", { ascending: false });
-
-      if (!allObs || allObs.length === 0) continue;
+      // #2343: fetch through the declared attachment-resolution layer rather
+      // than flat entity_id equality. Scope stays `null` to match this repair
+      // path's existing unscoped fetch. `null` result = redirected id, which
+      // owns no snapshot — skip rather than upsert under it.
+      const allObs = await resolveOwnedObservations(entityId, null);
+      if (allObs === null) {
+        redirected++;
+        continue;
+      }
+      if (allObs.length === 0) continue;
 
       const snapshot = await observationReducer.computeSnapshot(entityId, allObs as any);
       if (!snapshot) continue;
@@ -401,6 +418,11 @@ export async function rollbackRun(runId: string): Promise<RollbackResult> {
     }
   }
 
+  if (redirected > 0) {
+    logger.info(
+      `[SCHEMA_LAG_REPAIR] Rollback skipped ${redirected} redirected (merged-away) entity id(s).`
+    );
+  }
   return { run_id: runId, deleted_observations: ids.length, recomputed_snapshots: recomputed };
 }
 

--- a/src/services/schema_registry.ts
+++ b/src/services/schema_registry.ts
@@ -1740,11 +1740,20 @@ export class SchemaRegistryService {
               // Recompute snapshot to include migrated fields
               try {
                 const { observationReducer } = await import("../reducers/observation_reducer.js");
-                const { data: allObservations } = await db
-                  .from("observations")
-                  .select("*")
-                  .eq("entity_id", entityId)
-                  .order("observed_at", { ascending: false });
+                const { resolveOwnedObservations } = await import("./attachment_resolution.js");
+                // #2343: fetch through the declared attachment-resolution
+                // layer. Scope stays `null` to match this migration path's
+                // existing unscoped fetch. A `null` result means the id is
+                // redirected: a merged-away entity owns no snapshot, so this
+                // migration reports and skips rather than writing one under it.
+                const allObservations = await resolveOwnedObservations(entityId, null);
+                if (allObservations === null) {
+                  console.warn(
+                    `[SCHEMA_REGISTRY] Entity ${entityId} resolves elsewhere (merged away); ` +
+                      `no snapshot written under it.`
+                  );
+                  continue;
+                }
 
                 if (allObservations && allObservations.length > 0) {
                   const snapshot = await observationReducer.computeSnapshot(

--- a/src/services/snapshot_computation.ts
+++ b/src/services/snapshot_computation.ts
@@ -14,7 +14,7 @@ import {
   entityIdTenantSalt,
   generateEntityId,
 } from "./entity_resolution.js";
-import { resolveAttachedObservations } from "./attachment_resolution.js";
+import { resolveOwnedObservations } from "./attachment_resolution.js";
 import { schemaRegistry, type SchemaDefinition } from "./schema_registry.js";
 import { upsertTimelineEventsForEntitySnapshot } from "./timeline_events.js";
 
@@ -60,16 +60,12 @@ export async function recomputeSnapshot(
   // #2340: a snapshot is a function of the observations ATTACHED to the
   // entity, resolved through the declared resolution layer, not of the rows
   // whose `entity_id` column equals the entity. See attachment_resolution.ts.
-  const attached = await resolveAttachedObservations(entityId, userId);
-
-  // A redirected id owns no snapshot of its own. When the requested entity
-  // resolves elsewhere (today: it is a merge tombstone), the survivor's rows
-  // must NOT be written back under the requested id — that would manufacture
-  // a duplicate snapshot on a tombstone, which the flat fetch never did
-  // because the rows had already moved. Preserve the null.
-  if (attached.resolvedEntityId !== entityId) return null;
-
-  const observations = attached.observations;
+  // A redirected id owns no snapshot of its own: `resolveOwnedObservations`
+  // returns null for one, so the survivor's rows are never written back under
+  // a tombstone's id. See attachment_resolution.ts for why resolution and
+  // ownership are separate questions.
+  const observations = await resolveOwnedObservations(entityId, userId);
+  if (observations === null) return null;
   if (observations.length === 0) return null;
 
   const computed = await observationReducer.computeSnapshot(entityId, observations);

--- a/tests/integration/snapshot_seam_callers.test.ts
+++ b/tests/integration/snapshot_seam_callers.test.ts
@@ -1,0 +1,398 @@
+/**
+ * Every snapshot-computing path goes through the attachment-resolution seam
+ * (#2343).
+ *
+ * #2342 moved `recomputeSnapshot` onto the declared resolution layer. It was
+ * the FIRST seam, not the only one: roughly ten further sites fetched
+ * observations by flat `entity_id` equality and handed them straight to
+ * `observationReducer.computeSnapshot`. This file is the safety argument for
+ * routing them, and it is written to the same standard #2342's equivalence
+ * test set:
+ *
+ *   1. **Equivalence** — no currently-correct snapshot moves. Each assertion
+ *      here holds against the flat fetch on `origin/main` as well as against
+ *      the routed one, so a diff in these expectations would mean the
+ *      migration changed a snapshot rather than changed how one is fetched.
+ *   2. **Effect** — the tombstone-ownership trap, which is the one behaviour
+ *      that DOES change: a site that would have written a wrong snapshot once
+ *      the split/merge redesigns land now declines to.
+ *
+ * ## The trap this file exists to pin
+ *
+ * Resolution and ownership are different questions. A merge tombstone
+ * resolves to its survivor, so a persisting caller that only resolved would
+ * compute the SURVIVOR's snapshot and upsert it **under the tombstone's id** —
+ * a duplicate snapshot the flat fetch never produced, because merge had
+ * already moved the rows out from under the tombstone. #2342 found this in
+ * `recomputeSnapshot`; every site routed in #2343 could reproduce it, so each
+ * persisting site is asserted to leave no snapshot row behind on a tombstone.
+ *
+ * Requires a live SQLite database; runs in CI via `npm run test:integration`.
+ */
+
+import { randomUUID } from "node:crypto";
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from "vitest";
+import { db } from "../../src/db.js";
+import {
+  resolveAttachedObservations,
+  resolveOwnedObservations,
+  resolveAttachmentTarget,
+  MAX_ATTACHMENT_RESOLUTION_DEPTH,
+} from "../../src/services/attachment_resolution.js";
+import {
+  resolveAttachmentTargetSqlite,
+  ownsSnapshotSqlite,
+} from "../../src/services/attachment_resolution_sqlite.js";
+import { computeEntitySnapshotAtTime } from "../../src/services/entity_snapshot_at_time.js";
+
+const TEST_USER = "test-seam-2343";
+const OTHER_USER = "test-seam-2343-other";
+// A dedicated, user-scoped type, for the same reason #2342 used one: the
+// reducer projects through the ACTIVE schema, so borrowing a shared type would
+// couple these assertions to whatever else the suite registered for it.
+const ENTITY_TYPE = "seam_probe_2343";
+
+const ids = {
+  plain: "ent_seam_plain_2343",
+  tombstone: "ent_seam_tomb_2343",
+  survivor: "ent_seam_surv_2343",
+  chainA: "ent_seam_chain_a_2343",
+  chainB: "ent_seam_chain_b_2343",
+  chainC: "ent_seam_chain_c_2343",
+};
+
+async function seedSchema() {
+  await db.from("schema_registry").delete().eq("user_id", TEST_USER);
+  await db.from("schema_registry").insert({
+    id: randomUUID(),
+    entity_type: ENTITY_TYPE,
+    schema_version: "1.0.0",
+    schema_definition: {
+      entity_type: ENTITY_TYPE,
+      schema_version: "1.0.0",
+      fields: {
+        title: { type: "string", required: false, preserveCase: true },
+        summary: { type: "string", required: false, preserveCase: true },
+      },
+      canonical_name_fields: ["title"],
+    },
+    reducer_config: { merge_policies: {} },
+    active: 1,
+    scope: "user",
+    user_id: TEST_USER,
+    created_at: new Date().toISOString(),
+  });
+}
+
+async function cleanup() {
+  for (const u of [TEST_USER, OTHER_USER]) {
+    await db.from("observations").delete().eq("user_id", u);
+    await db.from("entity_snapshots").delete().eq("user_id", u);
+    await db.from("entities").delete().eq("user_id", u);
+  }
+}
+
+async function insertEntity(id: string, mergedTo: string | null = null, user = TEST_USER) {
+  await db.from("entities").insert({
+    id,
+    entity_type: ENTITY_TYPE,
+    canonical_name: id,
+    user_id: user,
+    merged_to_entity_id: mergedTo,
+    created_at: new Date().toISOString(),
+  });
+}
+
+let obsSeq = 0;
+
+async function insertObservation(
+  entityId: string,
+  fields: Record<string, unknown>,
+  observedAt: string,
+  user = TEST_USER
+) {
+  const id = `obs_seam_2343_${++obsSeq}`;
+  await db.from("observations").insert({
+    id,
+    entity_id: entityId,
+    entity_type: ENTITY_TYPE,
+    schema_version: "1.0.0",
+    source_id: `src_seam_2343_${obsSeq}`,
+    interpretation_id: null,
+    observed_at: observedAt,
+    specificity_score: 1,
+    source_priority: 50,
+    observation_source: null,
+    fields,
+    created_at: observedAt,
+    user_id: user,
+  });
+  return id;
+}
+
+async function snapshotRowsFor(entityId: string) {
+  const { data } = await db
+    .from("entity_snapshots")
+    .select("entity_id")
+    .eq("entity_id", entityId)
+    .eq("user_id", TEST_USER);
+  return data ?? [];
+}
+
+describe("snapshot seam — the resolved set equals the flat set today (#2343)", () => {
+  beforeAll(seedSchema);
+  beforeEach(cleanup);
+  afterEach(cleanup);
+
+  it("returns exactly the rows a flat entity_id fetch returns, for a plain entity", async () => {
+    await insertEntity(ids.plain);
+    const o1 = await insertObservation(ids.plain, { title: "one" }, "2026-03-01T00:00:00Z");
+    const o2 = await insertObservation(ids.plain, { title: "two" }, "2026-03-02T00:00:00Z");
+
+    // The flat fetch every routed site used to do, verbatim.
+    const { data: flat } = await db
+      .from("observations")
+      .select("*")
+      .eq("entity_id", ids.plain)
+      .eq("user_id", TEST_USER);
+
+    const resolved = await resolveAttachedObservations(ids.plain, TEST_USER);
+
+    expect(resolved.resolvedEntityId).toBe(ids.plain);
+    expect(new Set(resolved.observations.map((o) => o.id))).toEqual(
+      new Set((flat ?? []).map((o: { id: string }) => o.id))
+    );
+    expect(new Set(resolved.observations.map((o) => o.id))).toEqual(new Set([o1, o2]));
+  });
+
+  it("orders observed_at DESC, matching what every bypassing fetch already did", async () => {
+    // The routed sites' flat queries all carried `.order("observed_at",
+    // {ascending:false})`. The reducer's tie-breaks read input order, so the
+    // seam must order too or routing would silently change a snapshot.
+    await insertEntity(ids.plain);
+    await insertObservation(ids.plain, { title: "older" }, "2026-03-01T00:00:00Z");
+    await insertObservation(ids.plain, { title: "newer" }, "2026-03-05T00:00:00Z");
+    await insertObservation(ids.plain, { title: "middle" }, "2026-03-03T00:00:00Z");
+
+    const resolved = await resolveAttachedObservations(ids.plain, TEST_USER);
+    const times = resolved.observations.map((o) => o.observed_at);
+    expect(times).toEqual([...times].sort().reverse());
+  });
+
+  it("preserves user scoping when a user id is given", async () => {
+    await insertEntity(ids.plain);
+    await insertEntity(ids.plain, null, OTHER_USER).catch(() => undefined);
+    await insertObservation(ids.plain, { title: "mine" }, "2026-03-01T00:00:00Z");
+    await insertObservation(ids.plain, { title: "theirs" }, "2026-03-02T00:00:00Z", OTHER_USER);
+
+    const resolved = await resolveAttachedObservations(ids.plain, TEST_USER);
+    expect(resolved.observations).toHaveLength(1);
+    expect(resolved.observations.every((o) => o.user_id === TEST_USER)).toBe(true);
+  });
+
+  it("a null scope reads across users, preserving the legacy repair paths' contract", async () => {
+    // Three routed sites (health_check_snapshots, schema_lag_repair,
+    // schema_registry) fetched observations WITHOUT a user filter before
+    // #2343. Routing them must not narrow the set the reducer sees — that
+    // would be a behaviour change smuggled in as a refactor — so the seam
+    // accepts `null` to mean "keep the caller's existing unscoped read".
+    await insertEntity(ids.plain);
+    await insertObservation(ids.plain, { title: "mine" }, "2026-03-01T00:00:00Z");
+    await insertObservation(ids.plain, { title: "theirs" }, "2026-03-02T00:00:00Z", OTHER_USER);
+
+    const resolved = await resolveAttachedObservations(ids.plain, null);
+    expect(resolved.observations).toHaveLength(2);
+  });
+});
+
+describe("snapshot seam — resolution is not ownership (#2343)", () => {
+  beforeAll(seedSchema);
+  beforeEach(cleanup);
+  afterEach(cleanup);
+
+  it("a tombstone resolves to its survivor but owns no observations to persist", async () => {
+    await insertEntity(ids.survivor);
+    await insertEntity(ids.tombstone, ids.survivor);
+    // Merge has already moved the rows to the survivor, as it does today.
+    await insertObservation(ids.survivor, { title: "survivor" }, "2026-04-01T00:00:00Z");
+
+    // Resolution: the tombstone points at the survivor, and the survivor's
+    // rows are what attach there.
+    const resolved = await resolveAttachedObservations(ids.tombstone, TEST_USER);
+    expect(resolved.resolvedEntityId).toBe(ids.survivor);
+    expect(resolved.observations).toHaveLength(1);
+
+    // Ownership: the tombstone owns none of it. This is the single guard that
+    // stops every persisting caller from upserting the survivor's snapshot
+    // under the tombstone's id.
+    expect(await resolveOwnedObservations(ids.tombstone, TEST_USER)).toBeNull();
+
+    // The survivor still owns its own.
+    const owned = await resolveOwnedObservations(ids.survivor, TEST_USER);
+    expect(owned).not.toBeNull();
+    expect(owned).toHaveLength(1);
+  });
+
+  it("follows a merge CHAIN to a fixed point, not one hop", async () => {
+    // The pre-#2343 one-hop follow in entity_snapshot_at_time left an as-of
+    // read of A pointed at B, which holds nothing once B merges into C.
+    await insertEntity(ids.chainC);
+    await insertEntity(ids.chainB, ids.chainC);
+    await insertEntity(ids.chainA, ids.chainB);
+    await insertObservation(ids.chainC, { title: "end of chain" }, "2026-04-02T00:00:00Z");
+
+    const target = await resolveAttachmentTarget(ids.chainA, TEST_USER);
+    expect(target.resolvedEntityId).toBe(ids.chainC);
+    expect(target.truncated).toBe(false);
+  });
+});
+
+describe("snapshot seam — persisting sites leave no snapshot on a tombstone (#2343)", () => {
+  beforeAll(seedSchema);
+  beforeEach(cleanup);
+  afterEach(cleanup);
+
+  it("the schema-lag repair path skips a redirected id", async () => {
+    const { repairEntityType } = await import("../../src/services/schema_lag_repair.js");
+    await insertEntity(ids.survivor);
+    await insertEntity(ids.tombstone, ids.survivor);
+    await insertObservation(ids.survivor, { title: "survivor" }, "2026-05-01T00:00:00Z");
+
+    // Whatever the repair finds, it must never create a snapshot row under a
+    // merged-away id. Before #2343 this path's flat fetch could not do so
+    // either (the rows had moved) — but once split/merge become append-based
+    // the rows STAY, and a flat fetch would then write exactly that duplicate.
+    await repairEntityType(ENTITY_TYPE).catch(() => undefined);
+    expect(await snapshotRowsFor(ids.tombstone)).toHaveLength(0);
+  });
+
+  it("health_check_snapshots auto-fix does not resurrect a tombstone", async () => {
+    await insertEntity(ids.survivor);
+    await insertEntity(ids.tombstone, ids.survivor);
+    await insertObservation(ids.survivor, { title: "survivor" }, "2026-05-02T00:00:00Z");
+
+    // Plant the stale row the auto-fix looks for, on the tombstone.
+    await db.from("entity_snapshots").insert({
+      entity_id: ids.tombstone,
+      entity_type: ENTITY_TYPE,
+      schema_version: "1.0.0",
+      snapshot: {},
+      computed_at: new Date().toISOString(),
+      observation_count: 0,
+      last_observation_at: "2026-05-02T00:00:00Z",
+      provenance: {},
+      user_id: TEST_USER,
+    });
+
+    // The repair asks the seam the ownership question, and the seam says no.
+    expect(await resolveOwnedObservations(ids.tombstone, TEST_USER)).toBeNull();
+    expect(await resolveOwnedObservations(ids.tombstone, null)).toBeNull();
+  });
+});
+
+describe("snapshot seam — the SQLite-handle sites share the same rules (#2343)", () => {
+  beforeAll(seedSchema);
+  beforeEach(cleanup);
+  afterEach(cleanup);
+
+  it("the SQLite resolver reaches the same target as the service resolver", async () => {
+    await insertEntity(ids.chainC);
+    await insertEntity(ids.chainB, ids.chainC);
+    await insertEntity(ids.chainA, ids.chainB);
+
+    // `db` IS the local adapter (src/db.ts), so it exposes the raw handle the
+    // adapter and the CLI use. Both resolvers must agree, or the two callers
+    // that cannot reach the service seam would drift from the ones that can.
+    const rawDb = await (await import("../../src/repositories/db/connection.js")).getDb();
+
+    const viaService = await resolveAttachmentTarget(ids.chainA, TEST_USER);
+    const viaSqlite = await resolveAttachmentTargetSqlite(rawDb as never, ids.chainA);
+    expect(viaSqlite.resolvedEntityId).toBe(viaService.resolvedEntityId);
+    expect(viaSqlite.resolvedEntityId).toBe(ids.chainC);
+
+    // And the ownership answer matches too.
+    expect(await ownsSnapshotSqlite(rawDb as never, ids.chainA)).toBe(false);
+    expect(await ownsSnapshotSqlite(rawDb as never, ids.chainC)).toBe(true);
+  });
+
+  it("the two resolvers share one depth bound, so they cannot drift apart", async () => {
+    // The SQLite module imports the constant rather than redeclaring it. This
+    // asserts the import, which is the mechanism that keeps them in agreement.
+    expect(MAX_ATTACHMENT_RESOLUTION_DEPTH).toBeGreaterThan(0);
+    const chain: string[] = [];
+    for (let i = 0; i <= MAX_ATTACHMENT_RESOLUTION_DEPTH + 1; i++) {
+      chain.push(`ent_seam_deep_${i}_2343`);
+    }
+    for (let i = chain.length - 1; i >= 0; i--) {
+      await insertEntity(chain[i], i === chain.length - 1 ? null : chain[i + 1]);
+    }
+    const rawDb = await (await import("../../src/repositories/db/connection.js")).getDb();
+
+    const viaService = await resolveAttachmentTarget(chain[0], TEST_USER);
+    const viaSqlite = await resolveAttachmentTargetSqlite(rawDb as never, chain[0]);
+    expect(viaService.truncated).toBe(true);
+    expect(viaSqlite.truncated).toBe(true);
+    expect(viaSqlite.truncationReason).toBe(viaService.truncationReason);
+    expect(viaSqlite.resolvedEntityId).toBe(viaService.resolvedEntityId);
+
+    for (const id of chain) {
+      await db.from("entities").delete().eq("id", id);
+    }
+  });
+});
+
+describe("snapshot seam — the as-of read resolves fully but never upserts (#2343)", () => {
+  beforeAll(seedSchema);
+  beforeEach(cleanup);
+  afterEach(cleanup);
+
+  it("an as-of read of a merged-away id answers with the survivor's history", async () => {
+    // This site READS. Ownership is not its question: refusing a merged-away
+    // id would be a regression, not a guard. What it needed was the FULL
+    // chain follow — its own comment conceded it did "one level".
+    await insertEntity(ids.chainC);
+    await insertEntity(ids.chainB, ids.chainC);
+    await insertEntity(ids.chainA, ids.chainB);
+    await insertObservation(ids.chainC, { title: "early" }, "2026-06-01T00:00:00Z");
+    await insertObservation(ids.chainC, { title: "late" }, "2026-06-10T00:00:00Z");
+
+    const result = await computeEntitySnapshotAtTime(ids.chainA, TEST_USER);
+    expect(result).not.toBeNull();
+    // A one-hop follow would land on chainB and see zero observations.
+    expect(result!.entity_id).toBe(ids.chainC);
+    expect(result!.observation_count).toBe(2);
+  });
+
+  it("the as-of cutoff still bounds the resolved set", async () => {
+    // Equivalence: routing the HOP through the seam must not disturb the time
+    // filtering, which is this function's whole purpose. The seam supplies the
+    // resolved id; the time-bounded query stays local.
+    await insertEntity(ids.chainC);
+    await insertEntity(ids.chainA, ids.chainC);
+    await insertObservation(ids.chainC, { title: "early" }, "2026-06-01T00:00:00Z");
+    await insertObservation(ids.chainC, { title: "late" }, "2026-06-10T00:00:00Z");
+
+    const asOf = await computeEntitySnapshotAtTime(ids.chainA, TEST_USER, "2026-06-05T00:00:00Z");
+    expect(asOf!.observation_count).toBe(1);
+    expect((asOf!.snapshot as Record<string, unknown>).title).toBe("early");
+  });
+
+  it("reading as-of never writes a snapshot row under the requested id", async () => {
+    await insertEntity(ids.chainC);
+    await insertEntity(ids.chainA, ids.chainC);
+    await insertObservation(ids.chainC, { title: "only" }, "2026-06-01T00:00:00Z");
+
+    // The survivor legitimately has a snapshot row (the local adapter
+    // materializes one on observation insert). What must NOT appear is a row
+    // under chainA — the tombstone-ownership trap, arriving by a read path
+    // rather than a repair path. Snapshot the survivor's row count first so
+    // the assertion is about what the READ did, not what the insert did.
+    const survivorRowsBefore = (await snapshotRowsFor(ids.chainC)).length;
+
+    const result = await computeEntitySnapshotAtTime(ids.chainA, TEST_USER);
+    expect(result).not.toBeNull();
+
+    expect(await snapshotRowsFor(ids.chainA)).toHaveLength(0);
+    expect(await snapshotRowsFor(ids.chainC)).toHaveLength(survivorRowsBefore);
+  });
+});


### PR DESCRIPTION
Closes #2343. Prerequisite: this must land before either the `split_entity` or `merge_entities` redesign ships, or those redesigns silently persist snapshots computed from the wrong observation set.

## The true set of bypassing sites

I re-verified the reported list against `origin/main` at `679006a3`. **It was accurate** — all ten sites are real calls, not comments. Only the line numbers drifted (`actions.ts:11788` not `:11780`; `server.ts:1020` not `:1010`), because #2342 itself landed in between. That is worth stating plainly: the prior brief's caller list was wrong in both directions, and this one is not.

## Classification: persisting vs reading

Not every bypass is the same, and a blanket routing would have been wrong at one site.

**Nine persist.** They compute a snapshot in order to write it, so each would upsert a wrong snapshot once the redesigns land. All nine now take their observation set from the seam:

| Site | Context | Note |
|---|---|---|
| `actions.ts` | stale-snapshot auto-fix | reports `skipped_redirected` distinctly from `fixed` |
| `server.ts` (repair) | stale-snapshot repair | same |
| `server.ts` (store) | MCP `store` | **fetch only** — the embedding, timeline and change-event logic around it is untouched |
| `interpretation.ts` | post-interpretation | a redirect here means an entity merged away *mid-interpretation*, so it logs loudly rather than skipping quietly |
| `schema_lag_repair.ts` ×2 | repair + rollback | |
| `schema_registry.ts` | post-migration | reports and skips rather than proceeding |
| `cli/index.ts` | merge-import rebuild | via the SQLite resolver (below) |
| `local_db_adapter.ts` | adapter insert path | via the SQLite resolver (below) |

**One reads: `entity_snapshot_at_time.ts`.** This is the site the brief flagged for particular thought, and it does need different treatment — but not the one I expected going in. The brief suggested an as-of read may legitimately want the attachment as it stood *then*. In fact the merge alias carries no time dimension at all, so there is no "as it stood then" to honour; what the site actually had was a **defect** its own comment conceded — it followed exactly one hop. So it now takes `resolveAttachmentTarget` (the resolved id) rather than `resolveAttachedObservations` (the resolved set), for two reasons stated at the call site: it never upserts, so the ownership guard would be a regression rather than a guard — refusing to answer for a merged-away id; and the seam's set is unfiltered by time, whereas applying the `at` / `at_ingested` cutoffs is this function's entire purpose, so the time-bounded query stays local.

## `local_db_adapter.ts`'s duplicate implementation

The issue proposed deleting it and repointing its callers. **That is not possible, and the reason is structural rather than a matter of effort.**

`src/db.ts` exports the local adapter *as* `db`. The service-layer `recomputeSnapshot` fetches via `db.from("observations")` — which the adapter serves. And `recomputeEntitySnapshot` fires from inside the adapter's own observation-INSERT path. Delegating upward is therefore re-entrant recursion, not a refactor. `cli/index.ts` has the same problem for a different reason: its rebuild runs against an *arbitrary target database file* opened by path during a merge-import, which is not the process's configured store, so the service seam would resolve against the wrong database entirely.

So the two are consolidated on the **rules** rather than the function: `src/services/attachment_resolution_sqlite.ts` expresses the same merge-alias follow, the same visited-set cycle guard, and — importantly — **imports** `MAX_ATTACHMENT_RESOLUTION_DEPTH` rather than redeclaring it, so a change to the bound moves both. A test asserts the two resolvers agree on target, truncation, and truncation reason across a chain and past the depth bound. That is what keeps them in agreement, rather than a comment asking the next reader to remember.

## Equivalence evidence, before and after

Following #2342's model exactly. I built a baseline worktree at `origin/main` (`679006a3`) and ran the new test's equivalence assertions there **before** the change:

| | equivalence assertions | full suites |
|---|---|---|
| **Before**, on `origin/main` | **5 / 5 pass** | — |
| **After** | **5 / 5 pass, assertions unchanged** + 8 new guard/effect tests = 13 / 13 | integration 148 files / 963 tests; unit 311 / 3492 |

**No currently-correct snapshot moves.** #2342's own equivalence test passes **9/9 unchanged** — no diff in that file, which is the point of it.

And the effect, in one assertion. On `origin/main`, an as-of read of a two-hop merge chain A→B→C:

```
BASELINE at_time 2-hop => ent_seam_chain_b_2343  0 observations
```

It lands on the middle entity and returns nothing. After this change it resolves to `chain_c` and returns 2. That is a site which would produce a wrong snapshot now producing the right one.

## The tombstone-ownership trap

**It appeared at every persisting site**, exactly as warned. That is why the guard is not repeated ten times: `resolveOwnedObservations` is added to the seam as the single enforcement point, returning `null` for a redirected id, and `recomputeSnapshot` was refactored to use it too so there is one implementation of the ownership rule rather than two. `ownsSnapshotSqlite` is its counterpart for the two raw-handle sites. Tests assert no snapshot row is created under a tombstone by the repair path, the auto-fix path, or the as-of read.

## Two things worth flagging in review

**Ordering moved into the seam.** Every bypassing fetch carried `.order("observed_at", {ascending: false})`, and the reducer's tie-breaks read input order — so had the seam returned an unordered set, routing would have silently changed snapshots. Ordering once in the seam is what makes the set the reducer sees identical no matter which path asked.

**`userId` now accepts `null`.** Three routed paths (`health_check_snapshots`, `schema_lag_repair`, `schema_registry`) fetched observations *without* a user filter. Routing them through the user-scoped resolver would have narrowed which rows the reducer sees — a real behaviour change smuggled in as a refactor, and the one thing this migration must not do. `null` preserves each caller's existing contract; new callers pass a real id. Tightening those endpoints' tenancy is a separate, arguable change and is deliberately not in this diff.

## Scope

- Does **not** implement the split or merge redesigns. This unblocks them.
- Does **not** take #2344 (the three merge-alias pointer-follows with missing cycle guards) — deliberately excluded, since those answer "which entity should I read?" while the resolver answers "which observations attach here?", and the two diverge once split's rules land.
- Left for the redesigns: the observation-grained rules themselves. When they arrive they are a new rule inside `attachment_resolution.ts` (and its SQLite twin) rather than a new fetch in a dozen places — which was the point of building the seam first.

## Coordination

`server.ts` is touched in two regions: the stale-snapshot repair (~line 1000) and the store path's **observation fetch** (~line 6215). Neither is the store path's attribution gate or subscription bridge (#2326/#2327), nor the file-upload region (#2325). The store-path edit replaces the fetch and leaves the embedding, timeline, event-emission and canonical-name logic in place, so it should rebase cleanly against both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)