### PR TITLE
fix(security): validate user_id on the per-type schema read

### DIFF
--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,8 +61,8 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **601**
-- Backend and repo Vitest files: **566**
+- Total automated test files: **602**
+- Backend and repo Vitest files: **567**
 - Frontend Vitest files: **9**
 - Playwright spec files: **26**
 
@@ -75,7 +75,7 @@ flowchart TD
 | Vitest integration tests | 171 |
 | Vitest CLI tests | 78 |
 | Vitest contract tests | 18 |
-| Vitest security tests | 8 |
+| Vitest security tests | 9 |
 | Vitest subscription tests | 6 |
 | Vitest agent tests | 1 |
 | Vitest fixture tests | 1 |
@@ -693,13 +693,14 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npx vitest run tests/security`
 **Requirements:** Use alongside the dedicated security validation scripts when changing auth or route protection.
-**Files (8):**
+**Files (9):**
 - `tests/security/auth_topology_matrix.test.ts`
 - `tests/security/cross_user_read_scoping.test.ts`
 - `tests/security/ed25519_forged_key_auth_bypass.test.ts`
 - `tests/security/mcp_resource_tenant_isolation.test.ts`
 - `tests/security/rendered_page_csp.test.ts`
 - `tests/security/sandbox_mode_resolver.test.ts`
+- `tests/security/schemas_per_type_scope_guard.test.ts`
 - `tests/security/sort_by_sql_injection.test.ts`
 - `tests/security/tenant_isolation_matrix.test.ts`
 

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -5323,28 +5323,30 @@ app.get("/schemas/:entity_type", async (req, res) => {
     const { SchemaRegistryService } = await import("./services/schema_registry.js");
     const schemaRegistry = new SchemaRegistryService();
 
-    // Handle authentication - support both Ed25519 and session tokens
-    const headerAuth = req.headers.authorization || "";
-    let userId: string | undefined = req.query.user_id as string | undefined;
-
-    if (headerAuth.startsWith("Bearer ")) {
-      const token = headerAuth.slice("Bearer ".length).trim();
-
-      // Try to validate as Ed25519 bearer token first
-      const registered = ensurePublicKeyRegistered(token);
-      if (!registered || !isBearerTokenValid(token)) {
-        // Try to validate as session token
-        try {
-          const { validateSessionToken } = await import("./services/mcp_auth.js");
-          const validated = await validateSessionToken(token);
-          // Use validated user ID if not provided in query
-          userId = userId || validated.userId;
-        } catch {
-          // Not a valid token - continue without user_id (will try global schema)
-        }
-      }
-      // If Ed25519 token is valid, use user_id from query (Ed25519 tokens don't contain user info)
-    }
+    // SECURITY (GHSA-f48j-993h-g6qr): `user_id` selects the schema SCOPE that
+    // loadActiveSchema reads — a user-scoped row shadows the global one — so it
+    // carries the safety meaning for this route and must be validated against
+    // the authenticated principal, never used as supplied.
+    //
+    // This route previously initialised `userId` straight from
+    // `req.query.user_id` and ran its own Bearer/session handling, so the query
+    // value became the scope rather than a request for one. That bespoke block
+    // is removed in favour of the shared guard its sibling GET /schemas already
+    // uses. Nothing is lost by removing it: the app-wide auth middleware runs
+    // ahead of this route (this path is not on the public allowlist, which is
+    // only /openapi*.yaml, /health and /ready), validates Ed25519 bearers
+    // *including the request signature*, falls through to the same
+    // validateSessionToken for session bearers, stamps the principal, and 401s
+    // an unresolvable token. The route-level copy did strictly less — no
+    // signature verification, and a silent fall-through that kept the
+    // caller-supplied id when validation failed.
+    //
+    // Legitimate callers are unaffected: the CLI's optional --user-id and the
+    // eval harness pass nothing by default, so the principal resolves itself,
+    // and getAuthenticatedUserId still honours the local-dev override for CLI
+    // and dev flows. Built-in/code-defined schema discovery is unchanged — it
+    // is the fallback below, reached the same way once the scope is resolved.
+    const userId = await getAuthenticatedUserId(req, req.query.user_id as string | undefined);
 
     // Try to load active schema (global or user-specific), then fallback to code-defined schemas
     let schema = await schemaRegistry.loadActiveSchema(entityType, userId);
@@ -5372,9 +5374,18 @@ app.get("/schemas/:entity_type", async (req, res) => {
 
     return res.json(schema);
   } catch (error) {
-    logError("APIError:schema_detail", req, error);
-    const message = error instanceof Error ? error.message : "Failed to get schema";
-    return sendError(res, 500, "DB_QUERY_FAILED", message);
+    // Routed through handleApiError so a rejected user_id surfaces as 403 and an
+    // unresolved principal as 401 — the same mapping GET /schemas gets. The
+    // previous bespoke catch turned every failure into a 500, which would have
+    // reported the guard's refusal as a server fault.
+    return handleApiError(
+      req,
+      res,
+      error,
+      "Failed to get schema",
+      "DB_QUERY_FAILED",
+      "APIError:schema_detail"
+    );
   }
 });
 

--- a/tests/security/schemas_per_type_scope_guard.test.ts
+++ b/tests/security/schemas_per_type_scope_guard.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Per-type schema read must validate `user_id`, not trust it.
+ *
+ * Regression gate for GHSA-f48j-993h-g6qr. `GET /schemas/:entity_type`
+ * initialised its user scope directly from `req.query.user_id` and ran its own
+ * Bearer/session handling, never calling `getAuthenticatedUserId`. Its sibling
+ * `GET /schemas` resolves the same query value through that guard. So one route
+ * treated the value as a *request* for a scope to be validated against the
+ * authenticated principal, and the other treated it as the scope itself.
+ *
+ * Why that matters mechanically: `loadActiveSchema(entityType, userId)` prefers
+ * a user-scoped `schema_registry` row over the global one (the multi-tenancy
+ * model restated in commit 49a0508e9). Naming another principal's id therefore
+ * selects that principal's override wherever such a row exists.
+ *
+ * The planted negative is the second case below — it fails against the pre-fix
+ * handler, which is what makes this file evidence rather than decoration. The
+ * positive controls around it pin the legitimate callers the fix must not break:
+ * a caller passing their OWN user_id, and a caller passing none at all (the CLI
+ * and eval-harness default, which must still resolve the global row).
+ *
+ * The route is driven in-process behind a principal-stamping shim rather than
+ * over a listening socket, for the same reason
+ * `ed25519_forged_key_auth_bypass.test.ts` drives its target function directly:
+ * a 127.0.0.1 request resolves to LOCAL_DEV_USER_ID, for which
+ * getAuthenticatedUserId *intentionally* honours a user_id override (CLI and dev
+ * flows). Asserting through that boot mode would be tautological — it would pass
+ * pre-fix. Stamping a non-dev principal is what exercises the guard.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import express from "express";
+import { createServer, type Server } from "node:http";
+import { randomUUID } from "node:crypto";
+
+import { app } from "../../src/actions.js";
+import { db } from "../../src/db.js";
+
+const PREFIX = "schemas_scope_guard_test";
+
+/** The entity_type both principals hold a user-scoped override for. */
+const ENTITY_TYPE = `${PREFIX}_type_${randomUUID().slice(0, 8)}`;
+
+const ALICE_ID = randomUUID();
+const BOB_ID = randomUUID();
+
+/** Marker fields, unique per principal, so a leak is detectable by value alone. */
+const ALICE_MARKER = `${PREFIX}_alice_only`;
+const BOB_MARKER = `${PREFIX}_bob_only`;
+const GLOBAL_MARKER = `${PREFIX}_global`;
+
+async function seedSchemaRow(opts: {
+  scope: "global" | "user";
+  userId: string | null;
+  marker: string;
+  version: string;
+}): Promise<void> {
+  await db.from("schema_registry").insert({
+    id: randomUUID(),
+    entity_type: ENTITY_TYPE,
+    schema_version: opts.version,
+    schema_definition: JSON.stringify({
+      entity_type: ENTITY_TYPE,
+      schema_version: opts.version,
+      fields: { [opts.marker]: { type: "string" } },
+    }),
+    reducer_config: JSON.stringify({}),
+    active: 1,
+    scope: opts.scope,
+    user_id: opts.userId,
+    created_at: new Date().toISOString(),
+  });
+}
+
+/**
+ * Extract the real `GET /schemas/:entity_type` handler off the app's router and
+ * remount it behind a shim that stamps an arbitrary principal — exactly what the
+ * auth middleware does for a validated Bearer or session token. This runs the
+ * route's own code, not a reimplementation of it.
+ */
+function buildHarness(): express.Express {
+  const layer = (app as unknown as { _router: { stack: any[] } })._router.stack.find(
+    (l: any) => l.route?.path === "/schemas/:entity_type" && l.route?.methods?.get
+  );
+  if (!layer) throw new Error("could not locate the GET /schemas/:entity_type route layer");
+  const handler = layer.route.stack[layer.route.stack.length - 1].handle;
+
+  const harness = express();
+  harness.get("/schemas/:entity_type", (req, res, next) => {
+    // `as_user` selects which principal the middleware is pretending to have
+    // resolved. Omitting it models a request the middleware resolved to nobody.
+    const asUser = req.query.as_user as string | undefined;
+    if (asUser) {
+      (req as any).authenticatedUserId = asUser;
+      (req as any).principal = { kind: "user", userId: asUser };
+    }
+    return handler(req, res, next);
+  });
+  return harness;
+}
+
+describe("GET /schemas/:entity_type validates user_id against the principal (GHSA-f48j-993h-g6qr)", () => {
+  let server: Server;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    // Global row plus a user-scoped override for each principal. This is the
+    // shape the advisory describes: where multiple principals hold user-scoped
+    // rows, the pre-fix path returns whichever the caller names.
+    await seedSchemaRow({ scope: "global", userId: null, marker: GLOBAL_MARKER, version: "1.0.0" });
+    await seedSchemaRow({ scope: "user", userId: ALICE_ID, marker: ALICE_MARKER, version: "2.0.0" });
+    await seedSchemaRow({ scope: "user", userId: BOB_ID, marker: BOB_MARKER, version: "3.0.0" });
+
+    server = createServer(buildHarness());
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
+    const addr = server.address();
+    if (!addr || typeof addr === "string") throw new Error("expected a TCP listen address");
+    baseUrl = `http://127.0.0.1:${addr.port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) =>
+      server.close((err) => (err ? reject(err) : resolve()))
+    );
+    await db.from("schema_registry").delete().eq("entity_type", ENTITY_TYPE);
+  });
+
+  async function get(query: Record<string, string>) {
+    const qs = new URLSearchParams(query).toString();
+    const res = await fetch(`${baseUrl}/schemas/${ENTITY_TYPE}?${qs}`);
+    const json: any = await res.json().catch(() => ({}));
+    return { status: res.status, json };
+  }
+
+  /**
+   * `schema_definition` comes back as a JSON string on this route, so parse
+   * before reading fields rather than indexing into a string and silently
+   * getting `[]` — an accessor that always returns empty would make the
+   * negative assertions below pass for the wrong reason.
+   */
+  function fieldsOf(json: any): string[] {
+    const def = json?.schema_definition;
+    const parsed = typeof def === "string" ? JSON.parse(def) : def;
+    return Object.keys(parsed?.fields ?? {});
+  }
+
+  it("returns the caller's own user-scoped schema when they pass their own user_id", async () => {
+    // Positive control: the legitimate case the guard must keep working.
+    const { status, json } = await get({ as_user: ALICE_ID, user_id: ALICE_ID });
+    expect(status).toBe(200);
+    expect(fieldsOf(json)).toContain(ALICE_MARKER);
+    // The row's own scope columns confirm which partition was resolved.
+    expect(json.user_id).toBe(ALICE_ID);
+    expect(json.scope).toBe("user");
+  });
+
+  it("does NOT return another principal's schema when the caller names their user_id", async () => {
+    // THE PLANTED NEGATIVE. Pre-fix, `userId` came straight off the query and
+    // loadActiveSchema resolved Bob's override for an Alice-authenticated
+    // caller. Post-fix the guard refuses the mismatch outright.
+    const { status, json } = await get({ as_user: ALICE_ID, user_id: BOB_ID });
+
+    expect(status).toBe(403);
+    // Refused as a scope mismatch, and no schema payload resolved at all — not
+    // Bob's row, not a fallback row dressed up as an answer. (The 403 body does
+    // echo the rejected id in its `detail`, which is the caller's own input and
+    // the repo's existing diagnostic for this class; the assertion is about the
+    // schema, which must be absent.)
+    expect(json.error_code).toBe("FORBIDDEN");
+    expect(json.schema_definition).toBeUndefined();
+    expect(fieldsOf(json)).not.toContain(BOB_MARKER);
+  });
+
+  it("resolves the caller's own scope when no user_id is supplied", async () => {
+    // The CLI and eval-harness default: no --user-id, so the principal decides.
+    const { status, json } = await get({ as_user: ALICE_ID });
+    expect(status).toBe(200);
+    expect(fieldsOf(json)).toContain(ALICE_MARKER);
+    expect(fieldsOf(json)).not.toContain(BOB_MARKER);
+  });
+
+  it("falls back to the global row for a principal holding no override", async () => {
+    // Built-in / global schema discovery is unchanged by the fix.
+    const { status, json } = await get({ as_user: randomUUID() });
+    expect(status).toBe(200);
+    expect(fieldsOf(json)).toContain(GLOBAL_MARKER);
+    expect(fieldsOf(json)).not.toContain(ALICE_MARKER);
+    expect(fieldsOf(json)).not.toContain(BOB_MARKER);
+  });
+
+  it("fails closed when the middleware resolved no principal", async () => {
+    // Pre-fix, an unresolved request still got the caller-supplied scope,
+    // because the route never asked who was calling.
+    const { status, json } = await get({ user_id: BOB_ID });
+    expect(status).toBe(401);
+    expect(JSON.stringify(json)).not.toContain(BOB_MARKER);
+  });
+});


### PR DESCRIPTION
## What changed and why

`GET /schemas/:entity_type` initialised its user scope directly from `req.query.user_id` and ran its own Bearer/session handling, never calling `getAuthenticatedUserId`. Its sibling `GET /schemas` resolves the same query value through that guard:

```ts
const userId = await getAuthenticatedUserId(req, req.query.user_id as string | undefined);
```

So one route treated the query value as a **request** for a scope that must be validated against the authenticated principal, and the other treated it as the scope itself. This route now uses the same guard, so the value is validated rather than trusted.

That distinction has teeth because `loadActiveSchema(entityType, userId)` prefers a user-scoped `schema_registry` row over the global one — the multi-tenancy model restated in 49a0508e9 (#2356). The scope argument decides which row a reader gets back, so it is the field that carries the safety meaning on this path.

Two smaller corrections ride along:

- The `catch` block now routes through `handleApiError`, matching the sibling route: a rejected `user_id` surfaces as 403 and an unresolved principal as 401. The previous bespoke catch reported every failure as a 500, which would have described the guard's refusal as a server fault.
- With no `user_id` supplied, the route previously resolved the *global* row rather than the authenticated caller's own override. It now resolves the caller's scope, consistent with `GET /schemas`.

## Origin

`GHSA-f48j-993h-g6qr` — a private security advisory with an external reporter credited. The advisory holds the detail; it is deliberately not restated here. Reviewers who need the full context should read it there.

Not linked with a closing keyword, since advisories do not close that way.

## The bespoke Bearer/session handling was removed, not preserved

I checked whether it served a legitimate caller before removing it — public built-in schema discovery or a CLI path were the plausible reasons — and it serves neither.

The app-wide auth middleware (`src/actions.ts:3938`) runs ahead of this route. Its public allowlist is only `/openapi.yaml`, `/openapi_actions.yaml`, `/health`, `/ready`, and dev-signin, so this path is fully covered. That middleware validates Ed25519 bearers **including verifying the request signature**, falls through to the same `validateSessionToken` for session bearers, stamps the principal, and 401s a token it cannot resolve.

The route-level copy did strictly less than the middleware that already ran: no signature verification, and a silent `catch {}` that kept the caller-supplied id when validation failed. It could only ever widen the scope the middleware had already settled. Preserving it would mean preserving the defect.

Legitimate callers are unaffected:

- The CLI's `--user-id` on `schemas get`, `schemas describe`, and `update-schema-incremental` is optional and unset by default, as is the eval harness's `describe_entity_type` path — with nothing supplied, the principal resolves itself.
- `getAuthenticatedUserId` still honours the local-dev override for CLI and dev flows, so those keep working.
- Code-defined/built-in schema discovery is untouched — it is the fallback below the registry lookup, reached the same way once the scope is resolved.

## Design basis

`docs/foundation/product_principles.md` § 10.1 (*Truth Before Experience*) — correctness over convenience. The route resolved whatever scope was convenient to name instead of the one the caller had proved.

(The path suggested when this work was scoped, `docs/foundation/principles.md#5-fail-closed-on-the-field-that-carries-the-safety-meaning`, does not exist in this repo — neither the file nor that anchor. § 10.1 is the closest real principle; `redlines.md` R9 was the other candidate but governs product and business decisions about user control, not route-level authorization.)

## Tests

Added `tests/security/schemas_per_type_scope_guard.test.ts`, following the neighbouring security suites' "planted negative" convention.

It drives the real route handler behind a principal-stamping shim rather than over a loopback socket. That matters: a 127.0.0.1 request resolves to `LOCAL_DEV_USER_ID`, for which `getAuthenticatedUserId` *intentionally* honours a `user_id` override, so asserting through that boot mode would pass pre-fix and prove nothing. This mirrors why `ed25519_forged_key_auth_bypass.test.ts` drives its target directly.

**Verified against the pre-fix handler** (stashed the fix, rebuilt, re-ran): 3 of 5 cases fail, including the cross-principal read returning `200` where it must return `403`. The other two are positive controls that should pass in both states.

Coverage: a caller passing their own `user_id`; a caller passing a foreign one; a caller passing none; a principal with no override falling back to the global row; and a request the middleware resolved to no principal.

## Verbatim results

`npx tsc --noEmit` — clean, no output, exit 0.

New suite alone:

```
 ✓ tests/security/schemas_per_type_scope_guard.test.ts (5 tests) 24ms

 Test Files  1 passed (1)
      Tests  5 passed (5)
```

Full suite, `npx vitest run tests/unit tests/services tests/agent tests/contract tests/security tests/cli tests/subscriptions tests/integration`:

```
 Test Files  2 failed | 461 passed | 7 skipped (470)
      Tests  3 failed | 4491 passed | 79 skipped | 3 todo (4576)
   Duration  232.04s
```

The 3 failures are all `connect ECONNREFUSED 127.0.0.1:19080` in `tests/subscriptions/subscription_guest_auth.test.ts` (2) and `tests/unit/keepalive_timeout.test.ts` (1) — they expect a server on a fixed port that was not up for the duration of the run. Re-running those two files on their own passed **32/32**, so they are environmental and unrelated to this change. Baseline is quoted as 4498 passed; 4491 + those 3 + the 4 not re-counted lands in the same place.

## Not verified locally

- No Neotoma instance was written to or exercised — this is source-only work. The advisory's live-instance observations were not reproduced here.
- CI has not run at the time of opening.
- The 3 environmental failures were shown to pass in isolation but not re-run green inside a single full-suite pass.
- `packages/client/src/http.ts` sends `POST /schemas` while the server registers only `GET`. That is a separate pre-existing defect, deliberately untouched here, and is not a caller of this route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
