### PR TITLE
Let an operator trust their own app's OAuth callback URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -291,6 +291,19 @@ CURSOR_CLOUD_API_KEY=your-cursor-cloud-api-key-here
 # stack traces in responses / logs. Default off in production. See S-5.
 # NEOTOMA_VERBOSE_ERRORS=0
 # NEOTOMA_LOG_STACKS=0
+#
+# OAuth callback URLs an operator additionally trusts to receive an
+# authorization code when the authorize request arrives via a tunnel.
+# Comma-separated list of EXACT, FULL callback URLs — not origins: the example
+# below authorises that one path and nothing else on that host.
+# Empty by default; unset keeps the built-in allowlist (localhost, loopback,
+# cursor:/vscode:/app:, this instance's own origin, ChatGPT and Claude) exactly
+# as it was. Entries must be https:, except to a loopback host.
+# FAILS CLOSED: if any entry is malformed, the WHOLE list is rejected and the
+# server does not start, naming the bad entry — a partially-applied allowlist
+# would enforce something other than what you configured, silently.
+# See docs/operations/configuration.md § Trusted OAuth callback URLs.
+# NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS=https://app.example.com/auth/callback
 
 # =============================================================================
 # AAuth hardware attestation — Linux TPM 2.0 (FU-4 / packages/aauth-tpm2)

--- a/docs/operations/configuration.md
+++ b/docs/operations/configuration.md
@@ -79,12 +79,31 @@ NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS=https://app.example.com/auth/callback
 Several entries are comma-separated. Rules worth knowing before you set it:
 
 - **Exact full URLs, not origins.** The example above authorises `https://app.example.com/auth/callback` and **not** `https://app.example.com/anything-else`. Configure every callback path you need.
-- **https only**, unless the host is loopback. A plaintext `http://` entry to any other host is ignored rather than honoured.
-- A trailing slash is insignificant; the host is compared case-insensitively; the path is compared **case-sensitively**; a default port (`:443`) is equivalent to none.
-- Query string and fragment on the incoming request are ignored, so the usual `?code=...&state=...` callback matches.
-- A malformed or non-https entry is skipped without disabling the rest of the list.
+- **https only**, unless the host is loopback. A plaintext `http://` entry to any other host is rejected rather than honoured.
+- **A bad entry rejects the whole list, and the server will not start.** See below.
 
-If a redirect is refused, the 400 response says how many entries are configured, which distinguishes an unset variable from a typo or an exact-match miss.
+#### What the server compares
+
+A redirect is accepted when the request's callback and a configured entry agree on **scheme, host, port and path** — all four. In detail:
+
+| Part | How it is compared |
+| --- | --- |
+| Scheme | Must match. `https` does not authorise its `http` twin. |
+| Host | Case-**insensitive**. `APP.EXAMPLE.COM` matches `app.example.com`. |
+| Port | Must match, but a default port is equivalent to none: `https://app.example.com` = `https://app.example.com:443`. |
+| Path | Case-**sensitive**. `/Auth/Callback` does **not** match `/auth/callback`. A trailing slash is insignificant in either direction. Dot segments resolve first, so `/auth/callback/../admin` is compared as `/auth/admin`. An encoded slash (`%2F`) is not a path separator. |
+| Query and fragment | **Ignored on both sides**, so the usual `?code=...&state=...` callback matches. |
+| Userinfo | Any URL carrying `user:password@` is rejected. |
+
+If a redirect is refused, the `400` response names the callback URL the server actually compared (scheme, host and path — query and fragment are stripped) and says how many entries are configured. That is usually enough to tell a near miss — a trailing slash, a port, a case difference — from a typo or an unset variable, without needing server logs.
+
+#### A malformed entry fails the whole list, loudly
+
+If **any** entry cannot be used as a trusted callback URL, the entire list is rejected and **the server fails to start** with an error naming the offending entry by position and value. Entries 1 and 3 do not quietly survive a bad entry 2.
+
+This is deliberate. The friendlier alternative — skip the bad entry, honour the rest — makes the allowlist enforce something other than what you wrote, with no signal that it did: the refusal a dropped entry produces looks exactly like an exact-match miss. A startup failure is noisy, but it happens immediately and before any sign-in is served, rather than surfacing weeks later as an unexplained OAuth failure.
+
+Entries are rejected when they are unparseable, use a scheme other than `https:`/`http:`, are plaintext `http:` to a non-loopback host, or carry `user:password@` userinfo. To recover, either fix the entry the error names, or unset the variable entirely to fall back to the built-in allowlist.
 
 > The variable is `NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS`. Early planning notes for this feature called it `NEOTOMA_TRUSTED_OAUTH_CALLBACKS`; that name was never implemented and setting it has no effect.
 

--- a/docs/operations/configuration.md
+++ b/docs/operations/configuration.md
@@ -86,6 +86,8 @@ Several entries are comma-separated. Rules worth knowing before you set it:
 
 If a redirect is refused, the 400 response says how many entries are configured, which distinguishes an unset variable from a typo or an exact-match miss.
 
+> The variable is `NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS`. Early planning notes for this feature called it `NEOTOMA_TRUSTED_OAUTH_CALLBACKS`; that name was never implemented and setting it has no effect.
+
 See [Deployment Modes](deployment.md) and [Agent Access Control](agent_access_control.md).
 
 ## Encryption

--- a/docs/operations/configuration.md
+++ b/docs/operations/configuration.md
@@ -62,8 +62,29 @@ See [Running the Server](running_the_server.md) for transports and processes.
 | --- | --- |
 | `NEOTOMA_REQUIRE_KEY_FOR_OAUTH` | Require a key for OAuth connections |
 | `NEOTOMA_OAUTH_CLIENT_ID` | MCP OAuth client id (hosted mode) |
+| `NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS` | Comma-separated **exact** callback URLs additionally trusted to receive an authorization code when the authorize request arrives via a tunnel. Empty by default. See below. |
 | `NEOTOMA_SANDBOX_MODE` | Opt into the public hosted-sandbox profile |
 | `NEOTOMA_REFUSE_MODE` | `warn` or `enforce` when a no-auth, non-loopback topology is detected |
+
+### Trusted OAuth callback URLs
+
+When an authorize request reaches a local-backend instance over a tunnel, the `redirect_uri` must be on an allowlist, so an authorization code is never handed to a third-party site. Built in are the `cursor:`/`vscode:`/`app:` schemes, localhost and loopback, this instance's own origin, and the ChatGPT and Claude callbacks.
+
+To let a **self-hosted first-party app** complete sign-in against a hosted instance, set its callback URL:
+
+```bash
+NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS=https://app.example.com/auth/callback
+```
+
+Several entries are comma-separated. Rules worth knowing before you set it:
+
+- **Exact full URLs, not origins.** The example above authorises `https://app.example.com/auth/callback` and **not** `https://app.example.com/anything-else`. Configure every callback path you need.
+- **https only**, unless the host is loopback. A plaintext `http://` entry to any other host is ignored rather than honoured.
+- A trailing slash is insignificant; the host is compared case-insensitively; the path is compared **case-sensitively**; a default port (`:443`) is equivalent to none.
+- Query string and fragment on the incoming request are ignored, so the usual `?code=...&state=...` callback matches.
+- A malformed or non-https entry is skipped without disabling the rest of the list.
+
+If a redirect is refused, the 400 response says how many entries are configured, which distinguishes an unset variable from a typo or an exact-match miss.
 
 See [Deployment Modes](deployment.md) and [Agent Access Control](agent_access_control.md).
 

--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,20 +61,20 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **602**
-- Backend and repo Vitest files: **567**
+- Total automated test files: **605**
+- Backend and repo Vitest files: **570**
 - Frontend Vitest files: **9**
 - Playwright spec files: **26**
 
 ### Suite counts
 | Suite | Files |
 |---|---:|
-| Vitest unit tests | 165 |
+| Vitest unit tests | 166 |
 | Vitest service tests | 44 |
 | Source-adjacent tests | 66 |
-| Vitest integration tests | 171 |
+| Vitest integration tests | 172 |
 | Vitest CLI tests | 78 |
-| Vitest contract tests | 18 |
+| Vitest contract tests | 19 |
 | Vitest security tests | 9 |
 | Vitest subscription tests | 6 |
 | Vitest agent tests | 1 |
@@ -109,7 +109,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/unit`
 **Requirements:** Basic `.env` if required by the module under test.
-**Files (165):**
+**Files (166):**
 - `tests/unit/aauth_admission.test.ts`
 - `tests/unit/aauth_attestation_apple_se.test.ts`
 - `tests/unit/aauth_attestation_revocation.test.ts`
@@ -152,6 +152,7 @@ flowchart TD
 - `tests/unit/config_data_dir_resolution.test.ts`
 - `tests/unit/config_db_backend.test.ts`
 - `tests/unit/config_sqlite_path.test.ts`
+- `tests/unit/config_trusted_callbacks.test.ts`
 - `tests/unit/content_field_store_warning.test.ts`
 - `tests/unit/conversation_schema_bootstrap.test.ts`
 - `tests/unit/conversation_session_uuid_bridge.test.ts`
@@ -405,7 +406,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm run test:integration` or `npx vitest run tests/integration`
 **Requirements:** Database configured; remote-dependent subsets additionally need `RUN_REMOTE_TESTS=1`.
-**Files (171):**
+**Files (172):**
 - `tests/integration/aauth_attribution_stamping.test.ts`
 - `tests/integration/aauth_mcp_capability_parity.test.ts`
 - `tests/integration/aauth_mcp_initialize_admission.test.ts`
@@ -496,6 +497,7 @@ flowchart TD
 - `tests/integration/mcp_npm_check_update_capability_delta.test.ts`
 - `tests/integration/mcp_npm_check_update.test.ts`
 - `tests/integration/mcp_oauth_token_endpoint.test.ts`
+- `tests/integration/mcp_oauth_trusted_callback.test.ts`
 - `tests/integration/mcp_query_variations.test.ts`
 - `tests/integration/mcp_relationship_variations.test.ts`
 - `tests/integration/mcp_resource_variations.test.ts`
@@ -668,7 +670,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/contract`
 **Requirements:** Generated contract artifacts present when the suite expects them.
-**Files (18):**
+**Files (19):**
 - `tests/contract/cli_handler_dist_smoke.test.ts`
 - `tests/contract/contract_mapping.test.ts`
 - `tests/contract/contract_mcp_cli_parity.test.ts`
@@ -677,6 +679,7 @@ flowchart TD
 - `tests/contract/get_entities_alias.test.ts`
 - `tests/contract/ironclaw_integration.test.ts`
 - `tests/contract/legacy_payloads/replay.test.ts`
+- `tests/contract/mcp_oauth_authorize_responses.test.ts`
 - `tests/contract/mcp_stdio_output_safety.test.ts`
 - `tests/contract/mcp_tool_dispatch_coverage.test.ts`
 - `tests/contract/openapi_schema.test.ts`

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2949,7 +2949,36 @@ paths:
           schema: { type: string }
       responses:
         "302":
-          description: Redirect to authorization URL
+          description: |
+            Redirect to the authorization URL, or to /mcp/oauth/key-auth when
+            NEOTOMA_REQUIRE_KEY_FOR_OAUTH is set and the request carries no valid
+            key session.
+        "400":
+          description: |
+            Authorization refused before any redirect. The body is a plain-text
+            sentence addressed to the human in the browser, NOT an ErrorEnvelope:
+            this endpoint is reached by a user-agent mid-OAuth-redirect, so the
+            response is rendered directly in the address bar. A JSON envelope
+            would be read by nobody at this point in the flow. Machine clients
+            MUST treat any 400 here as a terminal refusal of the authorization
+            request and MUST NOT parse the body; the reason is carried by the
+            server's structured warn log, not by this response.
+
+            Emitted for: a missing `redirect_uri`; a missing `state`; a missing
+            or non-S256 PKCE challenge on a non-OpenAI redirect; a `dev_stub`
+            request while dev_stub is disabled; and a `redirect_uri` that is not
+            on the tunnel allowlist (built-in entries plus any exact callback
+            URLs configured in NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS).
+          content:
+            text/plain:
+              schema: { type: string }
+        "500":
+          description: |
+            Authorization failed unexpectedly. Plain-text body, for the same
+            browser-facing reason as the 400 above.
+          content:
+            text/plain:
+              schema: { type: string }
 
   /mcp/oauth/token:
     post:

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -3029,13 +3029,21 @@ app.get("/mcp/oauth/authorize", async (req, res) => {
         // proxy) so an Inspector callback on this instance's own origin is allowed.
         const selfHost = req.header("x-forwarded-host")?.split(",")[0]?.trim() || req.get("host");
         if (!isRedirectUriAllowedForTunnel(redirect_uri, selfHost)) {
+          // Name the config variable and whether it is even set: an operator who
+          // has configured a callback and still gets refused otherwise has no way
+          // to tell a typo from an unset variable from an exact-match miss.
+          const trustedCount = config.oauthTrustedCallbackUrls.length;
           logger.warn("[MCP OAuth] Authorize rejected: redirect_uri not allowed for tunnel", {
             redirect_uri: sanitizeRedirectUriForLog(redirect_uri),
+            trusted_callback_urls_configured: trustedCount,
           });
           return res
             .status(400)
             .send(
-              "redirect_uri is not allowed when connecting via a tunnel. Use cursor://, localhost, loopback, or trusted callback URLs (OpenAI/Claude)."
+              "redirect_uri is not allowed when connecting via a tunnel. Use cursor://, localhost, loopback, or trusted callback URLs (OpenAI/Claude). " +
+                (trustedCount > 0
+                  ? `This instance has ${trustedCount} operator-configured callback URL(s) in NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS; none matched. That list is matched on the EXACT full callback URL (scheme, host, port and path), and plaintext http: is only honoured for loopback hosts.`
+                  : "To trust a self-hosted app's callback, set NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS to its exact full callback URL (for example https://app.example.com/auth/callback).")
             );
         }
       }

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -2971,6 +2971,25 @@ app.get("/mcp/oauth/google/callback", async (req, res) => {
   }
 });
 
+/**
+ * Send an authorize-endpoint refusal as plain text.
+ *
+ * `res.send(string)` defaults to `text/html`, which makes the body an HTML sink.
+ * That matters here because this endpoint is reached by a BROWSER, before any
+ * authentication, with a `redirect_uri` supplied by whoever crafted the link —
+ * so anything echoed from the request into an HTML body would execute on this
+ * instance's own origin. Setting `text/plain` removes the sink rather than
+ * filtering it, which is what makes it safe to name the rejected redirect_uri
+ * in the body below.
+ *
+ * Plain text (rather than the canonical JSON ErrorEnvelope) is also the right
+ * shape for the reader: this renders in a browser address bar mid-redirect, for
+ * a human. Declared as `text/plain` in openapi.yaml under `mcpOAuthAuthorize`.
+ */
+function sendAuthorizeRefusal(res: express.Response, status: number, message: string) {
+  return res.status(status).type("text/plain").send(message);
+}
+
 // RFC 8414 authorization endpoint (GET) for Cursor and other OAuth clients
 app.get("/mcp/oauth/authorize", async (req, res) => {
   try {
@@ -2990,11 +3009,11 @@ app.get("/mcp/oauth/authorize", async (req, res) => {
 
     if (!redirect_uri) {
       logger.warn("[MCP OAuth] Authorize rejected: missing redirect_uri");
-      return res.status(400).send("redirect_uri is required");
+      return sendAuthorizeRefusal(res, 400, "redirect_uri is required");
     }
     if (!state) {
       logger.warn("[MCP OAuth] Authorize rejected: missing state");
-      return res.status(400).send("state is required");
+      return sendAuthorizeRefusal(res, 400, "state is required");
     }
     const isOpenAiCustomGptRedirect =
       redirect_uri &&
@@ -3005,7 +3024,11 @@ app.get("/mcp/oauth/authorize", async (req, res) => {
       logger.warn("[MCP OAuth] Authorize rejected: missing PKCE for non-OpenAI redirect", {
         redirect_uri: sanitizeRedirectUriForLog(redirect_uri),
       });
-      return res.status(400).send("code_challenge and code_challenge_method=S256 are required");
+      return sendAuthorizeRefusal(
+        res,
+        400,
+        "code_challenge and code_challenge_method=S256 are required"
+      );
     }
     if (!hasPkce && isOpenAiCustomGptRedirect) {
       // Allow OAuth without client PKCE for OpenAI Custom GPT only (weaker security; see docs).
@@ -3016,9 +3039,11 @@ app.get("/mcp/oauth/authorize", async (req, res) => {
       return res.redirect(`/mcp/oauth/key-auth?next=${encodeURIComponent(nextPath)}`);
     }
     if (dev_stub === "1" || dev_stub === "true") {
-      return res
-        .status(400)
-        .send("dev_stub is disabled. OAuth requires key authentication via /mcp/oauth/key-auth.");
+      return sendAuthorizeRefusal(
+        res,
+        400,
+        "dev_stub is disabled. OAuth requires key authentication via /mcp/oauth/key-auth."
+      );
     }
 
     if (config.storageBackend === "local") {
@@ -3033,18 +3058,31 @@ app.get("/mcp/oauth/authorize", async (req, res) => {
           // has configured a callback and still gets refused otherwise has no way
           // to tell a typo from an unset variable from an exact-match miss.
           const trustedCount = config.oauthTrustedCallbackUrls.length;
+          const sanitizedRedirectUri = sanitizeRedirectUriForLog(redirect_uri);
           logger.warn("[MCP OAuth] Authorize rejected: redirect_uri not allowed for tunnel", {
-            redirect_uri: sanitizeRedirectUriForLog(redirect_uri),
+            redirect_uri: sanitizedRedirectUri,
             trusted_callback_urls_configured: trustedCount,
           });
-          return res
-            .status(400)
-            .send(
-              "redirect_uri is not allowed when connecting via a tunnel. Use cursor://, localhost, loopback, or trusted callback URLs (OpenAI/Claude). " +
-                (trustedCount > 0
-                  ? `This instance has ${trustedCount} operator-configured callback URL(s) in NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS; none matched. That list is matched on the EXACT full callback URL (scheme, host, port and path), and plaintext http: is only honoured for loopback hosts.`
-                  : "To trust a self-hosted app's callback, set NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS to its exact full callback URL (for example https://app.example.com/auth/callback).")
-            );
+          return sendAuthorizeRefusal(
+            res,
+            400,
+            "redirect_uri is not allowed when connecting via a tunnel. Use cursor://, localhost, loopback, or trusted callback URLs (OpenAI/Claude). " +
+              // Echo what the server actually compared. An operator on a hosted
+              // deploy has no log access, and every likely failure here is a
+              // NEAR miss (trailing slash, port, case, a dot segment that
+              // resolved) — indistinguishable from a typo or a client-side bug
+              // without seeing the value the server saw. Safe to echo because
+              // this response is text/plain (see sendAuthorizeRefusal) and
+              // because the value is sanitized: scheme, host and path only,
+              // with query and fragment — where the code and state live —
+              // already stripped.
+              (sanitizedRedirectUri
+                ? `The server compared: ${sanitizedRedirectUri} (query and fragment ignored). `
+                : "") +
+              (trustedCount > 0
+                ? `This instance has ${trustedCount} operator-configured callback URL(s) in NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS; none matched. That list is matched on the EXACT full callback URL: scheme, host, port and path must all agree. The host is compared case-insensitively and the path case-sensitively; a trailing slash and a default port (:443) are insignificant; query and fragment are ignored; and plaintext http: is only honoured for loopback hosts.`
+                : "To trust a self-hosted app's callback, set NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS to its exact full callback URL (for example https://app.example.com/auth/callback).")
+          );
         }
       }
 
@@ -3110,7 +3148,7 @@ app.get("/mcp/oauth/authorize", async (req, res) => {
     return res.redirect(result.authUrl);
   } catch (error: any) {
     logError("MCPOAuthAuthorize", req, error);
-    return res.status(500).send(error.message ?? "Authorization failed");
+    return sendAuthorizeRefusal(res, 500, error.message ?? "Authorization failed");
   }
 });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -214,6 +214,19 @@ export const config = {
     (process.env.NEOTOMA_MCP_COMPACT_INSTRUCTIONS || "").toLowerCase() === "1" ||
     (process.env.NEOTOMA_MCP_COMPACT_INSTRUCTIONS || "").toLowerCase() === "true",
   oauthClientId: process.env.NEOTOMA_OAUTH_CLIENT_ID || "",
+  /**
+   * Additional exact callback URLs an operator trusts to receive an authorization
+   * code when the authorize request arrives via a tunnel (non-local Host).
+   *
+   * Comma-separated list of FULL callback URLs, not origins — `https://app.example.com/auth/callback`
+   * authorises that path and nothing else on that host. Entries must be https: unless
+   * they point at a loopback host. Empty by default: an operator who sets nothing keeps
+   * exactly the behaviour they had before this existed.
+   */
+  oauthTrustedCallbackUrls: (process.env.NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS || "")
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0),
   requireKeyForOauth:
     (process.env.NEOTOMA_REQUIRE_KEY_FOR_OAUTH || "true").toLowerCase() !== "false",
   // Encryption settings (local backend)

--- a/src/config.ts
+++ b/src/config.ts
@@ -174,6 +174,91 @@ if (dbBackend !== "sqlite" && dbBackend !== "libsql") {
   );
 }
 
+const OAUTH_CALLBACK_LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]", "::1"]);
+
+/**
+ * Why an entry is refused, phrased for an operator reading a startup failure.
+ * Returns null when the entry is acceptable.
+ */
+function describeTrustedCallbackDefect(entry: string): string | null {
+  let url: URL;
+  try {
+    url = new URL(entry);
+  } catch {
+    return "not a parseable absolute URL (a full URL with a scheme is required, e.g. https://app.example.com/auth/callback)";
+  }
+  const protocol = url.protocol.toLowerCase();
+  if (protocol !== "https:" && protocol !== "http:") {
+    return `scheme "${protocol}" is not supported here (use https:, or http: only for a loopback host)`;
+  }
+  if (url.username || url.password) {
+    return "carries userinfo (user:password@host), which is a URL-spoofing vector and is never load-bearing in a callback";
+  }
+  const host = url.hostname.toLowerCase();
+  if (!host) {
+    return "has no host";
+  }
+  if (protocol === "http:" && !OAUTH_CALLBACK_LOOPBACK_HOSTS.has(host)) {
+    return "is plaintext http: to a non-loopback host, which would ship authorization codes in cleartext (use https:)";
+  }
+  return null;
+}
+
+/**
+ * Parse NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS, FAILING CLOSED on the whole list.
+ *
+ * If any entry is malformed, the entire list is rejected and startup fails —
+ * entries 1 and 3 do not survive a bad entry 2. This is deliberate and is the
+ * condition pre-registered on #2384 before implementation.
+ *
+ * The rejected alternative was skipping a bad entry and honouring the rest. That
+ * is friendlier on a typo, but it makes an allowlist enforce something other than
+ * what the operator wrote, with no signal that it did: the refusal a bad entry
+ * produces is indistinguishable from an exact-match miss. An allowlist is a
+ * security control, and a control that silently binds less than its configuration
+ * says is the failure mode in docs/foundation/principles.md#1. Refusing to start
+ * is loud, immediate, and happens before any authorization request is served,
+ * rather than surfacing as an unexplained sign-in failure weeks later.
+ *
+ * The blast radius of the strict reading is bounded: this throws only when the
+ * operator has actually set the variable. Leaving it unset is the default and is
+ * unaffected.
+ */
+function parseTrustedCallbackUrls(raw: string | undefined): string[] {
+  const entries = (raw || "")
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+
+  const defects = entries
+    .map((entry, index) => {
+      const defect = describeTrustedCallbackDefect(entry);
+      // The entry is operator-authored config, not user input, and is already
+      // echoed in startup logs; but userinfo is the one part that could carry a
+      // credential, so redact it rather than printing it back.
+      return defect ? `  entry ${index + 1} ("${redactUrlUserinfo(entry)}"): ${defect}` : null;
+    })
+    .filter((defect): defect is string => defect !== null);
+
+  if (defects.length > 0) {
+    throw new Error(
+      `Invalid NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS: ${defects.length} of ${entries.length} ` +
+        `entries are not usable as trusted OAuth callback URLs.\n${defects.join("\n")}\n` +
+        `The whole list is rejected rather than partially applied, so the allowlist in force ` +
+        `always matches what is configured. Fix the entries above, or unset the variable to ` +
+        `fall back to the built-in allowlist (localhost, loopback, cursor:/vscode:/app:, this ` +
+        `instance's own origin, and the ChatGPT/Claude callbacks).`
+    );
+  }
+
+  return entries;
+}
+
+/** Replace any `user:password@` in a URL-ish string, for safe echoing in errors. */
+function redactUrlUserinfo(value: string): string {
+  return value.replace(/^([a-zA-Z][a-zA-Z0-9+.-]*:\/\/)[^/@]*@/, "$1<redacted>@");
+}
+
 export const config = {
   projectRoot,
   storageBackend,
@@ -222,11 +307,13 @@ export const config = {
    * authorises that path and nothing else on that host. Entries must be https: unless
    * they point at a loopback host. Empty by default: an operator who sets nothing keeps
    * exactly the behaviour they had before this existed.
+   *
+   * Validated at load, fail-closed on the WHOLE list: one malformed entry rejects
+   * every entry and fails startup. See parseTrustedCallbackUrls above for why.
    */
-  oauthTrustedCallbackUrls: (process.env.NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS || "")
-    .split(",")
-    .map((entry) => entry.trim())
-    .filter((entry) => entry.length > 0),
+  oauthTrustedCallbackUrls: parseTrustedCallbackUrls(
+    process.env.NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS
+  ),
   requireKeyForOauth:
     (process.env.NEOTOMA_REQUIRE_KEY_FOR_OAUTH || "true").toLowerCase() !== "false",
   // Encryption settings (local backend)

--- a/src/services/__tests__/mcp_oauth.test.ts
+++ b/src/services/__tests__/mcp_oauth.test.ts
@@ -265,6 +265,75 @@ describe("MCP OAuth Service", () => {
       );
     });
 
+    it("ignores the query string entirely rather than making it part of the match", () => {
+      // DOCUMENTING THE CHOSEN RULE, not merely asserting "it works": the query
+      // string is NOT part of the exact match. canonicalCallbackUrl compares
+      // protocol + host + port + pathname and drops query and fragment, so a
+      // difference in the query cannot cause either a false accept or a false
+      // reject. Both directions are asserted below so the rule is pinned.
+      //
+      // Why this is the right rule here: the redirect_uri that arrives at
+      // authorize is the client's REGISTERED callback, and the authorization
+      // code is appended to it as ?code=&state= by this server afterwards. A
+      // client that registered `/auth/callback` and is sent to
+      // `/auth/callback?code=…` must still match, so treating the query as
+      // significant would break every real callback. Nothing is given away by
+      // ignoring it: the query cannot change WHERE the browser sends the code,
+      // which is what the allowlist exists to constrain.
+
+      // A configured entry with no query matches a request carrying any query.
+      setTrusted(["https://app.example.com/auth/callback"]);
+      expect(
+        isRedirectUriAllowedForTunnel("https://app.example.com/auth/callback?code=abc&state=xyz")
+      ).toBe(true);
+      // ...including a query that differs from any other request's query.
+      expect(
+        isRedirectUriAllowedForTunnel("https://app.example.com/auth/callback?tenant=other")
+      ).toBe(true);
+
+      // And symmetrically: a configured entry that itself carries a query still
+      // matches a request with a DIFFERENT query, or none at all, because the
+      // query is dropped from both sides before comparison.
+      setTrusted(["https://app.example.com/auth/callback?env=prod"]);
+      expect(
+        isRedirectUriAllowedForTunnel("https://app.example.com/auth/callback?env=staging")
+      ).toBe(true);
+      expect(isRedirectUriAllowedForTunnel("https://app.example.com/auth/callback")).toBe(true);
+
+      // The path remains significant even when the query would "look" right —
+      // ignoring the query must not soften the path match.
+      expect(isRedirectUriAllowedForTunnel("https://app.example.com/other?env=prod")).toBe(false);
+    });
+
+    it("treats a trailing slash as insignificant, including against a query and on the root path", () => {
+      // DOCUMENTING THE CHOSEN RULE: a trailing slash is stripped from the
+      // pathname on BOTH sides before comparison, so `/cb` and `/cb/` are the
+      // same callback. An operator should not be locked out by a slash.
+      //
+      // The root path is the deliberate exception: `https://host` and
+      // `https://host/` both parse to pathname "/", which is left as "/" rather
+      // than stripped to "", so a configured root callback still matches
+      // itself and does not collapse into an empty path.
+      setTrusted(["https://app.example.com/auth/callback"]);
+      // Trailing slash on the request, combined with a real query.
+      expect(isRedirectUriAllowedForTunnel("https://app.example.com/auth/callback/?code=abc")).toBe(
+        true
+      );
+
+      // A root-path callback matches with and without the slash...
+      setTrusted(["https://app.example.com/"]);
+      expect(isRedirectUriAllowedForTunnel("https://app.example.com")).toBe(true);
+      expect(isRedirectUriAllowedForTunnel("https://app.example.com/")).toBe(true);
+      // ...and does NOT thereby trust every path on that host.
+      expect(isRedirectUriAllowedForTunnel("https://app.example.com/admin")).toBe(false);
+
+      // The slash rule does not merge genuinely different paths.
+      setTrusted(["https://app.example.com/auth/callback"]);
+      expect(isRedirectUriAllowedForTunnel("https://app.example.com/auth/callback/extra")).toBe(
+        false
+      );
+    });
+
     it("refuses the same origin at a different path", () => {
       // The #2215 defect in miniature: trusting an origin must not trust the host.
       setTrusted(["https://app.example.com/auth/callback"]);

--- a/src/services/__tests__/mcp_oauth.test.ts
+++ b/src/services/__tests__/mcp_oauth.test.ts
@@ -18,6 +18,7 @@ import {
   isRedirectUriAllowedForTunnel,
 } from "../mcp_oauth.js";
 import { OAuthError } from "../mcp_oauth_errors.js";
+import { config } from "../../config.js";
 import { randomBytes } from "node:crypto";
 import path from "path";
 import { rmSync } from "fs";
@@ -223,6 +224,193 @@ describe("MCP OAuth Service", () => {
     it("rejects unrelated hosted redirects", () => {
       expect(isRedirectUriAllowedForTunnel("https://claude.ai/other/path")).toBe(false);
       expect(isRedirectUriAllowedForTunnel("https://example.com/oauth/callback")).toBe(false);
+    });
+  });
+
+  describe("operator-configured trusted callback URLs", () => {
+    const original = [...config.oauthTrustedCallbackUrls];
+
+    function setTrusted(entries: string[]): void {
+      config.oauthTrustedCallbackUrls.length = 0;
+      config.oauthTrustedCallbackUrls.push(...entries);
+    }
+
+    afterEach(() => {
+      setTrusted(original);
+    });
+
+    it("defaults to empty, changing nothing for an operator who sets no variable", () => {
+      // The default from a real process with no NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS set.
+      expect(original).toEqual([]);
+      setTrusted([]);
+      expect(
+        isRedirectUriAllowedForTunnel("https://bottega8-dashboard.fly.dev/auth/callback")
+      ).toBe(false);
+      expect(isRedirectUriAllowedForTunnel("https://app.example.com/auth/callback")).toBe(false);
+    });
+
+    it("allows a configured exact callback URL", () => {
+      setTrusted(["https://app.example.com/auth/callback"]);
+      expect(isRedirectUriAllowedForTunnel("https://app.example.com/auth/callback")).toBe(true);
+    });
+
+    it("allows a configured callback carrying a query string or fragment", () => {
+      // A real client callback arrives with ?code=&state=; only origin+path is compared.
+      setTrusted(["https://app.example.com/auth/callback"]);
+      expect(
+        isRedirectUriAllowedForTunnel("https://app.example.com/auth/callback?state=abc123")
+      ).toBe(true);
+      expect(isRedirectUriAllowedForTunnel("https://app.example.com/auth/callback#frag")).toBe(
+        true
+      );
+    });
+
+    it("refuses the same origin at a different path", () => {
+      // The #2215 defect in miniature: trusting an origin must not trust the host.
+      setTrusted(["https://app.example.com/auth/callback"]);
+      expect(isRedirectUriAllowedForTunnel("https://app.example.com/anything-else")).toBe(false);
+      expect(isRedirectUriAllowedForTunnel("https://app.example.com/")).toBe(false);
+      expect(isRedirectUriAllowedForTunnel("https://app.example.com/auth/callback2")).toBe(false);
+      expect(isRedirectUriAllowedForTunnel("https://app.example.com/auth")).toBe(false);
+    });
+
+    it("refuses a path-traversal walk out of the configured callback path", () => {
+      // The URL parser resolves `..` before we compare, so this is /auth/admin.
+      setTrusted(["https://app.example.com/auth/callback"]);
+      expect(isRedirectUriAllowedForTunnel("https://app.example.com/auth/callback/../admin")).toBe(
+        false
+      );
+      expect(
+        isRedirectUriAllowedForTunnel("https://app.example.com/auth/callback/%2E%2E/admin")
+      ).toBe(false);
+    });
+
+    it("treats a dot segment that resolves back to the callback as the callback", () => {
+      setTrusted(["https://app.example.com/auth/callback"]);
+      expect(isRedirectUriAllowedForTunnel("https://app.example.com/auth/./callback")).toBe(true);
+      expect(isRedirectUriAllowedForTunnel("https://app.example.com/x/../auth/callback")).toBe(
+        true
+      );
+    });
+
+    it("ignores host case but respects path case", () => {
+      setTrusted(["https://app.example.com/auth/callback"]);
+      // Hosts are case-insensitive.
+      expect(isRedirectUriAllowedForTunnel("HTTPS://APP.EXAMPLE.COM/auth/callback")).toBe(true);
+      // Paths are not.
+      expect(isRedirectUriAllowedForTunnel("https://app.example.com/auth/CALLBACK")).toBe(false);
+      expect(isRedirectUriAllowedForTunnel("https://app.example.com/Auth/callback")).toBe(false);
+    });
+
+    it("normalises a configured entry's own case too", () => {
+      setTrusted(["HTTPS://APP.EXAMPLE.COM/auth/callback"]);
+      expect(isRedirectUriAllowedForTunnel("https://app.example.com/auth/callback")).toBe(true);
+    });
+
+    it("treats a trailing slash as insignificant in either direction", () => {
+      setTrusted(["https://app.example.com/auth/callback/"]);
+      expect(isRedirectUriAllowedForTunnel("https://app.example.com/auth/callback")).toBe(true);
+      setTrusted(["https://app.example.com/auth/callback"]);
+      expect(isRedirectUriAllowedForTunnel("https://app.example.com/auth/callback/")).toBe(true);
+    });
+
+    it("resolves backslashes the way a browser would", () => {
+      setTrusted(["https://app.example.com/auth/callback"]);
+      expect(isRedirectUriAllowedForTunnel("https:\\\\app.example.com\\auth\\callback")).toBe(true);
+      // And a backslash walk out of the path is still refused.
+      expect(
+        isRedirectUriAllowedForTunnel("https:\\\\app.example.com\\auth\\callback\\..\\admin")
+      ).toBe(false);
+    });
+
+    it("treats a default port as equivalent to no port, and a non-default port as distinct", () => {
+      setTrusted(["https://app.example.com/auth/callback"]);
+      expect(isRedirectUriAllowedForTunnel("https://app.example.com:443/auth/callback")).toBe(true);
+      expect(isRedirectUriAllowedForTunnel("https://app.example.com:8443/auth/callback")).toBe(
+        false
+      );
+      setTrusted(["https://app.example.com:8443/auth/callback"]);
+      expect(isRedirectUriAllowedForTunnel("https://app.example.com:8443/auth/callback")).toBe(
+        true
+      );
+      expect(isRedirectUriAllowedForTunnel("https://app.example.com/auth/callback")).toBe(false);
+    });
+
+    it("does not treat an encoded slash as a path separator", () => {
+      setTrusted(["https://app.example.com/auth/callback"]);
+      expect(isRedirectUriAllowedForTunnel("https://app.example.com/auth%2Fcallback")).toBe(false);
+    });
+
+    it("refuses plaintext http: to a non-loopback host even when configured", () => {
+      // Fail closed on operator misconfiguration rather than shipping codes in cleartext.
+      setTrusted(["http://evil.com/cb"]);
+      expect(isRedirectUriAllowedForTunnel("http://evil.com/cb")).toBe(false);
+      setTrusted(["http://app.example.com/auth/callback"]);
+      expect(isRedirectUriAllowedForTunnel("http://app.example.com/auth/callback")).toBe(false);
+    });
+
+    it("does not let a configured https entry authorise its http twin", () => {
+      setTrusted(["https://app.example.com/auth/callback"]);
+      expect(isRedirectUriAllowedForTunnel("http://app.example.com/auth/callback")).toBe(false);
+    });
+
+    it("refuses a URL carrying userinfo on either side", () => {
+      // `https://app.example.com@evil.com/cb` reads as the trusted host to a human
+      // skimming config but resolves to evil.com.
+      setTrusted(["https://app.example.com/auth/callback"]);
+      expect(isRedirectUriAllowedForTunnel("https://evil.com@app.example.com/auth/callback")).toBe(
+        false
+      );
+      setTrusted(["https://app.example.com@evil.com/auth/callback"]);
+      expect(isRedirectUriAllowedForTunnel("https://evil.com/auth/callback")).toBe(false);
+    });
+
+    it("refuses a host that merely contains or extends the configured host", () => {
+      setTrusted(["https://app.example.com/auth/callback"]);
+      expect(isRedirectUriAllowedForTunnel("https://app.example.com.evil.com/auth/callback")).toBe(
+        false
+      );
+      expect(isRedirectUriAllowedForTunnel("https://evil-app.example.com/auth/callback")).toBe(
+        false
+      );
+      expect(isRedirectUriAllowedForTunnel("https://sub.app.example.com/auth/callback")).toBe(
+        false
+      );
+    });
+
+    it("honours several configured entries and skips a malformed one", () => {
+      // One bad entry must not silently disable the rest of the list.
+      setTrusted([
+        "not a url",
+        "https://a.example.com/cb",
+        "http://evil.com/cb",
+        "https://b.example.com/cb",
+      ]);
+      expect(isRedirectUriAllowedForTunnel("https://a.example.com/cb")).toBe(true);
+      expect(isRedirectUriAllowedForTunnel("https://b.example.com/cb")).toBe(true);
+      expect(isRedirectUriAllowedForTunnel("http://evil.com/cb")).toBe(false);
+      expect(isRedirectUriAllowedForTunnel("https://c.example.com/cb")).toBe(false);
+    });
+
+    it("leaves the pre-existing allowlist intact when entries are configured", () => {
+      setTrusted(["https://app.example.com/auth/callback"]);
+      expect(isRedirectUriAllowedForTunnel("cursor://auth/callback")).toBe(true);
+      expect(isRedirectUriAllowedForTunnel("http://localhost:5195/oauth")).toBe(true);
+      expect(isRedirectUriAllowedForTunnel("https://chatgpt.com/aip/g-123/oauth/callback")).toBe(
+        true
+      );
+      expect(isRedirectUriAllowedForTunnel("https://claude.ai/api/mcp/auth_callback")).toBe(true);
+      // ...and does not loosen what it refused before.
+      expect(isRedirectUriAllowedForTunnel("https://claude.ai/other/path")).toBe(false);
+      expect(isRedirectUriAllowedForTunnel("https://example.com/oauth/callback")).toBe(false);
+    });
+
+    it("authorises the motivating self-hosted dashboard callback exactly", () => {
+      setTrusted(["https://bottega8-dashboard.fly.dev/auth/callback"]);
+      expect(
+        isRedirectUriAllowedForTunnel("https://bottega8-dashboard.fly.dev/auth/callback")
+      ).toBe(true);
+      expect(isRedirectUriAllowedForTunnel("https://bottega8-dashboard.fly.dev/admin")).toBe(false);
     });
   });
 

--- a/src/services/__tests__/mcp_oauth.test.ts
+++ b/src/services/__tests__/mcp_oauth.test.ts
@@ -447,18 +447,17 @@ describe("MCP OAuth Service", () => {
       );
     });
 
-    it("honours several configured entries and skips a malformed one", () => {
-      // One bad entry must not silently disable the rest of the list.
-      setTrusted([
-        "not a url",
-        "https://a.example.com/cb",
-        "http://evil.com/cb",
-        "https://b.example.com/cb",
-      ]);
+    it("honours several configured entries, each on its own exact terms", () => {
+      // A well-formed multi-entry list: every entry authorises its own exact
+      // callback and nothing else. (A list containing a MALFORMED entry cannot
+      // reach this matcher at all — config parsing rejects the whole list at
+      // load; see the fail-closed suite in src/__tests__/config_trusted_callbacks.test.ts.)
+      setTrusted(["https://a.example.com/cb", "https://b.example.com/cb"]);
       expect(isRedirectUriAllowedForTunnel("https://a.example.com/cb")).toBe(true);
       expect(isRedirectUriAllowedForTunnel("https://b.example.com/cb")).toBe(true);
-      expect(isRedirectUriAllowedForTunnel("http://evil.com/cb")).toBe(false);
       expect(isRedirectUriAllowedForTunnel("https://c.example.com/cb")).toBe(false);
+      // Configuring two hosts does not merge their paths.
+      expect(isRedirectUriAllowedForTunnel("https://a.example.com/other")).toBe(false);
     });
 
     it("leaves the pre-existing allowlist intact when entries are configured", () => {

--- a/src/services/mcp_oauth.ts
+++ b/src/services/mcp_oauth.ts
@@ -377,8 +377,11 @@ export function isRedirectUriInConfiguredAllowlist(redirectUri: string): boolean
   if (!candidate) return false;
   for (const configured of config.oauthTrustedCallbackUrls) {
     const allowed = canonicalCallbackUrl(configured);
-    // A malformed or non-https entry is skipped, not fatal: one bad entry must not
-    // silently disable the rest of an operator's list.
+    // `allowed` is non-null for every entry that survives config parsing:
+    // `parseTrustedCallbackUrls` in src/config.ts rejects the whole list at load
+    // if any entry is malformed, so a bad entry can never reach here to be
+    // silently skipped. The null-guard remains as a defence-in-depth belt on a
+    // helper that is exported and could be called with an unvalidated list.
     if (allowed && allowed === candidate) return true;
   }
   return false;

--- a/src/services/mcp_oauth.ts
+++ b/src/services/mcp_oauth.ts
@@ -314,10 +314,83 @@ function validateRedirectUri(redirectUri: string): void {
   }
 }
 
+const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]", "::1"]);
+
+/**
+ * Canonical form of a callback URL for exact comparison, or null if the URL is
+ * unparseable or not one we will ever honour.
+ *
+ * Normalisation is delegated to the WHATWG URL parser wherever the parser and a
+ * browser agree, because the browser is what will actually perform the redirect:
+ *   - backslashes are resolved as slashes, the way a browser resolves them;
+ *   - dot segments are resolved (`/auth/callback/../admin` becomes `/auth/admin`,
+ *     which then simply fails to match the configured `/auth/callback`);
+ *   - the host is lowercased; a default port (443/80) is dropped.
+ * On top of that we:
+ *   - compare protocol + host + port + pathname only, so a query string or
+ *     fragment on the request cannot smuggle a mismatch past the comparison and
+ *     equally cannot cause a legitimate callback carrying `?state=` to be refused;
+ *   - preserve pathname case, which is correctly case-SENSITIVE (unlike the host);
+ *   - treat a trailing slash as insignificant, since `/cb` and `/cb/` reach the
+ *     same handler in every server we care about and an operator should not be
+ *     punished for the difference;
+ *   - refuse any URL carrying userinfo. `https://evil.com@app.example.com/cb` is
+ *     harmless to the URL parser but is a well-worn way to make a URL read as one
+ *     host to a human reviewing config and resolve as another;
+ *   - refuse plaintext http: to anything but a loopback host, so an operator who
+ *     misconfigures `http://evil.com/cb` fails closed rather than silently
+ *     shipping authorization codes over the wire in cleartext.
+ */
+function canonicalCallbackUrl(value: string): string | null {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return null;
+  }
+  const protocol = url.protocol.toLowerCase();
+  if (protocol !== "https:" && protocol !== "http:") return null;
+  // Credentials in a callback URL are never load-bearing and are a spoofing vector.
+  if (url.username || url.password) return null;
+  const host = url.hostname.toLowerCase();
+  if (!host) return null;
+  // Plaintext only to loopback, where there is no wire to sniff.
+  if (protocol === "http:" && !LOOPBACK_HOSTS.has(host)) return null;
+  const port = url.port ? `:${url.port}` : "";
+  // Trailing slash is insignificant; everything else about the path is significant.
+  const path = url.pathname.length > 1 ? url.pathname.replace(/\/+$/, "") : url.pathname;
+  return `${protocol}//${host}${port}${path}`;
+}
+
+/**
+ * Exact-match check against the operator-configured trusted callback URLs
+ * (NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS). Empty by default.
+ *
+ * Deliberately matches a FULL callback URL rather than an origin: a configured
+ * `https://app.example.com/auth/callback` authorises that one path and NOT
+ * `https://app.example.com/anything-else`. Trusting a whole third-party origin is
+ * the defect reported in #2215; this does not add a second instance of it.
+ */
+export function isRedirectUriInConfiguredAllowlist(redirectUri: string): boolean {
+  if (config.oauthTrustedCallbackUrls.length === 0) return false;
+  const candidate = canonicalCallbackUrl(redirectUri);
+  if (!candidate) return false;
+  for (const configured of config.oauthTrustedCallbackUrls) {
+    const allowed = canonicalCallbackUrl(configured);
+    // A malformed or non-https entry is skipped, not fatal: one bad entry must not
+    // silently disable the rest of an operator's list.
+    if (allowed && allowed === candidate) return true;
+  }
+  return false;
+}
+
 /**
  * Redirect URIs allowed when the authorization request is from a tunnel (non-local Host).
  * Prevents sending the authorization code to a third-party site. Allows localhost, loopback,
- * known app schemes, and trusted hosted OAuth callbacks (OpenAI/Claude).
+ * known app schemes, trusted hosted OAuth callbacks (OpenAI/Claude), and any exact
+ * callback URLs the operator configured via NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS
+ * (empty by default, so this function's behaviour is unchanged unless an operator
+ * opts in).
  */
 export function isRedirectUriAllowedForTunnel(redirectUri: string, selfHost?: string): boolean {
   if (!redirectUri || typeof redirectUri !== "string") return false;
@@ -339,6 +412,9 @@ export function isRedirectUriAllowedForTunnel(redirectUri: string, selfHost?: st
       if (host === self) return true;
     }
     if (host === "chatgpt.com" || host === "chat.openai.com") return true;
+    // Operator-configured exact callback URLs. Additive: empty by default, and
+    // checked only after every pre-existing rule has already declined.
+    if (isRedirectUriInConfiguredAllowlist(redirectUri)) return true;
     if (
       (host === "claude.ai" || host === "www.claude.ai") &&
       (url.pathname === "/api/mcp/auth_callback" ||

--- a/src/shared/openapi_types.ts
+++ b/src/shared/openapi_types.ts
@@ -4495,12 +4495,52 @@ export interface operations {
     };
     requestBody?: never;
     responses: {
-      /** @description Redirect to authorization URL */
+      /**
+       * @description Redirect to the authorization URL, or to /mcp/oauth/key-auth when
+       *     NEOTOMA_REQUIRE_KEY_FOR_OAUTH is set and the request carries no valid
+       *     key session.
+       */
       302: {
         headers: {
           [name: string]: unknown;
         };
         content?: never;
+      };
+      /**
+       * @description Authorization refused before any redirect. The body is a plain-text
+       *     sentence addressed to the human in the browser, NOT an ErrorEnvelope:
+       *     this endpoint is reached by a user-agent mid-OAuth-redirect, so the
+       *     response is rendered directly in the address bar. A JSON envelope
+       *     would be read by nobody at this point in the flow. Machine clients
+       *     MUST treat any 400 here as a terminal refusal of the authorization
+       *     request and MUST NOT parse the body; the reason is carried by the
+       *     server's structured warn log, not by this response.
+       *
+       *     Emitted for: a missing `redirect_uri`; a missing `state`; a missing
+       *     or non-S256 PKCE challenge on a non-OpenAI redirect; a `dev_stub`
+       *     request while dev_stub is disabled; and a `redirect_uri` that is not
+       *     on the tunnel allowlist (built-in entries plus any exact callback
+       *     URLs configured in NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS).
+       */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "text/plain": string;
+        };
+      };
+      /**
+       * @description Authorization failed unexpectedly. Plain-text body, for the same
+       *     browser-facing reason as the 400 above.
+       */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "text/plain": string;
+        };
       };
     };
   };

--- a/tests/__snapshots__/agentic_eval/oauth_operator_trusted_callback__cursor-hooks__claude-haiku-4.snap.json
+++ b/tests/__snapshots__/agentic_eval/oauth_operator_trusted_callback__cursor-hooks__claude-haiku-4.snap.json
@@ -1,0 +1,289 @@
+{
+  "requests": [
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "REFERS_TO",
+        "source_entity_id": "ent_mock_12",
+        "target_entity_id": "ent_mock_9"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "REFERS_TO",
+        "source_entity_id": "ent_mock_19",
+        "target_entity_id": "ent_mock_16"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/store",
+      "body": {
+        "entities": [
+          {
+            "client_name": "Cursor",
+            "conversation_id": "<id:1>",
+            "cwd": "<env>",
+            "data_source": "cursor-hook",
+            "entity_type": "conversation",
+            "harness": "cursor-hook",
+            "hook_event": "beforeSubmitPrompt",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "repository_root": "<env>",
+            "scope_summary": "<env>",
+            "thread_kind": "human_agent",
+            "title": "<env>",
+            "workspace_kind": "<env>"
+          },
+          {
+            "content": "Sign-in to my instance fails for the dashboard I deployed at https://bottega8-dashboard.fly.dev — authorize returns 'redirect_uri is not allowed when connecting via a tunnel'. Figure out what I need to configure and remember it.",
+            "cwd": "<env>",
+            "data_source": "cursor-hook",
+            "entity_type": "conversation_message",
+            "harness": "cursor",
+            "hook_event": "beforeSubmitPrompt",
+            "role": "user",
+            "sender_kind": "user",
+            "turn_key": "oauth_operator_trusted_callback__cursor-hooks__claude-haiku-4:turn-1"
+          }
+        ],
+        "idempotency_key": "<id:2>",
+        "relationships": [
+          {
+            "relationship_type": "PART_OF",
+            "source_index": 1,
+            "target_index": 0
+          }
+        ]
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/store",
+      "body": {
+        "entities": [
+          {
+            "context_source": "cursor-hook",
+            "conversation_id": "<id:3>",
+            "cwd": "<env>",
+            "data_source": "cursor-hook",
+            "entity_type": "conversation_turn",
+            "git_branch": "<env>",
+            "harness": "cursor",
+            "hook_event": "before_submit_prompt",
+            "hook_events": [
+              "before_submit_prompt"
+            ],
+            "model": "claude-haiku-4",
+            "session_id": "<id:1>",
+            "started_at": "<ts>",
+            "stored_entity_ids": [
+              "ent_mock_3"
+            ],
+            "turn_id": "<id:4>",
+            "turn_key": "oauth_operator_trusted_callback__cursor-hooks__claude-haiku-4:turn-1",
+            "working_directory": "<env>"
+          }
+        ],
+        "idempotency_key": "<id:5>"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/store",
+      "body": {
+        "entities": [
+          {
+            "cwd": "<env>",
+            "data_source": "cursor-hook",
+            "entity_type": "tool_invocation",
+            "harness": "cursor",
+            "has_error": false,
+            "hook_event": "postToolUse",
+            "input_summary": "{\"entity_types\":[\"instance_config\"],\"query\":\"oauth trusted callback urls\"}",
+            "invoked_at": "<ts>",
+            "output_summary": "{\"entities\":[],\"count\":0}",
+            "status": null,
+            "tool_name": "mcp_neotoma_retrieve_entities",
+            "turn_key": "oauth_operator_trusted_callback__cursor-hooks__claude-haiku-4:turn-1"
+          }
+        ],
+        "idempotency_key": "<id:6>"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/store",
+      "body": {
+        "entities": [
+          {
+            "context_source": "cursor-hook",
+            "cwd": "<env>",
+            "data_source": "cursor-hook",
+            "entity_type": "conversation_turn",
+            "git_branch": "<env>",
+            "harness": "cursor",
+            "hook_event": "post_tool_use",
+            "hook_events": [
+              "post_tool_use"
+            ],
+            "model": "claude-haiku-4",
+            "neotoma_tool_failures": 0,
+            "retrieve_calls": 1,
+            "session_id": "<id:1>",
+            "store_structured_calls": 0,
+            "stored_entity_ids": [
+              "ent_mock_9"
+            ],
+            "tool_invocation_count": 1,
+            "turn_id": "<id:4>",
+            "turn_key": "oauth_operator_trusted_callback__cursor-hooks__claude-haiku-4:turn-1",
+            "working_directory": "<env>"
+          }
+        ],
+        "idempotency_key": "<id:5>"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/store",
+      "body": {
+        "entities": [
+          {
+            "cwd": "<env>",
+            "data_source": "cursor-hook",
+            "entity_type": "tool_invocation",
+            "harness": "cursor",
+            "has_error": false,
+            "hook_event": "postToolUse",
+            "input_summary": "{\"entities\":[{\"entity_type\":\"instance_config\",\"name\":\"NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS\",\"value\":\"https://bottega8-dashboard.fly.dev/auth/callback\",\"matching_rule\":\"exact full callback URL — scheme, host, port and path; query and fragment ignored; trailing slash insignificant\",\"default\":\"empty\",\"notes\":\"Empty by default, so an unset variable preserves prior behaviour exactly. Matched on the E...",
+            "invoked_at": "<ts>",
+            "output_summary": "{\"stored\":1,\"entity_ids\":[\"ent_oauth_cfg_001\"]}",
+            "status": null,
+            "tool_name": "mcp_neotoma_store",
+            "turn_key": "oauth_operator_trusted_callback__cursor-hooks__claude-haiku-4:turn-1"
+          }
+        ],
+        "idempotency_key": "<id:7>"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/store",
+      "body": {
+        "entities": [
+          {
+            "context_source": "cursor-hook",
+            "cwd": "<env>",
+            "data_source": "cursor-hook",
+            "entity_type": "conversation_turn",
+            "git_branch": "<env>",
+            "harness": "cursor",
+            "hook_event": "post_tool_use",
+            "hook_events": [
+              "post_tool_use"
+            ],
+            "model": "claude-haiku-4",
+            "neotoma_tool_failures": 0,
+            "retrieve_calls": 1,
+            "session_id": "<id:1>",
+            "store_structured_calls": 1,
+            "stored_entity_ids": [
+              "ent_mock_16"
+            ],
+            "tool_invocation_count": 2,
+            "turn_id": "<id:4>",
+            "turn_key": "oauth_operator_trusted_callback__cursor-hooks__claude-haiku-4:turn-1",
+            "working_directory": "<env>"
+          }
+        ],
+        "idempotency_key": "<id:5>"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/store",
+      "body": {
+        "entities": [
+          {
+            "content": "The instance refuses any callback that is not on its tunnel allowlist, and that list is empty until you set it. Set NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS to the exact full callback URL — https://bottega8-dashboard.fly.dev/auth/callback — not just the host. It is matched exactly: that path is authorised and nothing else on that host, the query string and a trailing slash are ignored, and plaintext http: is accepted only for loopback. I have recorded the setting so it survives this session.",
+            "cwd": "<env>",
+            "data_source": "cursor-hook",
+            "entity_type": "conversation_message",
+            "harness": "cursor",
+            "hook_event": "stop",
+            "observed_at": "<ts>",
+            "role": "assistant",
+            "sender_kind": "assistant",
+            "turn_key": "oauth_operator_trusted_callback__cursor-hooks__claude-haiku-4:turn-1:assistant"
+          }
+        ],
+        "idempotency_key": "<id:8>"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/store",
+      "body": {
+        "entities": [
+          {
+            "context_source": "cursor-hook",
+            "conversation_id": "<id:3>",
+            "cwd": "<env>",
+            "data_source": "cursor-hook",
+            "ended_at": "<ts>",
+            "entity_type": "conversation_turn",
+            "git_branch": "<env>",
+            "harness": "cursor",
+            "harness_loop_count": 0,
+            "hook_event": "stop",
+            "hook_events": [
+              "stop"
+            ],
+            "model": "claude-haiku-4",
+            "neotoma_tool_failures": 0,
+            "reminder_injected": true,
+            "retrieve_calls": 1,
+            "safety_net_used": false,
+            "session_id": "<id:1>",
+            "status": "completed",
+            "store_structured_calls": 1,
+            "tool_invocation_count": 2,
+            "turn_id": "<id:4>",
+            "turn_key": "oauth_operator_trusted_callback__cursor-hooks__claude-haiku-4:turn-1",
+            "working_directory": "<env>"
+          }
+        ],
+        "idempotency_key": "<id:5>"
+      }
+    }
+  ],
+  "outputs": [
+    {
+      "hook": "beforeSubmitPrompt",
+      "exitCode": 0,
+      "output": {}
+    },
+    {
+      "hook": "postToolUse",
+      "exitCode": 0,
+      "output": {
+        "additional_context": "Neotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nForbidden: reusing the user-phase conversation_message `turn_key` for the closing assistant store (must use `{conversation_id}:{turn_id}:assistant`, not the bare `{conversation_id}:{turn_id}`).\nNote: this client (claude-haiku-4) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial."
+      }
+    },
+    {
+      "hook": "postToolUse",
+      "exitCode": 0,
+      "output": {}
+    },
+    {
+      "hook": "stop",
+      "exitCode": 0,
+      "output": {}
+    }
+  ]
+}

--- a/tests/__snapshots__/agentic_eval/oauth_operator_trusted_callback__cursor-hooks__claude-sonnet-4.5.snap.json
+++ b/tests/__snapshots__/agentic_eval/oauth_operator_trusted_callback__cursor-hooks__claude-sonnet-4.5.snap.json
@@ -1,0 +1,289 @@
+{
+  "requests": [
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "REFERS_TO",
+        "source_entity_id": "ent_mock_12",
+        "target_entity_id": "ent_mock_9"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "REFERS_TO",
+        "source_entity_id": "ent_mock_19",
+        "target_entity_id": "ent_mock_16"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/store",
+      "body": {
+        "entities": [
+          {
+            "client_name": "Cursor",
+            "conversation_id": "<id:1>",
+            "cwd": "<env>",
+            "data_source": "cursor-hook",
+            "entity_type": "conversation",
+            "harness": "cursor-hook",
+            "hook_event": "beforeSubmitPrompt",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "repository_root": "<env>",
+            "scope_summary": "<env>",
+            "thread_kind": "human_agent",
+            "title": "<env>",
+            "workspace_kind": "<env>"
+          },
+          {
+            "content": "Sign-in to my instance fails for the dashboard I deployed at https://bottega8-dashboard.fly.dev — authorize returns 'redirect_uri is not allowed when connecting via a tunnel'. Figure out what I need to configure and remember it.",
+            "cwd": "<env>",
+            "data_source": "cursor-hook",
+            "entity_type": "conversation_message",
+            "harness": "cursor",
+            "hook_event": "beforeSubmitPrompt",
+            "role": "user",
+            "sender_kind": "user",
+            "turn_key": "oauth_operator_trusted_callback__cursor-hooks__claude-sonnet-4.5:turn-1"
+          }
+        ],
+        "idempotency_key": "<id:2>",
+        "relationships": [
+          {
+            "relationship_type": "PART_OF",
+            "source_index": 1,
+            "target_index": 0
+          }
+        ]
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/store",
+      "body": {
+        "entities": [
+          {
+            "context_source": "cursor-hook",
+            "conversation_id": "<id:3>",
+            "cwd": "<env>",
+            "data_source": "cursor-hook",
+            "entity_type": "conversation_turn",
+            "git_branch": "<env>",
+            "harness": "cursor",
+            "hook_event": "before_submit_prompt",
+            "hook_events": [
+              "before_submit_prompt"
+            ],
+            "model": "claude-sonnet-4.5",
+            "session_id": "<id:1>",
+            "started_at": "<ts>",
+            "stored_entity_ids": [
+              "ent_mock_3"
+            ],
+            "turn_id": "<id:4>",
+            "turn_key": "oauth_operator_trusted_callback__cursor-hooks__claude-sonnet-4.5:turn-1",
+            "working_directory": "<env>"
+          }
+        ],
+        "idempotency_key": "<id:5>"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/store",
+      "body": {
+        "entities": [
+          {
+            "cwd": "<env>",
+            "data_source": "cursor-hook",
+            "entity_type": "tool_invocation",
+            "harness": "cursor",
+            "has_error": false,
+            "hook_event": "postToolUse",
+            "input_summary": "{\"entity_types\":[\"instance_config\"],\"query\":\"oauth trusted callback urls\"}",
+            "invoked_at": "<ts>",
+            "output_summary": "{\"entities\":[],\"count\":0}",
+            "status": null,
+            "tool_name": "mcp_neotoma_retrieve_entities",
+            "turn_key": "oauth_operator_trusted_callback__cursor-hooks__claude-sonnet-4.5:turn-1"
+          }
+        ],
+        "idempotency_key": "<id:6>"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/store",
+      "body": {
+        "entities": [
+          {
+            "context_source": "cursor-hook",
+            "cwd": "<env>",
+            "data_source": "cursor-hook",
+            "entity_type": "conversation_turn",
+            "git_branch": "<env>",
+            "harness": "cursor",
+            "hook_event": "post_tool_use",
+            "hook_events": [
+              "post_tool_use"
+            ],
+            "model": "claude-sonnet-4.5",
+            "neotoma_tool_failures": 0,
+            "retrieve_calls": 1,
+            "session_id": "<id:1>",
+            "store_structured_calls": 0,
+            "stored_entity_ids": [
+              "ent_mock_9"
+            ],
+            "tool_invocation_count": 1,
+            "turn_id": "<id:4>",
+            "turn_key": "oauth_operator_trusted_callback__cursor-hooks__claude-sonnet-4.5:turn-1",
+            "working_directory": "<env>"
+          }
+        ],
+        "idempotency_key": "<id:5>"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/store",
+      "body": {
+        "entities": [
+          {
+            "cwd": "<env>",
+            "data_source": "cursor-hook",
+            "entity_type": "tool_invocation",
+            "harness": "cursor",
+            "has_error": false,
+            "hook_event": "postToolUse",
+            "input_summary": "{\"entities\":[{\"entity_type\":\"instance_config\",\"name\":\"NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS\",\"value\":\"https://bottega8-dashboard.fly.dev/auth/callback\",\"matching_rule\":\"exact full callback URL — scheme, host, port and path; query and fragment ignored; trailing slash insignificant\",\"default\":\"empty\",\"notes\":\"Empty by default, so an unset variable preserves prior behaviour exactly. Matched on the E...",
+            "invoked_at": "<ts>",
+            "output_summary": "{\"stored\":1,\"entity_ids\":[\"ent_oauth_cfg_001\"]}",
+            "status": null,
+            "tool_name": "mcp_neotoma_store",
+            "turn_key": "oauth_operator_trusted_callback__cursor-hooks__claude-sonnet-4.5:turn-1"
+          }
+        ],
+        "idempotency_key": "<id:7>"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/store",
+      "body": {
+        "entities": [
+          {
+            "context_source": "cursor-hook",
+            "cwd": "<env>",
+            "data_source": "cursor-hook",
+            "entity_type": "conversation_turn",
+            "git_branch": "<env>",
+            "harness": "cursor",
+            "hook_event": "post_tool_use",
+            "hook_events": [
+              "post_tool_use"
+            ],
+            "model": "claude-sonnet-4.5",
+            "neotoma_tool_failures": 0,
+            "retrieve_calls": 1,
+            "session_id": "<id:1>",
+            "store_structured_calls": 1,
+            "stored_entity_ids": [
+              "ent_mock_16"
+            ],
+            "tool_invocation_count": 2,
+            "turn_id": "<id:4>",
+            "turn_key": "oauth_operator_trusted_callback__cursor-hooks__claude-sonnet-4.5:turn-1",
+            "working_directory": "<env>"
+          }
+        ],
+        "idempotency_key": "<id:5>"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/store",
+      "body": {
+        "entities": [
+          {
+            "content": "The instance refuses any callback that is not on its tunnel allowlist, and that list is empty until you set it. Set NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS to the exact full callback URL — https://bottega8-dashboard.fly.dev/auth/callback — not just the host. It is matched exactly: that path is authorised and nothing else on that host, the query string and a trailing slash are ignored, and plaintext http: is accepted only for loopback. I have recorded the setting so it survives this session.",
+            "cwd": "<env>",
+            "data_source": "cursor-hook",
+            "entity_type": "conversation_message",
+            "harness": "cursor",
+            "hook_event": "stop",
+            "observed_at": "<ts>",
+            "role": "assistant",
+            "sender_kind": "assistant",
+            "turn_key": "oauth_operator_trusted_callback__cursor-hooks__claude-sonnet-4.5:turn-1:assistant"
+          }
+        ],
+        "idempotency_key": "<id:8>"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/store",
+      "body": {
+        "entities": [
+          {
+            "context_source": "cursor-hook",
+            "conversation_id": "<id:3>",
+            "cwd": "<env>",
+            "data_source": "cursor-hook",
+            "ended_at": "<ts>",
+            "entity_type": "conversation_turn",
+            "git_branch": "<env>",
+            "harness": "cursor",
+            "harness_loop_count": 0,
+            "hook_event": "stop",
+            "hook_events": [
+              "stop"
+            ],
+            "model": "claude-sonnet-4.5",
+            "neotoma_tool_failures": 0,
+            "reminder_injected": true,
+            "retrieve_calls": 1,
+            "safety_net_used": false,
+            "session_id": "<id:1>",
+            "status": "completed",
+            "store_structured_calls": 1,
+            "tool_invocation_count": 2,
+            "turn_id": "<id:4>",
+            "turn_key": "oauth_operator_trusted_callback__cursor-hooks__claude-sonnet-4.5:turn-1",
+            "working_directory": "<env>"
+          }
+        ],
+        "idempotency_key": "<id:5>"
+      }
+    }
+  ],
+  "outputs": [
+    {
+      "hook": "beforeSubmitPrompt",
+      "exitCode": 0,
+      "output": {}
+    },
+    {
+      "hook": "postToolUse",
+      "exitCode": 0,
+      "output": {
+        "additional_context": "Neotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nForbidden: reusing the user-phase conversation_message `turn_key` for the closing assistant store (must use `{conversation_id}:{turn_id}:assistant`, not the bare `{conversation_id}:{turn_id}`)."
+      }
+    },
+    {
+      "hook": "postToolUse",
+      "exitCode": 0,
+      "output": {}
+    },
+    {
+      "hook": "stop",
+      "exitCode": 0,
+      "output": {}
+    }
+  ]
+}

--- a/tests/__snapshots__/agentic_eval/oauth_operator_trusted_callback__cursor-hooks__composer-2.snap.json
+++ b/tests/__snapshots__/agentic_eval/oauth_operator_trusted_callback__cursor-hooks__composer-2.snap.json
@@ -1,0 +1,289 @@
+{
+  "requests": [
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "REFERS_TO",
+        "source_entity_id": "ent_mock_12",
+        "target_entity_id": "ent_mock_9"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "REFERS_TO",
+        "source_entity_id": "ent_mock_19",
+        "target_entity_id": "ent_mock_16"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/store",
+      "body": {
+        "entities": [
+          {
+            "client_name": "Cursor",
+            "conversation_id": "<id:1>",
+            "cwd": "<env>",
+            "data_source": "cursor-hook",
+            "entity_type": "conversation",
+            "harness": "cursor-hook",
+            "hook_event": "beforeSubmitPrompt",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "repository_root": "<env>",
+            "scope_summary": "<env>",
+            "thread_kind": "human_agent",
+            "title": "<env>",
+            "workspace_kind": "<env>"
+          },
+          {
+            "content": "Sign-in to my instance fails for the dashboard I deployed at https://bottega8-dashboard.fly.dev — authorize returns 'redirect_uri is not allowed when connecting via a tunnel'. Figure out what I need to configure and remember it.",
+            "cwd": "<env>",
+            "data_source": "cursor-hook",
+            "entity_type": "conversation_message",
+            "harness": "cursor",
+            "hook_event": "beforeSubmitPrompt",
+            "role": "user",
+            "sender_kind": "user",
+            "turn_key": "oauth_operator_trusted_callback__cursor-hooks__composer-2:turn-1"
+          }
+        ],
+        "idempotency_key": "<id:2>",
+        "relationships": [
+          {
+            "relationship_type": "PART_OF",
+            "source_index": 1,
+            "target_index": 0
+          }
+        ]
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/store",
+      "body": {
+        "entities": [
+          {
+            "context_source": "cursor-hook",
+            "conversation_id": "<id:3>",
+            "cwd": "<env>",
+            "data_source": "cursor-hook",
+            "entity_type": "conversation_turn",
+            "git_branch": "<env>",
+            "harness": "cursor",
+            "hook_event": "before_submit_prompt",
+            "hook_events": [
+              "before_submit_prompt"
+            ],
+            "model": "composer-2",
+            "session_id": "<id:1>",
+            "started_at": "<ts>",
+            "stored_entity_ids": [
+              "ent_mock_3"
+            ],
+            "turn_id": "<id:4>",
+            "turn_key": "oauth_operator_trusted_callback__cursor-hooks__composer-2:turn-1",
+            "working_directory": "<env>"
+          }
+        ],
+        "idempotency_key": "<id:5>"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/store",
+      "body": {
+        "entities": [
+          {
+            "cwd": "<env>",
+            "data_source": "cursor-hook",
+            "entity_type": "tool_invocation",
+            "harness": "cursor",
+            "has_error": false,
+            "hook_event": "postToolUse",
+            "input_summary": "{\"entity_types\":[\"instance_config\"],\"query\":\"oauth trusted callback urls\"}",
+            "invoked_at": "<ts>",
+            "output_summary": "{\"entities\":[],\"count\":0}",
+            "status": null,
+            "tool_name": "mcp_neotoma_retrieve_entities",
+            "turn_key": "oauth_operator_trusted_callback__cursor-hooks__composer-2:turn-1"
+          }
+        ],
+        "idempotency_key": "<id:6>"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/store",
+      "body": {
+        "entities": [
+          {
+            "context_source": "cursor-hook",
+            "cwd": "<env>",
+            "data_source": "cursor-hook",
+            "entity_type": "conversation_turn",
+            "git_branch": "<env>",
+            "harness": "cursor",
+            "hook_event": "post_tool_use",
+            "hook_events": [
+              "post_tool_use"
+            ],
+            "model": "composer-2",
+            "neotoma_tool_failures": 0,
+            "retrieve_calls": 1,
+            "session_id": "<id:1>",
+            "store_structured_calls": 0,
+            "stored_entity_ids": [
+              "ent_mock_9"
+            ],
+            "tool_invocation_count": 1,
+            "turn_id": "<id:4>",
+            "turn_key": "oauth_operator_trusted_callback__cursor-hooks__composer-2:turn-1",
+            "working_directory": "<env>"
+          }
+        ],
+        "idempotency_key": "<id:5>"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/store",
+      "body": {
+        "entities": [
+          {
+            "cwd": "<env>",
+            "data_source": "cursor-hook",
+            "entity_type": "tool_invocation",
+            "harness": "cursor",
+            "has_error": false,
+            "hook_event": "postToolUse",
+            "input_summary": "{\"entities\":[{\"entity_type\":\"instance_config\",\"name\":\"NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS\",\"value\":\"https://bottega8-dashboard.fly.dev/auth/callback\",\"matching_rule\":\"exact full callback URL — scheme, host, port and path; query and fragment ignored; trailing slash insignificant\",\"default\":\"empty\",\"notes\":\"Empty by default, so an unset variable preserves prior behaviour exactly. Matched on the E...",
+            "invoked_at": "<ts>",
+            "output_summary": "{\"stored\":1,\"entity_ids\":[\"ent_oauth_cfg_001\"]}",
+            "status": null,
+            "tool_name": "mcp_neotoma_store",
+            "turn_key": "oauth_operator_trusted_callback__cursor-hooks__composer-2:turn-1"
+          }
+        ],
+        "idempotency_key": "<id:7>"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/store",
+      "body": {
+        "entities": [
+          {
+            "context_source": "cursor-hook",
+            "cwd": "<env>",
+            "data_source": "cursor-hook",
+            "entity_type": "conversation_turn",
+            "git_branch": "<env>",
+            "harness": "cursor",
+            "hook_event": "post_tool_use",
+            "hook_events": [
+              "post_tool_use"
+            ],
+            "model": "composer-2",
+            "neotoma_tool_failures": 0,
+            "retrieve_calls": 1,
+            "session_id": "<id:1>",
+            "store_structured_calls": 1,
+            "stored_entity_ids": [
+              "ent_mock_16"
+            ],
+            "tool_invocation_count": 2,
+            "turn_id": "<id:4>",
+            "turn_key": "oauth_operator_trusted_callback__cursor-hooks__composer-2:turn-1",
+            "working_directory": "<env>"
+          }
+        ],
+        "idempotency_key": "<id:5>"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/store",
+      "body": {
+        "entities": [
+          {
+            "content": "The instance refuses any callback that is not on its tunnel allowlist, and that list is empty until you set it. Set NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS to the exact full callback URL — https://bottega8-dashboard.fly.dev/auth/callback — not just the host. It is matched exactly: that path is authorised and nothing else on that host, the query string and a trailing slash are ignored, and plaintext http: is accepted only for loopback. I have recorded the setting so it survives this session.",
+            "cwd": "<env>",
+            "data_source": "cursor-hook",
+            "entity_type": "conversation_message",
+            "harness": "cursor",
+            "hook_event": "stop",
+            "observed_at": "<ts>",
+            "role": "assistant",
+            "sender_kind": "assistant",
+            "turn_key": "oauth_operator_trusted_callback__cursor-hooks__composer-2:turn-1:assistant"
+          }
+        ],
+        "idempotency_key": "<id:8>"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/store",
+      "body": {
+        "entities": [
+          {
+            "context_source": "cursor-hook",
+            "conversation_id": "<id:3>",
+            "cwd": "<env>",
+            "data_source": "cursor-hook",
+            "ended_at": "<ts>",
+            "entity_type": "conversation_turn",
+            "git_branch": "<env>",
+            "harness": "cursor",
+            "harness_loop_count": 0,
+            "hook_event": "stop",
+            "hook_events": [
+              "stop"
+            ],
+            "model": "composer-2",
+            "neotoma_tool_failures": 0,
+            "reminder_injected": true,
+            "retrieve_calls": 1,
+            "safety_net_used": false,
+            "session_id": "<id:1>",
+            "status": "completed",
+            "store_structured_calls": 1,
+            "tool_invocation_count": 2,
+            "turn_id": "<id:4>",
+            "turn_key": "oauth_operator_trusted_callback__cursor-hooks__composer-2:turn-1",
+            "working_directory": "<env>"
+          }
+        ],
+        "idempotency_key": "<id:5>"
+      }
+    }
+  ],
+  "outputs": [
+    {
+      "hook": "beforeSubmitPrompt",
+      "exitCode": 0,
+      "output": {}
+    },
+    {
+      "hook": "postToolUse",
+      "exitCode": 0,
+      "output": {
+        "additional_context": "Neotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nForbidden: reusing the user-phase conversation_message `turn_key` for the closing assistant store (must use `{conversation_id}:{turn_id}:assistant`, not the bare `{conversation_id}:{turn_id}`).\nNote: this client (composer-2) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial."
+      }
+    },
+    {
+      "hook": "postToolUse",
+      "exitCode": 0,
+      "output": {}
+    },
+    {
+      "hook": "stop",
+      "exitCode": 0,
+      "output": {}
+    }
+  ]
+}

--- a/tests/__snapshots__/agentic_eval/oauth_operator_trusted_callback__cursor-hooks__gpt-5.5-fast.snap.json
+++ b/tests/__snapshots__/agentic_eval/oauth_operator_trusted_callback__cursor-hooks__gpt-5.5-fast.snap.json
@@ -1,0 +1,289 @@
+{
+  "requests": [
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "REFERS_TO",
+        "source_entity_id": "ent_mock_12",
+        "target_entity_id": "ent_mock_9"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "REFERS_TO",
+        "source_entity_id": "ent_mock_19",
+        "target_entity_id": "ent_mock_16"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/store",
+      "body": {
+        "entities": [
+          {
+            "client_name": "Cursor",
+            "conversation_id": "<id:1>",
+            "cwd": "<env>",
+            "data_source": "cursor-hook",
+            "entity_type": "conversation",
+            "harness": "cursor-hook",
+            "hook_event": "beforeSubmitPrompt",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "repository_root": "<env>",
+            "scope_summary": "<env>",
+            "thread_kind": "human_agent",
+            "title": "<env>",
+            "workspace_kind": "<env>"
+          },
+          {
+            "content": "Sign-in to my instance fails for the dashboard I deployed at https://bottega8-dashboard.fly.dev — authorize returns 'redirect_uri is not allowed when connecting via a tunnel'. Figure out what I need to configure and remember it.",
+            "cwd": "<env>",
+            "data_source": "cursor-hook",
+            "entity_type": "conversation_message",
+            "harness": "cursor",
+            "hook_event": "beforeSubmitPrompt",
+            "role": "user",
+            "sender_kind": "user",
+            "turn_key": "oauth_operator_trusted_callback__cursor-hooks__gpt-5.5-fast:turn-1"
+          }
+        ],
+        "idempotency_key": "<id:2>",
+        "relationships": [
+          {
+            "relationship_type": "PART_OF",
+            "source_index": 1,
+            "target_index": 0
+          }
+        ]
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/store",
+      "body": {
+        "entities": [
+          {
+            "context_source": "cursor-hook",
+            "conversation_id": "<id:3>",
+            "cwd": "<env>",
+            "data_source": "cursor-hook",
+            "entity_type": "conversation_turn",
+            "git_branch": "<env>",
+            "harness": "cursor",
+            "hook_event": "before_submit_prompt",
+            "hook_events": [
+              "before_submit_prompt"
+            ],
+            "model": "gpt-5.5-fast",
+            "session_id": "<id:1>",
+            "started_at": "<ts>",
+            "stored_entity_ids": [
+              "ent_mock_3"
+            ],
+            "turn_id": "<id:4>",
+            "turn_key": "oauth_operator_trusted_callback__cursor-hooks__gpt-5.5-fast:turn-1",
+            "working_directory": "<env>"
+          }
+        ],
+        "idempotency_key": "<id:5>"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/store",
+      "body": {
+        "entities": [
+          {
+            "cwd": "<env>",
+            "data_source": "cursor-hook",
+            "entity_type": "tool_invocation",
+            "harness": "cursor",
+            "has_error": false,
+            "hook_event": "postToolUse",
+            "input_summary": "{\"entity_types\":[\"instance_config\"],\"query\":\"oauth trusted callback urls\"}",
+            "invoked_at": "<ts>",
+            "output_summary": "{\"entities\":[],\"count\":0}",
+            "status": null,
+            "tool_name": "mcp_neotoma_retrieve_entities",
+            "turn_key": "oauth_operator_trusted_callback__cursor-hooks__gpt-5.5-fast:turn-1"
+          }
+        ],
+        "idempotency_key": "<id:6>"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/store",
+      "body": {
+        "entities": [
+          {
+            "context_source": "cursor-hook",
+            "cwd": "<env>",
+            "data_source": "cursor-hook",
+            "entity_type": "conversation_turn",
+            "git_branch": "<env>",
+            "harness": "cursor",
+            "hook_event": "post_tool_use",
+            "hook_events": [
+              "post_tool_use"
+            ],
+            "model": "gpt-5.5-fast",
+            "neotoma_tool_failures": 0,
+            "retrieve_calls": 1,
+            "session_id": "<id:1>",
+            "store_structured_calls": 0,
+            "stored_entity_ids": [
+              "ent_mock_9"
+            ],
+            "tool_invocation_count": 1,
+            "turn_id": "<id:4>",
+            "turn_key": "oauth_operator_trusted_callback__cursor-hooks__gpt-5.5-fast:turn-1",
+            "working_directory": "<env>"
+          }
+        ],
+        "idempotency_key": "<id:5>"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/store",
+      "body": {
+        "entities": [
+          {
+            "cwd": "<env>",
+            "data_source": "cursor-hook",
+            "entity_type": "tool_invocation",
+            "harness": "cursor",
+            "has_error": false,
+            "hook_event": "postToolUse",
+            "input_summary": "{\"entities\":[{\"entity_type\":\"instance_config\",\"name\":\"NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS\",\"value\":\"https://bottega8-dashboard.fly.dev/auth/callback\",\"matching_rule\":\"exact full callback URL — scheme, host, port and path; query and fragment ignored; trailing slash insignificant\",\"default\":\"empty\",\"notes\":\"Empty by default, so an unset variable preserves prior behaviour exactly. Matched on the E...",
+            "invoked_at": "<ts>",
+            "output_summary": "{\"stored\":1,\"entity_ids\":[\"ent_oauth_cfg_001\"]}",
+            "status": null,
+            "tool_name": "mcp_neotoma_store",
+            "turn_key": "oauth_operator_trusted_callback__cursor-hooks__gpt-5.5-fast:turn-1"
+          }
+        ],
+        "idempotency_key": "<id:7>"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/store",
+      "body": {
+        "entities": [
+          {
+            "context_source": "cursor-hook",
+            "cwd": "<env>",
+            "data_source": "cursor-hook",
+            "entity_type": "conversation_turn",
+            "git_branch": "<env>",
+            "harness": "cursor",
+            "hook_event": "post_tool_use",
+            "hook_events": [
+              "post_tool_use"
+            ],
+            "model": "gpt-5.5-fast",
+            "neotoma_tool_failures": 0,
+            "retrieve_calls": 1,
+            "session_id": "<id:1>",
+            "store_structured_calls": 1,
+            "stored_entity_ids": [
+              "ent_mock_16"
+            ],
+            "tool_invocation_count": 2,
+            "turn_id": "<id:4>",
+            "turn_key": "oauth_operator_trusted_callback__cursor-hooks__gpt-5.5-fast:turn-1",
+            "working_directory": "<env>"
+          }
+        ],
+        "idempotency_key": "<id:5>"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/store",
+      "body": {
+        "entities": [
+          {
+            "content": "The instance refuses any callback that is not on its tunnel allowlist, and that list is empty until you set it. Set NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS to the exact full callback URL — https://bottega8-dashboard.fly.dev/auth/callback — not just the host. It is matched exactly: that path is authorised and nothing else on that host, the query string and a trailing slash are ignored, and plaintext http: is accepted only for loopback. I have recorded the setting so it survives this session.",
+            "cwd": "<env>",
+            "data_source": "cursor-hook",
+            "entity_type": "conversation_message",
+            "harness": "cursor",
+            "hook_event": "stop",
+            "observed_at": "<ts>",
+            "role": "assistant",
+            "sender_kind": "assistant",
+            "turn_key": "oauth_operator_trusted_callback__cursor-hooks__gpt-5.5-fast:turn-1:assistant"
+          }
+        ],
+        "idempotency_key": "<id:8>"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/store",
+      "body": {
+        "entities": [
+          {
+            "context_source": "cursor-hook",
+            "conversation_id": "<id:3>",
+            "cwd": "<env>",
+            "data_source": "cursor-hook",
+            "ended_at": "<ts>",
+            "entity_type": "conversation_turn",
+            "git_branch": "<env>",
+            "harness": "cursor",
+            "harness_loop_count": 0,
+            "hook_event": "stop",
+            "hook_events": [
+              "stop"
+            ],
+            "model": "gpt-5.5-fast",
+            "neotoma_tool_failures": 0,
+            "reminder_injected": true,
+            "retrieve_calls": 1,
+            "safety_net_used": false,
+            "session_id": "<id:1>",
+            "status": "completed",
+            "store_structured_calls": 1,
+            "tool_invocation_count": 2,
+            "turn_id": "<id:4>",
+            "turn_key": "oauth_operator_trusted_callback__cursor-hooks__gpt-5.5-fast:turn-1",
+            "working_directory": "<env>"
+          }
+        ],
+        "idempotency_key": "<id:5>"
+      }
+    }
+  ],
+  "outputs": [
+    {
+      "hook": "beforeSubmitPrompt",
+      "exitCode": 0,
+      "output": {}
+    },
+    {
+      "hook": "postToolUse",
+      "exitCode": 0,
+      "output": {
+        "additional_context": "Neotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nForbidden: reusing the user-phase conversation_message `turn_key` for the closing assistant store (must use `{conversation_id}:{turn_id}:assistant`, not the bare `{conversation_id}:{turn_id}`).\nNote: this client (gpt-5.5-fast) is on a small/fast model. Treat the above as a hard checklist — run it every turn even when the answer feels trivial."
+      }
+    },
+    {
+      "hook": "postToolUse",
+      "exitCode": 0,
+      "output": {}
+    },
+    {
+      "hook": "stop",
+      "exitCode": 0,
+      "output": {}
+    }
+  ]
+}

--- a/tests/__snapshots__/agentic_eval/oauth_operator_trusted_callback__cursor-hooks__gpt-5.5-medium.snap.json
+++ b/tests/__snapshots__/agentic_eval/oauth_operator_trusted_callback__cursor-hooks__gpt-5.5-medium.snap.json
@@ -1,0 +1,289 @@
+{
+  "requests": [
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "REFERS_TO",
+        "source_entity_id": "ent_mock_12",
+        "target_entity_id": "ent_mock_9"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/create_relationship",
+      "body": {
+        "relationship_type": "REFERS_TO",
+        "source_entity_id": "ent_mock_19",
+        "target_entity_id": "ent_mock_16"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/store",
+      "body": {
+        "entities": [
+          {
+            "client_name": "Cursor",
+            "conversation_id": "<id:1>",
+            "cwd": "<env>",
+            "data_source": "cursor-hook",
+            "entity_type": "conversation",
+            "harness": "cursor-hook",
+            "hook_event": "beforeSubmitPrompt",
+            "repository_name": "<env>",
+            "repository_remote": "<env>",
+            "repository_root": "<env>",
+            "scope_summary": "<env>",
+            "thread_kind": "human_agent",
+            "title": "<env>",
+            "workspace_kind": "<env>"
+          },
+          {
+            "content": "Sign-in to my instance fails for the dashboard I deployed at https://bottega8-dashboard.fly.dev — authorize returns 'redirect_uri is not allowed when connecting via a tunnel'. Figure out what I need to configure and remember it.",
+            "cwd": "<env>",
+            "data_source": "cursor-hook",
+            "entity_type": "conversation_message",
+            "harness": "cursor",
+            "hook_event": "beforeSubmitPrompt",
+            "role": "user",
+            "sender_kind": "user",
+            "turn_key": "oauth_operator_trusted_callback__cursor-hooks__gpt-5.5-medium:turn-1"
+          }
+        ],
+        "idempotency_key": "<id:2>",
+        "relationships": [
+          {
+            "relationship_type": "PART_OF",
+            "source_index": 1,
+            "target_index": 0
+          }
+        ]
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/store",
+      "body": {
+        "entities": [
+          {
+            "context_source": "cursor-hook",
+            "conversation_id": "<id:3>",
+            "cwd": "<env>",
+            "data_source": "cursor-hook",
+            "entity_type": "conversation_turn",
+            "git_branch": "<env>",
+            "harness": "cursor",
+            "hook_event": "before_submit_prompt",
+            "hook_events": [
+              "before_submit_prompt"
+            ],
+            "model": "gpt-5.5-medium",
+            "session_id": "<id:1>",
+            "started_at": "<ts>",
+            "stored_entity_ids": [
+              "ent_mock_3"
+            ],
+            "turn_id": "<id:4>",
+            "turn_key": "oauth_operator_trusted_callback__cursor-hooks__gpt-5.5-medium:turn-1",
+            "working_directory": "<env>"
+          }
+        ],
+        "idempotency_key": "<id:5>"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/store",
+      "body": {
+        "entities": [
+          {
+            "cwd": "<env>",
+            "data_source": "cursor-hook",
+            "entity_type": "tool_invocation",
+            "harness": "cursor",
+            "has_error": false,
+            "hook_event": "postToolUse",
+            "input_summary": "{\"entity_types\":[\"instance_config\"],\"query\":\"oauth trusted callback urls\"}",
+            "invoked_at": "<ts>",
+            "output_summary": "{\"entities\":[],\"count\":0}",
+            "status": null,
+            "tool_name": "mcp_neotoma_retrieve_entities",
+            "turn_key": "oauth_operator_trusted_callback__cursor-hooks__gpt-5.5-medium:turn-1"
+          }
+        ],
+        "idempotency_key": "<id:6>"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/store",
+      "body": {
+        "entities": [
+          {
+            "context_source": "cursor-hook",
+            "cwd": "<env>",
+            "data_source": "cursor-hook",
+            "entity_type": "conversation_turn",
+            "git_branch": "<env>",
+            "harness": "cursor",
+            "hook_event": "post_tool_use",
+            "hook_events": [
+              "post_tool_use"
+            ],
+            "model": "gpt-5.5-medium",
+            "neotoma_tool_failures": 0,
+            "retrieve_calls": 1,
+            "session_id": "<id:1>",
+            "store_structured_calls": 0,
+            "stored_entity_ids": [
+              "ent_mock_9"
+            ],
+            "tool_invocation_count": 1,
+            "turn_id": "<id:4>",
+            "turn_key": "oauth_operator_trusted_callback__cursor-hooks__gpt-5.5-medium:turn-1",
+            "working_directory": "<env>"
+          }
+        ],
+        "idempotency_key": "<id:5>"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/store",
+      "body": {
+        "entities": [
+          {
+            "cwd": "<env>",
+            "data_source": "cursor-hook",
+            "entity_type": "tool_invocation",
+            "harness": "cursor",
+            "has_error": false,
+            "hook_event": "postToolUse",
+            "input_summary": "{\"entities\":[{\"entity_type\":\"instance_config\",\"name\":\"NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS\",\"value\":\"https://bottega8-dashboard.fly.dev/auth/callback\",\"matching_rule\":\"exact full callback URL — scheme, host, port and path; query and fragment ignored; trailing slash insignificant\",\"default\":\"empty\",\"notes\":\"Empty by default, so an unset variable preserves prior behaviour exactly. Matched on the E...",
+            "invoked_at": "<ts>",
+            "output_summary": "{\"stored\":1,\"entity_ids\":[\"ent_oauth_cfg_001\"]}",
+            "status": null,
+            "tool_name": "mcp_neotoma_store",
+            "turn_key": "oauth_operator_trusted_callback__cursor-hooks__gpt-5.5-medium:turn-1"
+          }
+        ],
+        "idempotency_key": "<id:7>"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/store",
+      "body": {
+        "entities": [
+          {
+            "context_source": "cursor-hook",
+            "cwd": "<env>",
+            "data_source": "cursor-hook",
+            "entity_type": "conversation_turn",
+            "git_branch": "<env>",
+            "harness": "cursor",
+            "hook_event": "post_tool_use",
+            "hook_events": [
+              "post_tool_use"
+            ],
+            "model": "gpt-5.5-medium",
+            "neotoma_tool_failures": 0,
+            "retrieve_calls": 1,
+            "session_id": "<id:1>",
+            "store_structured_calls": 1,
+            "stored_entity_ids": [
+              "ent_mock_16"
+            ],
+            "tool_invocation_count": 2,
+            "turn_id": "<id:4>",
+            "turn_key": "oauth_operator_trusted_callback__cursor-hooks__gpt-5.5-medium:turn-1",
+            "working_directory": "<env>"
+          }
+        ],
+        "idempotency_key": "<id:5>"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/store",
+      "body": {
+        "entities": [
+          {
+            "content": "The instance refuses any callback that is not on its tunnel allowlist, and that list is empty until you set it. Set NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS to the exact full callback URL — https://bottega8-dashboard.fly.dev/auth/callback — not just the host. It is matched exactly: that path is authorised and nothing else on that host, the query string and a trailing slash are ignored, and plaintext http: is accepted only for loopback. I have recorded the setting so it survives this session.",
+            "cwd": "<env>",
+            "data_source": "cursor-hook",
+            "entity_type": "conversation_message",
+            "harness": "cursor",
+            "hook_event": "stop",
+            "observed_at": "<ts>",
+            "role": "assistant",
+            "sender_kind": "assistant",
+            "turn_key": "oauth_operator_trusted_callback__cursor-hooks__gpt-5.5-medium:turn-1:assistant"
+          }
+        ],
+        "idempotency_key": "<id:8>"
+      }
+    },
+    {
+      "method": "POST",
+      "endpoint": "/store",
+      "body": {
+        "entities": [
+          {
+            "context_source": "cursor-hook",
+            "conversation_id": "<id:3>",
+            "cwd": "<env>",
+            "data_source": "cursor-hook",
+            "ended_at": "<ts>",
+            "entity_type": "conversation_turn",
+            "git_branch": "<env>",
+            "harness": "cursor",
+            "harness_loop_count": 0,
+            "hook_event": "stop",
+            "hook_events": [
+              "stop"
+            ],
+            "model": "gpt-5.5-medium",
+            "neotoma_tool_failures": 0,
+            "reminder_injected": true,
+            "retrieve_calls": 1,
+            "safety_net_used": false,
+            "session_id": "<id:1>",
+            "status": "completed",
+            "store_structured_calls": 1,
+            "tool_invocation_count": 2,
+            "turn_id": "<id:4>",
+            "turn_key": "oauth_operator_trusted_callback__cursor-hooks__gpt-5.5-medium:turn-1",
+            "working_directory": "<env>"
+          }
+        ],
+        "idempotency_key": "<id:5>"
+      }
+    }
+  ],
+  "outputs": [
+    {
+      "hook": "beforeSubmitPrompt",
+      "exitCode": 0,
+      "output": {}
+    },
+    {
+      "hook": "postToolUse",
+      "exitCode": 0,
+      "output": {
+        "additional_context": "Neotoma turn must-do (compact; full rules at MCP `instructions`):\n0. Every turn must interact with Neotoma at least once, usually by storing the conversation turn.\n1. Bounded retrieval first when the user message implies known entities (retrieve_entity_by_identifier for ids, retrieve_entities for category lists).\n2. User-phase store (one **`store`** MCP call): conversation + user conversation_message (sender_kind=user) + any extracted entities; PART_OF message->conversation; REFERS_TO message->each extracted entity.\n3. Tool calls and host edits run AFTER step 2.\n4. Closing store: assistant conversation_message (sender_kind=assistant, exact reply text) with REFERS_TO to every entity the reply cites or produced; PART_OF same conversation.\n5. Display rule: when this turn created/updated/retrieved non-bookkeeping entities, the visible reply ends with a `🧠 Neotoma` section listing them as bullets.\nForbidden: skipping store on greetings, persisting only the user message, ending the turn without the assistant store. Idempotency keys are per-turn unique.\nForbidden: reusing the user-phase conversation_message `turn_key` for the closing assistant store (must use `{conversation_id}:{turn_id}:assistant`, not the bare `{conversation_id}:{turn_id}`)."
+      }
+    },
+    {
+      "hook": "postToolUse",
+      "exitCode": 0,
+      "output": {}
+    },
+    {
+      "hook": "stop",
+      "exitCode": 0,
+      "output": {}
+    }
+  ]
+}

--- a/tests/contract/mcp_oauth_authorize_responses.test.ts
+++ b/tests/contract/mcp_oauth_authorize_responses.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Contract coverage for `GET /mcp/oauth/authorize` (operationId
+ * `mcpOAuthAuthorize`).
+ *
+ * Why this file exists: until the change that added it, `openapi.yaml` declared
+ * a single `302` for this operation while the handler in `src/actions.ts` also
+ * emitted five distinct `400`s and a `500`. Every one of those refusals was an
+ * observable response with no declaration behind it, so contract tests and
+ * clients were blind to the entire refusal surface — including the one whose
+ * body #2383 changed.
+ *
+ * `docs/architecture/openapi_contract_flow.md` puts handlers downstream of the
+ * spec: "When handlers and spec disagree, the contract tests fail and the spec
+ * wins". That only has teeth if some test actually compares the two. This is
+ * that test for this endpoint: it drives the REAL handler over HTTP for each
+ * documented refusal and asserts the status it returns is declared, with the
+ * media type the spec says it uses.
+ *
+ * The `400` is deliberately `text/plain` rather than the canonical
+ * `ErrorEnvelope`. This endpoint is reached by a BROWSER mid-OAuth-redirect, so
+ * the body renders in the address bar for a human; a JSON envelope shown raw
+ * there is strictly worse for the person who has to act on it. That choice is
+ * declared in the spec, and asserted here, rather than left implicit.
+ */
+
+import { rmSync } from "node:fs";
+import path from "node:path";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { load } from "js-yaml";
+import { readFileSync } from "node:fs";
+
+import { resolveOpenApiPath } from "../../src/shared/openapi_file.js";
+
+import type { Server } from "node:http";
+
+/** A public (non-loopback) client IP, so `isLocalRequest` returns false. */
+const TUNNEL_CLIENT_IP = "203.0.113.7";
+
+const VALID_PKCE = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM";
+
+type DeclaredResponses = Record<string, { content?: Record<string, unknown> }>;
+
+let declared: DeclaredResponses;
+let currentTempDir: string | null = null;
+let importCounter = 0;
+
+beforeAll(() => {
+  const spec = load(readFileSync(resolveOpenApiPath(), "utf8")) as {
+    paths: Record<string, Record<string, { operationId?: string; responses?: DeclaredResponses }>>;
+  };
+  const operation = spec.paths["/mcp/oauth/authorize"]?.get;
+  expect(operation?.operationId).toBe("mcpOAuthAuthorize");
+  declared = operation?.responses ?? {};
+});
+
+async function loadApp(tempDir: string): Promise<{ listen: (port: number) => Server }> {
+  process.env.NEOTOMA_DATA_DIR = tempDir;
+  process.env.NEOTOMA_RAW_STORAGE_DIR = path.join(tempDir, "sources");
+  process.env.NEOTOMA_MCP_TOKEN_ENCRYPTION_KEY =
+    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+  process.env.MCP_TOKEN_ENCRYPTION_KEY =
+    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+  // Otherwise authorize redirects to the key-auth gate before it evaluates any
+  // of the refusal branches below.
+  process.env.NEOTOMA_REQUIRE_KEY_FOR_OAUTH = "false";
+  delete process.env.NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS;
+
+  const actionsUrl = new URL("../../src/actions.js", import.meta.url).href;
+  const actions = await import(`${actionsUrl}?cacheBust=${Date.now()}-${importCounter++}`);
+
+  const { config } = await import(new URL("../../src/config.js", import.meta.url).href);
+  config.oauthTrustedCallbackUrls.length = 0;
+
+  return actions.app;
+}
+
+/** Issue an authorize request as if it arrived over a tunnel. */
+async function authorize(
+  app: { listen: (port: number) => Server },
+  query: Record<string, string>
+): Promise<{ status: number; contentType: string; body: string }> {
+  const server = app.listen(0);
+  try {
+    const address = server.address();
+    if (!address || typeof address !== "object") {
+      throw new Error("Expected HTTP server to bind to an ephemeral port");
+    }
+    const response = await fetch(
+      `http://127.0.0.1:${address.port}/mcp/oauth/authorize?${new URLSearchParams(query)}`,
+      {
+        redirect: "manual",
+        headers: {
+          "x-forwarded-for": TUNNEL_CLIENT_IP,
+          "x-forwarded-host": "instance.example.com",
+        },
+      }
+    );
+    return {
+      status: response.status,
+      contentType: response.headers.get("content-type") ?? "",
+      body: await response.text(),
+    };
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((err?: Error) => (err ? reject(err) : resolve()));
+    });
+  }
+}
+
+describe("mcpOAuthAuthorize response contract", () => {
+  afterEach(() => {
+    delete process.env.NEOTOMA_REQUIRE_KEY_FOR_OAUTH;
+    delete process.env.NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS;
+    if (currentTempDir) {
+      rmSync(currentTempDir, { recursive: true, force: true });
+      currentTempDir = null;
+    }
+  });
+
+  it("declares every status the handler can return", () => {
+    // The spec must not silently regress to the 302-only declaration that let
+    // the refusal surface go undeclared in the first place.
+    expect(Object.keys(declared).sort()).toEqual(["302", "400", "500"]);
+  });
+
+  it("declares the refusal as plain text, not the JSON ErrorEnvelope", () => {
+    // Deliberate: a browser mid-redirect renders this body to a human. If a
+    // future change moves this path onto ErrorEnvelope, this assertion should
+    // fail and force that decision to be made explicitly rather than by drift.
+    expect(Object.keys(declared["400"]?.content ?? {})).toEqual(["text/plain"]);
+    expect(Object.keys(declared["500"]?.content ?? {})).toEqual(["text/plain"]);
+  });
+
+  // Each case below is one refusal branch in `src/actions.ts`. All of them
+  // predate #2383; the tunnel case is the one whose body #2383 changed.
+  const refusals: Array<{ name: string; query: Record<string, string> }> = [
+    {
+      name: "missing redirect_uri",
+      query: { state: "s", code_challenge: VALID_PKCE, code_challenge_method: "S256" },
+    },
+    {
+      name: "missing state",
+      query: {
+        redirect_uri: "http://localhost:5195/oauth",
+        code_challenge: VALID_PKCE,
+        code_challenge_method: "S256",
+      },
+    },
+    {
+      name: "missing PKCE on a non-OpenAI redirect",
+      query: { redirect_uri: "http://localhost:5195/oauth", state: "s" },
+    },
+    {
+      name: "dev_stub while disabled",
+      query: {
+        redirect_uri: "http://localhost:5195/oauth",
+        state: "s",
+        code_challenge: VALID_PKCE,
+        code_challenge_method: "S256",
+        dev_stub: "1",
+      },
+    },
+    {
+      name: "redirect_uri not on the tunnel allowlist",
+      query: {
+        redirect_uri: "https://not-configured.example.com/callback",
+        state: "s",
+        code_challenge: VALID_PKCE,
+        code_challenge_method: "S256",
+      },
+    },
+  ];
+
+  for (const refusal of refusals) {
+    it(`answers a declared 400 for: ${refusal.name}`, async () => {
+      currentTempDir = path.join(process.cwd(), "tmp", `neotoma-authorize-contract-${Date.now()}`);
+      const app = await loadApp(currentTempDir);
+
+      const response = await authorize(app, refusal.query);
+
+      expect(response.status).toBe(400);
+      // The status the handler emits is one the spec declares.
+      expect(declared[String(response.status)]).toBeTruthy();
+      // ...and with the media type it declares for it.
+      expect(response.contentType).toContain("text/plain");
+      // A refusal with an empty body would satisfy the status assertions while
+      // telling the human in the browser nothing.
+      expect(response.body.length).toBeGreaterThan(0);
+    });
+  }
+
+  it("does not render an echoed redirect_uri as HTML", async () => {
+    // This endpoint is pre-auth and browser-reached, and the 400 now echoes the
+    // sanitized redirect_uri so an operator can self-diagnose a near miss. That
+    // echo is only safe while the response is text/plain: as text/html, a
+    // crafted redirect_uri would execute on this instance's own origin. This
+    // pins the media type at the sink, so a future `res.send(...)` regression
+    // fails here rather than in production.
+    currentTempDir = path.join(process.cwd(), "tmp", `neotoma-authorize-contract-${Date.now()}`);
+    const app = await loadApp(currentTempDir);
+
+    const injected = "https://evil.example.com/cb</p><script>alert(1)</script>";
+    const response = await authorize(app, {
+      redirect_uri: injected,
+      state: "s",
+      code_challenge: VALID_PKCE,
+      code_challenge_method: "S256",
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.contentType).toContain("text/plain");
+    expect(response.contentType).not.toContain("text/html");
+    // The sanitizer drops query/fragment; the path is echoed, so the guarantee
+    // that matters is the media type, asserted above.
+    expect(response.body).toContain("The server compared:");
+  });
+
+  it("never echoes the query string, where the code and state live", async () => {
+    currentTempDir = path.join(process.cwd(), "tmp", `neotoma-authorize-contract-${Date.now()}`);
+    const app = await loadApp(currentTempDir);
+
+    const response = await authorize(app, {
+      redirect_uri: "https://evil.example.com/cb?code=SECRET_CODE&token=SECRET_TOKEN",
+      state: "s",
+      code_challenge: VALID_PKCE,
+      code_challenge_method: "S256",
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body).not.toContain("SECRET_CODE");
+    expect(response.body).not.toContain("SECRET_TOKEN");
+    expect(response.body).toContain("https://evil.example.com/cb");
+  });
+
+  it("answers a declared 302 when the redirect_uri is allowed", async () => {
+    currentTempDir = path.join(process.cwd(), "tmp", `neotoma-authorize-contract-${Date.now()}`);
+    const app = await loadApp(currentTempDir);
+
+    const response = await authorize(app, {
+      redirect_uri: "http://localhost:5195/oauth",
+      state: "s",
+      code_challenge: VALID_PKCE,
+      code_challenge_method: "S256",
+    });
+
+    expect(response.status).toBe(302);
+    expect(declared["302"]).toBeTruthy();
+  });
+});

--- a/tests/fixtures/agentic_eval/oauth_operator_trusted_callback.json
+++ b/tests/fixtures/agentic_eval/oauth_operator_trusted_callback.json
@@ -1,0 +1,106 @@
+{
+  "meta": {
+    "id": "oauth_operator_trusted_callback",
+    "description": "An operator diagnoses why their self-hosted app's OAuth callback is refused and records the NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS fix as durable memory. SCOPE NOTE: Tier 1 is the hook-lifecycle layer and runs against a MOCK Neotoma server, so this fixture asserts what the agent REMEMBERS about the allowlist, not that the allowlist enforces. The enforcement itself — that the exact configured callback is accepted at /mcp/oauth/authorize and a sibling path, a traversal and an unconfigured host are refused — is asserted over real HTTP in tests/integration/mcp_oauth_trusted_callback.test.ts, and the matching rule is covered unit-level in src/services/__tests__/mcp_oauth.test.ts. See that integration file for the effect-level evidence this tier cannot express.",
+    "harnesses": ["cursor-hooks"],
+    "models": [
+      "composer-2",
+      "gpt-5.5-fast",
+      "claude-haiku-4",
+      "claude-sonnet-4.5",
+      "gpt-5.5-medium"
+    ],
+    "tags": ["oauth", "operator-config", "turn-lifecycle", "tool-loop"]
+  },
+  "events": [
+    {
+      "hook": "beforeSubmitPrompt",
+      "payload": {
+        "prompt": "Sign-in to my instance fails for the dashboard I deployed at https://bottega8-dashboard.fly.dev — authorize returns 'redirect_uri is not allowed when connecting via a tunnel'. Figure out what I need to configure and remember it."
+      }
+    },
+    {
+      "hook": "postToolUse",
+      "payload": {
+        "tool_name": "mcp_neotoma_retrieve_entities",
+        "tool_input": {
+          "entity_types": ["instance_config"],
+          "query": "oauth trusted callback urls"
+        },
+        "tool_output": {
+          "entities": [],
+          "count": 0
+        }
+      }
+    },
+    {
+      "hook": "postToolUse",
+      "payload": {
+        "tool_name": "mcp_neotoma_store",
+        "tool_input": {
+          "entities": [
+            {
+              "entity_type": "instance_config",
+              "name": "NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS",
+              "value": "https://bottega8-dashboard.fly.dev/auth/callback",
+              "matching_rule": "exact full callback URL — scheme, host, port and path; query and fragment ignored; trailing slash insignificant",
+              "default": "empty",
+              "notes": "Empty by default, so an unset variable preserves prior behaviour exactly. Matched on the EXACT callback URL rather than the origin, so configuring it authorises that one path and not the rest of the host. Plaintext http: is honoured only for loopback hosts."
+            }
+          ],
+          "idempotency_key": "oauth-trusted-callback-eval-001"
+        },
+        "tool_output": {
+          "stored": 1,
+          "entity_ids": ["ent_oauth_cfg_001"]
+        }
+      }
+    },
+    {
+      "hook": "stop",
+      "payload": {
+        "text": "The instance refuses any callback that is not on its tunnel allowlist, and that list is empty until you set it. Set NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS to the exact full callback URL — https://bottega8-dashboard.fly.dev/auth/callback — not just the host. It is matched exactly: that path is authorised and nothing else on that host, the query string and a trailing slash are ignored, and plaintext http: is accepted only for loopback. I have recorded the setting so it survives this session."
+      }
+    }
+  ],
+  "assertions": {
+    "default": [
+      {
+        "type": "entity_stored",
+        "entity_type": "conversation_message",
+        "where": { "role": "user" }
+      },
+      {
+        "type": "entity_stored",
+        "entity_type": "conversation_message",
+        "where": { "role": "assistant" }
+      },
+      {
+        "type": "entity_stored",
+        "entity_type": "conversation_turn"
+      },
+      {
+        "type": "entity_stored",
+        "entity_type": "tool_invocation",
+        "where": { "tool_name": "mcp_neotoma_store" }
+      },
+      {
+        "type": "entity_stored",
+        "entity_type": "tool_invocation",
+        "where": { "tool_name": "mcp_neotoma_retrieve_entities" }
+      },
+      {
+        "type": "field_present",
+        "entity_type": "tool_invocation",
+        "field": "input_summary",
+        "where": { "tool_name": "mcp_neotoma_store" }
+      },
+      {
+        "type": "request_count",
+        "endpoint": "/store",
+        "op": "gte",
+        "value": 3
+      }
+    ]
+  }
+}

--- a/tests/integration/mcp_oauth_trusted_callback.test.ts
+++ b/tests/integration/mcp_oauth_trusted_callback.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Effect-level coverage for NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS, driven through
+ * the REAL `/mcp/oauth/authorize` HTTP handler rather than the pure allowlist
+ * function.
+ *
+ * Why this file exists as an integration test rather than a unit test: the QA
+ * contract on #2384 asks that the operator-configured callback be shown to
+ * actually change what the endpoint does — "a test asserts the reported effect
+ * ... not merely that the config value is accepted or parsed without error".
+ * `src/services/__tests__/mcp_oauth.test.ts` already covers the matching rule
+ * exhaustively at the unit level; what it cannot show is that the value is
+ * WIRED — that the config the operator sets reaches the branch in
+ * `src/actions.ts` that produces the 400. That wiring is what this asserts.
+ *
+ * Reaching the tunnel branch requires three things, all of which mirror what a
+ * real hosted deployment looks like:
+ *   - `config.storageBackend === "local"` (the local-backend tunnel guard);
+ *   - a NON-local request, which is what the `x-forwarded-for` public IP below
+ *     produces — a loopback socket alone would be treated as local and skip the
+ *     allowlist entirely;
+ *   - `NEOTOMA_REQUIRE_KEY_FOR_OAUTH=false`, so the handler does not redirect to
+ *     the key-auth gate before it ever evaluates the redirect_uri.
+ */
+
+import { rmSync } from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { Server } from "node:http";
+
+let currentTempDir: string | null = null;
+let importCounter = 0;
+
+/** A public (non-loopback) client IP, so `isLocalRequest` returns false. */
+const TUNNEL_CLIENT_IP = "203.0.113.7";
+
+const CONFIGURED_CALLBACK = "https://app.example.com/auth/callback";
+
+async function loadAppWithTrustedCallbacks(
+  tempDir: string,
+  trusted: string | undefined
+): Promise<{ app: { listen: (port: number) => Server } }> {
+  process.env.NEOTOMA_DATA_DIR = tempDir;
+  process.env.NEOTOMA_RAW_STORAGE_DIR = path.join(tempDir, "sources");
+  process.env.NEOTOMA_MCP_TOKEN_ENCRYPTION_KEY =
+    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+  process.env.MCP_TOKEN_ENCRYPTION_KEY =
+    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+  // Otherwise authorize redirects to the key-auth gate before it evaluates
+  // redirect_uri, and the allowlist branch is never reached.
+  process.env.NEOTOMA_REQUIRE_KEY_FOR_OAUTH = "false";
+
+  if (trusted === undefined) {
+    delete process.env.NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS;
+  } else {
+    process.env.NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS = trusted;
+  }
+
+  const actionsUrl = new URL("../../src/actions.js", import.meta.url).href;
+  const cacheBust = `cacheBust=${Date.now()}-${importCounter++}`;
+  const actions = await import(`${actionsUrl}?${cacheBust}`);
+
+  // `src/config.ts` builds `config` as a module-scope object literal, read from
+  // process.env exactly once per process. Cache-busting `actions.js` does NOT
+  // re-evaluate it — the specifier `../config.js` still resolves to the one
+  // cached instance — so setting the env var alone would silently affect only
+  // whichever test imported first. Mutating the live array in place is what the
+  // unit suite does too, and it keeps the assertions honest: the app under test
+  // reads the same array the handler reads.
+  const { config } = await import(new URL("../../src/config.js", import.meta.url).href);
+  const entries = (process.env.NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS || "")
+    .split(",")
+    .map((entry: string) => entry.trim())
+    .filter((entry: string) => entry.length > 0);
+  config.oauthTrustedCallbackUrls.length = 0;
+  config.oauthTrustedCallbackUrls.push(...entries);
+
+  return { app: actions.app };
+}
+
+/**
+ * Issue an authorize request as if it arrived over a tunnel, and report what the
+ * endpoint did. A 400 carrying the tunnel-refusal text is a reject; anything
+ * else (a redirect to the login/consent step) means the redirect_uri was
+ * accepted and the flow proceeded.
+ */
+async function authorizeOverTunnel(
+  app: { listen: (port: number) => Server },
+  redirectUri: string
+): Promise<{ status: number; body: string; rejectedByAllowlist: boolean }> {
+  const server = app.listen(0);
+  try {
+    const address = server.address();
+    if (!address || typeof address !== "object") {
+      throw new Error("Expected HTTP server to bind to an ephemeral port");
+    }
+    const query = new URLSearchParams({
+      redirect_uri: redirectUri,
+      state: "test-state-value",
+      code_challenge: "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+      code_challenge_method: "S256",
+    });
+    const response = await fetch(
+      `http://127.0.0.1:${address.port}/mcp/oauth/authorize?${query}`,
+      {
+        redirect: "manual",
+        headers: {
+          // Makes the request non-local, which is what puts the tunnel
+          // allowlist in the path at all.
+          "x-forwarded-for": TUNNEL_CLIENT_IP,
+          "x-forwarded-host": "instance.example.com",
+        },
+      }
+    );
+    const body = await response.text();
+    return {
+      status: response.status,
+      body,
+      rejectedByAllowlist:
+        response.status === 400 &&
+        body.includes("redirect_uri is not allowed when connecting via a tunnel"),
+    };
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((err?: Error) => (err ? reject(err) : resolve()));
+    });
+  }
+}
+
+describe("operator-configured OAuth trusted callback URLs (HTTP authorize surface)", () => {
+  afterEach(async () => {
+    delete process.env.NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS;
+    delete process.env.NEOTOMA_REQUIRE_KEY_FOR_OAUTH;
+    // The live config array is shared process-wide; leaving entries in it would
+    // leak an operator-configured allowlist into every later suite in this file.
+    const { config } = await import(new URL("../../src/config.js", import.meta.url).href);
+    config.oauthTrustedCallbackUrls.length = 0;
+    if (currentTempDir) {
+      rmSync(currentTempDir, { recursive: true, force: true });
+      currentTempDir = null;
+    }
+  });
+
+  it("refuses the operator's callback when the variable is unset, and accepts it once set", async () => {
+    // The whole feature in one assertion pair: the ONLY thing that changes
+    // between these two runs is the environment variable, so an accept in the
+    // second run cannot come from anywhere else.
+    currentTempDir = path.join(process.cwd(), "tmp", `neotoma-oauth-trusted-${Date.now()}`);
+
+    const unset = await loadAppWithTrustedCallbacks(currentTempDir, undefined);
+    const before = await authorizeOverTunnel(unset.app, CONFIGURED_CALLBACK);
+    expect(before.rejectedByAllowlist).toBe(true);
+    // The refusal tells an operator the variable is not set, rather than
+    // leaving them unable to tell that from a typo.
+    expect(before.body).toContain("NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS");
+
+    const configured = await loadAppWithTrustedCallbacks(currentTempDir, CONFIGURED_CALLBACK);
+    const after = await authorizeOverTunnel(configured.app, CONFIGURED_CALLBACK);
+    expect(after.rejectedByAllowlist).toBe(false);
+    // Accepted means the handler moved on to the login/consent step.
+    expect(after.status).toBeGreaterThanOrEqual(300);
+    expect(after.status).toBeLessThan(400);
+  });
+
+  it("authorises only the configured path, not the rest of that host", async () => {
+    // #2215 in miniature, asserted at the HTTP surface: configuring a callback
+    // must not hand the whole origin to the caller.
+    currentTempDir = path.join(process.cwd(), "tmp", `neotoma-oauth-trusted-${Date.now()}`);
+    const { app } = await loadAppWithTrustedCallbacks(currentTempDir, CONFIGURED_CALLBACK);
+
+    const sibling = await authorizeOverTunnel(app, "https://app.example.com/admin");
+    expect(sibling.rejectedByAllowlist).toBe(true);
+
+    const traversal = await authorizeOverTunnel(
+      app,
+      "https://app.example.com/auth/callback/../admin"
+    );
+    expect(traversal.rejectedByAllowlist).toBe(true);
+
+    // A real callback carries ?code=&state=; ignoring query is what lets it match.
+    const withQuery = await authorizeOverTunnel(
+      app,
+      "https://app.example.com/auth/callback?code=abc&state=xyz"
+    );
+    expect(withQuery.rejectedByAllowlist).toBe(false);
+  });
+
+  it("still refuses a host that was never configured", async () => {
+    // Guards against the failure mode where the new branch is accidentally
+    // wired to allow everything once any entry is configured.
+    currentTempDir = path.join(process.cwd(), "tmp", `neotoma-oauth-trusted-${Date.now()}`);
+    const { app } = await loadAppWithTrustedCallbacks(currentTempDir, CONFIGURED_CALLBACK);
+
+    const unrelated = await authorizeOverTunnel(app, "https://not-configured.example.com/callback");
+    expect(unrelated.rejectedByAllowlist).toBe(true);
+    // ...and the refusal now reports that entries ARE configured, which is what
+    // distinguishes an exact-match miss from an unset variable.
+    expect(unrelated.body).toContain("1 operator-configured callback URL(s)");
+  });
+
+  it("leaves the pre-existing hardcoded allowlist deciding exactly as before", async () => {
+    // The default-unset regression guard at the HTTP surface. The unit suite
+    // (tests/services/__tests__/tunnel_oauth.test.ts) covers the full matrix;
+    // this confirms the wiring does not disturb it.
+    currentTempDir = path.join(process.cwd(), "tmp", `neotoma-oauth-trusted-${Date.now()}`);
+    const { app } = await loadAppWithTrustedCallbacks(currentTempDir, undefined);
+
+    const loopback = await authorizeOverTunnel(app, "http://localhost:5195/oauth");
+    expect(loopback.rejectedByAllowlist).toBe(false);
+
+    const thirdParty = await authorizeOverTunnel(app, "https://evil.com/steal-code");
+    expect(thirdParty.rejectedByAllowlist).toBe(true);
+  });
+});

--- a/tests/unit/config_trusted_callbacks.test.ts
+++ b/tests/unit/config_trusted_callbacks.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Fail-closed parsing of NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS (#2384 invariant 5).
+ *
+ * The condition pre-registered on #2384 before implementation: "If the allowlist
+ * string contains 3 entries and entry #2 is malformed, the parse must throw for
+ * the *whole list* (rejecting entries 1 and 3 along with 2), not silently drop
+ * only the bad entry and admit the good ones."
+ *
+ * That is what these tests pin. The alternative — skipping a bad entry and
+ * honouring the rest — is friendlier on a typo but makes the allowlist enforce
+ * something other than what the operator wrote, with no signal that it did: the
+ * refusal a dropped entry produces is indistinguishable from an exact-match miss.
+ *
+ * `src/config.ts` validates at module load (a top-level call, not inside an
+ * exported function), so these exercise it via fresh dynamic imports under
+ * different env values, following tests/unit/config_db_backend.test.ts.
+ */
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+async function importFreshConfig() {
+  vi.resetModules();
+  return import("../../src/config.ts");
+}
+
+async function makeProjectRoot(prefix: string): Promise<{ homeDir: string; projectRoot: string }> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  const homeDir = path.join(root, "home");
+  const projectRoot = path.join(root, "project");
+  await fs.mkdir(homeDir, { recursive: true });
+  await fs.mkdir(projectRoot, { recursive: true });
+  await fs.writeFile(
+    path.join(projectRoot, "package.json"),
+    JSON.stringify({ name: "neotoma", version: "0.0.0-test" }, null, 2)
+  );
+  return { homeDir, projectRoot };
+}
+
+async function stubBaseEnv(prefix: string) {
+  const { homeDir, projectRoot } = await makeProjectRoot(prefix);
+  vi.stubEnv("HOME", homeDir);
+  vi.stubEnv("USERPROFILE", homeDir);
+  vi.stubEnv("NEOTOMA_ENV", "development");
+  vi.stubEnv("NEOTOMA_PROJECT_ROOT", projectRoot);
+  vi.stubEnv("NEOTOMA_DATA_DIR", path.join(projectRoot, "data"));
+}
+
+describe("NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS parsing", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it("defaults to an empty list when unset", async () => {
+    await stubBaseEnv("neotoma-trusted-cb-default-");
+    vi.stubEnv("NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS", "");
+
+    const { config } = await importFreshConfig();
+    expect(config.oauthTrustedCallbackUrls).toEqual([]);
+  });
+
+  it("accepts a well-formed multi-entry list, trimming whitespace", async () => {
+    await stubBaseEnv("neotoma-trusted-cb-valid-");
+    vi.stubEnv(
+      "NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS",
+      " https://a.example.com/cb , https://b.example.com/auth/callback "
+    );
+
+    const { config } = await importFreshConfig();
+    expect(config.oauthTrustedCallbackUrls).toEqual([
+      "https://a.example.com/cb",
+      "https://b.example.com/auth/callback",
+    ]);
+  });
+
+  it("accepts http: for a loopback host", async () => {
+    await stubBaseEnv("neotoma-trusted-cb-loopback-");
+    vi.stubEnv("NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS", "http://localhost:5195/oauth/callback");
+
+    const { config } = await importFreshConfig();
+    expect(config.oauthTrustedCallbackUrls).toEqual(["http://localhost:5195/oauth/callback"]);
+  });
+
+  // The pre-registered invariant, stated literally: three entries, the second
+  // malformed, and entries 1 and 3 must NOT survive.
+  it("rejects the WHOLE list when one entry of three is malformed", async () => {
+    await stubBaseEnv("neotoma-trusted-cb-partial-");
+    vi.stubEnv(
+      "NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS",
+      "https://a.example.com/cb,not a url,https://c.example.com/cb"
+    );
+
+    // Startup fails rather than quietly honouring entries 1 and 3.
+    await expect(importFreshConfig()).rejects.toThrow(
+      /Invalid NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS/
+    );
+  });
+
+  it("identifies WHICH entry is bad, by position and value", async () => {
+    // An error that says only "the list is invalid" would leave the operator
+    // bisecting their own config by hand.
+    await stubBaseEnv("neotoma-trusted-cb-names-");
+    vi.stubEnv(
+      "NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS",
+      "https://a.example.com/cb,not a url,https://c.example.com/cb"
+    );
+
+    await expect(importFreshConfig()).rejects.toThrow(/entry 2 \("not a url"\)/);
+  });
+
+  it("reports every bad entry at once, not just the first", async () => {
+    await stubBaseEnv("neotoma-trusted-cb-multi-bad-");
+    vi.stubEnv(
+      "NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS",
+      "not a url,https://ok.example.com/cb,ftp://x/y"
+    );
+
+    await expect(importFreshConfig()).rejects.toThrow(/2 of 3 entries/);
+  });
+
+  it.each([
+    ["a plaintext http: entry to a non-loopback host", "http://evil.example.com/cb", /cleartext/],
+    ["a non-http(s) scheme", "ftp://app.example.com/cb", /scheme "ftp:"/],
+    ["an unparseable entry", "app.example.com/cb", /not a parseable absolute URL/],
+    ["an entry carrying userinfo", "https://app.example.com@evil.example.com/cb", /userinfo/],
+  ])("fails closed on %s", async (_label, value, expected) => {
+    await stubBaseEnv("neotoma-trusted-cb-reject-");
+    vi.stubEnv("NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS", value);
+
+    await expect(importFreshConfig()).rejects.toThrow(expected);
+  });
+
+  it("redacts userinfo rather than echoing a possible credential", async () => {
+    // The error text lands in startup logs; the one part of a callback URL that
+    // could carry a secret must not be printed back verbatim.
+    await stubBaseEnv("neotoma-trusted-cb-redact-");
+    vi.stubEnv("NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS", "https://user:hunter2@app.example.com/cb");
+
+    const error = await importFreshConfig().then(
+      () => null,
+      (err: Error) => err
+    );
+    expect(error).toBeTruthy();
+    expect(error!.message).not.toContain("hunter2");
+    expect(error!.message).toContain("<redacted>@");
+  });
+
+  it("tells the operator how to recover", async () => {
+    await stubBaseEnv("neotoma-trusted-cb-recover-");
+    vi.stubEnv("NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS", "not a url");
+
+    // Both routes out: fix the entry, or unset and fall back to the built-ins.
+    await expect(importFreshConfig()).rejects.toThrow(/unset the variable/);
+  });
+});


### PR DESCRIPTION
Closes #2384

**Design basis: no design applies** — the kernel documents (principles, work_model, gates_and_workflows) govern how the swarm's own work moves through steps and batches; none states an invariant about OAuth redirect-URI trust boundaries or credential/callback validation. This inherits the Design-basis section of parent issue #2384 and does not re-litigate it. Related prior art this mechanism is intended to converge with: #2215 (exact-match vs. origin-match).

## The operator-facing problem

A self-hosted first-party app cannot complete sign-in against a hosted Neotoma instance. When an authorize request reaches a local-backend instance over a tunnel, `isRedirectUriAllowedForTunnel` requires the `redirect_uri` to be on a **hardcoded** allowlist: the `cursor:`/`vscode:`/`app:` schemes, localhost and loopback, this instance's own origin, and the ChatGPT and Claude callbacks. Anything else gets:

> redirect_uri is not allowed when connecting via a tunnel. Use cursor://, localhost, loopback, or trusted callback URLs (OpenAI/Claude).

That list is correct as far as it goes — it exists to stop an authorization code being handed to a third-party site — but there is no way for an operator to add the app *they* deployed. An operator running their own dashboard at `https://bottega8-dashboard.fly.dev` against their own instance has no supported path forward. That is the gap this closes.

## What this adds

`NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS`: a comma-separated list of callback URLs, read in the existing `src/config.ts` idiom alongside `oauthClientId` and `requireKeyForOauth`.

```bash
NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS=https://app.example.com/auth/callback
```

**It defaults to empty.** An operator who sets nothing gets exactly the behaviour they had before this existed, and the new check is consulted only after every pre-existing rule has already declined. Nothing about localhost, the app schemes, or the ChatGPT/Claude entries is loosened — this is purely additive.

## Design decisions

**Exact callback URLs, not origins.** A configured `https://app.example.com/auth/callback` authorises that path and **not** `https://app.example.com/anything-else`. #2215 reports the existing allowlist trusting whole third-party origins as a defect; adding a second, operator-configurable instance of the same weakness would have been the easy version of this change and the wrong one. Exact matching is also what makes the variable safe to hand an operator: the blast radius of a mistake is one path, not one host.

**Compare parsed URLs, not strings.** String comparison of URLs is a reliable source of bypasses. Normalisation is delegated to the WHATWG `URL` parser wherever the parser and a browser agree — the browser is what will actually perform the redirect, so its interpretation is the one that matters:

- backslashes resolve as slashes, the way a browser resolves them;
- dot segments resolve, so `/auth/callback/../admin` becomes `/auth/admin` and then simply fails to match;
- the host lowercases; a default port (`:443`) drops.

On top of that:

- compare protocol + host + port + pathname only. Query and fragment are ignored, so a real `?code=…&state=…` callback matches and neither can smuggle a mismatch past the comparison;
- pathname case is **preserved** — paths are correctly case-sensitive, unlike hosts;
- a trailing slash is insignificant in either direction; an operator should not be punished for `/cb` vs `/cb/`;
- an encoded slash (`%2F`) is **not** treated as a path separator;
- any URL carrying userinfo is refused. `https://app.example.com@evil.com/cb` is harmless to the parser but is a well-worn way to make a URL read as one host to a human reviewing config and resolve as another.

**Plaintext `http:` fails closed.** A configured `http://evil.com/cb` is not honoured. `http:` is accepted only for loopback hosts, where there is no wire to sniff. An operator who misconfigures this gets a refusal, not a silent downgrade to shipping authorization codes in cleartext. A configured `https` entry likewise does not authorise its `http` twin.

**A bad entry fails the whole list, at load.** If any configured entry is unparseable, uses a scheme other than `https:`/`http:`, is plaintext `http:` to a non-loopback host, or carries userinfo, the **entire list is rejected and the server does not start**, with an error naming every bad entry by position and value (userinfo redacted). Entries 1 and 3 do not quietly survive a bad entry 2.

This is the condition #2384 pre-registered before implementation, and it is the right call on the merits: an allowlist is a security control, and one that silently enforces less than its configuration says does not bind — the refusal a dropped entry produces is indistinguishable from an exact-match miss. It matches how `src/config.ts` already treats an invalid `NEOTOMA_DB_BACKEND`. The cost is real (one typo can lock an operator out of every callback) and is recorded as a possible follow-up rather than acted on here.

**The rejection names the variable.** The 400 now reports how many entries are configured, which is what distinguishes an unset variable from a typo from an exact-match miss. The warn log keeps using `sanitizeRedirectUriForLog` and adds the configured count — a count, never the URLs themselves.

## What an operator must set

Only the one variable, on the instance brokering the OAuth flow. For the motivating case:

```bash
NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS=https://bottega8-dashboard.fly.dev/auth/callback
```

Several callbacks are comma-separated. Every distinct callback path must be listed; listing the origin is deliberately not a thing you can do. Documented in `docs/operations/configuration.md`.

## What this does NOT do

**It does not touch the third-party origin matching that #2215 reports.** The `chatgpt.com` / `chat.openai.com` host-scoped entries are untouched by this PR, and the `claude.ai` entries keep their existing four exact pathnames. This change is additive and deliberately stays out of the way of that fix.

**How a fix for #2215 ought to relate to this.** #2215's own proposed fix is to "register them explicitly rather than accepting the origin wholesale" — which is precisely the mechanism added here. The good outcome is that #2215 **converges on this exact-match comparison** rather than inventing a second one: replace the two bare host checks with exact callback URLs run through the same `canonicalCallbackUrl` normalisation, so there is one definition of "this redirect URI matches that callback" in the codebase rather than two that can drift. If a future maintainer instead adds a second matching path, the normalisation rules above are the ones that would need duplicating — which is the argument for not doing it.

One honest note against #2215's acceptance criteria: it asks for a regression test "exercising the redirect validation through the reachable entry point rather than the helper." The tests here exercise the helper, following the existing convention of `mcp_oauth.test.ts`. An end-to-end test through `GET /mcp/oauth/authorize` would be a genuine improvement and belongs with the #2215 work.

## Enforcement call sites (arch condition — grep result, recorded not assumed)

`grep -rn 'isRedirectUriAllowedForTunnel' --include='*.ts' --include='*.tsx' --include='*.md' --include='*.mdc' .` (excluding `node_modules/`, `dist/`):

| Location | Kind |
| --- | --- |
| `src/services/mcp_oauth.ts:398` | definition |
| `src/actions.ts:3052,3056` | **the one non-test call site** — dynamic import + the guard itself |
| `src/services/__tests__/mcp_oauth.test.ts` | tests |
| `src/services/__tests__/tunnel_oauth.test.ts` | tests |
| `inspector/src/lib/oauth_signin.ts:30` | **prose only** — a comment describing the server-side constraint, not a client-side reimplementation |
| `docs/developer/mcp_oauth_implementation.md:83,110` | docs |
| `docs/developer/tunnel_auth_audit_matrix.md:20,21,56,77` | docs |

There is a single enforcement point, so cross-surface parity holds by there being one surface. The Inspector reference is the only thing that could have been a second implementation, and it is not one.

## OpenAPI contract

`openapi.yaml` declared only a `302` for `mcpOAuthAuthorize`, while the handler also answered **five** `400`s and a `500` — all pre-existing on `origin/main`, one of whose bodies this PR changed. This declares the **whole** response set the endpoint emits, not just the one touched here: declaring one of five would make the spec newly false about the other four.

The `400`/`500` stay **`text/plain`** rather than moving to `ErrorEnvelope`, because this endpoint is reached by a browser mid-redirect and the body renders in the address bar for a human (`mcpOAuthKeyAuthGet` sets the precedent for a declared non-JSON body). Writing the contract test surfaced that `res.send(string)` was serving these as `text/html` — an HTML sink on a pre-auth endpoint reflecting caller-supplied input — now fixed by `sendAuthorizeRefusal` setting `text/plain` explicitly.

## Tests

`src/services/__tests__/mcp_oauth.test.ts` extended with 18 cases, including the adversarial normalisation ones: path traversal (`/auth/callback/../admin`, and its `%2E%2E` form), a configured trailing slash against a request without one and vice versa, `HTTPS://APP.EXAMPLE.COM/auth/callback`, backslash paths, `%2F`, default vs non-default ports, userinfo on either side, host-suffix and subdomain near-misses (`app.example.com.evil.com`), and `http:` to a non-loopback host while configured. Plus: the empty default changes nothing, and the pre-existing allowlist still behaves identically when entries are configured.

Verified the new tests actually bind: disabling the one new line in `isRedirectUriAllowedForTunnel` fails 10 of them.

```
 ✓ src/services/__tests__/mcp_oauth.test.ts (60 tests) 336ms

 Test Files  1 passed (1)
      Tests  60 passed (60)
```

Broader run over the OAuth and config suites touching these files — `mcp_oauth`, `tunnel_oauth`, `oauth_key_gate`, `oauth_state`, `mcp_oauth_token_endpoint`, `google_oidc`, and the four config suites:

```
 Test Files  10 passed (10)
      Tests  138 passed (138)
```

The full suite was not run directly per #2090, though the pre-commit hook's own gate (type-check, lint, format-check, full unit suite, integration suite) passed on this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


