### PR TITLE
fix(config): refuse the user-level data dir fallback under test (#2387)

### DIFF
--- a/docs/operations/configuration.md
+++ b/docs/operations/configuration.md
@@ -18,25 +18,37 @@ All state lives under one directory you control, set by `NEOTOMA_DATA_DIR` (defa
 
 Resolution order for the data directory and variables: a project-local `.env`, then `~/.config/neotoma/.env`, then built-in defaults.
 
+### Under test, the user-level step is refused
+
+A test-shaped process — one with `VITEST` set, `NODE_ENV=test`, or `NEOTOMA_REQUIRE_EXPLICIT_DATA_DIR=1` — does **not** fall back to `~/.config/neotoma/.env` for its data directory. If it reaches that step it stops and exits non-zero, naming the variable to set.
+
+The reason is that the user-level config names the data directory holding real data. A test process, or a CLI child a test spawns without passing `NEOTOMA_DATA_DIR` through, would otherwise read and write that directory silently and succeed — so the mistake is invisible, and a test can pass on residue left in real data rather than on the code under test.
+
+So set `NEOTOMA_DATA_DIR` to a test-scoped directory, and pass it explicitly to every CLI child process a test spawns rather than relying on inheritance. To exercise the user-level fallback deliberately, set `NEOTOMA_ALLOW_USER_ENV_IN_TEST=1`.
+
+Nothing changes for normal operation: the interactive CLI, the server, and every non-test entry point resolve the data directory exactly as the order above describes.
+
 ## Environments
 
 `NEOTOMA_ENV` selects the profile: `development` (default) or `production`. The profiles use separate database files, source directories, and logs so a dev stack never touches prod data. Production also changes default ports and tightens auth expectations.
 
 ## Core variables
 
-| Variable | Purpose | Default |
-| --- | --- | --- |
-| `NEOTOMA_ENV` | `development` or `production` | `development` |
-| `NEOTOMA_DATA_DIR` | Root data directory | local `data/` |
-| `NEOTOMA_SQLITE_PATH` | Explicit database file path | `{dataDir}/neotoma.db` (dev) |
-| `NEOTOMA_DB_BACKEND` | DB driver: `sqlite` (synchronous, zero-config) or `libsql` (concurrent — statements run off the event loop via worker-hosted driver for local files, or @libsql/client for remote sqld/Turso, so slow queries can't freeze the server; recommended for hosted/agent-heavy/shared instances) | `sqlite` |
-| `NEOTOMA_DB_URL` | libsql connection URL (`file:` for embedded local, `http(s)://`/`libsql://` for remote sqld/Turso) | `file:{NEOTOMA_SQLITE_PATH}` |
-| `NEOTOMA_DB_AUTH_TOKEN` | Auth token for remote libsql connections | unset |
-| `NEOTOMA_DB_READER_WORKERS` | Read-only worker connections for the local `libsql` backend (WAL lets them run concurrently with the writer). Reads go to the least-loaded reader, so raising this adds capacity rather than just slots | `2` |
-| `NEOTOMA_DB_STATEMENT_TIMEOUT_MS` | Per-statement budget for reads on that reader pool. On expiry the reader is terminated (the synchronous driver cannot be interrupted mid-statement) and respawns on the next read, so one runaway query cannot hold a pool slot indefinitely. Writes and statements inside a transaction are never timed out. `0` disables | `30000` |
-| `NEOTOMA_RAW_STORAGE_DIR` | Content-addressed source files | `{dataDir}/sources` |
-| `NEOTOMA_LOGS_DIR` / `NEOTOMA_EVENT_LOG_PATH` | Log directory and event log file | under `{dataDir}/logs` |
-| `NEOTOMA_HOST_URL` / `NEOTOMA_PUBLIC_BASE_URL` | Public URL of this instance | auto-discovered or unset |
+| Variable                                       | Purpose                                                                                                                                                                                                                                                                                                                    | Default                      |
+| ---------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------- |
+| `NEOTOMA_ENV`                                  | `development` or `production`                                                                                                                                                                                                                                                                                              | `development`                |
+| `NEOTOMA_DATA_DIR`                             | Root data directory                                                                                                                                                                                                                                                                                                        | local `data/`                |
+| `NEOTOMA_REQUIRE_EXPLICIT_DATA_DIR`            | `1` demands an explicit `NEOTOMA_DATA_DIR`: refuse the `~/.config/neotoma/.env` fallback and exit non-zero. Implied by `VITEST` / `NODE_ENV=test`                                                                                                                                                                          | unset                        |
+| `NEOTOMA_ALLOW_USER_ENV_IN_TEST`               | `1` re-permits that fallback in a test-shaped process, for a test that means to exercise it                                                                                                                                                                                                                                | unset                        |
+| `NEOTOMA_SQLITE_PATH`                          | Explicit database file path                                                                                                                                                                                                                                                                                                | `{dataDir}/neotoma.db` (dev) |
+| `NEOTOMA_DB_BACKEND`                           | DB driver: `sqlite` (synchronous, zero-config) or `libsql` (concurrent — statements run off the event loop via worker-hosted driver for local files, or @libsql/client for remote sqld/Turso, so slow queries can't freeze the server; recommended for hosted/agent-heavy/shared instances)                                | `sqlite`                     |
+| `NEOTOMA_DB_URL`                               | libsql connection URL (`file:` for embedded local, `http(s)://`/`libsql://` for remote sqld/Turso)                                                                                                                                                                                                                         | `file:{NEOTOMA_SQLITE_PATH}` |
+| `NEOTOMA_DB_AUTH_TOKEN`                        | Auth token for remote libsql connections                                                                                                                                                                                                                                                                                   | unset                        |
+| `NEOTOMA_DB_READER_WORKERS`                    | Read-only worker connections for the local `libsql` backend (WAL lets them run concurrently with the writer). Reads go to the least-loaded reader, so raising this adds capacity rather than just slots                                                                                                                    | `2`                          |
+| `NEOTOMA_DB_STATEMENT_TIMEOUT_MS`              | Per-statement budget for reads on that reader pool. On expiry the reader is terminated (the synchronous driver cannot be interrupted mid-statement) and respawns on the next read, so one runaway query cannot hold a pool slot indefinitely. Writes and statements inside a transaction are never timed out. `0` disables | `30000`                      |
+| `NEOTOMA_RAW_STORAGE_DIR`                      | Content-addressed source files                                                                                                                                                                                                                                                                                             | `{dataDir}/sources`          |
+| `NEOTOMA_LOGS_DIR` / `NEOTOMA_EVENT_LOG_PATH`  | Log directory and event log file                                                                                                                                                                                                                                                                                           | under `{dataDir}/logs`       |
+| `NEOTOMA_HOST_URL` / `NEOTOMA_PUBLIC_BASE_URL` | Public URL of this instance                                                                                                                                                                                                                                                                                                | auto-discovered or unset     |
 
 ### When to opt into `NEOTOMA_DB_BACKEND=libsql`
 
@@ -49,22 +61,22 @@ Before flipping the variable on an existing database, run `npx tsx scripts/valid
 
 ## Server and ports
 
-| Variable | Purpose | Default |
-| --- | --- | --- |
+| Variable                             | Purpose                    | Default                 |
+| ------------------------------------ | -------------------------- | ----------------------- |
 | `NEOTOMA_HTTP_PORT` (or `HTTP_PORT`) | HTTP API and HTTP MCP port | `3080` dev, `3180` prod |
-| `WS_PORT` | WebSocket MCP bridge port | `8280` |
+| `WS_PORT`                            | WebSocket MCP bridge port  | `8280`                  |
 
 See [Running the Server](running_the_server.md) for transports and processes.
 
 ## Auth and access
 
-| Variable | Purpose |
-| --- | --- |
-| `NEOTOMA_REQUIRE_KEY_FOR_OAUTH` | Require a key for OAuth connections |
-| `NEOTOMA_OAUTH_CLIENT_ID` | MCP OAuth client id (hosted mode) |
+| Variable                              | Purpose                                                                                                                                                                     |
+| ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `NEOTOMA_REQUIRE_KEY_FOR_OAUTH`       | Require a key for OAuth connections                                                                                                                                         |
+| `NEOTOMA_OAUTH_CLIENT_ID`             | MCP OAuth client id (hosted mode)                                                                                                                                           |
 | `NEOTOMA_OAUTH_TRUSTED_CALLBACK_URLS` | Comma-separated **exact** callback URLs additionally trusted to receive an authorization code when the authorize request arrives via a tunnel. Empty by default. See below. |
-| `NEOTOMA_SANDBOX_MODE` | Opt into the public hosted-sandbox profile |
-| `NEOTOMA_REFUSE_MODE` | `warn` or `enforce` when a no-auth, non-loopback topology is detected |
+| `NEOTOMA_SANDBOX_MODE`                | Opt into the public hosted-sandbox profile                                                                                                                                  |
+| `NEOTOMA_REFUSE_MODE`                 | `warn` or `enforce` when a no-auth, non-loopback topology is detected                                                                                                       |
 
 ### Trusted OAuth callback URLs
 
@@ -86,14 +98,14 @@ Several entries are comma-separated. Rules worth knowing before you set it:
 
 A redirect is accepted when the request's callback and a configured entry agree on **scheme, host, port and path** — all four. In detail:
 
-| Part | How it is compared |
-| --- | --- |
-| Scheme | Must match. `https` does not authorise its `http` twin. |
-| Host | Case-**insensitive**. `APP.EXAMPLE.COM` matches `app.example.com`. |
-| Port | Must match, but a default port is equivalent to none: `https://app.example.com` = `https://app.example.com:443`. |
-| Path | Case-**sensitive**. `/Auth/Callback` does **not** match `/auth/callback`. A trailing slash is insignificant in either direction. Dot segments resolve first, so `/auth/callback/../admin` is compared as `/auth/admin`. An encoded slash (`%2F`) is not a path separator. |
-| Query and fragment | **Ignored on both sides**, so the usual `?code=...&state=...` callback matches. |
-| Userinfo | Any URL carrying `user:password@` is rejected. |
+| Part               | How it is compared                                                                                                                                                                                                                                                        |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Scheme             | Must match. `https` does not authorise its `http` twin.                                                                                                                                                                                                                   |
+| Host               | Case-**insensitive**. `APP.EXAMPLE.COM` matches `app.example.com`.                                                                                                                                                                                                        |
+| Port               | Must match, but a default port is equivalent to none: `https://app.example.com` = `https://app.example.com:443`.                                                                                                                                                          |
+| Path               | Case-**sensitive**. `/Auth/Callback` does **not** match `/auth/callback`. A trailing slash is insignificant in either direction. Dot segments resolve first, so `/auth/callback/../admin` is compared as `/auth/admin`. An encoded slash (`%2F`) is not a path separator. |
+| Query and fragment | **Ignored on both sides**, so the usual `?code=...&state=...` callback matches.                                                                                                                                                                                           |
+| Userinfo           | Any URL carrying `user:password@` is rejected.                                                                                                                                                                                                                            |
 
 If a redirect is refused, the `400` response names the callback URL the server actually compared (scheme, host and path — query and fragment are stripped) and says how many entries are configured. That is usually enough to tell a near miss — a trailing slash, a port, a case difference — from a typo or an unset variable, without needing server logs.
 
@@ -111,23 +123,23 @@ See [Deployment Modes](deployment.md) and [Agent Access Control](agent_access_co
 
 ## Encryption
 
-| Variable | Purpose |
-| --- | --- |
-| `NEOTOMA_ENCRYPTION_ENABLED` | Turn on AES-256-GCM at-rest column encryption |
-| `NEOTOMA_KEY_FILE_PATH` | Path to a 32-byte key file |
-| `NEOTOMA_MNEMONIC` / `NEOTOMA_MNEMONIC_PASSPHRASE` | BIP-39 mnemonic key source |
-| `NEOTOMA_LOG_ENCRYPTION_ENABLED` | Encrypt the event log |
-| `NEOTOMA_MCP_TOKEN_ENCRYPTION_KEY` | Encrypt stored MCP OAuth tokens |
+| Variable                                           | Purpose                                       |
+| -------------------------------------------------- | --------------------------------------------- |
+| `NEOTOMA_ENCRYPTION_ENABLED`                       | Turn on AES-256-GCM at-rest column encryption |
+| `NEOTOMA_KEY_FILE_PATH`                            | Path to a 32-byte key file                    |
+| `NEOTOMA_MNEMONIC` / `NEOTOMA_MNEMONIC_PASSPHRASE` | BIP-39 mnemonic key source                    |
+| `NEOTOMA_LOG_ENCRYPTION_ENABLED`                   | Encrypt the event log                         |
+| `NEOTOMA_MCP_TOKEN_ENCRYPTION_KEY`                 | Encrypt stored MCP OAuth tokens               |
 
 See [Encryption and Key Management](encryption.md).
 
 ## Search, inspector, and docs
 
-| Variable | Purpose |
-| --- | --- |
-| `OPENAI_API_KEY` | Enables semantic vector search (embeddings); keyword search works without it |
-| `NEOTOMA_INSPECTOR_DISABLE` / `NEOTOMA_PUBLIC_INSPECTOR_URL` / `NEOTOMA_INSPECTOR_BASE_PATH` | Control the bundled Inspector |
-| `NEOTOMA_DOCS_SHOW_INTERNAL` | Show `visibility: internal` docs in the in-app `/docs` browser |
+| Variable                                                                                     | Purpose                                                                      |
+| -------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `OPENAI_API_KEY`                                                                             | Enables semantic vector search (embeddings); keyword search works without it |
+| `NEOTOMA_INSPECTOR_DISABLE` / `NEOTOMA_PUBLIC_INSPECTOR_URL` / `NEOTOMA_INSPECTOR_BASE_PATH` | Control the bundled Inspector                                                |
+| `NEOTOMA_DOCS_SHOW_INTERNAL`                                                                 | Show `visibility: internal` docs in the in-app `/docs` browser               |
 
 ## Limits and mirror
 

--- a/docs/testing/automated_test_catalog.md
+++ b/docs/testing/automated_test_catalog.md
@@ -61,15 +61,15 @@ flowchart TD
 - Do not hand-edit suite inventory entries in this file. Update the generator or the repository tree, then regenerate.
 
 ## Repo-wide summary
-- Total automated test files: **605**
-- Backend and repo Vitest files: **570**
+- Total automated test files: **606**
+- Backend and repo Vitest files: **571**
 - Frontend Vitest files: **9**
 - Playwright spec files: **26**
 
 ### Suite counts
 | Suite | Files |
 |---|---:|
-| Vitest unit tests | 166 |
+| Vitest unit tests | 167 |
 | Vitest service tests | 44 |
 | Source-adjacent tests | 66 |
 | Vitest integration tests | 172 |
@@ -109,7 +109,7 @@ flowchart TD
 **Runner:** `vitest`
 **Command:** `npm test -- tests/unit`
 **Requirements:** Basic `.env` if required by the module under test.
-**Files (166):**
+**Files (167):**
 - `tests/unit/aauth_admission.test.ts`
 - `tests/unit/aauth_attestation_apple_se.test.ts`
 - `tests/unit/aauth_attestation_revocation.test.ts`
@@ -151,6 +151,7 @@ flowchart TD
 - `tests/unit/compliance_scorecard.test.ts`
 - `tests/unit/config_data_dir_resolution.test.ts`
 - `tests/unit/config_db_backend.test.ts`
+- `tests/unit/config_refuses_user_env_under_test.test.ts`
 - `tests/unit/config_sqlite_path.test.ts`
 - `tests/unit/config_trusted_callbacks.test.ts`
 - `tests/unit/content_field_store_warning.test.ts`

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,17 +19,76 @@ function resolveUserEnvPath(): string | null {
   return join(homeDir, ".config", "neotoma", ".env");
 }
 
+/**
+ * Is this process test-shaped (issue #2387)?
+ *
+ * `VITEST` is set by the vitest runner in workers; `NODE_ENV=test` is set by
+ * `vitest.global_setup.ts` and is the conventional signal a child process
+ * inherits. `NEOTOMA_REQUIRE_EXPLICIT_DATA_DIR=1` lets any caller demand the
+ * same strictness without pretending to be a test.
+ */
+function requiresExplicitDataDir(): boolean {
+  if (process.env.NEOTOMA_REQUIRE_EXPLICIT_DATA_DIR?.trim() === "1") return true;
+  if (process.env.VITEST?.trim()) return true;
+  return process.env.NODE_ENV?.trim() === "test";
+}
+
+/** Deliberate opt-in that re-permits the user-level fallback under test (issue #2387). */
+function userEnvFallbackAllowedInTest(): boolean {
+  return process.env.NEOTOMA_ALLOW_USER_ENV_IN_TEST?.trim() === "1";
+}
+
+/**
+ * Refuse the `~/.config/neotoma/.env` data-directory fallback in a test-shaped
+ * process (issue #2387).
+ *
+ * A CLI child spawned by a test does not necessarily inherit `NEOTOMA_DATA_DIR`.
+ * Without this guard such a child hydrated the variable from the user-level
+ * config and then read and wrote the data directory it names — the operator's
+ * real database — silently and with exit code 0. A test that passes against
+ * residue in real data is green for the wrong reason twice over, and the write
+ * itself is invisible because nothing fails.
+ *
+ * So: stop, name the variable to set, and exit non-zero. Non-test processes are
+ * untouched — the interactive CLI and the server keep hydrating exactly as
+ * before — and `NEOTOMA_ALLOW_USER_ENV_IN_TEST=1` re-permits it for the rare
+ * test that genuinely means to exercise the fallback.
+ */
+function refuseUserEnvFallbackUnderTest(userEnvPath: string, configuredDataDir: string): never {
+  const message = [
+    "[neotoma] Refusing to resolve the data directory from the user-level config while running under test.",
+    `  A test-shaped process (VITEST / NODE_ENV=test / NEOTOMA_REQUIRE_EXPLICIT_DATA_DIR=1) has no explicit NEOTOMA_DATA_DIR,`,
+    `  so ${userEnvPath} would have pointed it at a data directory holding real data.`,
+    "",
+    "  Set NEOTOMA_DATA_DIR to a test-scoped directory in the environment of this process",
+    "  (and pass it explicitly to any CLI child process the test spawns).",
+    "  To exercise the user-level fallback on purpose, set NEOTOMA_ALLOW_USER_ENV_IN_TEST=1.",
+  ].join("\n");
+  process.stderr.write(`${message}\n`);
+  // Length, not content: the configured path may name a real operator directory.
+  process.stderr.write(
+    `[neotoma] (refused user-level data directory: ${configuredDataDir.length} chars, not used)\n`
+  );
+  process.exit(1);
+}
+
 function hydrateDataDirFromUserEnvConfig(): void {
   if (process.env.NEOTOMA_DATA_DIR?.trim()) return;
   const userEnvPath = resolveUserEnvPath();
   if (!userEnvPath || !existsSync(userEnvPath)) return;
+  let configuredDataDir: string | undefined;
   try {
     const parsed = dotenv.parse(readFileSync(userEnvPath, "utf-8"));
-    const configuredDataDir = parsed.NEOTOMA_DATA_DIR?.trim();
-    if (configuredDataDir) process.env.NEOTOMA_DATA_DIR = configuredDataDir;
+    configuredDataDir = parsed.NEOTOMA_DATA_DIR?.trim();
   } catch {
     // Ignore invalid user env files and continue with existing fallbacks.
+    return;
   }
+  if (!configuredDataDir) return;
+  if (requiresExplicitDataDir() && !userEnvFallbackAllowedInTest()) {
+    refuseUserEnvFallbackUnderTest(userEnvPath, configuredDataDir);
+  }
+  process.env.NEOTOMA_DATA_DIR = configuredDataDir;
 }
 
 function isNeotomaRepoRoot(candidate: string | null | undefined): candidate is string {

--- a/tests/cli/cli_init_interactive.test.ts
+++ b/tests/cli/cli_init_interactive.test.ts
@@ -257,7 +257,10 @@ describe("CLI init interactive flows", () => {
         JSON.stringify({ name: "neotoma", version: "0.0.0-test" }, null, 2)
       );
       await fs.writeFile(path.join(configuredRepoRoot, "src", "cli", "index.ts"), "// marker\n");
-      await writeCliConfig(homeDir, { project_root: configuredRepoRoot, repo_root: configuredRepoRoot });
+      await writeCliConfig(homeDir, {
+        project_root: configuredRepoRoot,
+        repo_root: configuredRepoRoot,
+      });
 
       await withTempCwd(async (cwd) => {
         await fs.writeFile(
@@ -299,7 +302,15 @@ describe("CLI init interactive flows", () => {
         const defaultCli = await loadCli();
         try {
           await expectExitZero(() =>
-            defaultCli.runCli(["node", "cli", "init", "--skip-db", "--skip-env", "--auth-mode", "dev_local"])
+            defaultCli.runCli([
+              "node",
+              "cli",
+              "init",
+              "--skip-db",
+              "--skip-env",
+              "--auth-mode",
+              "dev_local",
+            ])
           );
         } finally {
           restoreTty();
@@ -316,7 +327,15 @@ describe("CLI init interactive flows", () => {
         const advancedCli = await loadCli();
         try {
           await expectExitZero(() =>
-            advancedCli.runCli(["node", "cli", "init", "--advanced", "--skip-db", "--auth-mode", "dev_local"])
+            advancedCli.runCli([
+              "node",
+              "cli",
+              "init",
+              "--advanced",
+              "--skip-db",
+              "--auth-mode",
+              "dev_local",
+            ])
           );
         } finally {
           restoreTty();
@@ -324,10 +343,12 @@ describe("CLI init interactive flows", () => {
         expect(advancedFlow.prompts.join(" ")).toMatch(/Path to Neotoma source checkout/i);
         expect(advancedFlow.prompts.join(" ")).toMatch(/Apply MCP \+ CLI updates to:/i);
         expect(
-          advancedFlow.prompts.filter((prompt) => /Path to Neotoma source checkout/i.test(prompt)).length
+          advancedFlow.prompts.filter((prompt) => /Path to Neotoma source checkout/i.test(prompt))
+            .length
         ).toBe(1);
         expect(
-          advancedFlow.prompts.filter((prompt) => /Apply MCP \+ CLI updates to:/i.test(prompt)).length
+          advancedFlow.prompts.filter((prompt) => /Apply MCP \+ CLI updates to:/i.test(prompt))
+            .length
         ).toBe(1);
         const sourcePromptIndex = advancedFlow.prompts.findIndex((prompt) =>
           /Path to Neotoma source checkout/i.test(prompt)
@@ -350,7 +371,16 @@ describe("CLI init interactive flows", () => {
         const { runCli } = await loadCli();
         try {
           await expectExitZero(() =>
-            runCli(["node", "cli", "init", "--advanced", "--skip-db", "--skip-env", "--auth-mode", "dev_local"])
+            runCli([
+              "node",
+              "cli",
+              "init",
+              "--advanced",
+              "--skip-db",
+              "--skip-env",
+              "--auth-mode",
+              "dev_local",
+            ])
           );
         } finally {
           restoreTty();
@@ -372,13 +402,24 @@ describe("CLI init interactive flows", () => {
         const { runCli } = await loadCli();
         try {
           await expectExitZero(() =>
-            runCli(["node", "cli", "init", "--advanced", "--skip-db", "--skip-env", "--auth-mode", "dev_local"])
+            runCli([
+              "node",
+              "cli",
+              "init",
+              "--advanced",
+              "--skip-db",
+              "--skip-env",
+              "--auth-mode",
+              "dev_local",
+            ])
           );
         } finally {
           restoreTty();
         }
         const prompts = flow.prompts.join(" ");
-        expect(prompts).toMatch(/Configure MCP configuration \(add\/update MCP servers\)\? \[Y\/n\]:/i);
+        expect(prompts).toMatch(
+          /Configure MCP configuration \(add\/update MCP servers\)\? \[Y\/n\]:/i
+        );
       });
     });
   });
@@ -470,14 +511,7 @@ describe("CLI init interactive flows", () => {
         const { runCli } = await loadCli();
         try {
           await expectExitZero(() =>
-            runCli([
-              "node",
-              "cli",
-              "init",
-              "--skip-db",
-              "--openai-api-key",
-              "test-openai-key",
-            ])
+            runCli(["node", "cli", "init", "--skip-db", "--openai-api-key", "test-openai-key"])
           );
         } finally {
           restoreTty();
@@ -494,23 +528,33 @@ describe("CLI init interactive flows", () => {
   });
 
   it("prefers NEOTOMA_DATA_DIR from selected env file", async () => {
-    await withTempHome(async (homeDir) => {
-      const envDir = path.join(homeDir, ".config", "neotoma");
-      const envPath = path.join(envDir, ".env");
-      const configuredDataDir = path.join(homeDir, "Documents", "data");
-      await fs.mkdir(envDir, { recursive: true });
-      await fs.writeFile(envPath, `NEOTOMA_DATA_DIR=${configuredDataDir}\n`);
+    // This case deliberately exercises the user-level env fallback, against a
+    // synthetic HOME. A test-shaped process refuses that fallback by default
+    // (issue #2387), so opt in explicitly — the synthetic home holds no real data.
+    const previousAllow = process.env.NEOTOMA_ALLOW_USER_ENV_IN_TEST;
+    process.env.NEOTOMA_ALLOW_USER_ENV_IN_TEST = "1";
+    try {
+      await withTempHome(async (homeDir) => {
+        const envDir = path.join(homeDir, ".config", "neotoma");
+        const envPath = path.join(envDir, ".env");
+        const configuredDataDir = path.join(homeDir, "Documents", "data");
+        await fs.mkdir(envDir, { recursive: true });
+        await fs.writeFile(envPath, `NEOTOMA_DATA_DIR=${configuredDataDir}\n`);
 
-      const { resolveInitDataDirDefaults } = await loadCli();
-      const defaults = await resolveInitDataDirDefaults({
-        repoRoot: null,
-        envPath,
-        homeDir,
-        cwd: homeDir,
+        const { resolveInitDataDirDefaults } = await loadCli();
+        const defaults = await resolveInitDataDirDefaults({
+          repoRoot: null,
+          envPath,
+          homeDir,
+          cwd: homeDir,
+        });
+
+        expect(defaults.configuredEnvDataDir).toBe(configuredDataDir);
+        expect(defaults.defaultDataDir).toBe(configuredDataDir);
       });
-
-      expect(defaults.configuredEnvDataDir).toBe(configuredDataDir);
-      expect(defaults.defaultDataDir).toBe(configuredDataDir);
-    });
+    } finally {
+      if (previousAllow === undefined) delete process.env.NEOTOMA_ALLOW_USER_ENV_IN_TEST;
+      else process.env.NEOTOMA_ALLOW_USER_ENV_IN_TEST = previousAllow;
+    }
   });
 });

--- a/tests/unit/config_data_dir_resolution.test.ts
+++ b/tests/unit/config_data_dir_resolution.test.ts
@@ -16,6 +16,9 @@ describe("runtime config data dir resolution", () => {
   });
 
   it("loads NEOTOMA_DATA_DIR from ~/.config/neotoma/.env when process env is unset", async () => {
+    // This case exercises the user-level fallback on purpose, which a test-shaped
+    // process now refuses by default (issue #2387), so it opts in explicitly.
+    vi.stubEnv("NEOTOMA_ALLOW_USER_ENV_IN_TEST", "1");
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "neotoma-config-user-env-"));
     const homeDir = path.join(root, "home");
     const projectRoot = path.join(root, "project");

--- a/tests/unit/config_refuses_user_env_under_test.test.ts
+++ b/tests/unit/config_refuses_user_env_under_test.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Issue #2387 — a test-shaped process must not resolve its data directory from
+ * the user-level config (`~/.config/neotoma/.env`).
+ *
+ * Before the fix, a CLI child spawned by a test that did not inherit
+ * `NEOTOMA_DATA_DIR` hydrated it from the user-level config and then operated on
+ * the data directory named there — real data — silently, exiting 0. The isolation
+ * every CLI test relied on was ambient: nothing asserted it.
+ *
+ * These cases drive the **built** config module in a real child process, because
+ * the refusal path calls `process.exit` and cannot be observed in-process. Every
+ * case uses a synthetic `HOME` containing a synthetic user-level config, so no
+ * real config file or database is read, written, or even resolved.
+ */
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+/** A directory that stands in for the operator's real one. Never actually used. */
+const STANDIN_DIR_NAME = "stands-in-for-real-data";
+
+let sandbox: string;
+let homeDir: string;
+let standInDataDir: string;
+let probePath: string;
+
+interface ProbeResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+/**
+ * Run the built config module in a child process with a synthetic HOME.
+ *
+ * `NEOTOMA_DATA_DIR` and `VITEST` are cleared from the inherited environment
+ * first — that inheritance is exactly what made the defect invisible — so each
+ * case states the environment it means to test.
+ */
+async function runProbe(overrides: Record<string, string>): Promise<ProbeResult> {
+  const env: Record<string, string> = { ...process.env } as Record<string, string>;
+  delete env.NEOTOMA_DATA_DIR;
+  delete env.VITEST;
+  delete env.NEOTOMA_ALLOW_USER_ENV_IN_TEST;
+  delete env.NEOTOMA_REQUIRE_EXPLICIT_DATA_DIR;
+  env.HOME = homeDir;
+  env.USERPROFILE = homeDir;
+  env.NEOTOMA_PROJECT_ROOT = projectRoot;
+  for (const [key, value] of Object.entries(overrides)) env[key] = value;
+
+  try {
+    const { stdout, stderr } = await execFileAsync(process.execPath, [probePath], {
+      env,
+      cwd: projectRoot,
+    });
+    return { code: 0, stdout, stderr };
+  } catch (error) {
+    const failure = error as { code?: number; stdout?: string; stderr?: string };
+    return { code: failure.code ?? 1, stdout: failure.stdout ?? "", stderr: failure.stderr ?? "" };
+  }
+}
+
+describe("config refuses the user-level data dir fallback under test (#2387)", () => {
+  beforeAll(async () => {
+    sandbox = await fs.mkdtemp(path.join(os.tmpdir(), "neotoma-2387-"));
+    homeDir = path.join(sandbox, "home");
+    standInDataDir = path.join(sandbox, STANDIN_DIR_NAME);
+    await fs.mkdir(path.join(homeDir, ".config", "neotoma"), { recursive: true });
+    await fs.mkdir(standInDataDir, { recursive: true });
+    await fs.writeFile(
+      path.join(homeDir, ".config", "neotoma", ".env"),
+      `NEOTOMA_DATA_DIR=${standInDataDir}\n`
+    );
+
+    // The probe must live inside the repo so its relative import of the built
+    // config resolves; it is removed in afterAll.
+    probePath = path.join(projectRoot, `probe_config_2387_${process.pid}.mjs`);
+    await fs.writeFile(
+      probePath,
+      [
+        'import { config } from "./dist/config.js";',
+        'console.log("RESOLVED_DATA_DIR=" + config.dataDir);',
+        "",
+      ].join("\n")
+    );
+  });
+
+  afterAll(async () => {
+    if (probePath) await fs.rm(probePath, { force: true });
+    if (sandbox) await fs.rm(sandbox, { recursive: true, force: true });
+  });
+
+  it("refuses and exits non-zero when NODE_ENV=test and no data dir is set", async () => {
+    const result = await runProbe({ NODE_ENV: "test" });
+
+    expect(result.code).not.toBe(0);
+    expect(result.stdout).not.toContain("RESOLVED_DATA_DIR=");
+    // The message must name the variable to set, or the refusal is not actionable.
+    expect(result.stderr).toContain("NEOTOMA_DATA_DIR");
+    expect(result.stderr).toContain("NEOTOMA_ALLOW_USER_ENV_IN_TEST");
+    // It must not silently resolve to the user-level path, nor leak it.
+    expect(result.stderr).not.toContain(standInDataDir);
+  });
+
+  it("refuses and exits non-zero when VITEST is set and no data dir is set", async () => {
+    const result = await runProbe({ VITEST: "true" });
+
+    expect(result.code).not.toBe(0);
+    expect(result.stdout).not.toContain("RESOLVED_DATA_DIR=");
+    expect(result.stderr).toContain("NEOTOMA_DATA_DIR");
+  });
+
+  it("refuses when NEOTOMA_REQUIRE_EXPLICIT_DATA_DIR=1 outside a test runner", async () => {
+    const result = await runProbe({ NEOTOMA_REQUIRE_EXPLICIT_DATA_DIR: "1" });
+
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toContain("NEOTOMA_DATA_DIR");
+  });
+
+  it("proceeds when a test-shaped process sets an explicit data dir", async () => {
+    const explicit = path.join(sandbox, "explicit-test-data");
+    await fs.mkdir(explicit, { recursive: true });
+
+    const result = await runProbe({ NODE_ENV: "test", NEOTOMA_DATA_DIR: explicit });
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain(`RESOLVED_DATA_DIR=${explicit}`);
+    expect(result.stdout).not.toContain(standInDataDir);
+  });
+
+  it("proceeds via the escape hatch when a test opts in deliberately", async () => {
+    const result = await runProbe({ NODE_ENV: "test", NEOTOMA_ALLOW_USER_ENV_IN_TEST: "1" });
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain(`RESOLVED_DATA_DIR=${standInDataDir}`);
+  });
+
+  /**
+   * The regression guard. Normal operation — the interactive CLI, the server —
+   * must keep hydrating from the user-level config exactly as before. If this
+   * goes red, the fix has broken every non-test entry point.
+   */
+  it("still hydrates from the user-level config in a non-test process", async () => {
+    const result = await runProbe({ NODE_ENV: "" });
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain(`RESOLVED_DATA_DIR=${standInDataDir}`);
+  });
+
+  it("falls back to projectRoot/data under test when the user config names no data dir", async () => {
+    const bareHome = path.join(sandbox, "bare-home");
+    await fs.mkdir(path.join(bareHome, ".config", "neotoma"), { recursive: true });
+    await fs.writeFile(path.join(bareHome, ".config", "neotoma", ".env"), "NEOTOMA_ENV=test\n");
+
+    const result = await runProbe({ NODE_ENV: "test", HOME: bareHome, USERPROFILE: bareHome });
+
+    // Nothing to refuse: no user-level data dir exists, so the pre-existing
+    // projectRoot/data default still applies and the process proceeds.
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain(`RESOLVED_DATA_DIR=${path.join(projectRoot, "data")}`);
+  });
+});


### PR DESCRIPTION
Closes #2387

## Design basis

No `docs/foundation/` design governs this diff — it is a runtime safety guard on data-directory resolution, not a change to the work model, a gate, or a principle. The contract it implements is this repo's own `docs/operations/configuration.md` § Data directory, whose stated resolution order (project-local `.env`, then the user-level config, then built-in defaults) this diff amends with one exception for test-shaped processes; that doc is updated in the same commit. `NEOTOMA_REQUIRE_EXPLICIT_DATA_DIR` is the name #2387 itself proposed.

## The mechanism, reproduced before changing anything

Verified against `origin/main` (`2fc45a45a`). The issue's reading holds:

- `hydrateDataDirFromUserEnvConfig()` returns early if `NEOTOMA_DATA_DIR` is already set; otherwise it parses the user-level config built from `$HOME` and assigns `process.env.NEOTOMA_DATA_DIR` from it, with a `catch` that swallows errors silently.
- That function is called unconditionally at module load.
- `const dataDir = process.env.NEOTOMA_DATA_DIR || join(projectRoot, "data");`

Reproduced empirically by running the **built** config module in a child process with a synthetic `HOME` whose user-level config names a stand-in directory. No real config file or database was read, written, or resolved at any point in this work.

```
[plain child, NODE_ENV unset]        exit=0  RESOLVED_DATA_DIR=<stand-in dir>
[test-shaped child, NODE_ENV=test]   exit=0  RESOLVED_DATA_DIR=<stand-in dir>
[test-shaped child, VITEST=true]     exit=0  RESOLVED_DATA_DIR=<stand-in dir>
```

A test-shaped process with no explicit data directory resolved to whatever the user-level config named, silently, exiting 0. Test isolation held only because the vitest worker inherits the variable from `vitest.global_setup.ts` and `exec` passes it to children implicitly — nothing asserted it.

## What changed

`src/config.ts` only, plus tests and the configuration doc.

- **`requiresExplicitDataDir()`** — true when `VITEST` is set, `NODE_ENV === "test"`, or `NEOTOMA_REQUIRE_EXPLICIT_DATA_DIR=1`.
- **`userEnvFallbackAllowedInTest()`** — the escape hatch, `NEOTOMA_ALLOW_USER_ENV_IN_TEST=1`.
- **`refuseUserEnvFallbackUnderTest()`** — writes an actionable message naming `NEOTOMA_DATA_DIR` and the escape hatch, then `process.exit(1)`. Not a warning, not a fallback to `projectRoot/data`.
- The refusal fires **only where the fallback would actually be taken** — test-shaped, no explicit data dir, *and* a user-level config that names one. A checkout whose user config names no data directory still reaches the `projectRoot/data` default exactly as before, which is why the non-test paths are untouched.
- The message reports the refused path's **length, not its content**: it may name a real operator directory.

`dataDir`'s shape is unchanged. `src/actions.ts` and `src/server.ts` are untouched. PR #1942's test file is untouched — it already passes its data directory explicitly.

## Tests

New `tests/unit/config_refuses_user_env_under_test.test.ts` — 7 cases. They drive the **built** config module in real child processes, because the refusal calls `process.exit` and cannot be observed in-process. Every case uses a synthetic `HOME`.

| Case | Expected |
| --- | --- |
| `NODE_ENV=test`, no data dir | refuses, exit non-zero, message names the variable, does not leak the path |
| `VITEST` set, no data dir | refuses, exit non-zero |
| `NEOTOMA_REQUIRE_EXPLICIT_DATA_DIR=1` outside a runner | refuses, exit non-zero |
| test-shaped + explicit data dir | proceeds, resolves the explicit dir |
| test-shaped + escape hatch | proceeds, resolves the user-level dir |
| **non-test, no data dir** | **still hydrates from the user-level config — the regression guard** |
| test-shaped, user config names no data dir | proceeds, resolves `projectRoot/data` |

**Effect verification against the real built CLI binary** (not just the config module), same synthetic `HOME`:

```
[real CLI, test-shaped (NODE_ENV=test)] exit=1  stderr[0]=[neotoma] Refusing to resolve the data directory from the user-level config while running under test.
[real CLI, non-test (regression guard)] exit=0  "data_dir": "<stand-in dir>", "data_dir_source": "env"
```

### Planted failure — proof the guard can go red

Removed the two-line guard from `hydrateDataDirFromUserEnvConfig()`, rebuilt, re-ran:

```
× refuses and exits non-zero when NODE_ENV=test and no data dir is set
× refuses and exits non-zero when VITEST is set and no data dir is set
× refuses when NEOTOMA_REQUIRE_EXPLICIT_DATA_DIR=1 outside a test runner
✓ proceeds when a test-shaped process sets an explicit data dir
✓ proceeds via the escape hatch when a test opts in deliberately
✓ still hydrates from the user-level config in a non-test process
✓ falls back to projectRoot/data under test when the user config names no data dir
Test Files  1 failed (1)
```

Exactly the three refusal cases went red; the four "proceeds" cases, including the regression guard, stayed green. Guard restored, all 7 green again.

### Cross-surface parity

Full suite on this branch: **540 test files passed, 7 skipped, 0 failed.** `tsc --noEmit` clean. The MCP/HTTP startup path is unaffected — it is a non-test process, and the 540-file run includes the integration and contract suites that boot the server.

### One existing test the guard caught in the act

`tests/cli/cli_init_interactive.test.ts` → "prefers NEOTOMA_DATA_DIR from selected env file" went red on the first full CLI run: it builds a synthetic `HOME` with a user-level config naming a data directory and then imports the CLI in-process, so it hit the refusal. That is the defect's own pattern — a test relying on the user-level fallback — caught by the guard rather than by a reviewer. It is a deliberate exercise of the fallback against a synthetic home holding no real data, so it now opts in via the escape hatch, scoped with try/finally because that file has no env-cleanup hook. `tests/unit/config_data_dir_resolution.test.ts` needed the same opt-in for the same reason. Those two are the only occurrences in 547 test files.

## On #1504 and #172 — checked, and neither is a live sibling

The issue suggested these might be one family. Read both; the family framing is right about the shape but both instances are already closed out, so there is nothing shared and live to fix:

- **#1504** (`NEOTOMA_SQLITE_PATH` advertised but ignored) — **already fixed on `main`.** `src/config.ts` now reads `process.env.NEOTOMA_SQLITE_PATH` before the derived default, and `tests/unit/config_sqlite_path.test.ts` covers both the override-set and override-unset paths. The issue is still open but labelled `resolved-in-release`; it looks like a bookkeeping close rather than work.
- **#172** (`upload --local` defaulting toward the wrong directory) — **CLOSED**, with coverage in `tests/unit/cli_bug_fixes.test.ts`.

So the accurate statement is that all three belong to one family — *config resolution that silently picks a surprising directory instead of refusing* — and this PR closes the last open member of it. No scope was expanded; neither issue's code was touched.

## Not done here

Per the issue's scope: no residue was audited or removed from any real database, and nothing was deleted anywhere. Extending the refusal to non-test CLI paths remains the open follow-up question #2387 raises and is deliberately out of scope. The issue's second defect — auditing every CLI-invoking test for implicit inheritance — is now partly mechanical rather than manual: the guard fails any such test loudly, and the full-suite run above found exactly two, both addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
