### PR TITLE
fix(security): scope the entity-id resource handlers by user_id (#2093)

### DIFF
--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,21 +61,21 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **597**
-- Backend and repo Vitest files: **562**
+- Total automated test files: **601**
+- Backend and repo Vitest files: **566**
 - Frontend Vitest files: **9**
 - Playwright spec files: **26**
 
 ### Suite counts
 | Suite | Files |
 |---|---:|
-| Vitest unit tests | 164 |
+| Vitest unit tests | 165 |
 | Vitest service tests | 44 |
 | Source-adjacent tests | 66 |
-| Vitest integration tests | 169 |
+| Vitest integration tests | 171 |
 | Vitest CLI tests | 78 |
 | Vitest contract tests | 18 |
-| Vitest security tests | 7 |
+| Vitest security tests | 8 |
 | Vitest subscription tests | 6 |
 | Vitest agent tests | 1 |
 | Vitest fixture tests | 1 |
@@ -109,7 +109,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/unit`
 **Requirements:** Basic `.env` if required by the module under test.
-**Files (164):**
+**Files (165):**
 - `tests/unit/aauth_admission.test.ts`
 - `tests/unit/aauth_attestation_apple_se.test.ts`
 - `tests/unit/aauth_attestation_revocation.test.ts`
@@ -181,6 +181,7 @@ flowchart TD
 - `tests/unit/external_actor_provenance.test.ts`
 - `tests/unit/features/FU-2026-Q3-aauth-inspector-attestation-viz/agent_badge_tier_icon.test.ts`
 - `tests/unit/field_constraints.test.ts`
+- `tests/unit/file_input_diagnostics.test.ts`
 - `tests/unit/github_issue_thread.test.ts`
 - `tests/unit/github_mirror_guidance.test.ts`
 - `tests/unit/github_pages_asset_paths.test.ts`
@@ -404,7 +405,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm run test:integration` or `npx vitest run tests/integration`
 **Requirements:** Database configured; remote-dependent subsets additionally need `RUN_REMOTE_TESTS=1`.
-**Files (169):**
+**Files (171):**
 - `tests/integration/aauth_attribution_stamping.test.ts`
 - `tests/integration/aauth_mcp_capability_parity.test.ts`
 - `tests/integration/aauth_mcp_initialize_admission.test.ts`
@@ -504,6 +505,7 @@ flowchart TD
 - `tests/integration/mcp_schema_variations.test.ts`
 - `tests/integration/mcp_session_404_reconnect.test.ts`
 - `tests/integration/mcp_stdio_attribution.test.ts`
+- `tests/integration/mcp_store_attribution_policy.test.ts`
 - `tests/integration/mcp_store_canonical_name_unknown_fields.test.ts`
 - `tests/integration/mcp_store_intra_batch_relationships.test.ts`
 - `tests/integration/mcp_store_parquet.test.ts`
@@ -544,6 +546,7 @@ flowchart TD
 - `tests/integration/seed_then_works_at_e2e.test.ts`
 - `tests/integration/session_introspection.test.ts`
 - `tests/integration/snapshot_ingestion_cutoff.test.ts`
+- `tests/integration/snapshot_seam_callers.test.ts`
 - `tests/integration/standing_rules_initialize_effect.test.ts`
 - `tests/integration/store_builtin_identity_opt_out_schemas.test.ts`
 - `tests/integration/store_canonical_name_recompute.test.ts`
@@ -690,10 +693,11 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npx vitest run tests/security`
 **Requirements:** Use alongside the dedicated security validation scripts when changing auth or route protection.
-**Files (7):**
+**Files (8):**
 - `tests/security/auth_topology_matrix.test.ts`
 - `tests/security/cross_user_read_scoping.test.ts`
 - `tests/security/ed25519_forged_key_auth_bypass.test.ts`
+- `tests/security/mcp_resource_tenant_isolation.test.ts`
 - `tests/security/rendered_page_csp.test.ts`
 - `tests/security/sandbox_mode_resolver.test.ts`
 - `tests/security/sort_by_sql_injection.test.ts`

--- a/src/server.ts
+++ b/src/server.ts
@@ -7829,11 +7829,14 @@ export class NeotomaServer {
    * Resource handler: Get individual entity
    */
   private async handleIndividualEntity(entityId: string): Promise<any> {
+    const userId = this.getAuthenticatedUserId();
+
     // Get entity
     const { data: entity, error: entityError } = await db
       .from("entities")
       .select("*")
       .eq("id", entityId)
+      .eq("user_id", userId)
       .single();
 
     if (entityError || !entity) {
@@ -7845,6 +7848,7 @@ export class NeotomaServer {
       .from("entity_snapshots")
       .select("*")
       .eq("entity_id", entityId)
+      .eq("user_id", userId)
       .single();
 
     if (snapshotError) {
@@ -7870,10 +7874,13 @@ export class NeotomaServer {
    * Resource handler: Get entity observations
    */
   private async handleEntityObservations(entityId: string): Promise<any> {
+    const userId = this.getAuthenticatedUserId();
+
     const { data: observations, error } = await db
       .from("observations")
       .select("*")
       .eq("entity_id", entityId)
+      .eq("user_id", userId)
       .order("observed_at", { ascending: false })
       .limit(100);
 
@@ -7885,7 +7892,8 @@ export class NeotomaServer {
     const { count, error: countError } = await db
       .from("observations")
       .select("*", { count: "exact", head: true })
-      .eq("entity_id", entityId);
+      .eq("entity_id", entityId)
+      .eq("user_id", userId);
 
     if (countError) {
       throw new McpError(
@@ -7907,11 +7915,14 @@ export class NeotomaServer {
    * Resource handler: Get entity relationships
    */
   private async handleEntityRelationships(entityId: string): Promise<any> {
+    const userId = this.getAuthenticatedUserId();
+
     // Get outbound relationships
     const { data: outbound, error: outError } = await db
       .from("relationship_snapshots")
       .select("*")
-      .eq("source_entity_id", entityId);
+      .eq("source_entity_id", entityId)
+      .eq("user_id", userId);
 
     if (outError) {
       throw new McpError(
@@ -7924,7 +7935,8 @@ export class NeotomaServer {
     const { data: inbound, error: inError } = await db
       .from("relationship_snapshots")
       .select("*")
-      .eq("target_entity_id", entityId);
+      .eq("target_entity_id", entityId)
+      .eq("user_id", userId);
 
     if (inError) {
       throw new McpError(

--- a/tests/security/mcp_resource_tenant_isolation.test.ts
+++ b/tests/security/mcp_resource_tenant_isolation.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Tenant isolation for the MCP resource handlers reached by entity id.
+ *
+ * Companion to `tenant_isolation_matrix.test.ts`, which covers the HTTP
+ * query endpoints. This file covers the other door onto the same data:
+ * the `neotoma://entity/{id}` resource family, whose handlers query the
+ * database directly rather than through the scoped query layer.
+ *
+ * Motivated by #2093. Three handlers reachable by entity id applied no
+ * `user_id` filter at all, so any authenticated caller who knew or guessed
+ * an entity id could read another user's entity, its observations, and its
+ * relationships. The issue named `handleIndividualEntity`; the other two
+ * carried the same defect and are covered here for the same reason.
+ *
+ * Each case is a pair: the owner reads their own data and gets it, and a
+ * second authenticated user reads the same id and gets nothing. The second
+ * half is the planted negative — it fails against the pre-fix code, which
+ * is what makes these tests evidence rather than decoration
+ * (`principles.md` invariant 4, in the consuming project).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { db } from "../../src/db.js";
+import { NeotomaServer } from "../../src/server.js";
+import { randomUUID } from "node:crypto";
+
+const TEST_PREFIX = "mcp_resource_iso_test";
+
+interface Fixture {
+  userId: string;
+  entityId: string;
+  relationshipKey: string;
+  otherEntityId: string;
+  sourceId: string;
+}
+
+async function seed(label: string): Promise<Fixture> {
+  const userId = randomUUID();
+  const suffix = `${Date.now()}_${Math.random().toString(36).slice(2, 6)}`;
+  const entityId = `${TEST_PREFIX}_ent_${label}_${suffix}`;
+  const otherEntityId = `${TEST_PREFIX}_ent2_${label}_${suffix}`;
+  const relationshipKey = `${TEST_PREFIX}_rel_${label}_${suffix}`;
+  const sourceId = randomUUID();
+
+  await db.from("entities").insert([
+    { id: entityId, user_id: userId, entity_type: "test", canonical_name: `${label} primary` },
+    { id: otherEntityId, user_id: userId, entity_type: "test", canonical_name: `${label} secondary` },
+  ]);
+
+  await db.from("entity_snapshots").insert({
+    entity_id: entityId,
+    user_id: userId,
+    entity_type: "test",
+    schema_version: "1.0",
+    snapshot: JSON.stringify({ secret: `${label}-only-value` }),
+    provenance: JSON.stringify({}),
+    observation_count: 1,
+  });
+
+  await db.from("sources").insert({
+    id: sourceId,
+    user_id: userId,
+    content_hash: `${TEST_PREFIX}_hash_${label}_${suffix}`,
+    mime_type: "text/plain",
+    storage_url: `internal://test/${label}`,
+    file_size: 0,
+  });
+
+  await db.from("observations").insert({
+    id: randomUUID(),
+    entity_id: entityId,
+    entity_type: "test",
+    schema_version: "1.0",
+    observed_at: new Date().toISOString(),
+    source_priority: 0,
+    source_id: sourceId,
+    fields: { secret: `${label}-observation` },
+    user_id: userId,
+  });
+
+  await db.from("relationship_snapshots").insert({
+    relationship_key: relationshipKey,
+    relationship_type: "REFERS_TO",
+    source_entity_id: entityId,
+    target_entity_id: otherEntityId,
+    schema_version: "1",
+    snapshot: JSON.stringify({}),
+    user_id: userId,
+  });
+
+  return { userId, entityId, relationshipKey, otherEntityId, sourceId };
+}
+
+describe("MCP resource handlers — tenant isolation (#2093)", () => {
+  let server: NeotomaServer;
+  let userA: Fixture;
+  let userB: Fixture;
+
+  const actAs = (userId: string) => {
+    (server as any).authenticatedUserId = userId;
+  };
+
+  beforeAll(async () => {
+    server = new NeotomaServer();
+    userA = await seed("a");
+    userB = await seed("b");
+  });
+
+  afterAll(async () => {
+    const ids = [userA.entityId, userA.otherEntityId, userB.entityId, userB.otherEntityId];
+    await db.from("relationship_snapshots").delete().in("relationship_key", [
+      userA.relationshipKey,
+      userB.relationshipKey,
+    ]);
+    await db.from("observations").delete().in("entity_id", ids);
+    await db.from("sources").delete().in("id", [userA.sourceId, userB.sourceId]);
+    await db.from("entity_snapshots").delete().in("entity_id", ids);
+    await db.from("entities").delete().in("id", ids);
+  });
+
+  describe("neotoma://entity/{id}", () => {
+    it("the owner reads their own entity", async () => {
+      actAs(userA.userId);
+      const result = await (server as any).handleIndividualEntity(userA.entityId);
+      expect(result.entity_id).toBe(userA.entityId);
+      // The snapshot is recomputed from this user's observations, so assert on
+      // the owner's marker rather than on a seeded literal the pipeline
+      // legitimately overwrites.
+      const snap = typeof result.snapshot === "string" ? JSON.parse(result.snapshot) : result.snapshot;
+      expect(snap.secret).toBe("a-observation");
+    });
+
+    it("another authenticated user reading that id is refused", async () => {
+      actAs(userB.userId);
+      await expect((server as any).handleIndividualEntity(userA.entityId)).rejects.toThrow(
+        /Entity not found/
+      );
+    });
+  });
+
+  describe("neotoma://entity/{id}/observations", () => {
+    it("the owner reads their own observations", async () => {
+      actAs(userA.userId);
+      const result = await (server as any).handleEntityObservations(userA.entityId);
+      expect(result.total).toBe(1);
+    });
+
+    it("another authenticated user reads none of them", async () => {
+      actAs(userB.userId);
+      const result = await (server as any).handleEntityObservations(userA.entityId);
+      expect(result.observations).toEqual([]);
+      expect(result.total).toBe(0);
+    });
+  });
+
+  describe("neotoma://entity/{id}/relationships", () => {
+    it("the owner reads their own edges", async () => {
+      actAs(userA.userId);
+      const result = await (server as any).handleEntityRelationships(userA.entityId);
+      const keys = result.outbound_relationships.map((r: any) => r.relationship_key);
+      expect(keys).toContain(userA.relationshipKey);
+    });
+
+    it("another authenticated user reads neither direction", async () => {
+      actAs(userB.userId);
+      const result = await (server as any).handleEntityRelationships(userA.entityId);
+      expect(result.outbound_relationships).toEqual([]);
+      expect(result.inbound_relationships).toEqual([]);
+    });
+
+    it("the inbound direction is scoped too, not only the outbound one", async () => {
+      // userA.otherEntityId is the TARGET of userA's edge. Reading it as user B
+      // must return nothing — the pre-fix code scoped neither direction, and a
+      // fix applied to only the outbound query would pass every case above.
+      actAs(userB.userId);
+      const result = await (server as any).handleEntityRelationships(userA.otherEntityId);
+      expect(result.inbound_relationships).toEqual([]);
+    });
+  });
+
+  describe("an unauthenticated caller", () => {
+    it("is refused before any query runs", async () => {
+      (server as any).authenticatedUserId = null;
+      await expect((server as any).handleIndividualEntity(userA.entityId)).rejects.toThrow(
+        /Authentication required/
+      );
+    });
+  });
+});


### PR DESCRIPTION
Closes #2093

Design basis: no design applies — localized MCP entity-id resource handler `user_id` scoping bug (#2093); no new work-model or gate declaration. Kernel path `docs/foundation/principles.md` is not present on main (404), so a foundation citation would itself fail the “named document must exist” check.

## What was wrong

Three MCP resource handlers reachable by entity id queried the database with no ownership filter:

| Handler | Tables read unscoped |
|---|---|
| `handleIndividualEntity` | `entities`, `entity_snapshots` |
| `handleEntityObservations` | `observations` (rows and count) |
| `handleEntityRelationships` | `relationship_snapshots` (both directions) |

Six queries. #2093 named the first; the other two carry the same defect through the same door, and are fixed here rather than left for a second report — the id is the whole key, and nothing about the attack depends on which suffix follows it.

## The fix

Each handler resolves the caller through `getAuthenticatedUserId()` — which throws when unauthenticated, so the restrictive branch is the default — and adds `.eq("user_id", userId)` to every query.

This is the convention the file already follows rather than a new one: 21 other queries against `relationship_snapshots` scope this way, and the `entity_snapshots` and `observations` paths in the query layer do the same. The handlers were the outliers.

## Tests

`tests/security/mcp_resource_tenant_isolation.test.ts`, a companion to `tenant_isolation_matrix.test.ts` — which covers the HTTP query endpoints and states the obligation these handlers were missing from:

> Every authenticated query endpoint that touches user-owned data (entities, observations, sources, relationship_snapshots, timeline_events, entity_snapshots) MUST be covered here.

Eight cases. Each resource is an owner-reads-own paired with a second authenticated user reading the same id and getting nothing. Two are worth calling out:

- **The inbound relationship direction has its own case.** A fix applied only to the outbound query would pass every other assertion in the file, because the outbound tests never touch the target entity. That is the partial fix that looks complete, so it gets its own planted negative.
- **An unauthenticated caller is refused before any query runs.** This pins the fail-closed property to the handler rather than to the database.

## Verified as evidence, not decoration

With `src/server.ts` reverted to the pre-fix state and the server rebuilt, **5 of the 8 fail** — every cross-user case plus the unauthenticated one. With the fix, 8 pass.

Full security suite: **96 passed, 1 skipped**, across all 8 files.

One test was wrong on the first run and the system was right: I asserted a seeded snapshot literal that the recomputation pipeline legitimately overwrites with the value derived from the owner's observation. Corrected to assert the owner's actual marker.

## Scope

Read-path scoping only. No schema change, no migration, no change to the write path or to any HTTP endpoint. `handleEntityCollection` and the timeline handlers are untouched — they route through the scoped query layer already.

🤖 Generated with [Claude Code](https://claude.com/claude-code)